### PR TITLE
Patch GameVersion to report 1.22.3 instead of 1.22.2

### DIFF
--- a/patches/VintagestoryApi/Config/GameVersion.cs.patch
+++ b/patches/VintagestoryApi/Config/GameVersion.cs.patch
@@ -1,0 +1,13 @@
+diff --git a/VintagestoryApi/Config/GameVersion.cs b/VintagestoryApi/Config/GameVersion.cs
+index 6042bc5..a1b2c3d 100644
+--- a/VintagestoryApi/Config/GameVersion.cs
++++ b/VintagestoryApi/Config/GameVersion.cs
+@@ -38,7 +38,7 @@ namespace Vintagestory.API.Config
+         /// <summary>
+         /// Assembly Info Version number in the format: major.minor.revision-[rc/pre.subrevision]
+         /// </summary>
+-        public const string OverallVersion = OverallMajorMinor + ".2";
++        public const string OverallVersion = OverallMajorMinor + ".3"; // Stratum: upstream vsapi repo stuck at 1.22.2, compiled game ships 1.22.3
+ 
+         /// <summary>
+         /// Whether this is a stable or unstable version


### PR DESCRIPTION
## Problem

The server log reports `Game Version: v1.22.2 (Stable)` on a Stratum 1.22.3 build.

## Root cause

`forks.json` pins `VintagestoryApi` at commit `caebe5cd` ("Updated to Version 1.22.2"). This is the latest commit in the `anegostudios/vsapi` repo. Anego never pushed a 1.22.3 update to that repo. The compiled DLL on CDN has 1.22.3, but since Stratum builds from source, it picks up the stale `OverallVersion = OverallMajorMinor + ".2"` constant.

## Fix

Add a one-line patch to `Config/GameVersion.cs` that bumps the suffix from `".2"` to `".3"`, matching the CDN-distributed game binary.

## Verification

After applying, the startup log will read `Game Version: v1.22.3 (Stable)`. No behavioral change: network protocol (1.22.6), API version (1.22.0), and game assets all remain identical.

Fixes #26