### PR TITLE
Adds Linux equivalents for the patch workflow scripts and updates `VintagestoryLib` to retain the vanilla client class surface in the server build.

### DIFF
--- a/patches/VintagestoryLib/Vintagestory.Client.NoObf/ClientPlatformWindows.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Client.NoObf/ClientPlatformWindows.cs.patch
@@ -1,5 +1,5 @@
 diff --git a/VintagestoryLib/Vintagestory.Client.NoObf/ClientPlatformWindows.cs b/VintagestoryLib/Vintagestory.Client.NoObf/ClientPlatformWindows.cs
-index 4f8ca6d..1dcaf54 100644
+index 4f8ca6d..50a4240 100644
 --- a/VintagestoryLib/Vintagestory.Client.NoObf/ClientPlatformWindows.cs
 +++ b/VintagestoryLib/Vintagestory.Client.NoObf/ClientPlatformWindows.cs
 @@ -362,11 +362,11 @@ public sealed class ClientPlatformWindows : ClientPlatformAbstract
@@ -15,6 +15,32 @@ index 4f8ca6d..1dcaf54 100644
  			}
  			((NativeWindow)window).CursorState = val;
  		}
+@@ -544,11 +544,11 @@ public sealed class ClientPlatformWindows : ClientPlatformAbstract
+ 		if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+ 		{
+ 			LogFrameworkVersions();
+ 		}
+ 		logger.Notification("OpenAL Version: " + AL.Get((ALGetString)45058));
+-		string text = Path.Combine(GamePaths.Binaries, "Lib/OpenTK.dll");
++		string text = System.IO.Path.Combine(GamePaths.Binaries, "Lib/OpenTK.dll");
+ 		if (File.Exists(text))
+ 		{
+ 			FileVersionInfo versionInfo = FileVersionInfo.GetVersionInfo(text);
+ 			logger.Notification("OpenTK Version: " + versionInfo.FileVersion + " (" + versionInfo.Comments + ")");
+ 		}
+@@ -703,11 +703,11 @@ public sealed class ClientPlatformWindows : ClientPlatformAbstract
+ 		minimalGuiShaderProgram = new ShaderProgramMinimalGui();
+ 		minimalGuiShaderProgram.Compile();
+ 		windowsize.Width = ((NativeWindow)window).ClientSize.X;
+ 		windowsize.Height = ((NativeWindow)window).ClientSize.Y;
+ 		GL.LineWidth(1.5f);
+-		ErrorCode error = GL.GetError();
++		OpenTK.Graphics.OpenGL.ErrorCode error = GL.GetError();
+ 		SupportsThickLines = (int)error != 1281;
+ 		cpuCoreCount = Environment.ProcessorCount;
+ 	}
+ 
+ 	public override void RebuildFrameBuffers()
 @@ -721,11 +721,11 @@ public sealed class ClientPlatformWindows : ClientPlatformAbstract
  		}
  	}
