### PR TITLE
Restore decompiled serialization metadata

### DIFF
--- a/patches/VintagestoryLib/Vintagestory.Client.NoObf/ClientSettings.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Client.NoObf/ClientSettings.cs.patch
@@ -1,0 +1,17 @@
+diff --git a/VintagestoryLib/Vintagestory.Client.NoObf/ClientSettings.cs b/VintagestoryLib/Vintagestory.Client.NoObf/ClientSettings.cs
+index 9786197..c1e2c75 100644
+--- a/VintagestoryLib/Vintagestory.Client.NoObf/ClientSettings.cs
++++ b/VintagestoryLib/Vintagestory.Client.NoObf/ClientSettings.cs
+@@ -7,11 +7,11 @@ using Vintagestory.API.Config;
+ using Vintagestory.API.MathTools;
+ using Vintagestory.Common;
+ 
+ namespace Vintagestory.Client.NoObf;
+ 
+-[JsonObject(/*Could not decode attribute arguments.*/)]
++[JsonObject(MemberSerialization.OptIn)]
+ public class ClientSettings : SettingsBase
+ {
+ 	private List<Action<string, KeyCombination>> OnKeyCombinationsUpdated = new List<Action<string, KeyCombination>>();
+ 
+ 	public static ClientSettings Inst;

--- a/patches/VintagestoryLib/Vintagestory.Client.NoObf/GltfAccessor.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Client.NoObf/GltfAccessor.cs.patch
@@ -1,0 +1,21 @@
+diff --git a/VintagestoryLib/Vintagestory.Client.NoObf/GltfAccessor.cs b/VintagestoryLib/Vintagestory.Client.NoObf/GltfAccessor.cs
+index f96ccd4..518d337 100644
+--- a/VintagestoryLib/Vintagestory.Client.NoObf/GltfAccessor.cs
++++ b/VintagestoryLib/Vintagestory.Client.NoObf/GltfAccessor.cs
+@@ -12,14 +12,14 @@ public class GltfAccessor
+ 	public VertexAttribPointerType ComponentType { get; set; }
+ 
+ 	[JsonProperty("count")]
+ 	public int Count { get; set; }
+ 
+-	[JsonProperty(/*Could not decode attribute arguments.*/)]
++	[JsonProperty("max", NullValueHandling = NullValueHandling.Ignore)]
+ 	public double[] Max { get; set; }
+ 
+-	[JsonProperty(/*Could not decode attribute arguments.*/)]
++	[JsonProperty("min", NullValueHandling = NullValueHandling.Ignore)]
+ 	public double[] Min { get; set; }
+ 
+ 	[JsonProperty("type")]
+ 	public EnumGltfAccessorType Type { get; set; }
+ }

