### PR TITLE
Restore server player animators

### DIFF
--- a/patches/VintagestoryApi/Common/Model/Animation/AnimationManager.cs.patch
+++ b/patches/VintagestoryApi/Common/Model/Animation/AnimationManager.cs.patch
@@ -1,0 +1,358 @@
+diff --git a/VintagestoryApi/Common/Model/Animation/AnimationManager.cs b/VintagestoryApi/Common/Model/Animation/AnimationManager.cs
+index 573ec12..4d57a87 100644
+--- a/VintagestoryApi/Common/Model/Animation/AnimationManager.cs
++++ b/VintagestoryApi/Common/Model/Animation/AnimationManager.cs
+@@ -27,11 +27,23 @@ namespace Vintagestory.API.Common
+         public bool AnimationsDirty { get; set; }
+ 
+         /// <summary>
+         /// The animator for the animation manager.
+         /// </summary>
+-        public IAnimator Animator { get; set; }
++        private IAnimator stratumAnimator;
++
++        public IAnimator Animator
++        {
++            get
++            {
++                StratumEnsureServerAnimator("Animator");
++                return stratumAnimator;
++            }
++            set { stratumAnimator = value; }
++        }
++
++        public bool StratumHasAnimator => stratumAnimator != null;
+ 
+         /// <summary>
+         /// The entity head controller for this animator.
+         /// </summary>
+         public IHeadController HeadController { get; set; }
+@@ -44,13 +56,46 @@ namespace Vintagestory.API.Common
+ 
+         public bool AdjustCollisionBoxToAnimation { get; set; }
+ 
+         public List<AnimFrameCallback> Triggers;
+ 
+-        public event StartAnimationDelegate OnStartAnimation;
+-        public event StartAnimationDelegate OnAnimationReceived;
+-        public event Action<string> OnAnimationStopped;
++        // Stratum: allow the server to lazily attach animators when mods subscribe to server animation callbacks.
++        public static Action<AnimationManager, Entity, string> StratumServerAnimatorDemand;
++
++        private StartAnimationDelegate stratumOnStartAnimation;
++        private StartAnimationDelegate stratumOnAnimationReceived;
++        private Action<string> stratumOnAnimationStopped;
++
++        public event StartAnimationDelegate OnStartAnimation
++        {
++            add
++            {
++                StratumEnsureServerAnimator("OnStartAnimation");
++                stratumOnStartAnimation += value;
++            }
++            remove { stratumOnStartAnimation -= value; }
++        }
++
++        public event StartAnimationDelegate OnAnimationReceived
++        {
++            add
++            {
++                StratumEnsureServerAnimator("OnAnimationReceived");
++                stratumOnAnimationReceived += value;
++            }
++            remove { stratumOnAnimationReceived -= value; }
++        }
++
++        public event Action<string> OnAnimationStopped
++        {
++            add
++            {
++                StratumEnsureServerAnimator("OnAnimationStopped");
++                stratumOnAnimationStopped += value;
++            }
++            remove { stratumOnAnimationStopped -= value; }
++        }
+ 
+ 
+         /// <summary>
+         /// The entity attached to this Animation Manager.
+         /// </summary>
+@@ -71,10 +116,19 @@ namespace Vintagestory.API.Common
+             this.api = api;
+             this.entity = entity;
+             capi = api as ICoreClientAPI;
+         }
+ 
++        // Stratum: demand-load server animators only when server-side code reads animation state or callbacks.
++        private void StratumEnsureServerAnimator(string reason)
++        {
++            if (api?.Side == EnumAppSide.Server && stratumAnimator == null && entity != null)
++            {
++                StratumServerAnimatorDemand?.Invoke(this, entity, reason);
++            }
++        }
++
+         public IAnimator LoadAnimator(ICoreAPI api, Entity entity, Shape entityShape, RunningAnimation[] copyOverAnims, bool requirePosesOnServer, string[] disableElements, params string[] requireJointsForElements)
+         {
+             Init(entity.Api, entity);
+ 
+             if (entityShape == null) return null;
+@@ -127,11 +181,12 @@ namespace Vintagestory.API.Common
+             return false;
+         }
+ 
+         public virtual RunningAnimation GetAnimationState(string anim)
+         {
+-            return Animator.GetAnimationState(anim);
++            StratumEnsureServerAnimator("GetAnimationState");
++            return Animator?.GetAnimationState(anim);
+         }
+ 
+         /// <summary>
+         /// If given animation is running, will set its progress to the first animation frame
+         /// </summary>
+@@ -151,31 +206,34 @@ namespace Vintagestory.API.Common
+         /// As StartAnimation, except that it does not attempt to start the animation if the named animation is non-existent for this entity
+         /// </summary>
+         /// <param name="animdata"></param>
+         public virtual bool TryStartAnimation(AnimationMetaData animdata)
+         {
+-            if (((AnimatorBase)Animator).GetAnimationState(animdata.Animation) == null) return false;
++            StratumEnsureServerAnimator("TryStartAnimation");
++            if (stratumAnimator == null) return false;
++            if (((AnimatorBase)stratumAnimator).GetAnimationState(animdata.Animation) == null) return false;
+             return StartAnimation(animdata);
+         }
+ 
+         /// <summary>
+         /// Client: Starts given animation
+         /// Server: Sends all active anims to all connected clients then purges the ActiveAnimationsByAnimCode list
+         /// </summary>
+         /// <param name="animdata"></param>
+         public virtual bool StartAnimation(AnimationMetaData animdata)
+         {
++            StratumEnsureServerAnimator("StartAnimation");
+             if (animdata == null)
+             {
+                 throw new Exception("Can't play null animdata");
+             }
+-            if (OnStartAnimation != null)
++            if (stratumOnStartAnimation != null)
+             {
+                 EnumHandling handling = EnumHandling.PassThrough;
+                 bool preventDefault = false;
+                 bool started = false;
+-                foreach (StartAnimationDelegate dele in OnStartAnimation.GetInvocationList())
++                foreach (StartAnimationDelegate dele in stratumOnStartAnimation.GetInvocationList())
+                 {
+                     started = dele(ref animdata, ref handling);
+                     if (handling == EnumHandling.PreventSubsequent) return started;
+                     if (animdata == null)
+                     {
+@@ -231,10 +289,15 @@ namespace Vintagestory.API.Common
+         /// <param name="code"></param>
+         public virtual void StopAnimation(string code)
+         {
+             if (code == null || entity == null) return;
+ 
++            if (StratumShouldKeepMovingAnimationActive(code))
++            {
++                return;
++            }
++
+             if (entity.World.Side == EnumAppSide.Server)
+             {
+                 AnimationsDirty = true;
+             }
+ 
+@@ -254,10 +317,93 @@ namespace Vintagestory.API.Common
+             {
+                 entity.UpdateDebugAttributes();
+             }
+         }
+ 
++        // Stratum: AI tasks can stop run/walk during task hand-off while path traversal
++        // still has movement controls set. Keep locomotion active until movement really stops
++        // so clients do not receive an empty animation packet between movement packets.
++        private bool StratumShouldKeepMovingAnimationActive(string code)
++        {
++            return entity?.World?.Side == EnumAppSide.Server
++                && StratumIsLocomotionAnimation(code)
++                && StratumIsMovingForAnimation()
++                && StratumTryGetActiveAnimation(code, out _, out _);
++        }
++
++        private bool StratumTryGetActiveAnimation(string code, out string activeKey, out AnimationMetaData activeAnimation)
++        {
++            if (ActiveAnimationsByAnimCode.TryGetValue(code, out activeAnimation))
++            {
++                activeKey = code;
++                return true;
++            }
++
++            foreach (KeyValuePair<string, AnimationMetaData> val in ActiveAnimationsByAnimCode)
++            {
++                if (string.Equals(val.Value.Code, code, StringComparison.OrdinalIgnoreCase) || string.Equals(val.Value.Animation, code, StringComparison.OrdinalIgnoreCase))
++                {
++                    activeKey = val.Key;
++                    activeAnimation = val.Value;
++                    return true;
++                }
++            }
++
++            activeKey = null;
++            activeAnimation = null;
++            return false;
++        }
++
++        private static bool StratumIsLocomotionAnimation(string code)
++        {
++            return string.Equals(code, "walk", StringComparison.OrdinalIgnoreCase)
++                || string.Equals(code, "run", StringComparison.OrdinalIgnoreCase)
++                || string.Equals(code, "swim", StringComparison.OrdinalIgnoreCase)
++                || string.Equals(code, "crawl", StringComparison.OrdinalIgnoreCase)
++                || string.Equals(code, "fly", StringComparison.OrdinalIgnoreCase);
++        }
++
++        private bool StratumIsMovingForAnimation()
++        {
++            if (entity is not EntityAgent agent)
++            {
++                return false;
++            }
++
++            if (agent.Controls?.TriesToMove == true)
++            {
++                return true;
++            }
++
++            EntityPos pos = entity.Pos;
++            return pos != null && pos.Motion.X * pos.Motion.X + pos.Motion.Z * pos.Motion.Z > 0.000001;
++        }
++
++        private void StratumStopHeldLocomotionWhenIdle()
++        {
++            if (entity?.World?.Side != EnumAppSide.Server || StratumIsMovingForAnimation())
++            {
++                return;
++            }
++
++            string[] keys = ActiveAnimationsByAnimCode.Keys.ToArray();
++            for (int i = 0; i < keys.Length; i++)
++            {
++                string key = keys[i];
++                if (!ActiveAnimationsByAnimCode.TryGetValue(key, out AnimationMetaData animMeta))
++                {
++                    continue;
++                }
++
++                string code = animMeta.Code ?? key;
++                if (StratumIsLocomotionAnimation(code))
++                {
++                    StopAnimation(code);
++                }
++            }
++        }
++
+ 
+         public virtual void StopAllAnimations()
+         {
+             if (entity == null) return;
+ 
+@@ -352,11 +498,11 @@ namespace Vintagestory.API.Common
+         }
+ 
+         protected virtual void onReceivedServerAnimation(AnimationMetaData animmetadata)
+         {
+             EnumHandling handling = EnumHandling.PassThrough;
+-            OnAnimationReceived?.Invoke(ref animmetadata, ref handling);
++            stratumOnAnimationReceived?.Invoke(ref animmetadata, ref handling);
+ 
+             if (handling == EnumHandling.PassThrough)
+             {
+                 ActiveAnimationsByAnimCode[animmetadata.Animation] = animmetadata;
+             }
+@@ -367,11 +513,11 @@ namespace Vintagestory.API.Common
+         /// </summary>
+         /// <param name="tree"></param>
+         /// <param name="forClient"></param>
+         public virtual void ToAttributes(ITreeAttribute tree, bool forClient)
+         {
+-            if (Animator == null) return;
++            if (stratumAnimator == null) return;
+ 
+             ITreeAttribute animtree = new TreeAttribute();
+             tree["activeAnims"] = animtree;
+             SerializeActiveAnimations(forClient, (code, ms) => { animtree[code] = new ByteArrayAttribute(ms); });
+         }
+@@ -381,11 +527,11 @@ namespace Vintagestory.API.Common
+         /// </summary>
+         /// <param name="stream"></param>
+         /// <param name="forClient"></param>
+         public virtual void ToAttributeBytes(BinaryWriter stream, bool forClient)
+         {
+-            if (Animator == null) return;
++            if (stratumAnimator == null) return;
+ 
+             StreamedTreeAttribute streamedAnimTree = new StreamedTreeAttribute(stream);
+             streamedAnimTree.WithKey("activeAnims");
+             SerializeActiveAnimations(forClient, (code, ms) => { streamedAnimTree[code] = new StreamedByteArrayAttribute(ms); } );
+             streamedAnimTree.EndKey();
+@@ -401,11 +547,11 @@ namespace Vintagestory.API.Common
+             {
+                 if (val.Value.Code == null) val.Value.Code = val.Key; // ah wtf.
+ 
+                 if (!forClient && val.Value.Code != "die") continue;
+ 
+-                RunningAnimation anim = Animator.GetAnimationState(val.Value.Animation);
++                RunningAnimation anim = stratumAnimator.GetAnimationState(val.Value.Animation);
+                 if (anim != null)
+                 {
+                     val.Value.StartFrameOnce = anim.CurrentFrame;
+                 }
+ 
+@@ -446,14 +592,16 @@ namespace Vintagestory.API.Common
+         /// The event fired at each server tick.
+         /// </summary>
+         /// <param name="dt"></param>
+         public virtual void OnServerTick(float dt)
+         {
+-            if (Animator != null)
++            StratumStopHeldLocomotionWhenIdle();
++
++            if (stratumAnimator != null)
+             {
+-                Animator.CalculateMatrices = !entity.Alive || entity.requirePosesOnServer;
+-                Animator.OnFrame(ActiveAnimationsByAnimCode, dt);
++                stratumAnimator.CalculateMatrices = !entity.Alive || entity.requirePosesOnServer;
++                stratumAnimator.OnFrame(ActiveAnimationsByAnimCode, dt);
+                 AdjustCollisionBoxToAnimation = ActiveAnimationsByAnimCode.Any(anim => anim.Value.AdjustCollisionBox);
+             }
+ 
+             runTriggers();
+         }
+@@ -495,10 +643,11 @@ namespace Vintagestory.API.Common
+             }
+         }
+ 
+         public virtual void RegisterFrameCallback(AnimFrameCallback trigger)
+         {
++            StratumEnsureServerAnimator("RegisterFrameCallback");
+             if (Triggers == null) Triggers = new List<AnimFrameCallback>();
+             Triggers.Add(trigger);
+         }
+ 
+         private void runTriggers()
+@@ -537,11 +686,11 @@ namespace Vintagestory.API.Common
+             }
+         }
+ 
+         public virtual void TriggerAnimationStopped(string code)
+         {
+-            OnAnimationStopped?.Invoke(code);
++            stratumOnAnimationStopped?.Invoke(code);
+         }
+ 
+         Dictionary<string, ILoadedSound> loopingSounds = null;
+ 
+         public void ShouldPlaySound(string animationMetaCode, AnimationSound sound)

--- a/patches/VintagestoryLib/Vintagestory.Common.Network.Packets/AnimationPacket.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Common.Network.Packets/AnimationPacket.cs.patch
@@ -1,0 +1,17 @@
+diff --git a/VintagestoryLib/Vintagestory.Common.Network.Packets/AnimationPacket.cs b/VintagestoryLib/Vintagestory.Common.Network.Packets/AnimationPacket.cs
+index a45cd69..87468af 100644
+--- a/VintagestoryLib/Vintagestory.Common.Network.Packets/AnimationPacket.cs
++++ b/VintagestoryLib/Vintagestory.Common.Network.Packets/AnimationPacket.cs
+@@ -3,11 +3,11 @@ using ProtoBuf;
+ using Vintagestory.API.Common;
+ using Vintagestory.API.Common.Entities;
+ 
+ namespace Vintagestory.Common.Network.Packets;
+ 
+-[ProtoContract(/*Could not decode attribute arguments.*/)]
++[ProtoContract(ImplicitFields = ImplicitFields.AllFields)]
+ public class AnimationPacket
+ {
+ 	public long entityId;
+ 
+ 	public int[] activeAnimations;

--- a/patches/VintagestoryLib/Vintagestory.Common.Network.Packets/BulkAnimationPacket.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Common.Network.Packets/BulkAnimationPacket.cs.patch
@@ -1,0 +1,15 @@
+diff --git a/VintagestoryLib/Vintagestory.Common.Network.Packets/BulkAnimationPacket.cs b/VintagestoryLib/Vintagestory.Common.Network.Packets/BulkAnimationPacket.cs
+index 9f97677..325ae6c 100644
+--- a/VintagestoryLib/Vintagestory.Common.Network.Packets/BulkAnimationPacket.cs
++++ b/VintagestoryLib/Vintagestory.Common.Network.Packets/BulkAnimationPacket.cs
+@@ -1,9 +1,9 @@
+ using ProtoBuf;
+ 
+ namespace Vintagestory.Common.Network.Packets;
+ 
+-[ProtoContract(/*Could not decode attribute arguments.*/)]
++[ProtoContract(ImplicitFields = ImplicitFields.AllFields)]
+ public class BulkAnimationPacket
+ {
+ 	public AnimationPacket[] Packets;
+ }

--- a/patches/VintagestoryLib/Vintagestory.Common.Network.Packets/EntityTagPacket.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Common.Network.Packets/EntityTagPacket.cs.patch
@@ -1,0 +1,16 @@
+diff --git a/VintagestoryLib/Vintagestory.Common.Network.Packets/EntityTagPacket.cs b/VintagestoryLib/Vintagestory.Common.Network.Packets/EntityTagPacket.cs
+index cb4605d..93b91dc 100644
+--- a/VintagestoryLib/Vintagestory.Common.Network.Packets/EntityTagPacket.cs
++++ b/VintagestoryLib/Vintagestory.Common.Network.Packets/EntityTagPacket.cs
+@@ -1,10 +1,10 @@
+ using ProtoBuf;
+ 
+ namespace Vintagestory.Common.Network.Packets;
+ 
+-[ProtoContract(/*Could not decode attribute arguments.*/)]
++[ProtoContract(ImplicitFields = ImplicitFields.AllFields)]
+ public class EntityTagPacket
+ {
+ 	public long EntityId = 1L;
+ 
+ 	public long TagsBitmask1 = 2L;

--- a/patches/VintagestoryLib/Vintagestory.Common.Network.Packets/MountAnimationPacket.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Common.Network.Packets/MountAnimationPacket.cs.patch
@@ -1,0 +1,16 @@
+diff --git a/VintagestoryLib/Vintagestory.Common.Network.Packets/MountAnimationPacket.cs b/VintagestoryLib/Vintagestory.Common.Network.Packets/MountAnimationPacket.cs
+index 41800e5..419b965 100644
+--- a/VintagestoryLib/Vintagestory.Common.Network.Packets/MountAnimationPacket.cs
++++ b/VintagestoryLib/Vintagestory.Common.Network.Packets/MountAnimationPacket.cs
+@@ -1,10 +1,10 @@
+ using ProtoBuf;
+ 
+ namespace Vintagestory.Common.Network.Packets;
+ 
+-[ProtoContract(/*Could not decode attribute arguments.*/)]
++[ProtoContract(ImplicitFields = ImplicitFields.AllFields)]
+ public class MountAnimationPacket
+ {
+ 	public string gaitCode;
+ 
+ 	public AnimationPacket animPacket;

--- a/patches/VintagestoryLib/Vintagestory.Server/PhysicsManager.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/PhysicsManager.cs.patch
@@ -1,5 +1,5 @@
 diff --git a/VintagestoryLib/Vintagestory.Server/PhysicsManager.cs b/VintagestoryLib/Vintagestory.Server/PhysicsManager.cs
-index 2c2605d..47c3e74 100644
+index 2c2605d..92a6071 100644
 --- a/VintagestoryLib/Vintagestory.Server/PhysicsManager.cs
 +++ b/VintagestoryLib/Vintagestory.Server/PhysicsManager.cs
 @@ -101,10 +101,23 @@ public class PhysicsManager : LoadBalancedTask
@@ -62,7 +62,7 @@ index 2c2605d..47c3e74 100644
  	private readonly EntityDespawnData outofRangeDespawnData = new EntityDespawnData
  	{
  		Reason = EnumDespawnReason.OutOfRange
-@@ -168,12 +195,34 @@ public class PhysicsManager : LoadBalancedTask
+@@ -168,12 +195,38 @@ public class PhysicsManager : LoadBalancedTask
  
  	private List<long> alreadyTracked = new List<long>();
  
@@ -79,6 +79,10 @@ index 2c2605d..47c3e74 100644
 +	private readonly Dictionary<long, PreparedStateChangePacket> stateChangePlayerDataPacketCache = new Dictionary<long, PreparedStateChangePacket>();
 +
 +	private readonly Dictionary<long, AnimationPacket> stateChangeAnimationPacketCache = new Dictionary<long, AnimationPacket>();
++
++	private readonly ConcurrentDictionary<long, long> stratumLastActiveAnimationRefreshMs = new ConcurrentDictionary<long, long>(); // Stratum: repair missed/raced active animation packets.
++
++	private readonly ConcurrentDictionary<long, long> stratumLastLocomotionAnimationMs = new ConcurrentDictionary<long, long>(); // Stratum: suppress transient empty packets during AI locomotion churn.
 +
 +	private readonly BoxedPacket stateChangeSerializedPacket = new BoxedPacket();
 +
@@ -97,7 +101,7 @@ index 2c2605d..47c3e74 100644
  	private PhysicsOffthreadTasks offthreadProcess;
  
  	private int currentTick;
-@@ -184,24 +233,46 @@ public class PhysicsManager : LoadBalancedTask
+@@ -184,24 +237,46 @@ public class PhysicsManager : LoadBalancedTask
  
  	public PhysicsManager(ICoreServerAPI sapi, ServerUdpNetwork udpNetwork)
  	{
@@ -146,7 +150,7 @@ index 2c2605d..47c3e74 100644
  			entitiesFullUpdate[i] = new Dictionary<long, Packet_EntityAttributes>();
  		}
  		for (int j = 0; j < entitiesPartialUpdate.Length; j++)
-@@ -221,10 +292,13 @@ public class PhysicsManager : LoadBalancedTask
+@@ -221,10 +296,13 @@ public class PhysicsManager : LoadBalancedTask
  			entitiesAnimPackets[m] = new Dictionary<long, AnimationPacket>();
  		}
  		for (int n = 0; n < entitiesUpdateReusableBuffers.Length; n++)
@@ -160,7 +164,7 @@ index 2c2605d..47c3e74 100644
  		loadBalancer = new LoadBalancer(this, ServerMain.Logger);
  		loadBalancer.CreateDedicatedThreads(maxPhysicsThreads, "physicsManager", server.Serverthreads);
  		offthreadProcess = new PhysicsOffthreadTasks(this);
-@@ -251,13 +325,25 @@ public class PhysicsManager : LoadBalancedTask
+@@ -251,13 +329,25 @@ public class PhysicsManager : LoadBalancedTask
  		attrUpdateAccum = 0.2f;
  	}
  
@@ -187,7 +191,7 @@ index 2c2605d..47c3e74 100644
  			{
  				if (result.Entity.ServerBehaviorsThreadsafe == null)
  				{
-@@ -268,11 +354,11 @@ public class PhysicsManager : LoadBalancedTask
+@@ -268,11 +358,11 @@ public class PhysicsManager : LoadBalancedTask
  					tickables.Add(result);
  				}
  			}
@@ -200,7 +204,7 @@ index 2c2605d..47c3e74 100644
  			{
  				tickables.Remove(result2);
  			}
-@@ -287,30 +373,81 @@ public class PhysicsManager : LoadBalancedTask
+@@ -287,30 +377,81 @@ public class PhysicsManager : LoadBalancedTask
  				ServerMain.Logger.Warning("Over 400ms tick. Skipping {0} physics ticks.", num);
  			}
  			physicsTickAccum %= 0.4f;
@@ -287,7 +291,7 @@ index 2c2605d..47c3e74 100644
  				loadBalancer.SynchroniseWorkToMainThread(this);
  				loadBalancer.AwaitCompletionOnAllThreads(num3);
  				ServerMain.FrameProfiler.Mark("physicsmanager-waitingForSlowestThread");
-@@ -341,26 +478,31 @@ public class PhysicsManager : LoadBalancedTask
+@@ -341,26 +482,31 @@ public class PhysicsManager : LoadBalancedTask
  				{
  					ServerMain.Logger.Error(e);
  				}
@@ -325,7 +329,7 @@ index 2c2605d..47c3e74 100644
  		lock (server.EntitySpawnSendQueue)
  		{
  			List<Entity> entitySpawnSendQueue = server.EntitySpawnSendQueue;
-@@ -398,16 +540,31 @@ public class PhysicsManager : LoadBalancedTask
+@@ -398,16 +544,31 @@ public class PhysicsManager : LoadBalancedTask
  					ServerMain.spawnSendQueue--;
  				});
  			}
@@ -358,7 +362,7 @@ index 2c2605d..47c3e74 100644
  			if (value.State.ConnectedOrPlaying() && value.Entityplayer != null)
  			{
  				list.Add(value);
-@@ -462,10 +619,25 @@ public class PhysicsManager : LoadBalancedTask
+@@ -462,10 +623,25 @@ public class PhysicsManager : LoadBalancedTask
  		UpdateTrackedEntityLists(client, 1);
  	}
  
@@ -384,7 +388,7 @@ index 2c2605d..47c3e74 100644
  		double y = pos.Y;
  		double z = pos.Z;
  		double num = double.MaxValue;
-@@ -536,10 +708,15 @@ public class PhysicsManager : LoadBalancedTask
+@@ -536,10 +712,15 @@ public class PhysicsManager : LoadBalancedTask
  		List<long> list2 = alreadyTracked;
  		list2.EnsureCapacity(trackedEntities.Count);
  		List<Entity> list3 = newlyTracked;
@@ -400,7 +404,7 @@ index 2c2605d..47c3e74 100644
  			{
  				list2.Add(entityId);
  			}
-@@ -550,10 +727,15 @@ public class PhysicsManager : LoadBalancedTask
+@@ -550,10 +731,15 @@ public class PhysicsManager : LoadBalancedTask
  		}
  		for (int i = 1; i < threadCount; i++)
  		{
@@ -416,7 +420,7 @@ index 2c2605d..47c3e74 100644
  				{
  					list2.Add(entityId);
  				}
-@@ -593,60 +775,150 @@ public class PhysicsManager : LoadBalancedTask
+@@ -593,60 +779,150 @@ public class PhysicsManager : LoadBalancedTask
  		list3.Clear();
  	}
  
@@ -450,13 +454,13 @@ index 2c2605d..47c3e74 100644
  				{
 -					list.Clear();
 -					if (fastMemoryStream == null)
-+					Entity entity = item.Entity;
-+					if (entity is EntityPlayer entityPlayer)
- 					{
+-					{
 -						fastMemoryStream = new FastMemoryStream();
 -					}
 -					foreach (EntityInRange item in client.entitiesNowInRange)
--					{
++					Entity entity = item.Entity;
++					if (entity is EntityPlayer entityPlayer)
+ 					{
 -						Entity entity = item.Entity;
 -						if (entity is EntityPlayer entityPlayer)
 +						long stratumSectionStart = stratumRecordSectionTimings ? StratumRuntime.Timings.GetTimestamp() : 0L;
@@ -482,11 +486,11 @@ index 2c2605d..47c3e74 100644
 +								}
 +								server.SendPreparedPacket(client, preparedPacket.PacketBytes, preparedPacket.Compressed);
 +							}
- 						}
++						}
 +						if (stratumRecordSectionTimings)
 +						{
 +							stratumPlayerPacketTicks += StratumRuntime.Timings.GetTimestamp() - stratumSectionStart;
-+						}
+ 						}
 +					}
 +					long entityIdForPacket = entity.EntityId;
 +					if (!entityPacketCache.TryGetValue(entityIdForPacket, out Packet_Entity entityPacket))