@@ -28,7 +54,189 @@ index 4f8ca6d..1dcaf54 100644
  	private void OnWindowResize(ResizeEventArgs e)
  	{
  		doResize = Environment.TickCount + 40;
-@@ -3452,14 +3452,14 @@ public sealed class ClientPlatformWindows : ClientPlatformAbstract
+@@ -1239,13 +1239,11 @@ public sealed class ClientPlatformWindows : ClientPlatformAbstract
+ 			GL.TexParameter((TextureTarget)3553, (TextureParameterName)10240, 9729);
+ 			GL.TexParameter((TextureTarget)3553, (TextureParameterName)4100, new float[4] { 1f, 1f, 1f, 1f });
+ 			GL.TexParameter((TextureTarget)3553, (TextureParameterName)10242, 33069);
+ 			GL.TexParameter((TextureTarget)3553, (TextureParameterName)10243, 33069);
+ 			GL.FramebufferTexture2D((FramebufferTarget)36160, (FramebufferAttachment)36067, (TextureTarget)3553, frameBufferRef3.ColorTextureIds[3], 0);
+-			DrawBuffersEnum[] array = new DrawBuffersEnum[4];
+-			RuntimeHelpers.InitializeArray(array, (RuntimeFieldHandle)/*OpCode not supported: LdMemberToken*/);
+-			DrawBuffersEnum[] array2 = (DrawBuffersEnum[])(object)array;
++			DrawBuffersEnum[] array2 = new DrawBuffersEnum[] { DrawBuffersEnum.ColorAttachment0, DrawBuffersEnum.ColorAttachment1, DrawBuffersEnum.ColorAttachment2, DrawBuffersEnum.ColorAttachment3 };
+ 			GL.DrawBuffers(4, array2);
+ 		}
+ 		else
+ 		{
+ 			DrawBuffersEnum[] array3 = (DrawBuffersEnum[])(object)new DrawBuffersEnum[2]
+@@ -1284,13 +1282,11 @@ public sealed class ClientPlatformWindows : ClientPlatformAbstract
+ 		GL.TexImage2D((TextureTarget)3553, 0, (PixelInternalFormat)32856, num, num2, 0, val, (PixelType)5121, (IntPtr)IntPtr.Zero);
+ 		GL.TexParameter((TextureTarget)3553, (TextureParameterName)10241, 9729);
+ 		GL.TexParameter((TextureTarget)3553, (TextureParameterName)10240, 9729);
+ 		GL.FramebufferTexture2D((FramebufferTarget)36160, (FramebufferAttachment)36066, (TextureTarget)3553, frameBufferRef3.ColorTextureIds[2], 0);
+ 		GL.FramebufferTexture2D((FramebufferTarget)36160, (FramebufferAttachment)36096, (TextureTarget)3553, list[0].DepthTextureId, 0);
+-		DrawBuffersEnum[] array4 = new DrawBuffersEnum[3];
+-		RuntimeHelpers.InitializeArray(array4, (RuntimeFieldHandle)/*OpCode not supported: LdMemberToken*/);
+-		DrawBuffersEnum[] array5 = (DrawBuffersEnum[])(object)array4;
++		DrawBuffersEnum[] array5 = new DrawBuffersEnum[] { DrawBuffersEnum.ColorAttachment0, DrawBuffersEnum.ColorAttachment1, DrawBuffersEnum.ColorAttachment2 };
+ 		GL.DrawBuffers(3, array5);
+ 		ClearFrameBuffer(EnumFrameBuffer.Transparent);
+ 		CheckFboStatus((FramebufferTarget)36160, EnumFrameBuffer.Transparent);
+ 		if (SetupSSAO)
+ 		{
+@@ -1684,13 +1680,11 @@ public sealed class ClientPlatformWindows : ClientPlatformAbstract
+ 			ScreenManager.FrameProfiler.Mark("rendTransp-fbbound");
+ 			GlDisableCullFace();
+ 			GlDepthMask(flag: false);
+ 			GlEnableDepthTest();
+ 			ScreenManager.FrameProfiler.Mark("rendTransp-dbset");
+-			DrawBuffersEnum[] array = new DrawBuffersEnum[3];
+-			RuntimeHelpers.InitializeArray(array, (RuntimeFieldHandle)/*OpCode not supported: LdMemberToken*/);
+-			DrawBuffersEnum[] array2 = (DrawBuffersEnum[])(object)array;
++			DrawBuffersEnum[] array2 = new DrawBuffersEnum[] { DrawBuffersEnum.ColorAttachment0, DrawBuffersEnum.ColorAttachment1, DrawBuffersEnum.ColorAttachment2 };
+ 			GL.DrawBuffers(3, array2);
+ 			GL.Enable((EnableCap)3042);
+ 			GL.BlendEquation(0, (BlendEquationMode)32774);
+ 			GL.BlendFunc(0, (BlendingFactorSrc)1, (BlendingFactorDest)1);
+ 			GL.BlendEquation(1, (BlendEquationMode)32774);
+@@ -1995,13 +1989,11 @@ public sealed class ClientPlatformWindows : ClientPlatformAbstract
+ 			final.FrostVignetting = ShaderUniforms.FrostVignetting;
+ 			RenderFullscreenTriangle(screenQuad);
+ 			final.Stop();
+ 			if (RenderSSAO)
+ 			{
+-				DrawBuffersEnum[] array2 = new DrawBuffersEnum[4];
+-				RuntimeHelpers.InitializeArray(array2, (RuntimeFieldHandle)/*OpCode not supported: LdMemberToken*/);
+-				array = (DrawBuffersEnum[])(object)array2;
++				array = new DrawBuffersEnum[] { DrawBuffersEnum.ColorAttachment0, DrawBuffersEnum.ColorAttachment1, DrawBuffersEnum.ColorAttachment2, DrawBuffersEnum.ColorAttachment3 };
+ 				GL.DrawBuffers(4, array);
+ 			}
+ 			else
+ 			{
+ 				array = (DrawBuffersEnum[])(object)new DrawBuffersEnum[2]
+@@ -2062,12 +2054,12 @@ public sealed class ClientPlatformWindows : ClientPlatformAbstract
+ 		//IL_0001: Unknown result type (might be due to invalid IL or missing references)
+ 		//IL_0006: Unknown result type (might be due to invalid IL or missing references)
+ 		//IL_0007: Unknown result type (might be due to invalid IL or missing references)
+ 		//IL_000d: Unknown result type (might be due to invalid IL or missing references)
+ 		//IL_0037: Expected I4, but got Unknown
+-		FramebufferErrorCode val = Ext.CheckFramebufferStatus(target);
+-		switch (val - 36053)
++		FramebufferErrorCode val = GL.CheckFramebufferStatus(target);
++		switch ((int)val - 36053)
+ 		{
+ 		case 0:
+ 			return;
+ 		case 1:
+ 			throw new Exception("FBO " + fbtype + ": One or more attachment points are not framebuffer attachment complete. This could mean there’s no texture attached or the format isn’t renderable. For color textures this means the base format must be RGB or RGBA and for depth textures it must be a DEPTH_COMPONENT format. Other causes of this error are that the width or height is zero or the z-offset is out of range in case of render to volume.");
+@@ -2082,22 +2074,22 @@ public sealed class ClientPlatformWindows : ClientPlatformAbstract
+ 		case 7:
+ 			throw new Exception("FBO " + fbtype + ": The attachment point referenced by GL.ReadBuffers() doesn’t have an attachment.");
+ 		case 8:
+ 			throw new Exception("FBO " + fbtype + ": This particular FBO configuration is not supported by the implementation.");
+ 		}
+-		throw new Exception("FBO " + fbtype + ": Framebuffer unknown error (" + ((object)(*(FramebufferErrorCode*)(&val))/*cast due to constrained. prefix*/).ToString() + ")");
++		throw new Exception("FBO " + fbtype + ": Framebuffer unknown error (" + val.ToString() + ")");
+ 	}
+ 
+ 	public override void CheckGlError(string errmsg = null)
+ 	{
+ 		//IL_0009: Unknown result type (might be due to invalid IL or missing references)
+ 		//IL_000e: Unknown result type (might be due to invalid IL or missing references)
+ 		//IL_000f: Unknown result type (might be due to invalid IL or missing references)
+ 		//IL_002c: Unknown result type (might be due to invalid IL or missing references)
+ 		if (GlErrorChecking)
+ 		{
+-			ErrorCode error = GL.GetError();
++			OpenTK.Graphics.OpenGL.ErrorCode error = GL.GetError();
+ 			if ((int)error != 0)
+ 			{
+ 				throw new Exception(string.Format("{0} - OpenGL threw an error: {1}", (errmsg == null) ? "" : (errmsg + " "), error));
+ 			}
+ 		}
+@@ -2109,11 +2101,11 @@ public sealed class ClientPlatformWindows : ClientPlatformAbstract
+ 		//IL_0005: Unknown result type (might be due to invalid IL or missing references)
+ 		//IL_0006: Unknown result type (might be due to invalid IL or missing references)
+ 		//IL_0050: Unknown result type (might be due to invalid IL or missing references)
+ 		//IL_0056: Invalid comparison between Unknown and I4
+ 		//IL_0037: Unknown result type (might be due to invalid IL or missing references)
+-		ErrorCode error = GL.GetError();
++		OpenTK.Graphics.OpenGL.ErrorCode error = GL.GetError();
+ 		if ((int)error != 0)
+ 		{
+ 			string arg = (ClientSettings.GlDebugMode ? "" : ". Enable Gl Debug Mode in the settings or clientsettings.json to track this error");
+ 			string message = string.Format("{0} - OpenGL threw an error: {1}{2}", (errmsg == null) ? "" : (errmsg + " "), error, arg);
+ 			Logger.Error(message);
+@@ -2127,14 +2119,14 @@ public sealed class ClientPlatformWindows : ClientPlatformAbstract
+ 	public unsafe override string GlGetError()
+ 	{
+ 		//IL_0000: Unknown result type (might be due to invalid IL or missing references)
+ 		//IL_0005: Unknown result type (might be due to invalid IL or missing references)
+ 		//IL_0006: Unknown result type (might be due to invalid IL or missing references)
+-		ErrorCode error = GL.GetError();
++		OpenTK.Graphics.OpenGL.ErrorCode error = GL.GetError();
+ 		if ((int)error != 0)
+ 		{
+-			return ((object)(*(ErrorCode*)(&error))/*cast due to constrained. prefix*/).ToString();
++			return ((object)(*(OpenTK.Graphics.OpenGL.ErrorCode*)(&error))/*cast due to constrained. prefix*/).ToString();
+ 		}
+ 		return null;
+ 	}
+ 
+ 	public override string GetGLShaderVersionString()
+@@ -2535,11 +2527,11 @@ public sealed class ClientPlatformWindows : ClientPlatformAbstract
+ 	{
+ 		if (ENABLE_MIPMAPS)
+ 		{
+ 			GL.BindTexture((TextureTarget)3553, textureId);
+ 			int num = default(int);
+-			GL.GetTexParameter((TextureTarget)3553, (GetTextureParameter)33085, ref num);
++			GL.GetTexParameter((TextureTarget)3553, (GetTextureParameter)33085, out num);
+ 			if (num > 0)
+ 			{
+ 				GL.TexParameter((TextureTarget)3553, (TextureParameterName)10241, 9986);
+ 				GL.GenerateMipmap((GenerateMipmapTarget)3553);
+ 				GL.TexParameter((TextureTarget)3553, (TextureParameterName)34049, 0f);
+@@ -2579,11 +2571,11 @@ public sealed class ClientPlatformWindows : ClientPlatformAbstract
+ 	public override int GlGetMaxTextureSize()
+ 	{
+ 		int result = 1024;
+ 		try
+ 		{
+-			GL.GetInteger((GetPName)3379, ref result);
++			GL.GetInteger((GetPName)3379, out result);
+ 		}
+ 		catch
+ 		{
+ 		}
+ 		return result;
+@@ -2616,11 +2608,11 @@ public sealed class ClientPlatformWindows : ClientPlatformAbstract
+ 		//IL_0016: Unknown result type (might be due to invalid IL or missing references)
+ 		VAO vAO = (VAO)modelRef;
+ 		BufferAccessMask val = (BufferAccessMask)34;
+ 		if (vAO.Persistent)
+ 		{
+-			val = (BufferAccessMask)(val | 0x50);
++			val = (BufferAccessMask)((int)val | 0x50);
+ 		}
+ 		bool persistent = vAO.Persistent;
+ 		if (data.xyz != null)
+ 		{
+ 			updateVAO(data.xyz, data.XyzOffset, data.XyzCount, vAO.xyzVboId, vAO.xyzPtr, persistent);
+@@ -3243,11 +3235,11 @@ public sealed class ClientPlatformWindows : ClientPlatformAbstract
+ 		}
+ 		VAO vAO = (VAO)modelRef;
+ 		BufferAccessMask val = (BufferAccessMask)34;
+ 		if (vAO.Persistent)
+ 		{
+-			val = (BufferAccessMask)(val | 0x50);
++			val = (BufferAccessMask)((int)val | 0x50);
+ 		}
+ 		bool persistent = vAO.Persistent;
+ 		int verticesCount = data.VerticesCount;
+ 		if (facedataBuffer == null || facedataBuffer.Length < verticesCount / 4)
+ 		{
+@@ -3452,14 +3444,14 @@ public sealed class ClientPlatformWindows : ClientPlatformAbstract
  			for (int i = 0; i < val.Height; i++)
  			{
  				for (int j = 0; j < val.Width; j++)
@@ -47,7 +255,7 @@ index 4f8ca6d..1dcaf54 100644
  			}
  			preLoadedCursors[cursorCoode] = new MouseCursor(hotx, hoty, val.Width, val.Height, array);
  			((SKNativeObject)val).Dispose();
-@@ -3549,11 +3549,11 @@ public sealed class ClientPlatformWindows : ClientPlatformAbstract
+@@ -3549,11 +3541,11 @@ public sealed class ClientPlatformWindows : ClientPlatformAbstract
  
  	private void Mouse_Move(MouseMoveEventArgs e)
  	{
@@ -60,7 +268,7 @@ index 4f8ca6d..1dcaf54 100644
  
  	private void SetMousePosition(float x, float y)
  	{
-@@ -3563,21 +3563,21 @@ public sealed class ClientPlatformWindows : ClientPlatformAbstract
+@@ -3563,21 +3555,21 @@ public sealed class ClientPlatformWindows : ClientPlatformAbstract
  		{
  			mouseY += ClientSettings.WeirdMacOSMouseYOffset;
  		}
@@ -85,7 +293,7 @@ index 4f8ca6d..1dcaf54 100644
  				deltaPrecise = (int)num,
  				value = (int)prevWheelValue,
  				valuePrecise = prevWheelValue
-@@ -3589,93 +3589,93 @@ public sealed class ClientPlatformWindows : ClientPlatformAbstract
+@@ -3589,93 +3581,93 @@ public sealed class ClientPlatformWindows : ClientPlatformAbstract
  	private void Mouse_ButtonDown(MouseButtonEventArgs e)
  	{
  		//IL_0002: Unknown result type (might be due to invalid IL or missing references)
@@ -141,7 +349,7 @@ index 4f8ca6d..1dcaf54 100644
  			return;
  		}
 -		int keyCode = KeyConverter.NewKeysToGlKeys[((KeyboardKeyEventArgs)(ref e)).Key];
-+		int keyCode = KeyConverter.NewKeysToGlKeys[e.Key];
++		int keyCode = KeyConverter.NewKeysToGlKeys[(int)e.Key];
  		foreach (KeyEventHandler keyEventHandler in keyEventHandlers)
  		{
  			KeyEvent keyEvent = new KeyEvent
@@ -175,7 +383,7 @@ index 4f8ca6d..1dcaf54 100644
  			return;
  		}
 -		int keyCode = KeyConverter.NewKeysToGlKeys[((KeyboardKeyEventArgs)(ref e)).Key];
-+		int keyCode = KeyConverter.NewKeysToGlKeys[e.Key];
++		int keyCode = KeyConverter.NewKeysToGlKeys[(int)e.Key];
  		lastKeyUpMs = EllapsedMs;
  		lastKeyUpKey = keyCode;
  		foreach (KeyEventHandler keyEventHandler in keyEventHandlers)
@@ -197,3 +405,29 @@ index 4f8ca6d..1dcaf54 100644
  	}
  
  	public override MouseEvent CreateMouseEvent(EnumMouseButton button)
+@@ -3710,11 +3702,11 @@ public sealed class ClientPlatformWindows : ClientPlatformAbstract
+ 			text = text.Insert(startIndex, shader.PrefixCode);
+ 		}
+ 		GL.ShaderSource(num, text);
+ 		GL.CompileShader(num);
+ 		int num2 = default(int);
+-		GL.GetShader(num, (ShaderParameter)35713, ref num2);
++		GL.GetShader(num, (ShaderParameter)35713, out num2);
+ 		if (num2 != 1)
+ 		{
+ 			string shaderInfoLog = GL.GetShaderInfoLog(num);
+ 			logger.Error("Shader compile error in {0} {1}", shader.Filename, shaderInfoLog.TrimEnd());
+ 			logger.VerboseDebug("{0}", text);
+@@ -3737,11 +3729,11 @@ public sealed class ClientPlatformWindows : ClientPlatformAbstract
+ 		{
+ 			GL.BindAttribLocation(program.ProgramId, attribute.Key, attribute.Value);
+ 		}
+ 		GL.LinkProgram(num);
+ 		int num2 = default(int);
+-		GL.GetProgram(num, (GetProgramParameterName)35714, ref num2);
++		GL.GetProgram(num, (GetProgramParameterName)35714, out num2);
+ 		string programInfoLog = GL.GetProgramInfoLog(num);
+ 		if (num2 != 1)
+ 		{
+ 			logger.Error("Link error in shader program for pass {0}: {1}", program.PassName, programInfoLog.TrimEnd());
+ 			result = false;

--- a/patches/VintagestoryLib/Vintagestory.Client.NoObf/OggDecoder.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Client.NoObf/OggDecoder.cs.patch
@@ -1,0 +1,17 @@
+diff --git a/VintagestoryLib/Vintagestory.Client.NoObf/OggDecoder.cs b/VintagestoryLib/Vintagestory.Client.NoObf/OggDecoder.cs
+index 7621b43..b3d9aa2 100644
+--- a/VintagestoryLib/Vintagestory.Client.NoObf/OggDecoder.cs
++++ b/VintagestoryLib/Vintagestory.Client.NoObf/OggDecoder.cs
+@@ -41,11 +41,11 @@ public class OggDecoder
+ 		Page val3 = (Page)(object)new OggPage();
+ 		Packet val4 = new Packet();
+ 		Info val5 = new Info();
+ 		Comment val6 = new Comment();
+ 		DspState val7 = new DspState();
+-		Block val8 = new Block(val7);
++		csvorbis.Block val8 = new csvorbis.Block(val7);
+ 		int num = 0;
+ 		val.init();
+ 		int num2 = 0;
+ 		int offset = val.buffer(4096);
+ 		byte[] data = val.data;

--- a/patches/VintagestoryLib/Vintagestory.Client.NoObf/SystemRenderOITLayers.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Client.NoObf/SystemRenderOITLayers.cs.patch
@@ -1,0 +1,19 @@
+diff --git a/VintagestoryLib/Vintagestory.Client.NoObf/SystemRenderOITLayers.cs b/VintagestoryLib/Vintagestory.Client.NoObf/SystemRenderOITLayers.cs
+index 9df8cc5..6fb5ff5 100644
+--- a/VintagestoryLib/Vintagestory.Client.NoObf/SystemRenderOITLayers.cs
++++ b/VintagestoryLib/Vintagestory.Client.NoObf/SystemRenderOITLayers.cs
+@@ -39,13 +39,11 @@ public class SystemRenderOITLayers : ClientSystem
+ 			currentActiveShader?.Use();
+ 			if (revealTextureId == 0 || transparentfb.Disposed)
+ 			{
+ 				rebuild();
+ 			}
+-			DrawBuffersEnum[] array = new DrawBuffersEnum[6];
+-			RuntimeHelpers.InitializeArray(array, (RuntimeFieldHandle)/*OpCode not supported: LdMemberToken*/);
+-			DrawBuffersEnum[] array2 = (DrawBuffersEnum[])(object)array;
++			DrawBuffersEnum[] array2 = new DrawBuffersEnum[] { DrawBuffersEnum.ColorAttachment0, DrawBuffersEnum.ColorAttachment1, DrawBuffersEnum.ColorAttachment2, DrawBuffersEnum.ColorAttachment3, DrawBuffersEnum.ColorAttachment4, DrawBuffersEnum.ColorAttachment5 };
+ 			GL.DrawBuffers(array2.Length, array2);
+ 			GL.BlendFunc(0, (BlendingFactorSrc)774, (BlendingFactorDest)0);
+ 			GL.BlendFunc(1, (BlendingFactorSrc)774, (BlendingFactorDest)0);
+ 			GL.BlendFunc(3, (BlendingFactorSrc)1, (BlendingFactorDest)1);
+ 			GL.BlendFunc(4, (BlendingFactorSrc)1, (BlendingFactorDest)1);

--- a/patches/VintagestoryLib/Vintagestory.Client.NoObf/SystemRenderSunMoon.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Client.NoObf/SystemRenderSunMoon.cs.patch
@@ -1,7 +1,38 @@
 diff --git a/VintagestoryLib/Vintagestory.Client.NoObf/SystemRenderSunMoon.cs b/VintagestoryLib/Vintagestory.Client.NoObf/SystemRenderSunMoon.cs
-index 34ff0fd..36dc7f1 100644
+index 34ff0fd..ac7f262 100644
 --- a/VintagestoryLib/Vintagestory.Client.NoObf/SystemRenderSunMoon.cs
 +++ b/VintagestoryLib/Vintagestory.Client.NoObf/SystemRenderSunMoon.cs
+@@ -52,11 +52,11 @@ public class SystemRenderSunMoon : ClientSystem
+ 		MeshData customQuadModelData = QuadMeshUtilExt.GetCustomQuadModelData(0f, 0f, 0f, ImageSize, ImageSize, byte.MaxValue, byte.MaxValue, byte.MaxValue, byte.MaxValue);
+ 		customQuadModelData.Flags = new int[4];
+ 		quadModel = game.Platform.UploadMesh(customQuadModelData);
+ 		game.eventManager.RegisterRenderer(OnRenderFrame3D, EnumRenderStage.Opaque, Name, 0.3);
+ 		game.eventManager.RegisterRenderer(OnRenderFrame3DPost, EnumRenderStage.Opaque, Name, 999.0);
+-		GL.GenQueries(1, ref occlQueryId);
++		GL.GenQueries(1, out occlQueryId);
+ 	}
+ 
+ 	private void OnRenderFrame3DPost(float obj)
+ 	{
+ 		//IL_0052: Unknown result type (might be due to invalid IL or missing references)
+@@ -101,15 +101,15 @@ public class SystemRenderSunMoon : ClientSystem
+ 		standard.ProjectionMatrix = game.api.renderapi.CurrentProjectionMatrix;
+ 		standard.Tex2D = suntextureId;
+ 		if (firstTickDone)
+ 		{
+ 			int num = default(int);
+-			GL.GetQueryObject(occlQueryId, (GetQueryObjectParam)34919, ref num);
++			GL.GetQueryObject(occlQueryId, (GetQueryObjectParam)34919, out num);
+ 			if (num > 0)
+ 			{
+ 				int num2 = default(int);
+-				GL.GetQueryObject(occlQueryId, (GetQueryObjectParam)34918, ref num2);
++				GL.GetQueryObject(occlQueryId, (GetQueryObjectParam)34918, out num2);
+ 				targetSunSpec = GameMath.Clamp((float)num2 / 1500f, 0f, 1f);
+ 				nowQuerying = false;
+ 			}
+ 		}
+ 		firstTickDone = true;
 @@ -220,26 +220,26 @@ public class SystemRenderSunMoon : ClientSystem
  			double[] top2 = game.PMatrix.Top;
  			double[] cameraMatrixOrigin2 = game.api.renderapi.CameraMatrixOrigin;

--- a/patches/VintagestoryLib/Vintagestory.Client/AudioOpenAl.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Client/AudioOpenAl.cs.patch
@@ -1,0 +1,16 @@
+diff --git a/VintagestoryLib/Vintagestory.Client/AudioOpenAl.cs b/VintagestoryLib/Vintagestory.Client/AudioOpenAl.cs
+index fa88f47..f929421 100644
+--- a/VintagestoryLib/Vintagestory.Client/AudioOpenAl.cs
++++ b/VintagestoryLib/Vintagestory.Client/AudioOpenAl.cs
+@@ -1,10 +1,11 @@
+ using System;
+ using System.Collections.Generic;
+ using System.IO;
+ using System.Linq;
+ using OpenTK.Audio.OpenAL;
++using EFX = OpenTK.Audio.OpenAL.ALC.EFX;
+ using OpenTK.Mathematics;
+ using Vintagestory.API.Common;
+ using Vintagestory.Client.NoObf;
+ 
+ namespace Vintagestory.Client;

--- a/patches/VintagestoryLib/Vintagestory.Client/ClientProgram.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Client/ClientProgram.cs.patch
@@ -1,0 +1,29 @@
+diff --git a/VintagestoryLib/Vintagestory.Client/ClientProgram.cs b/VintagestoryLib/Vintagestory.Client/ClientProgram.cs
+index 845553b..25daa7f 100644
+--- a/VintagestoryLib/Vintagestory.Client/ClientProgram.cs
++++ b/VintagestoryLib/Vintagestory.Client/ClientProgram.cs
+@@ -8,10 +8,11 @@ using System.Threading;
+ using CommandLine;
+ using OpenTK.Mathematics;
+ using OpenTK.Windowing.Common;
+ using OpenTK.Windowing.Desktop;
+ using OpenTK.Windowing.GraphicsLibraryFramework;
++using ErrorCallback = OpenTK.Windowing.GraphicsLibraryFramework.GLFWCallbacks.ErrorCallback;
+ using Vintagestory.API.Client;
+ using Vintagestory.API.Common;
+ using Vintagestory.API.Config;
+ using Vintagestory.API.MathTools;
+ using Vintagestory.API.Util;
+@@ -286,11 +287,11 @@ public class ClientProgram
+ 		{
+ 			Title = "Vintage Story",
+ 			APIVersion = new Version(num3, num4),
+ 			ClientSize = new Vector2i(ClientSettings.ScreenWidth, ClientSettings.ScreenHeight),
+ 			Flags = (ContextFlags)0,
+-			Vsync = (VSyncMode)(ClientSettings.VsyncMode != 0),
++			Vsync = ClientSettings.VsyncMode != 0 ? VSyncMode.On : VSyncMode.Off,
+ 			WindowState = val,
+ 			WindowBorder = (WindowBorder)ClientSettings.WindowBorder
+ 		};
+ 		if (RuntimeEnv.OS == OS.Mac)
+ 		{

--- a/patches/VintagestoryLib/Vintagestory.Client/GuiScreenDownloadMods.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Client/GuiScreenDownloadMods.cs.patch
@@ -1,7 +1,20 @@
 diff --git a/VintagestoryLib/Vintagestory.Client/GuiScreenDownloadMods.cs b/VintagestoryLib/Vintagestory.Client/GuiScreenDownloadMods.cs
-index 2fb4996..f613e69 100644
+index 2fb4996..df84b6d 100644
 --- a/VintagestoryLib/Vintagestory.Client/GuiScreenDownloadMods.cs
 +++ b/VintagestoryLib/Vintagestory.Client/GuiScreenDownloadMods.cs
+@@ -69,11 +69,11 @@ public class GuiScreenDownloadMods : GuiScreen
+ 			title = Lang.Get("downloadmods-title-dependencyinstall");
+ 			text = Lang.Get("downloadmods-dependencyinstall", string.Join(", ", modsToDownload));
+ 		}
+ 		else
+ 		{
+-			installPath = Path.Combine(GamePaths.DataPathServerMods, GamePaths.ReplaceInvalidChars(sourceServer.Host + "-" + sourceServer.Port));
++			installPath = System.IO.Path.Combine(GamePaths.DataPathServerMods, GamePaths.ReplaceInvalidChars(sourceServer.Host + "-" + sourceServer.Port));
+ 			title = Lang.Get("downloadmods-title-serverinstall");
+ 			text = Lang.Get("downloadmods-serverinstall", modsToDownload.Count);
+ 		}
+ 		return new GuiScreenDownloadMods(sourceServer, serverArgs, installPath, modsToDownload, title, text, screenManager, parentScreen);
+ 	}
 @@ -430,12 +430,10 @@ public class GuiScreenDownloadMods : GuiScreen
  			FocusedMouseCursor = ScreenManager.mainMenuComposer.MouseOverCursor;
  		}

--- a/patches/VintagestoryLib/Vintagestory.Client/GuiScreenGetUpdate.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Client/GuiScreenGetUpdate.cs.patch
@@ -1,0 +1,29 @@
+diff --git a/VintagestoryLib/Vintagestory.Client/GuiScreenGetUpdate.cs b/VintagestoryLib/Vintagestory.Client/GuiScreenGetUpdate.cs
+index 9d3a98e..a3e7916 100644
+--- a/VintagestoryLib/Vintagestory.Client/GuiScreenGetUpdate.cs
++++ b/VintagestoryLib/Vintagestory.Client/GuiScreenGetUpdate.cs
+@@ -84,22 +84,22 @@ internal class GuiScreenGetUpdate : GuiScreen
+ 		{
+ 			ElementComposer.GetDynamicText("status").SetNewText(Lang.Get("Download failed. Release {0} not found, possibly programming error. Please send us a bug report", ScreenManager.newestVersion));
+ 			return;
+ 		}
+ 		GameBuild build = release.WindowsUpdate ?? release.Windows;
+-		string dstPath = Path.Combine(Path.GetTempPath(), build.filename);
++		string dstPath = System.IO.Path.Combine(System.IO.Path.GetTempPath(), build.filename);
+ 		FileStream fileStream = File.Create(dstPath);
+ 		_gameReleaseDownloadCts = new CancellationTokenSource();
+ 		Progress<Tuple<int, long>> progress = new Progress<Tuple<int, long>>();
+ 		progress.ProgressChanged += onProgress;
+ 		TyronThreadPool.QueueTask(async delegate
+ 		{
+ 			try
+ 			{
+ 				await VSWebClient.Inst.DownloadAsync(build.urls["cdn"], fileStream, progress, _gameReleaseDownloadCts.Token);
+ 				fileStream.Close();
+-				string directoryName = Path.GetDirectoryName(Environment.ProcessPath);
++				string directoryName = System.IO.Path.GetDirectoryName(Environment.ProcessPath);
+ 				Process.Start(dstPath, "/SILENT /DIR=\"" + directoryName + "\"");
+ 				ScreenManager.GamePlatform.WindowExit("Installing update", EnumExitMode.SoftExit);
+ 			}
+ 			catch (Exception ex)
+ 			{

--- a/patches/VintagestoryLib/Vintagestory.Client/GuiScreenServerDashboard.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Client/GuiScreenServerDashboard.cs.patch
@@ -1,0 +1,19 @@
+diff --git a/VintagestoryLib/Vintagestory.Client/GuiScreenServerDashboard.cs b/VintagestoryLib/Vintagestory.Client/GuiScreenServerDashboard.cs
+index 39d65f2..25ee6b2 100644
+--- a/VintagestoryLib/Vintagestory.Client/GuiScreenServerDashboard.cs
++++ b/VintagestoryLib/Vintagestory.Client/GuiScreenServerDashboard.cs
+@@ -589,12 +589,12 @@ public class GuiScreenServerDashboard : GuiScreen
+ 	private void OnReturnFromCustomizer(bool didApply)
+ 	{
+ 		if (didApply)
+ 		{
+ 			wcu = customizeScreen.wcu;
+-			wcu.Jworldconfig.Token[(object)"Seed"] = JToken.op_Implicit(wcu.Seed);
+-			wcu.Jworldconfig.Token[(object)"MapSizeY"] = JToken.op_Implicit(wcu.MapsizeY);
++			wcu.Jworldconfig.Token[(object)"Seed"] = JToken.FromObject(wcu.Seed);
++			wcu.Jworldconfig.Token[(object)"MapSizeY"] = JToken.FromObject(wcu.MapsizeY);
+ 			string worldconfig = wcu.Jworldconfig.ToString();
+ 			backend.SetConfig(onStatusReady, null, worldconfig);
+ 		}
+ 		ScreenManager.LoadScreen(this);
+ 	}

--- a/patches/VintagestoryLib/Vintagestory.Client/GuiScreenSingleplayerModify.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Client/GuiScreenSingleplayerModify.cs.patch
@@ -1,5 +1,5 @@
 diff --git a/VintagestoryLib/Vintagestory.Client/GuiScreenSingleplayerModify.cs b/VintagestoryLib/Vintagestory.Client/GuiScreenSingleplayerModify.cs
-index 582a9a2..21ea495 100644
+index 582a9a2..9a8c4f9 100644
 --- a/VintagestoryLib/Vintagestory.Client/GuiScreenSingleplayerModify.cs
 +++ b/VintagestoryLib/Vintagestory.Client/GuiScreenSingleplayerModify.cs
 @@ -71,16 +71,16 @@ public class GuiScreenSingleplayerModify : GuiScreen
@@ -22,3 +22,29 @@ index 582a9a2..21ea495 100644
  				.WithFixedSize(470.0, 30.0), null, null, "worldname")
  				.AddStaticText(Lang.Get("Filename on disk"), CairoFont.WhiteSmallishText(), elementBounds2 = elementBounds2.BelowCopy())
  				.AddTextInput(elementBounds2.FlatCopy().WithAlignment(EnumDialogArea.RightFixed).WithFixedOffset(0.0, -3.0)
+@@ -141,11 +141,11 @@ public class GuiScreenSingleplayerModify : GuiScreen
+ 	{
+ 		if (ok)
+ 		{
+ 			FileInfo fileInfo = new FileInfo(worldfilename);
+ 			string path = string.Concat(str2: $"{DateTime.Now:yyyy-MM-dd_HH-mm-ss}", str0: fileInfo.Name.Replace(".vcdbs", ""), str1: "-bkp-", str3: ".vcdbs");
+-			File.Copy(worldfilename, Path.Combine(GamePaths.BackupSaves, path));
++			File.Copy(worldfilename, System.IO.Path.Combine(GamePaths.BackupSaves, path));
+ 			ScreenManager.LoadScreen(this);
+ 			ElementComposer.GetDynamicText("dyntextbottom").SetNewText(Lang.Get("Ok, backup created"));
+ 		}
+ 		else
+ 		{
+@@ -270,11 +270,11 @@ public class GuiScreenSingleplayerModify : GuiScreen
+ 		string text = ElementComposer.GetTextInput("filename").GetText();
+ 		if (fileInfo.Name != text)
+ 		{
+ 			try
+ 			{
+-				fileInfo.MoveTo(worldfilename = Path.Combine(fileInfo.DirectoryName, text));
++				fileInfo.MoveTo(worldfilename = System.IO.Path.Combine(fileInfo.DirectoryName, text));
+ 			}
+ 			catch (Exception)
+ 			{
+ 			}
+ 		}

--- a/patches/VintagestoryLib/Vintagestory.Client/LoadedSoundNative.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Client/LoadedSoundNative.cs.patch
@@ -1,8 +1,96 @@
 diff --git a/VintagestoryLib/Vintagestory.Client/LoadedSoundNative.cs b/VintagestoryLib/Vintagestory.Client/LoadedSoundNative.cs
-index e74280e..08b2540 100644
+index e74280e..2fda1ef 100644
 --- a/VintagestoryLib/Vintagestory.Client/LoadedSoundNative.cs
 +++ b/VintagestoryLib/Vintagestory.Client/LoadedSoundNative.cs
-@@ -293,11 +293,11 @@ public class LoadedSoundNative : ILoadedSound, IDisposable
+@@ -1,10 +1,11 @@
+ using System;
+ using System.Collections.Generic;
+ using System.Threading;
+ using System.Threading.Tasks;
+ using OpenTK.Audio.OpenAL;
++using EFX = OpenTK.Audio.OpenAL.ALC.EFX;
+ using OpenTK.Mathematics;
+ using Vintagestory.API.Client;
+ using Vintagestory.API.Common;
+ using Vintagestory.API.Config;
+ using Vintagestory.API.MathTools;
+@@ -55,11 +56,11 @@ public class LoadedSoundNative : ILoadedSound, IDisposable
+ 	public bool IsPlaying
+ 	{
+ 		get
+ 		{
+ 			int num = default(int);
+-			AL.GetSource(sourceId, (ALGetSourcei)4112, ref num);
++			AL.GetSource(sourceId, (ALGetSourcei)4112, out num);
+ 			if (!disposed)
+ 			{
+ 				return num == 4114;
+ 			}
+ 			return false;
+@@ -69,11 +70,11 @@ public class LoadedSoundNative : ILoadedSound, IDisposable
+ 	public bool IsPaused
+ 	{
+ 		get
+ 		{
+ 			int num = default(int);
+-			AL.GetSource(sourceId, (ALGetSourcei)4112, ref num);
++			AL.GetSource(sourceId, (ALGetSourcei)4112, out num);
+ 			if (!disposed)
+ 			{
+ 				return num == 4115;
+ 			}
+ 			return false;
+@@ -89,11 +90,11 @@ public class LoadedSoundNative : ILoadedSound, IDisposable
+ 			if (disposed)
+ 			{
+ 				return true;
+ 			}
+ 			int num = default(int);
+-			AL.GetSource(sourceId, (ALGetSourcei)4112, ref num);
++			AL.GetSource(sourceId, (ALGetSourcei)4112, out num);
+ 			if (num != 4114)
+ 			{
+ 				return num != 4115;
+ 			}
+ 			return false;
+@@ -104,11 +105,11 @@ public class LoadedSoundNative : ILoadedSound, IDisposable
+ 	{
+ 		get
+ 		{
+ 			if (!disposed)
+ 			{
+-				AL.GetSource(sourceId, (ALSourcef)4132, ref playbackPosition);
++				AL.GetSource(sourceId, (ALSourcef)4132, out playbackPosition);
+ 				testError("get playback pos");
+ 			}
+ 			return playbackPosition;
+ 		}
+ 		set
+@@ -272,32 +273,32 @@ public class LoadedSoundNative : ILoadedSound, IDisposable
+ 			fixed (byte* pcm = sample.Pcm)
+ 			{
+ 				AL.BufferData(bufferId, soundFormat, (void*)pcm, sample.Pcm.Length, sample.Rate);
+ 			}
+ 			int num = default(int);
+-			AL.GetBuffer(bufferId, (ALGetBufferi)8196, ref num);
++			AL.GetBuffer(bufferId, (ALGetBufferi)8196, out num);
+ 			int num2 = default(int);
+-			AL.GetBuffer(bufferId, (ALGetBufferi)8195, ref num2);
++			AL.GetBuffer(bufferId, (ALGetBufferi)8195, out num2);
+ 			soundLengthSeconds = 1f * (float)num / (float)(sample.Rate * sample.BitsPerSample / 8) / (float)num2;
+ 			float num3 = 0f - (float)(Math.Log(0.009999999776482582) / Math.Log(soundParams.Range));
+ 			float num4 = (float)Math.Max(3.0, Math.Pow(soundParams.Range, 0.5) - 2.0);
+ 			AL.DistanceModel((ALDistanceModel)53254);
+ 			AL.Source(sourceId, (ALSourcef)4129, num3);
+ 			AL.Source(sourceId, (ALSourcef)4128, (soundParams.ReferenceDistance != 3f) ? soundParams.ReferenceDistance : num4);
+ 			AL.Source(sourceId, (ALSourcef)4131, 9999f);
+ 			AL.Source(sourceId, (ALSourcei)4105, bufferId);
+ 			AL.Source(sourceId, (ALSourcef)4106, soundParams.Volume * GlobalVolume);
+ 			AL.Source(sourceId, (ALSourcef)4099, GameMath.Clamp(soundParams.Pitch + pitchOffset, 0.1f, 3f));
+-			bool flag = soundFormat - 4354 <= 1;
++			bool flag = ((int)soundFormat - 4354) <= 1;
+ 			if (flag && AudioOpenAl.UseHrtf)
+ 			{
  				AL.Source(sourceId, (ALSourcei)4147, 2);
  			}
  			if (soundParams.Position != null)
@@ -15,7 +103,20 @@ index e74280e..08b2540 100644
  			AL.Source(sourceId, (ALSourceb)514, soundParams.RelativePosition);
  			AL.Source(sourceId, (ALSourceb)4103, soundParams.ShouldLoop);
  			if (playbackPosition > 0f)
-@@ -433,11 +433,11 @@ public class LoadedSoundNative : ILoadedSound, IDisposable
+@@ -399,11 +400,11 @@ public class LoadedSoundNative : ILoadedSound, IDisposable
+ 		if (sourceId == 0)
+ 		{
+ 			disposed = true;
+ 			return;
+ 		}
+-		AL.GetSource(sourceId, (ALSourcef)4132, ref playbackPosition);
++		AL.GetSource(sourceId, (ALSourcef)4132, out playbackPosition);
+ 		AL.SourceStop(sourceId);
+ 		AL.Source(sourceId, (ALSourcei)4105, 0);
+ 		testError("disposestop");
+ 		DisposeLowPassfilter();
+ 		DisposeReverb();
+@@ -433,11 +434,11 @@ public class LoadedSoundNative : ILoadedSound, IDisposable
  		if (sourceId != 0)
  		{
  			if (!disposed)
@@ -28,7 +129,7 @@ index e74280e..08b2540 100644
  			testError("setposition x/y/z");
  		}
  	}
-@@ -461,11 +461,11 @@ public class LoadedSoundNative : ILoadedSound, IDisposable
+@@ -461,11 +462,11 @@ public class LoadedSoundNative : ILoadedSound, IDisposable
  		if (sourceId != 0)
  		{
  			if (!disposed)

--- a/patches/VintagestoryLib/Vintagestory.Client/ScreenManager.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Client/ScreenManager.cs.patch
@@ -1,0 +1,30 @@
+diff --git a/VintagestoryLib/Vintagestory.Client/ScreenManager.cs b/VintagestoryLib/Vintagestory.Client/ScreenManager.cs
+index 9651f17..08fb06f 100644
+--- a/VintagestoryLib/Vintagestory.Client/ScreenManager.cs
++++ b/VintagestoryLib/Vintagestory.Client/ScreenManager.cs
+@@ -601,11 +601,11 @@ public class ScreenManager : KeyEventHandler, MouseEventHandler, NewFrameHandler
+ 		string playStyle = ParsedArgs.PlayStyle;
+ 		string text = ParsedArgs.OpenWorldName;
+ 		if (text == null)
+ 		{
+ 			int num = 0;
+-			while (File.Exists(GamePaths.Saves + Path.DirectorySeparatorChar + "world" + num + ".vcdbs"))
++			while (File.Exists(GamePaths.Saves + System.IO.Path.DirectorySeparatorChar + "world" + num + ".vcdbs"))
+ 			{
+ 				num++;
+ 			}
+ 			text = "world" + num + ".vcdbs";
+ 		}
+@@ -620,11 +620,11 @@ public class ScreenManager : KeyEventHandler, MouseEventHandler, NewFrameHandler
+ 			{
+ 				if (playStyle2.LangCode == playStyle)
+ 				{
+ 					ConnectToSingleplayer(new StartServerArgs
+ 					{
+-						SaveFileLocation = GamePaths.Saves + Path.DirectorySeparatorChar + text + ".vcdbs",
++						SaveFileLocation = GamePaths.Saves + System.IO.Path.DirectorySeparatorChar + text + ".vcdbs",
+ 						WorldName = text,
+ 						PlayStyle = playStyle2.Code,
+ 						PlayStyleLangCode = playStyle2.LangCode,
+ 						WorldType = playStyle2.WorldType,
+ 						WorldConfiguration = playStyle2.WorldConfig,

--- a/patches/VintagestoryLib/Vintagestory.Common/ModContainer.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Common/ModContainer.cs.patch
@@ -1,5 +1,5 @@
 diff --git a/VintagestoryLib/Vintagestory.Common/ModContainer.cs b/VintagestoryLib/Vintagestory.Common/ModContainer.cs
-index a751fb0..9993228 100644
+index 96337d8..2d3bfc6 100644
 --- a/VintagestoryLib/Vintagestory.Common/ModContainer.cs
 +++ b/VintagestoryLib/Vintagestory.Common/ModContainer.cs
 @@ -10,10 +10,11 @@ using Mono.Cecil;

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,0 +1,342 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/bootstrap.sh [--version VERSION] [--server-archive PATH] [--client-lib-dir PATH] [--refresh]
+
+Builds a clean working tree by laying down:
+  1. Decompiled closed-source vanilla VS libraries from the official server archive.
+  2. Open-source Anego forks cloned at the refs pinned in forks.json.
+  3. Stratum patches and sources over those baselines.
+
+Options:
+  --version VERSION        Vintage Story server version to download. Default: 1.22.3
+  --server-archive PATH    Existing vs_server_*.zip or .tar.gz archive to use.
+  --client-lib-dir PATH    Optional full client Lib/ folder for client-only deps.
+  --refresh               Force re-extract, re-decompile, and re-clone.
+  -h, --help              Show this help.
+EOF
+}
+
+version="1.22.3"
+server_archive=""
+client_lib_dir="${VS_CLIENT_LIB_DIR:-}"
+refresh=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --version)
+      version="${2:?--version requires a value}"
+      shift 2
+      ;;
+    --server-archive|--server-zip)
+      server_archive="${2:?$1 requires a value}"
+      shift 2
+      ;;
+    --client-lib-dir)
+      client_lib_dir="${2:?--client-lib-dir requires a value}"
+      shift 2
+      ;;
+    --refresh)
+      refresh=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd -- "$script_dir/.." && pwd)"
+
+require_cmd() {
+  local cmd="$1"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "Missing required command: $cmd" >&2
+    exit 1
+  fi
+}
+
+install_ilspycmd_if_missing() {
+  if command -v ilspycmd >/dev/null 2>&1; then
+    return
+  fi
+
+  local dotnet_tools="$HOME/.dotnet/tools"
+  if [[ -x "$dotnet_tools/ilspycmd" ]]; then
+    export PATH="$dotnet_tools:$PATH"
+    return
+  fi
+
+  echo "Installing ilspycmd"
+  dotnet tool install -g ilspycmd >/dev/null
+  export PATH="$dotnet_tools:$PATH"
+}
+
+extract_archive() {
+  local archive="$1"
+  local dest="$2"
+
+  mkdir -p "$dest"
+  case "$archive" in
+    *.tar.gz|*.tgz)
+      tar -xzf "$archive" -C "$dest"
+      ;;
+    *.zip)
+      if command -v unzip >/dev/null 2>&1; then
+        unzip -q "$archive" -d "$dest"
+      else
+    python3 - "$archive" "$dest" <<'PY'
+import sys
+import zipfile
+
+with zipfile.ZipFile(sys.argv[1]) as archive:
+    archive.extractall(sys.argv[2])
+PY
+      fi
+      ;;
+    *)
+      echo "Unsupported server archive extension: $archive" >&2
+      exit 1
+      ;;
+  esac
+}
+
+normalize_lang_version() {
+  local dir="$1"
+  find "$dir" -maxdepth 1 -type f -name '*.csproj' -print0 |
+    while IFS= read -r -d '' csproj; do
+      perl -0pi -e 's#<LangVersion>15\.0</LangVersion>#<LangVersion>latest</LangVersion>#g' "$csproj"
+    done
+}
+
+normalize_lf() {
+  local dir="$1"
+  find "$dir" -type f \( \
+    -name '*.cs' -o \
+    -name '*.csproj' -o \
+    -name '*.json' -o \
+    -name '*.xml' -o \
+    -name '*.props' -o \
+    -name '*.targets' \
+  \) -print0 |
+    while IFS= read -r -d '' file; do
+      perl -0pi -e 's/\r\n/\n/g' "$file"
+    done
+}
+
+copy_tree_fresh() {
+  local src="$1"
+  local dst="$2"
+  rm -rf "$dst"
+  mkdir -p "$(dirname "$dst")"
+  cp -a "$src" "$dst"
+}
+
+download_server_archive() {
+  local cache_dir="$1"
+  mkdir -p "$cache_dir"
+
+  local archive_name="vs_server_linux-x64_${version}.tar.gz"
+  local archive_path="$cache_dir/$archive_name"
+  if [[ -f "$archive_path" ]]; then
+      echo "Using cached $archive_path" >&2
+      printf '%s\n' "$archive_path"
+      return
+  fi
+
+  local url="https://cdn.vintagestory.at/gamefiles/stable/$archive_name"
+  echo "Downloading $url" >&2
+  curl -L --fail --output "$archive_path" "$url"
+  printf '%s\n' "$archive_path"
+}
+
+copy_optional_client_libs() {
+  local src_dir="$1"
+  local dst_dir="$2"
+
+  if [[ -z "$src_dir" ]]; then
+    return
+  fi
+  if [[ ! -d "$src_dir" ]]; then
+    echo "Client lib dir not found: $src_dir" >&2
+    exit 1
+  fi
+
+  mkdir -p "$dst_dir"
+  local dlls=(
+    OpenTK.Graphics.dll
+    csogg.dll
+    csvorbis.dll
+    xplatforminterface.dll
+  )
+
+  for dll in "${dlls[@]}"; do
+    if [[ -f "$src_dir/$dll" ]]; then
+      cp -f "$src_dir/$dll" "$dst_dir/"
+    fi
+  done
+}
+
+require_cmd dotnet
+require_cmd git
+require_cmd find
+require_cmd perl
+require_cmd python3
+require_cmd tar
+require_cmd curl
+
+cd "$repo_root"
+
+lib_projects=("VintagestoryLib:baseline/VintagestoryLib:VintagestoryLib.dll" "VintagestoryServer:baseline/VintagestoryServer:VintagestoryServer.dll")
+vanilla_dir="$repo_root/.vanilla"
+baseline_dir="$repo_root/.baseline"
+zip_cache_dir="$repo_root/.vanilla-zips"
+
+if [[ "$refresh" == "1" ]]; then
+  rm -rf "$vanilla_dir" "$baseline_dir"
+fi
+
+if [[ -z "$server_archive" ]]; then
+  server_archive="$(download_server_archive "$zip_cache_dir")"
+fi
+
+if [[ ! -d "$vanilla_dir" ]]; then
+  if [[ ! -f "$server_archive" ]]; then
+    echo "Server archive not found: $server_archive" >&2
+    exit 1
+  fi
+  echo "Extracting $server_archive"
+  extract_archive "$server_archive" "$vanilla_dir"
+fi
+
+copy_optional_client_libs "$client_lib_dir" "$vanilla_dir/Lib"
+
+install_ilspycmd_if_missing
+
+for entry in "${lib_projects[@]}"; do
+  IFS=':' read -r project work_rel dll <<<"$entry"
+  dll_path="$(find "$vanilla_dir" -type f -name "$dll" -print -quit)"
+  if [[ -z "$dll_path" ]]; then
+    echo "Skipping $dll, not found in archive" >&2
+    continue
+  fi
+
+  out="$baseline_dir/$project"
+  if [[ ! -d "$out" || "$refresh" == "1" ]]; then
+    echo "Decompiling $dll into $out"
+    rm -rf "$out"
+    mkdir -p "$out"
+    ilspycmd "$dll_path" --project -o "$out" >/dev/null
+    normalize_lang_version "$out"
+  fi
+
+  copy_tree_fresh "$out" "$repo_root/$work_rel"
+done
+
+forks_file="$repo_root/forks.json"
+if [[ -f "$forks_file" ]]; then
+  mapfile -t forks < <(
+    python3 - "$forks_file" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], "r", encoding="utf-8") as file:
+    data = json.load(file)
+
+for fork in data.get("forks", []):
+    print(f"{fork['name']}\t{fork['url']}\t{fork['ref']}")
+PY
+  )
+
+  for fork in "${forks[@]}"; do
+    IFS=$'\t' read -r name url ref <<<"$fork"
+    base="$baseline_dir/$name"
+
+    if [[ ! -d "$base" || "$refresh" == "1" ]]; then
+      rm -rf "$base"
+      echo "Cloning $url at $ref into $base"
+      git clone --quiet "$url" "$base"
+      git -C "$base" checkout --quiet "$ref"
+      rm -rf "$base/.git"
+      normalize_lf "$base"
+    fi
+
+    copy_tree_fresh "$base" "$repo_root/$name"
+  done
+fi
+
+patches_dir="$repo_root/patches"
+vanilla_patch_projects=("VintagestoryLib" "VintagestoryServer")
+if [[ -d "$patches_dir" ]]; then
+  failed=()
+  while IFS= read -r -d '' patch; do
+    rel="${patch#$repo_root/}"
+    top_proj="$(printf '%s\n' "$rel" | cut -d/ -f2)"
+    apply_args=(apply --whitespace=nowarn)
+
+    for vanilla_project in "${vanilla_patch_projects[@]}"; do
+      if [[ "$top_proj" == "$vanilla_project" ]]; then
+        apply_args+=(--directory=baseline)
+        break
+      fi
+    done
+
+    echo "Applying $rel"
+    if ! output="$(git "${apply_args[@]}" "$patch" 2>&1)"; then
+      failed+=("$rel")
+      while IFS= read -r line; do
+        [[ -n "$line" ]] && echo "  $line"
+      done <<<"$output"
+    fi
+  done < <(find "$patches_dir" -type f -name '*.patch' -print0)
+
+  if [[ "${#failed[@]}" -gt 0 ]]; then
+    echo
+    echo "${#failed[@]} patch(es) failed to apply:" >&2
+    printf '  %s\n' "${failed[@]}" >&2
+    echo "Fix the conflicts in the working tree, then run scripts/extract-patches.sh." >&2
+  fi
+else
+  echo "No patches/ directory, skipping patch step."
+fi
+
+sources_dir="$repo_root/sources"
+if [[ -d "$sources_dir" ]]; then
+  while IFS= read -r -d '' project_dir; do
+    project="$(basename "$project_dir")"
+    dst="$repo_root/$project"
+
+    for vanilla_project in "${vanilla_patch_projects[@]}"; do
+      if [[ "$project" == "$vanilla_project" ]]; then
+        dst="$repo_root/baseline/$project"
+        break
+      fi
+    done
+
+    if [[ ! -d "$dst" ]]; then
+      echo "Warning: sources/$project has no matching working folder; skipping." >&2
+      continue
+    fi
+
+    while IFS= read -r -d '' src; do
+      rel="${src#$project_dir/}"
+      target="$dst/$rel"
+      mkdir -p "$(dirname "$target")"
+      cp -f "$src" "$target"
+    done < <(find "$project_dir" -type f -print0)
+
+    echo "Synced sources/$project into ${dst#$repo_root/}/"
+  done < <(find "$sources_dir" -mindepth 1 -maxdepth 1 -type d -print0)
+fi
+
+echo
+echo "Bootstrap complete. Run: dotnet build VintageStory.slnx -c Release"

--- a/scripts/extract-patches.sh
+++ b/scripts/extract-patches.sh
@@ -1,0 +1,233 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd -- "$script_dir/.." && pwd)"
+
+baseline_dir="$repo_root/.baseline"
+patches_dir="$repo_root/patches"
+sources_dir="$repo_root/sources"
+
+if [[ ! -d "$baseline_dir" ]]; then
+  echo "No .baseline/ found. Run scripts/bootstrap.sh first." >&2
+  exit 1
+fi
+
+export LC_ALL=C.UTF-8
+
+exclude_segments=(bin obj .vs .git Generated DevMenu ImGui)
+vanilla_projects=(VintagestoryLib VintagestoryServer)
+
+patches_written=0
+sources_written=0
+cleared=0
+
+declare -A kept_sources
+
+is_vanilla_project() {
+  local proj="$1"
+  local item
+  for item in "${vanilla_projects[@]}"; do
+    [[ "$item" == "$proj" ]] && return 0
+  done
+  return 1
+}
+
+is_excluded() {
+  local rel="$1"
+  local segment
+  IFS='/' read -r -a parts <<<"${rel//\\//}"
+  for segment in "${parts[@]}"; do
+    local excluded
+    for excluded in "${exclude_segments[@]}"; do
+      [[ "$segment" == "$excluded" ]] && return 0
+    done
+  done
+  return 1
+}
+
+normalize_text() {
+  local src="$1"
+  local dst="$2"
+  mkdir -p -- "$(dirname -- "$dst")"
+  sed '1s/^\xEF\xBB\xBF//' "$src" | perl -pe 's/\r\n/\n/g; s/\r/\n/g' > "$dst"
+}
+
+write_patch() {
+  local base_file="$1"
+  local work_file="$2"
+  local rel_path="$3"
+  local patch_file="$4"
+  local tmp_base tmp_work tmp_diff status
+
+  tmp_base="$(mktemp)"
+  tmp_work="$(mktemp)"
+  tmp_diff="$(mktemp)"
+  normalize_text "$base_file" "$tmp_base"
+  normalize_text "$work_file" "$tmp_work"
+
+  set +e
+  git --no-pager -c core.safecrlf=false diff --no-color --no-index -U5 -- "$tmp_base" "$tmp_work" > "$tmp_diff"
+  status=$?
+
+  if [[ "$status" -eq 1 ]]; then
+    mkdir -p -- "$(dirname -- "$patch_file")"
+    sed \
+      -e "s#^diff --git .*\$#diff --git a/$rel_path b/$rel_path#" \
+      -e "s#^--- .*\$#--- a/$rel_path#" \
+      -e "s#^+++ .*\$#+++ b/$rel_path#" \
+      "$tmp_diff" > "$patch_file"
+    ((patches_written += 1))
+  elif [[ "$status" -ne 0 ]]; then
+    cat "$tmp_diff" >&2
+    rm -f -- "$tmp_base" "$tmp_work" "$tmp_diff"
+    exit "$status"
+  fi
+
+  rm -f -- "$tmp_base" "$tmp_work" "$tmp_diff"
+  return "$status"
+}
+
+sync_new_file() {
+  local proj="$1"
+  local work_rel="$2"
+  local src_file="$3"
+  local dst="$sources_dir/$proj/$work_rel"
+
+  normalize_text "$src_file" "$dst"
+  kept_sources["$(realpath "$dst")"]=1
+  ((sources_written += 1))
+}
+
+clear_stale_patches() {
+  local proj="$1"
+  local base_root="$2"
+  local work_root="$3"
+  local proj_patch_dir="$patches_dir/$proj"
+
+  [[ -d "$proj_patch_dir" ]] || return 0
+
+  while IFS= read -r -d '' patch_file; do
+    local rel_patch rel_source base_file work_file
+    rel_patch="${patch_file#$proj_patch_dir/}"
+    rel_source="${rel_patch%.patch}"
+
+    if is_excluded "$rel_source"; then
+      rm -f -- "$patch_file"
+      ((cleared += 1))
+      continue
+    fi
+
+    base_file="$base_root/$rel_source"
+    work_file="$work_root/$rel_source"
+
+    if [[ -f "$base_file" && -f "$work_file" ]]; then
+      local tmp_base tmp_work
+      tmp_base="$(mktemp)"
+      tmp_work="$(mktemp)"
+      normalize_text "$base_file" "$tmp_base"
+      normalize_text "$work_file" "$tmp_work"
+      if cmp -s "$tmp_base" "$tmp_work"; then
+        rm -f -- "$patch_file"
+        ((cleared += 1))
+      fi
+      rm -f -- "$tmp_base" "$tmp_work"
+      continue
+    fi
+
+    if [[ ! -f "$base_file" && ! -f "$work_file" ]]; then
+      rm -f -- "$patch_file"
+      ((cleared += 1))
+    fi
+  done < <(find "$proj_patch_dir" -type f -name '*.patch' -print0)
+}
+
+clear_stale_sources() {
+  local proj="$1"
+  local proj_src_dir="$sources_dir/$proj"
+
+  [[ -d "$proj_src_dir" ]] || return 0
+
+  while IFS= read -r -d '' source_file; do
+    local full
+    full="$(realpath "$source_file")"
+    if [[ -z "${kept_sources[$full]+x}" ]]; then
+      rm -f -- "$source_file"
+      ((cleared += 1))
+    fi
+  done < <(find "$proj_src_dir" -type f -name '*.cs' -print0)
+
+  while IFS= read -r -d '' dir; do
+    rmdir --ignore-fail-on-non-empty "$dir" 2>/dev/null || true
+  done < <(find "$proj_src_dir" -depth -type d -print0)
+}
+
+project_names_from_forks() {
+  local forks_file="$repo_root/forks.json"
+  [[ -f "$forks_file" ]] || return 0
+
+  if command -v jq >/dev/null 2>&1; then
+    jq -r '.forks[]?.name' "$forks_file"
+  else
+    python3 - "$forks_file" <<'PY'
+import json
+import sys
+with open(sys.argv[1], encoding="utf-8") as f:
+    data = json.load(f)
+for fork in data.get("forks", []):
+    name = fork.get("name")
+    if name:
+        print(name)
+PY
+  fi
+}
+
+process_project() {
+  local proj="$1"
+  local work_root="$2"
+  local base_root="$3"
+
+  [[ -d "$work_root" && -d "$base_root" ]] || return 0
+
+  while IFS= read -r -d '' file; do
+    local rel base_file patch_file rel_patch status
+    rel="${file#$work_root/}"
+    rel="${rel//\\//}"
+    is_excluded "$rel" && continue
+
+    base_file="$base_root/$rel"
+    patch_file="$patches_dir/$proj/$rel.patch"
+    rel_patch="$proj/$rel"
+
+    if [[ ! -f "$base_file" ]]; then
+      sync_new_file "$proj" "$rel" "$file"
+      continue
+    fi
+
+    set +e
+    write_patch "$base_file" "$file" "$rel_patch" "$patch_file"
+    status=$?
+    set -e
+
+    if [[ "$status" -eq 0 && -f "$patch_file" ]]; then
+      rm -f -- "$patch_file"
+      ((cleared += 1))
+    fi
+  done < <(find "$work_root" -type f -name '*.cs' -print0)
+
+  clear_stale_patches "$proj" "$base_root" "$work_root"
+  clear_stale_sources "$proj"
+}
+
+cd "$repo_root"
+
+while IFS= read -r proj; do
+  [[ -n "$proj" ]] || continue
+  process_project "$proj" "$repo_root/$proj" "$baseline_dir/$proj"
+done < <(project_names_from_forks)
+
+for proj in "${vanilla_projects[@]}"; do
+  process_project "$proj" "$repo_root/baseline/$proj" "$baseline_dir/$proj"
+done
+
+echo "Wrote $patches_written patch(es), $sources_written source file(s); cleared $cleared stale entry(ies)."

--- a/sources/VintagestoryLib/VintagestoryLib.csproj
+++ b/sources/VintagestoryLib/VintagestoryLib.csproj
@@ -11,21 +11,8 @@
   </PropertyGroup>
   <PropertyGroup />
   <ItemGroup>
-    <Compile Remove="GuiScreen.cs" />
-    <Compile Remove="GuiScreenMainRight.cs" />
-    <Compile Remove="Vintagestory\ClientLogger.cs" />
-    <Compile Remove="Vintagestory.Client\**\*.cs" />
-    <Compile Remove="Vintagestory.Client.Gui\**\*.cs" />
-    <Compile Remove="Vintagestory.Client.MaxObf\**\*.cs" />
-    <Compile Remove="Vintagestory.Client.Network\**\*.cs" />
-    <Compile Remove="Vintagestory.Client.NoObf\**\*.cs" />
-    <Compile Remove="Vintagestory.Client.Util\**\*.cs" />
-    <Compile Remove="Vintagestory.ClientNative\**\*.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Vintagestory.Client.NoObf\INetworkConnection.cs" />
-    <Compile Include="Vintagestory.Client.NoObf\MonitorObject.cs" />
-    <Compile Include="Vintagestory.Client.NoObf\VintageStorySocket.cs" />
   </ItemGroup>
   <!-- Nimbus integration is optional. When the Nimbus.Shared project is checked
        out, define STRATUM_NIMBUS so the Nimbus/* folder and the patched baseline


### PR DESCRIPTION
## Summary

  Adds Linux equivalents for the patch workflow scripts:
  - `scripts/bootstrap.sh`
  - `scripts/extract-patches.sh`

  Also updates `VintagestoryLib` so the server build retains the vanilla client class surface. This avoids server side mod load failures when mods reference
  `Vintagestory.Client.NoObf` types that vanilla keeps available.


## Type

- [ ] Bug fix
- [ ] Performance
- [x] New feature
- [ ] Refactor or cleanup
- [x] Docs or build

## Checklist

- [x] `.\scripts\extract-patches.sh` ran clean.
- [x] `dotnet build VintageStory.slnx -c Release` is green.
- [ ] Every vanilla edit has a `// Stratum` marker.
- [x] No vanilla source committed.
- [x] Tested on a real server start, not just compilation.

  ## Performance numbers

  Not a performance change.

  ## Related issues

  Fixes #