--- a/patches/VintagestoryLib/Vintagestory.Client.NoObf/GltfPbrMetallicRoughness.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Client.NoObf/GltfPbrMetallicRoughness.cs.patch
@@ -1,0 +1,16 @@
+diff --git a/VintagestoryLib/Vintagestory.Client.NoObf/GltfPbrMetallicRoughness.cs b/VintagestoryLib/Vintagestory.Client.NoObf/GltfPbrMetallicRoughness.cs
+index 7b60172..7fad2e9 100644
+--- a/VintagestoryLib/Vintagestory.Client.NoObf/GltfPbrMetallicRoughness.cs
++++ b/VintagestoryLib/Vintagestory.Client.NoObf/GltfPbrMetallicRoughness.cs
+@@ -1,10 +1,10 @@
+ using Newtonsoft.Json;
+ 
+ namespace Vintagestory.Client.NoObf;
+ 
+-[JsonObject(/*Could not decode attribute arguments.*/)]
++[JsonObject(MemberSerialization.OptIn)]
+ public class GltfPbrMetallicRoughness
+ {
+ 	[JsonProperty("baseColorTexture")]
+ 	public GltfMatTexture BaseColorTexture { get; set; }
+ 

--- a/patches/VintagestoryLib/Vintagestory.Client.NoObf/GltfType.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Client.NoObf/GltfType.cs.patch
@@ -1,0 +1,17 @@
+diff --git a/VintagestoryLib/Vintagestory.Client.NoObf/GltfType.cs b/VintagestoryLib/Vintagestory.Client.NoObf/GltfType.cs
+index 6f29f45..3401132 100644
+--- a/VintagestoryLib/Vintagestory.Client.NoObf/GltfType.cs
++++ b/VintagestoryLib/Vintagestory.Client.NoObf/GltfType.cs
+@@ -1,11 +1,11 @@
+ using Newtonsoft.Json;
+ using Vintagestory.API.Client;
+ 
+ namespace Vintagestory.Client.NoObf;
+ 
+-[JsonObject(/*Could not decode attribute arguments.*/)]
++[JsonObject(MemberSerialization.OptIn)]
+ public class GltfType
+ {
+ 	public TextureAtlasPosition[] BaseTextures { get; set; }
+ 
+ 	public TextureAtlasPosition[] PBRTextures { get; set; }

--- a/patches/VintagestoryLib/Vintagestory.Client.NoObf/MacroBase.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Client.NoObf/MacroBase.cs.patch
@@ -1,0 +1,17 @@
+diff --git a/VintagestoryLib/Vintagestory.Client.NoObf/MacroBase.cs b/VintagestoryLib/Vintagestory.Client.NoObf/MacroBase.cs
+index 2600634..4f8ddb3 100644
+--- a/VintagestoryLib/Vintagestory.Client.NoObf/MacroBase.cs
++++ b/VintagestoryLib/Vintagestory.Client.NoObf/MacroBase.cs
+@@ -2,11 +2,11 @@ using System;
+ using Newtonsoft.Json;
+ using Vintagestory.API.Client;
+ 
+ namespace Vintagestory.Client.NoObf;
+ 
+-[JsonObject(/*Could not decode attribute arguments.*/)]
++[JsonObject(MemberSerialization.OptIn)]
+ public class MacroBase : IMacroBase
+ {
+ 	[JsonProperty]
+ 	public int Index { get; set; }
+ 

--- a/patches/VintagestoryLib/Vintagestory.Common/SettingsBase.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Common/SettingsBase.cs.patch
@@ -1,0 +1,17 @@
+diff --git a/VintagestoryLib/Vintagestory.Common/SettingsBase.cs b/VintagestoryLib/Vintagestory.Common/SettingsBase.cs
+index 477ca81..215024e 100644
+--- a/VintagestoryLib/Vintagestory.Common/SettingsBase.cs
++++ b/VintagestoryLib/Vintagestory.Common/SettingsBase.cs
+@@ -5,11 +5,11 @@ using System.Runtime.Serialization;
+ using Newtonsoft.Json;
+ using Vintagestory.API.Client;
+ 
+ namespace Vintagestory.Common;
+ 
+-[JsonObject(/*Could not decode attribute arguments.*/)]
++[JsonObject(MemberSerialization.OptIn)]
+ public abstract class SettingsBase : SettingsBaseNoObf, ISettings
+ {
+ 	protected bool isnewfile;
+ 
+ 	public abstract string FileName { get; }

--- a/patches/VintagestoryLib/Vintagestory.Common/StartServerArgs.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Common/StartServerArgs.cs.patch
@@ -1,8 +1,8 @@
 diff --git a/VintagestoryLib/Vintagestory.Common/StartServerArgs.cs b/VintagestoryLib/Vintagestory.Common/StartServerArgs.cs
-index 418a76c..cd2b7bb 100644
+index 418a76c..7457af5 100644
 --- a/VintagestoryLib/Vintagestory.Common/StartServerArgs.cs
 +++ b/VintagestoryLib/Vintagestory.Common/StartServerArgs.cs
-@@ -1,7 +1,9 @@
+@@ -1,13 +1,15 @@
  using System.Collections.Generic;
 +using System.Runtime.Serialization;
  using Newtonsoft.Json;
@@ -11,6 +11,13 @@ index 418a76c..cd2b7bb 100644
  using Vintagestory.API.Datastructures;
  
  namespace Vintagestory.Common;
+ 
+-[JsonObject(/*Could not decode attribute arguments.*/)]
++[JsonObject(MemberSerialization.OptIn)]
+ public class StartServerArgs
+ {
+ 	[JsonProperty]
+ 	public string Seed;
  
 @@ -49,10 +51,28 @@ public class StartServerArgs
  

--- a/patches/VintagestoryLib/Vintagestory.Server/ServerConfig.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/ServerConfig.cs.patch
@@ -1,8 +1,8 @@
 diff --git a/VintagestoryLib/Vintagestory.Server/ServerConfig.cs b/VintagestoryLib/Vintagestory.Server/ServerConfig.cs
-index 93750fa..405c556 100644
+index 93750fa..d777299 100644
 --- a/VintagestoryLib/Vintagestory.Server/ServerConfig.cs
 +++ b/VintagestoryLib/Vintagestory.Server/ServerConfig.cs
-@@ -4,10 +4,11 @@ using System.Drawing;
+@@ -4,46 +4,57 @@ using System.Drawing;
  using System.IO;
  using System.Linq;
  using System.Reflection;
@@ -14,10 +14,12 @@ index 93750fa..405c556 100644
  using Vintagestory.API.MathTools;
  using Vintagestory.API.Server;
  using Vintagestory.Common;
-@@ -16,34 +17,44 @@ using Vintagestory.Server.Network;
+ using Vintagestory.Server.Network;
+ 
  namespace Vintagestory.Server;
  
- [JsonObject(/*Could not decode attribute arguments.*/)]
+-[JsonObject(/*Could not decode attribute arguments.*/)]
++[JsonObject(MemberSerialization.OptIn)]
  public class ServerConfig : IServerConfig
  {
 +	[JsonIgnore]

--- a/patches/VintagestoryLib/Vintagestory.Server/ServerPlayerData.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/ServerPlayerData.cs.patch
@@ -1,0 +1,17 @@
+diff --git a/VintagestoryLib/Vintagestory.Server/ServerPlayerData.cs b/VintagestoryLib/Vintagestory.Server/ServerPlayerData.cs
+index 5392fb5..e585bd3 100644
+--- a/VintagestoryLib/Vintagestory.Server/ServerPlayerData.cs
++++ b/VintagestoryLib/Vintagestory.Server/ServerPlayerData.cs
+@@ -6,11 +6,11 @@ using Vintagestory.API.Server;
+ using Vintagestory.API.Util;
+ using Vintagestory.Common;
+ 
+ namespace Vintagestory.Server;
+ 
+-[JsonObject(/*Could not decode attribute arguments.*/)]
++[JsonObject(MemberSerialization.OptIn)]
+ public class ServerPlayerData : IComparable<ServerPlayerData>, IServerPlayerData
+ {
+ 	[JsonProperty]
+ 	public string PlayerUID;
+ 

--- a/patches/VintagestoryLib/Vintagestory.Server/ServerSettings.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/ServerSettings.cs.patch
@@ -1,0 +1,16 @@
+diff --git a/VintagestoryLib/Vintagestory.Server/ServerSettings.cs b/VintagestoryLib/Vintagestory.Server/ServerSettings.cs
+index f0ccce2..e835a2c 100644
+--- a/VintagestoryLib/Vintagestory.Server/ServerSettings.cs
++++ b/VintagestoryLib/Vintagestory.Server/ServerSettings.cs
+@@ -1,10 +1,10 @@
+ using Newtonsoft.Json;
+ 
+ namespace Vintagestory.Server;
+ 
+-[JsonObject(/*Could not decode attribute arguments.*/)]
++[JsonObject(MemberSerialization.OptIn)]
+ public class ServerSettings
+ {
+ 	public static ServerSettings instance = new ServerSettings();
+ 
+ 	[JsonProperty]


### PR DESCRIPTION
## Summary

Restores vanilla Newtonsoft serialization metadata that the decompiler failed to decode.

Several attributes were emitted as `/*Could not decode attribute arguments.*/`, which changed rebuilt runtime metadata from vanilla. This restores `JsonObject(MemberSerialization.OptIn)` and the missing `JsonProperty` name/null handling arguments so Stratum preserves vanilla JSON serialization behavior for settings, server config/player data, macros, and glTF metadata.


## Type

- [x] Bug fix
- [ ] Performance
- [ ] New feature
- [ ] Refactor or cleanup
- [ ] Docs or build

## Checklist

- [x] `.\scripts\extract-patches.sh` ran clean.
- [x] `dotnet build VintageStory.slnx -c Release` is green.
- [x] Every vanilla edit has a `// Stratum` marker.
- [x] No vanilla source committed.
- [x] Tested on a real server start, not just compilation.

  ## Testing

- Compared rebuilt serialization metadata against vanilla assemblies locally; `VintagestoryLib` had `0` remaining vanilla serialization metadata drift after the fix. (at least from what I found)
- Rebuilt the Linux single file server binary and windows binary.
- Ran the rebuilt Linux binary with `--stratum-refresh`; it applied the overlay and reached `Dedicated Server now running`.