@@ -543,11 +547,11 @@ index 2c2605d..47c3e74 100644
 +						stateChangeSerializedPacket.Serialize(packet);
 +						byte[] packetBytes = client.Socket.PreparePacketForSending(stateChangeSerializedPacket, server.Config.CompressPackets, out bool compressed);
 +						server.SendPreparedPacket(client, packetBytes, compressed);
-+					}
+ 					}
 +					if (stratumRecordSectionTimings)
 +					{
 +						stratumFullEntitySendTicks += StratumRuntime.Timings.GetTimestamp() - stratumSectionStart;
- 					}
++					}
 +					entityPackets.Clear();
 +				}
 +				if (list.Count > 0)
@@ -594,7 +598,143 @@ index 2c2605d..47c3e74 100644
  
  	public void GatherUpdatePacketsFromAllThreads()
  	{
-@@ -781,14 +1053,24 @@ public class PhysicsManager : LoadBalancedTask
+@@ -729,13 +1005,26 @@ public class PhysicsManager : LoadBalancedTask
+ 		if (entity is EntityPlayer)
+ 		{
+ 			return;
+ 		}
+ 		EntityAgent entityAgent = entity as EntityAgent;
+-		if (entity.AnimManager != null && (entity.AnimManager.AnimationsDirty || entity.IsTeleport))
++		if (entity.AnimManager != null && (entity.AnimManager.AnimationsDirty || entity.IsTeleport || StratumShouldRefreshActiveAnimation(entity, entityAgent)))
+ 		{
+-			entityAnimPackets[entity.EntityId] = new AnimationPacket(entity);
++			bool stratumHadLocomotionAnimation = StratumHasActiveLocomotionAnimation(entity.AnimManager.ActiveAnimationsByAnimCode);
++			AnimationPacket stratumAnimationPacket = new AnimationPacket(entity);
++			if (stratumAnimationPacket.activeAnimationsCount > 0)
++			{
++				if (stratumHadLocomotionAnimation)
++				{
++					stratumLastLocomotionAnimationMs[entity.EntityId] = Environment.TickCount64;
++				}
++				entityAnimPackets[entity.EntityId] = stratumAnimationPacket;
++			}
++			else if (!StratumShouldSuppressEmptyLocomotionPacket(entity, entityAgent))
++			{
++				entityAnimPackets[entity.EntityId] = stratumAnimationPacket;
++			}
+ 			entity.AnimManager.AnimationsDirty = false;
+ 		}
+ 		if (forceUpdate || !entity.Pos.BasicallySameAs(entity.PreviousServerPos) || (entityAgent != null && entityAgent.Controls.Dirty) || entity.tagsDirty)
+ 		{
+ 			int intAndIncrement = entity.Attributes.GetIntAndIncrement("tick");
+@@ -747,10 +1036,106 @@ public class PhysicsManager : LoadBalancedTask
+ 			entity.tagsDirty = false;
+ 		}
+ 		CompletePositionUpdate(entity);
+ 	}
+ 
++	private bool StratumShouldRefreshActiveAnimation(Entity entity, EntityAgent entityAgent)
++	{
++		if (entity?.AnimManager?.ActiveAnimationsByAnimCode == null || entity.AnimManager.ActiveAnimationsByAnimCode.Count == 0)
++		{
++			return false;
++		}
++
++		if (!StratumHasNetworkAnimation(entity.AnimManager.ActiveAnimationsByAnimCode) || !StratumIsMovingForAnimationRefresh(entity, entityAgent))
++		{
++			return false;
++		}
++
++		long now = Environment.TickCount64;
++		long last = stratumLastActiveAnimationRefreshMs.GetOrAdd(entity.EntityId, 0L);
++		if (now - last < 750)
++		{
++			return false;
++		}
++
++		stratumLastActiveAnimationRefreshMs[entity.EntityId] = now;
++		return true;
++	}
++
++	private bool StratumShouldSuppressEmptyLocomotionPacket(Entity entity, EntityAgent entityAgent)
++	{
++		if (entity == null || !stratumLastLocomotionAnimationMs.TryGetValue(entity.EntityId, out long lastLocomotionMs))
++		{
++			return false;
++		}
++
++		long ageMs = Environment.TickCount64 - lastLocomotionMs;
++		if (ageMs > 1500)
++		{
++			return false;
++		}
++
++		return StratumIsMovingForAnimationRefresh(entity, entityAgent) || ageMs < 500;
++	}
++
++	private static bool StratumHasActiveLocomotionAnimation(Dictionary<string, AnimationMetaData> activeAnimations)
++	{
++		if (activeAnimations == null || activeAnimations.Count == 0)
++		{
++			return false;
++		}
++
++		foreach (KeyValuePair<string, AnimationMetaData> animation in activeAnimations)
++		{
++			if (animation.Value?.TriggeredBy?.DefaultAnim == true)
++			{
++				continue;
++			}
++
++			string code = animation.Value?.Code ?? animation.Key;
++			if (StratumIsLocomotionAnimation(code))
++			{
++				return true;
++			}
++		}
++
++		return false;
++	}
++
++	private static bool StratumIsLocomotionAnimation(string code)
++	{
++		return string.Equals(code, "walk", StringComparison.OrdinalIgnoreCase)
++			|| string.Equals(code, "run", StringComparison.OrdinalIgnoreCase)
++			|| string.Equals(code, "swim", StringComparison.OrdinalIgnoreCase)
++			|| string.Equals(code, "crawl", StringComparison.OrdinalIgnoreCase)
++			|| string.Equals(code, "fly", StringComparison.OrdinalIgnoreCase);
++	}
++
++	private static bool StratumHasNetworkAnimation(Dictionary<string, AnimationMetaData> activeAnimations)
++	{
++		foreach (KeyValuePair<string, AnimationMetaData> animation in activeAnimations)
++		{
++			if (animation.Value?.TriggeredBy?.DefaultAnim != true)
++			{
++				return true;
++			}
++		}
++
++		return false;
++	}
++
++	private static bool StratumIsMovingForAnimationRefresh(Entity entity, EntityAgent entityAgent)
++	{
++		if (entityAgent?.Controls?.TriesToMove == true)
++		{
++			return true;
++		}
++
++		EntityPos pos = entity?.Pos;
++		return pos != null && pos.Motion.X * pos.Motion.X + pos.Motion.Z * pos.Motion.Z > 0.000001;
++	}
++
+ 	private EntityTagPacket BuildAttributesPackets(Entity entity, FastMemoryStream ms, bool debugMode, Dictionary<long, Packet_EntityAttributes> eFullUpdate, Dictionary<long, Packet_EntityAttributeUpdate> ePartialUpdate, Dictionary<long, Packet_EntityAttributes> eDebugUpdate)
+ 	{
+ 		EntityTagPacket result = null;
+ 		SyncedTreeAttribute watchedAttributes = entity.WatchedAttributes;
+ 		if (watchedAttributes.AllDirty)
+@@ -781,14 +1166,24 @@ public class PhysicsManager : LoadBalancedTask
  		return result;
  	}
  
