### PR TITLE
Fix spawn radius distribution bias in LocateRandomPosition

### DIFF
--- a/patches/VintagestoryLib/Vintagestory.Server/ServerMain.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/ServerMain.cs.patch
@@ -999,19 +999,6 @@ index 1017be9..bb2d35a 100644
  			SendServerIdentification(client.Player);
  			client.Entityplayer.Pos.SetFrom(entityPos);
  			SpawnEntity(client.Entityplayer);
-@@ -3814,11 +4165,11 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
- 
- 	public void LocateRandomPosition(Vec3d centerPos, float radius, int tries, ActionConsumable<BlockPos> testThisPosition, Action<BlockPos> onSearchOver)
- 	{
- 		Vec3d targetPos = centerPos.Clone();
- 		float num = (float)Math.PI * 2f * (float)rand.Value.NextDouble();
--		float num2 = GameMath.Sqrt(rand.Value.NextDouble()) * radius;
-+		float num2 = (float)rand.Value.NextDouble() * radius;
- 		targetPos.X += Math.Sin(num) * (double)num2;
- 		targetPos.Z += Math.Cos(num) * (double)num2;
- 		BlockPos asBlockPos = targetPos.AsBlockPos;
- 		if (tries <= 0)
- 		{
 @@ -3851,10 +4202,21 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  	}
  


### PR DESCRIPTION
The current patch replaces `GameMath.Sqrt(rand.Value.NextDouble()) * radius` with `(float)rand.Value.NextDouble() * radius`. This breaks uniform-area sampling over the spawn disc.

## The math

Uniform point sampling on a disc requires `r = sqrt(U) * R` where U is uniform on [0,1]. Without the sqrt, the probability density falls off as 1/r from center:

- **With sqrt (vanilla):** 50% of spawns land beyond 71% of the radius. Even spread.
- **Without sqrt (current):** 50% of spawns land within 50% of the radius. Center-biased.

## Practical impact

`LocateRandomPosition` feeds both `SpawnPlayerRandomlyAround` (first-join and delayed-join) and the CrowdSpawn feature. Players cluster near the center of the configured spawn radius instead of spreading across it. CrowdSpawn attempts to solve spawn crowding, but the broken distribution concentrates players in the same area it aims to spread them from.

## Fix

Drop the hunk. The vanilla line is correct. No Stratum marker needed since nothing changes from baseline.

## Verification

No build changes. The method signature and behavior match vanilla 1.22.3 (`ServerMain.cs`, around line 3815 in the decompiled source).