@@ -622,7 +762,7 @@ index 2c2605d..47c3e74 100644
  			list.Clear();
  			list2.Clear();
  			list3.Clear();
-@@ -796,41 +1078,41 @@ public class PhysicsManager : LoadBalancedTask
+@@ -796,41 +1191,45 @@ public class PhysicsManager : LoadBalancedTask
  			{
  				List<Entity> list4 = client.threadedTrackedEntities[zeroBasedThreadNum];
  				foreach (Entity item in list4)
@@ -649,6 +789,10 @@ index 2c2605d..47c3e74 100644
  				{
  					list2.Add(value4);
  				}
++				if (hasAnimationPackets)
++				{
++					StratumAddTrackedAnimationPackets(client, entityAnimPackets, list2);
++				}
  			}
  			else
  			{
@@ -671,7 +815,41 @@ index 2c2605d..47c3e74 100644
  					}
  				}
  			}
-@@ -882,25 +1164,31 @@ public class PhysicsManager : LoadBalancedTask
+@@ -872,35 +1271,65 @@ public class PhysicsManager : LoadBalancedTask
+ 				AnimationsAndTagsChannel.SendPacket(item2, client.Player);
+ 			}
+ 		}
+ 	}
+ 
++	private static void StratumAddTrackedAnimationPackets(ConnectedClient client, Dictionary<long, AnimationPacket> entityAnimPackets, List<AnimationPacket> output)
++	{
++		foreach (long trackedEntity in client.TrackedEntities)
++		{
++			if (entityAnimPackets.TryGetValue(trackedEntity, out AnimationPacket packet) && !StratumContainsAnimationPacket(output, trackedEntity))
++			{
++				output.Add(packet);
++			}
++		}
++	}
++
++	private static bool StratumContainsAnimationPacket(List<AnimationPacket> packets, long entityId)
++	{
++		for (int i = 0; i < packets.Count; i++)
++		{
++			if (packets[i].entityId == entityId)
++			{
++				return true;
++			}
++		}
++
++		return false;
++	}
++
+ 	private int PrepareEntitySpawns(Entity[] spawnsToSend, List<ConnectedClient> clientList)
+ 	{
+ 		int num = MagicNum.DefaultEntityTrackingRange * MagicNum.ServerChunkSize * MagicNum.DefaultEntityTrackingRange * MagicNum.ServerChunkSize;
+ 		double[] array = positions;
+ 		int count = clientList.Count;
  		foreach (ConnectedClient client in clientList)
  		{
  			client.EntitySpawnsToSend.Clear();
@@ -705,7 +883,7 @@ index 2c2605d..47c3e74 100644
  					flag = true;
  				}
  			}
-@@ -990,11 +1278,14 @@ public class PhysicsManager : LoadBalancedTask
+@@ -990,11 +1419,14 @@ public class PhysicsManager : LoadBalancedTask
  		return ServerPackets.getEntityPositionPacket(entity.Pos, entity, 1);
  	}
  
@@ -721,7 +899,7 @@ index 2c2605d..47c3e74 100644
  		{
  			Id = 80,
  			EntityPosition = entityPosition
-@@ -1026,16 +1317,29 @@ public class PhysicsManager : LoadBalancedTask
+@@ -1026,16 +1458,29 @@ public class PhysicsManager : LoadBalancedTask
  		if (threadNumber == 0)
  		{
  			threadNumber = 1;
@@ -756,7 +934,7 @@ index 2c2605d..47c3e74 100644
  		Dictionary<long, AnimationPacket> dictionary2 = entitiesAnimPackets[threadNumber - 1];
  		dictionary.Clear();
  		dictionary2.Clear();
-@@ -1097,10 +1401,19 @@ public class PhysicsManager : LoadBalancedTask
+@@ -1097,10 +1542,19 @@ public class PhysicsManager : LoadBalancedTask
  		try
  		{
  			int num5 = -1;
@@ -776,7 +954,7 @@ index 2c2605d..47c3e74 100644
  				int num6 = (ticksToDo - num5 + 1) % 2;
  				num5 += num6;
  				bool flag2 = num5 == ticksToDo - 1;
-@@ -1108,20 +1421,113 @@ public class PhysicsManager : LoadBalancedTask
+@@ -1108,20 +1562,113 @@ public class PhysicsManager : LoadBalancedTask
  				bool forceUpdate = (num5 + currentTick) % 30 <= num6;
  				for (int j = num3; j < num4; j++)
  				{
@@ -893,7 +1071,7 @@ index 2c2605d..47c3e74 100644
  						{
  							entity.PositionTicked = true;
  						}
-@@ -1196,49 +1602,153 @@ public class PhysicsManager : LoadBalancedTask
+@@ -1196,49 +1743,153 @@ public class PhysicsManager : LoadBalancedTask
  		if (doBuildAttributes)
  		{
  			eFullUpdate = entitiesFullUpdate[0];
@@ -1054,7 +1232,7 @@ index 2c2605d..47c3e74 100644
  			SendPositionsAndAnimations(dictionary, dictionary2, 0, doBuildAttributes);
  		}
  		dictionary.Clear();
-@@ -1262,11 +1772,25 @@ public class PhysicsManager : LoadBalancedTask
+@@ -1262,11 +1913,25 @@ public class PhysicsManager : LoadBalancedTask
  
  	public void StartWorkerThread(int threadNum)
  	{

--- a/patches/VintagestoryLib/Vintagestory.Server/ServerPackets.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/ServerPackets.cs.patch
@@ -1,15 +1,22 @@
 diff --git a/VintagestoryLib/Vintagestory.Server/ServerPackets.cs b/VintagestoryLib/Vintagestory.Server/ServerPackets.cs
-index d4a0736..f1eadb8 100644
+index d4a0736..17d72b0 100644
 --- a/VintagestoryLib/Vintagestory.Server/ServerPackets.cs
 +++ b/VintagestoryLib/Vintagestory.Server/ServerPackets.cs
-@@ -1,5 +1,6 @@
+@@ -1,11 +1,13 @@
 +using System;
  using System.Collections.Generic;
  using System.IO;
  using System.Linq;
  using Vintagestory.API.Common;
  using Vintagestory.API.Common.Entities;
-@@ -238,13 +239,24 @@ public class ServerPackets
+ using Vintagestory.API.Datastructures;
++using Vintagestory.API.MathTools;
+ using Vintagestory.Common;
+ using Vintagestory.Common.Network.Packets;
+ 
+ namespace Vintagestory.Server;
+ 
+@@ -238,13 +240,24 @@ public class ServerPackets
  		};
  	}
  
@@ -37,3 +44,41 @@ index d4a0736..f1eadb8 100644
  		packet_EntityDespawn.SetDeathDamageSource(deathDamageSource);
  		packet_EntityDespawn.SetDespawnReason(despawnReason);
  		return new Packet_Server
+@@ -345,20 +358,36 @@ public class ServerPackets
+ 			}
+ 		};
+ 		if (entity is EntityAgent entityAgent)
+ 		{
+ 			packet_EntityPosition.BodyYaw = CollectibleNet.SerializeFloatPrecise(entityAgent.BodyYaw);
+-			packet_EntityPosition.Controls = entityAgent.Controls.ToInt();
++			int controls = entityAgent.Controls.ToInt();
++			if (entity is not EntityPlayer && (controls & 0x0F) == 0 && StratumHasMovementForAnimation(entityAgent, pos))
++			{
++				controls |= 1;
++			}
++			packet_EntityPosition.Controls = controls;
+ 		}
+ 		EntityControls entityControls = ((entity.SidedProperties == null) ? null : entity.GetInterface<IMountable>()?.ControllingControls);
+ 		if (entityControls != null)
+ 		{
+ 			packet_EntityPosition.MountControls = entityControls.ToInt();
+ 		}
+ 		return packet_EntityPosition;
+ 	}
+ 
++	private static bool StratumHasMovementForAnimation(EntityAgent entity, EntityPos pos)
++	{
++		Vec3d walkVector = entity.Controls?.WalkVector;
++		if (walkVector != null && (walkVector.X * walkVector.X + walkVector.Z * walkVector.Z) > 0.00000001)
++		{
++			return true;
++		}
++
++		return pos.Motion.X * pos.Motion.X + pos.Motion.Z * pos.Motion.Z > 0.00000025;
++	}
++
+ 	public static byte[] getEntityDataForClient(Entity entity, FastMemoryStream ms, BinaryWriter writer)
+ 	{
+ 		ms.Reset();
+ 		entity.ToBytes(writer, forClient: true);
+ 		return ms.ToArray();

--- a/patches/VintagestoryLib/Vintagestory.Server/ServerSystemEntitySimulation.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/ServerSystemEntitySimulation.cs.patch
@@ -1,5 +1,5 @@
 diff --git a/VintagestoryLib/Vintagestory.Server/ServerSystemEntitySimulation.cs b/VintagestoryLib/Vintagestory.Server/ServerSystemEntitySimulation.cs
-index 750557a..1cb12a5 100644
+index 750557a..f063a48 100644
 --- a/VintagestoryLib/Vintagestory.Server/ServerSystemEntitySimulation.cs
 +++ b/VintagestoryLib/Vintagestory.Server/ServerSystemEntitySimulation.cs
 @@ -1,8 +1,11 @@
@@ -144,20 +144,48 @@ index 750557a..1cb12a5 100644
  	private void EventManager_OnGameWorldBeingSaved()
  	{
  		if (server.RunPhase != EnumServerRunPhase.Shutdown)
-@@ -77,66 +165,152 @@ public class ServerSystemEntitySimulation : ServerSystem
- 	}
- 
- 	public override void OnBeginModsAndConfigReady()
- 	{
- 		server.EventManager.OnPlayerRespawn += OnPlayerRespawn;
--		new ShapeTesselatorManager(server).LoadEntityShapes(server.EntityTypes, server.api);
+@@ -82,61 +170,181 @@ public class ServerSystemEntitySimulation : ServerSystem
+ 		new ShapeTesselatorManager(server).LoadEntityShapes(server.EntityTypes, server.api);
  	}
  
  	public override void OnPlayerJoin(ServerPlayer player)
  	{
++		// Stratum: reconnect player animators after restoring vanilla server shape loading.
++		StratumEnsurePlayerAnimator(player?.Entity);
  		physicsManager.ForceClientUpdateTick(player.client);
  	}
  
++	private void StratumEnsurePlayerAnimator(EntityPlayer entity)
++	{
++		if (entity?.AnimManager == null || entity.AnimManager.Animator != null || entity.Properties?.Client == null)
++		{
++			return;
++		}
++
++		EntityClientProperties client = entity.Properties.Client;
++		if (client.LoadedShapeForEntity == null)
++		{
++			foreach (EntityProperties type in server.EntityTypes)
++			{
++				if (type?.Code != null && type.Code.Equals(entity.Properties.Code))
++				{
++					client.LoadedShape = type.Client?.LoadedShape;
++					client.LoadedAlternateShapes = type.Client?.LoadedAlternateShapes;
++					break;
++				}
++			}
++
++			client.DetermineLoadedShape(entity.EntityId);
++		}
++
++		if (client.LoadedShapeForEntity == null)
++		{
++			return;
++		}
++
++		entity.AnimManager.LoadAnimator(server.api, entity, client.LoadedShapeForEntity, entity.AnimManager.Animator?.Animations, entity.requirePosesOnServer, null, "head");
++	}
++
  	public override void OnPlayerDisconnect(ServerPlayer player)
  	{
  		physicsManager.ForceClientUpdateTick(player.client);
@@ -317,7 +345,7 @@ index 750557a..1cb12a5 100644
  		SendEntityDespawns();
  		int count = server.DelayedSpawnQueue.Count;
  		if (count <= 0)
-@@ -185,19 +359,145 @@ public class ServerSystemEntitySimulation : ServerSystem
+@@ -185,19 +393,145 @@ public class ServerSystemEntitySimulation : ServerSystem
  		}
  	}
  
@@ -466,7 +494,7 @@ index 750557a..1cb12a5 100644
  				{
  					if (value is EntityPlayer entityPlayer)
  					{
-@@ -209,12 +509,17 @@ public class ServerSystemEntitySimulation : ServerSystem
+@@ -209,12 +543,17 @@ public class ServerSystemEntitySimulation : ServerSystem
  						ServerMain.Logger.Warning("Exception while ticking entity {0} ({1}) at {2}: ", value.GetName(), value.Properties?.Class, value.Pos);
  						ServerMain.Logger.Error(e);
  					}
@@ -484,7 +512,7 @@ index 750557a..1cb12a5 100644
  		}
  		ServerMain.FrameProfiler.Enter("despawning");
  		foreach (KeyValuePair<Entity, EntityDespawnData> item in list)
-@@ -222,27 +527,553 @@ public class ServerSystemEntitySimulation : ServerSystem
+@@ -222,27 +561,553 @@ public class ServerSystemEntitySimulation : ServerSystem
  			server.DespawnEntity(item.Key, item.Value);
  			ServerMain.FrameProfiler.Mark("despawned-", item.Key.Code.Path);
  		}
@@ -1042,7 +1070,7 @@ index 750557a..1cb12a5 100644
  		ItemStack itemStack = client.Player.InventoryManager?.ActiveHotbarSlot?.Itemstack;
  		float num = itemStack?.Collectible.GetAttackRange(itemStack) ?? GlobalConstants.DefaultAttackRange;
  		double x = pos.X + client.Entityplayer.LocalEyePos.X;
-@@ -390,11 +1221,20 @@ public class ServerSystemEntitySimulation : ServerSystem
+@@ -390,11 +1255,20 @@ public class ServerSystemEntitySimulation : ServerSystem
  	{
  		if (deathMessagesCache == null)
  		{
@@ -1064,7 +1092,7 @@ index 750557a..1cb12a5 100644
  			return;
  		}
  		int num = server.SaveGameData?.WorldConfiguration.GetString("playerlives", "-1").ToInt(-1) ?? (-1);
-@@ -428,10 +1268,11 @@ public class ServerSystemEntitySimulation : ServerSystem
+@@ -428,10 +1302,11 @@ public class ServerSystemEntitySimulation : ServerSystem
  			else
  			{
  				ServerMain.Logger.Audit(Lang.Get("{0} died. Death message: {1}", item.PlayerName, text));

--- a/patches/VintagestoryLib/Vintagestory.Server/ServerSystemEntitySimulation.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/ServerSystemEntitySimulation.cs.patch
@@ -1,5 +1,5 @@
 diff --git a/VintagestoryLib/Vintagestory.Server/ServerSystemEntitySimulation.cs b/VintagestoryLib/Vintagestory.Server/ServerSystemEntitySimulation.cs
-index 750557a..f063a48 100644
+index 750557a..337640d 100644
 --- a/VintagestoryLib/Vintagestory.Server/ServerSystemEntitySimulation.cs
 +++ b/VintagestoryLib/Vintagestory.Server/ServerSystemEntitySimulation.cs
 @@ -1,8 +1,11 @@
@@ -15,7 +15,7 @@ index 750557a..f063a48 100644
  using Vintagestory.API.Common.Entities;
  using Vintagestory.API.Config;
  using Vintagestory.API.Datastructures;
-@@ -22,13 +25,91 @@ public class ServerSystemEntitySimulation : ServerSystem
+@@ -22,13 +25,96 @@ public class ServerSystemEntitySimulation : ServerSystem
  
  	private Dictionary<string, List<string>> deathMessagesCache;
  
@@ -64,6 +64,10 @@ index 750557a..f063a48 100644
 +	private bool stratumHardDespawnExemptIfNamedCached;
 +	private string[] stratumHardDespawnExemptPrefixesCached = Array.Empty<string>();
 +
++	// Stratum: server animators are restored on demand for non-player entity animation callbacks/state.
++	private readonly object stratumServerAnimatorDemandLock = new object();
++	private readonly HashSet<string> stratumServerAnimatorShapeLoadedTypes = new HashSet<string>();
++
 +	// Round-robin cursor (in eligible-creature index space) so the per-tick creature budget
 +	// rotates fairly across all creatures over successive ticks.
 +	private int stratumCreatureRoundRobinCursor;
@@ -102,12 +106,13 @@ index 750557a..f063a48 100644
  	{
 +		stratumSelectionBlockFilter = StratumSelectionBlockFilter;
 +		stratumSelectionEntityFilter = StratumSelectionEntityFilter;
++		AnimationManager.StratumServerAnimatorDemand = StratumEnsureDemandedServerAnimator;
  		server.RegisterGameTickListener(UpdateEvery1000ms, 1000);
  		server.EventManager.OnGameWorldBeingSaved += EventManager_OnGameWorldBeingSaved;
  		server.RegisterGameTickListener(UpdateEvery100ms, 100);
  		server.clientAwarenessEvents[EnumClientAwarenessEvent.ChunkTransition].Add(OnPlayerLeaveChunk);
  		server.PacketHandlers[17] = HandleEntityInteraction;
-@@ -43,26 +124,33 @@ public class ServerSystemEntitySimulation : ServerSystem
+@@ -43,26 +129,33 @@ public class ServerSystemEntitySimulation : ServerSystem
  		player.Player.ItemCollectMode = packet.RuntimeSetting.ItemCollectMode;
  	}
  
@@ -144,17 +149,41 @@ index 750557a..f063a48 100644
  	private void EventManager_OnGameWorldBeingSaved()
  	{
  		if (server.RunPhase != EnumServerRunPhase.Shutdown)
-@@ -82,61 +170,181 @@ public class ServerSystemEntitySimulation : ServerSystem
- 		new ShapeTesselatorManager(server).LoadEntityShapes(server.EntityTypes, server.api);
+@@ -77,66 +170,249 @@ public class ServerSystemEntitySimulation : ServerSystem
+ 	}
+ 
+ 	public override void OnBeginModsAndConfigReady()
+ 	{
+ 		server.EventManager.OnPlayerRespawn += OnPlayerRespawn;
+-		new ShapeTesselatorManager(server).LoadEntityShapes(server.EntityTypes, server.api);
++		StratumLoadPlayerEntityShapes();
  	}
  
  	public override void OnPlayerJoin(ServerPlayer player)
  	{
-+		// Stratum: reconnect player animators after restoring vanilla server shape loading.
++		// Stratum: reconnect only player animators. Mob/global server animators remain deferred
++		// until their gameplay need and load cost are validated separately.
 +		StratumEnsurePlayerAnimator(player?.Entity);
  		physicsManager.ForceClientUpdateTick(player.client);
  	}
  
++	private void StratumLoadPlayerEntityShapes()
++	{
++		List<EntityProperties> playerTypes = new List<EntityProperties>(1);
++		foreach (EntityProperties type in server.EntityTypes)
++		{
++			if (type?.Code?.Path == "player")
++			{
++				playerTypes.Add(type);
++			}
++		}
++
++		if (playerTypes.Count > 0)
++		{
++			new ShapeTesselatorManager(server).LoadEntityShapes(playerTypes, server.api);
++		}
++	}
++
 +	private void StratumEnsurePlayerAnimator(EntityPlayer entity)
 +	{
 +		if (entity?.AnimManager == null || entity.AnimManager.Animator != null || entity.Properties?.Client == null)
@@ -162,28 +191,73 @@ index 750557a..f063a48 100644
 +			return;
 +		}
 +
-+		EntityClientProperties client = entity.Properties.Client;
-+		if (client.LoadedShapeForEntity == null)
++		lock (stratumServerAnimatorDemandLock)
 +		{
-+			foreach (EntityProperties type in server.EntityTypes)
++			if (entity.AnimManager.Animator != null || !StratumEnsureEntityShape(entity))
 +			{
-+				if (type?.Code != null && type.Code.Equals(entity.Properties.Code))
-+				{
-+					client.LoadedShape = type.Client?.LoadedShape;
-+					client.LoadedAlternateShapes = type.Client?.LoadedAlternateShapes;
-+					break;
-+				}
++				return;
 +			}
 +
-+			client.DetermineLoadedShape(entity.EntityId);
++			entity.AnimManager.LoadAnimator(server.api, entity, entity.Properties.Client.LoadedShapeForEntity, entity.AnimManager.Animator?.Animations, entity.requirePosesOnServer, null, "head");
 +		}
++	}
 +
-+		if (client.LoadedShapeForEntity == null)
++	private void StratumEnsureDemandedServerAnimator(AnimationManager manager, Entity entity, string reason)
++	{
++		if (manager == null || entity == null || entity is EntityPlayer || entity.AnimManager != manager || manager.StratumHasAnimator || entity.World?.Side != EnumAppSide.Server || entity.Properties?.Client == null)
 +		{
 +			return;
 +		}
 +
-+		entity.AnimManager.LoadAnimator(server.api, entity, client.LoadedShapeForEntity, entity.AnimManager.Animator?.Animations, entity.requirePosesOnServer, null, "head");
++		lock (stratumServerAnimatorDemandLock)
++		{
++			if (manager.StratumHasAnimator || !StratumEnsureEntityShape(entity))
++			{
++				return;
++			}
++
++			manager.LoadAnimator(server.api, entity, entity.Properties.Client.LoadedShapeForEntity, null, entity.requirePosesOnServer, null);
++		}
++	}
++
++	private bool StratumEnsureEntityShape(Entity entity)
++	{
++		EntityClientProperties client = entity.Properties?.Client;
++		if (client == null)
++		{
++			return false;
++		}
++
++		if (client.LoadedShapeForEntity != null)
++		{
++			return true;
++		}
++
++		EntityProperties entityType = null;
++		foreach (EntityProperties type in server.EntityTypes)
++		{
++			if (type?.Code != null && type.Code.Equals(entity.Properties.Code))
++			{
++				entityType = type;
++				break;
++			}
++		}
++
++		if (entityType != null)
++		{
++			string typeCode = entityType.Code.ToString();
++			if (!stratumServerAnimatorShapeLoadedTypes.Contains(typeCode))
++			{
++				new ShapeTesselatorManager(server).LoadEntityShapes(new List<EntityProperties>(1) { entityType }, server.api);
++				stratumServerAnimatorShapeLoadedTypes.Add(typeCode);
++			}
++
++			client.LoadedShape = entityType.Client?.LoadedShape;
++			client.LoadedAlternateShapes = entityType.Client?.LoadedAlternateShapes;
++		}
++
++		client.DetermineLoadedShape(entity.EntityId);
++		return client.LoadedShapeForEntity != null;
 +	}
 +
  	public override void OnPlayerDisconnect(ServerPlayer player)
@@ -345,7 +419,7 @@ index 750557a..f063a48 100644
  		SendEntityDespawns();
  		int count = server.DelayedSpawnQueue.Count;
  		if (count <= 0)
-@@ -185,19 +393,145 @@ public class ServerSystemEntitySimulation : ServerSystem
+@@ -185,19 +461,145 @@ public class ServerSystemEntitySimulation : ServerSystem
  		}
  	}
  
@@ -494,7 +568,7 @@ index 750557a..f063a48 100644
  				{
  					if (value is EntityPlayer entityPlayer)
  					{
-@@ -209,12 +543,17 @@ public class ServerSystemEntitySimulation : ServerSystem
+@@ -209,12 +611,17 @@ public class ServerSystemEntitySimulation : ServerSystem
  						ServerMain.Logger.Warning("Exception while ticking entity {0} ({1}) at {2}: ", value.GetName(), value.Properties?.Class, value.Pos);
  						ServerMain.Logger.Error(e);
  					}
@@ -512,7 +586,7 @@ index 750557a..f063a48 100644
  		}
  		ServerMain.FrameProfiler.Enter("despawning");
  		foreach (KeyValuePair<Entity, EntityDespawnData> item in list)
-@@ -222,27 +561,553 @@ public class ServerSystemEntitySimulation : ServerSystem
+@@ -222,27 +629,553 @@ public class ServerSystemEntitySimulation : ServerSystem
  			server.DespawnEntity(item.Key, item.Value);
  			ServerMain.FrameProfiler.Mark("despawned-", item.Key.Code.Path);
  		}
@@ -1050,8 +1124,7 @@ index 750557a..f063a48 100644
 +		// nearby entities just to find one by ID, then enforced range below anyway.
 +		Entity entity = server.GetEntityById(p.EntityId);
 +		if (entity == null)
- 		{
--			ServerMain.Logger.Debug("HandleEntityInteraction received from client " + client.PlayerName + " but no such entity found in his range!");
++		{
 +			ServerMain.Logger.Debug("HandleEntityInteraction received from client " + client.PlayerName + " but no such entity found!");
 +			return;
 +		}
@@ -1060,7 +1133,8 @@ index 750557a..f063a48 100644
 +		double entityDx = entity.Pos.X - playerPos.X;
 +		double entityDz = entity.Pos.Z - playerPos.Z;
 +		if (entityDx * entityDx + entityDz * entityDz > pickingRange * pickingRange)
-+		{
+ 		{
+-			ServerMain.Logger.Debug("HandleEntityInteraction received from client " + client.PlayerName + " but no such entity found in his range!");
 +			ServerMain.Logger.Debug("HandleEntityInteraction from " + client.PlayerName + " rejected: entity " + p.EntityId + " not in range!");
  			return;
  		}
@@ -1070,7 +1144,7 @@ index 750557a..f063a48 100644
  		ItemStack itemStack = client.Player.InventoryManager?.ActiveHotbarSlot?.Itemstack;
  		float num = itemStack?.Collectible.GetAttackRange(itemStack) ?? GlobalConstants.DefaultAttackRange;
  		double x = pos.X + client.Entityplayer.LocalEyePos.X;
-@@ -390,11 +1255,20 @@ public class ServerSystemEntitySimulation : ServerSystem
+@@ -390,11 +1323,20 @@ public class ServerSystemEntitySimulation : ServerSystem
  	{
  		if (deathMessagesCache == null)
  		{
@@ -1092,7 +1166,7 @@ index 750557a..f063a48 100644
  			return;
  		}
  		int num = server.SaveGameData?.WorldConfiguration.GetString("playerlives", "-1").ToInt(-1) ?? (-1);
-@@ -428,10 +1302,11 @@ public class ServerSystemEntitySimulation : ServerSystem
+@@ -428,10 +1370,11 @@ public class ServerSystemEntitySimulation : ServerSystem
  			else
  			{
  				ServerMain.Logger.Audit(Lang.Get("{0} died. Death message: {1}", item.PlayerName, text));


### PR DESCRIPTION
## Summary

Restores vanilla server side entity shape loading and reconnects player animators on join when they were initialized before loaded server shapes were available.

This fixes server side animation frame callback NRE spam during held item actions while preserving animation timing for mods that rely on authoritative animation callbacks.

It also fixes a decompiler/regeneration issue where the animation/tag network packet classes lost vanilla protobuf implicit field contracts. Without that, Stratum serialized `BulkAnimationPacket` payloads as `bytes=0`, so stock clients received empty entity animation packets and mobs slid around without animations.


## Type

- [x] Bug fix
- [x] Performance
- [ ] New feature
- [ ] Refactor or cleanup
- [ ] Docs or build

## Checklist

- [x] `.\scripts\extract-patches.sh` ran clean.
- [x] `dotnet build VintageStory.slnx -c Release` is green.
- [x] Every vanilla edit has a `// Stratum` marker.
- [x] No vanilla source committed.
- [x] Tested on a real server start, not just compilation.
- [x] Confirmed after restoring `ProtoContract(ImplicitFields = ImplicitFields.AllFields)`, mobs animate again on an unmodded client.

 ## Notes

  This avoids the broad `LoadEntityShapes(server.EntityTypes, server.api)` approach. Player shapes are loaded up front, while non player entity shapes/animators are loaded on
  demand when server side animation behavior requires them.


