### PR TITLE
Optimize DiscDepositGenerator

### DIFF
--- a/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/5.GenDeposits/Generators/DiscGenerator.cs.patch
+++ b/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/5.GenDeposits/Generators/DiscGenerator.cs.patch
@@ -1,0 +1,198 @@
+diff --git a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/5.GenDeposits/Generators/DiscGenerator.cs b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/5.GenDeposits/Generators/DiscGenerator.cs
+index 2b6633c..90ad42e 100644
+--- a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/5.GenDeposits/Generators/DiscGenerator.cs
++++ b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/5.GenDeposits/Generators/DiscGenerator.cs
+@@ -206,21 +206,56 @@ namespace Vintagestory.ServerMods
+             var rnd = new LCGRandom(Api.World.Seed);
+             absAvgQuantity = GetAbsAvgQuantity(rnd);
+         }
+ 
+ 
++        // Stratum start: 
++        // Calculates noise 20 times faster than DistortNoiseGen.Noise
++
++        const float invUintMax = 1.0f / uint.MaxValue;   // ~2.32830644e-10f
++
++        /// <summary>
++        /// Fast hash function returning 0-1
++        /// </summary>
++        /// <param name="x"></param>
++        /// <param name="z"></param>
++        /// <returns></returns>
++        float FastNoise(int x, int z)
++        {
++            uint hash = (uint)(x * 1619 + z * 31337);
++            hash = (hash ^ 61) ^ (hash >> 16);
++            hash *= 9;
++            hash ^= hash >> 4;
++            hash *= 0x27d4eb2d;
++            hash ^= hash >> 15;
++            return hash * invUintMax;
++        }
++
++        // Stratum end
++
++
+ 
+ 
+         public override void GenDeposit(IBlockAccessor blockAccessor, IServerChunk[] chunks, int chunkX, int chunkZ, BlockPos depoCenterPos, ref Dictionary<BlockPos, DepositVariant> subDepositsToPlace)
+         {
+             int radius = Math.Min(64, (int)Radius.nextFloat(1, DepositRand));
+             if (radius <= 0) return;
+ 
+             // Let's deform that perfect circle a bit (+/- 25%)
+-            float deform = GameMath.Clamp(DepositRand.NextFloat() - 0.5f, -0.25f, 0.25f);
+-            radiusX = radius - (int)(radius * deform);
+-            radiusZ = radius + (int)(radius * deform);
++            // Stratum start:
++
++            // Multiple minor improvements
++            // 1. Custom fast noise function
++            // 2. Variable reuse
++            // 3. One-time calculation of some division operations
++            // Testing on 10,200 generation chunks:
++            // - Total method execution time: decreased from 32.6 s to 9.1 s;
++            // - GC load: decreased from 256 MB to 198 MB.
++
++            int deformation = (int)(radius * (DepositRand.NextFloat() - 0.5f) * 0.5f);
++            radiusX = radius - deformation;
++            radiusZ = radius + deformation;
+ 
+             int baseX = chunkX * chunksize;
+             int baseZ = chunkZ * chunksize;
+ 
+             // No need to caluclate further if this deposit won't be part of this chunk
+@@ -277,10 +312,14 @@ namespace Vintagestory.ServerMods
+ 
+             float invChunkAreaSize = 1f / (chunksize * chunksize);
+             double val;
+ 
+             int posy;
++
++            Block placeblock;
++            DepositVariant[] childDeposits;
++
+             for (int posx = minx; posx < maxx; posx++)
+             {
+                 lx = posx - baseX;
+                 distx = posx - depoCenterPos.X;
+ 
+@@ -290,34 +329,32 @@ namespace Vintagestory.ServerMods
+                 {
+                     posy = depoCenterPos.Y;
+                     lz = posz - baseZ;
+                     distz = posz - depoCenterPos.Z;
+ 
+-
+-                    // Kinda weird mathematically speaking, but seems to work as a means to distort the perfect circleness of deposits ¯\_(ツ)_/¯
+-                    // Also not very efficient to use direct perlin noise in here :/
+-                    // But after ~10 hours of failing (=weird lines of missing deposit material) with a pre-generated 2d distortion map i give up >.>
+-                    val = 1 - (radius > 3 ? DistortNoiseGen.Noise(posx / 3.0, posz / 3.0) * 0.2 : 0);
++                    val = 1 - (radius > 3 ? (FastNoise(posx, posz) * 0.2f) : 0); // Stratum: our noise function for disc edges
+                     double distanceToEdge = val - (xSq + distz * distz * zRadSqInv);
+                     if (distanceToEdge < 0) continue;
+ 
+                     targetPos.Set(posx, posy, posz);
+                     loadYPosAndThickness(heremapchunk, lx, lz, targetPos, distanceToEdge);
+                     posy = targetPos.Y;
+                     if (posy >= worldheight) continue;
+ 
++                    int posyChunksizeMod = posy % chunksize;
++                    int posyChunksizeDiv = posy / chunksize;
+ 
+                     // Some deposits may not appear all over cliffs
+                     if (Math.Abs(depoCenterPos.Y - posy) > MaxYRoughness) continue;
+ 
+ 
+                     for (int y = 0; y < hereThickness; y++)
+                     {
+                         if (posy <= 1) continue;
+ 
+-                        int index3d = ((posy % chunksize) * chunksize + lz) * chunksize + lx;
+-                        int blockId = chunks[posy / chunksize].Data.GetBlockIdUnsafe(index3d);
++                        int index3d = ((posyChunksizeMod) * chunksize + lz) * chunksize + lx;
++                        int blockId = chunks[posyChunksizeDiv].Data.GetBlockIdUnsafe(index3d);
+ 
+ 
+                         if (!IgnoreParentTestPerBlock || !parentBlockOk)
+                         {
+                             parentBlockOk = placeBlockByInBlockId.TryGetValue(blockId, out resolvedPlaceBlock);
+@@ -325,37 +362,37 @@ namespace Vintagestory.ServerMods
+ 
+                         if (parentBlockOk && resolvedPlaceBlock.Blocks.Length > 0)
+                         {
+                             int gradeIndex = Math.Min(resolvedPlaceBlock.Blocks.Length - 1, depositGradeIndex);
+ 
+-                            Block placeblock = resolvedPlaceBlock.Blocks[gradeIndex];
++                            placeblock = resolvedPlaceBlock.Blocks[gradeIndex];
+ 
+-                            if (variant.WithBlockCallback || (WithLastLayerBlockCallback && y == hereThickness-1))
++                            if (variant.WithBlockCallback || (WithLastLayerBlockCallback && y == hereThickness - 1))
+                             {
+                                 targetPos.Y = posy;
+                                 placeblock.TryPlaceBlockForWorldGen(blockAccessor, targetPos, BlockFacing.UP, DepositRand);
+                             }
+                             else
+                             {
+-                                IChunkBlocks chunkdata = chunks[posy / chunksize].Data;
++                                IChunkBlocks chunkdata = chunks[posyChunksizeDiv].Data;
+                                 chunkdata.SetBlockUnsafe(index3d, placeblock.BlockId);
+                                 chunkdata.SetFluid(index3d, 0);
+                             }
+ 
+-                            DepositVariant[] childDeposits = variant.ChildDeposits;
++                            childDeposits = variant.ChildDeposits;
+                             if (childDeposits != null)
+                             {
+-                                for (int i = 0; i < childDeposits.Length; i++)
++                                foreach (var deposit in childDeposits)
+                                 {
+                                     float rndVal = DepositRand.NextFloat();
+-                                    float quantity = childDeposits[i].TriesPerChunk * invChunkAreaSize;
++                                    float quantity = deposit.TriesPerChunk * invChunkAreaSize;
+ 
+                                     if (quantity > rndVal)
+                                     {
+-                                        if (ShouldPlaceAdjustedForOreMap(childDeposits[i], posx, posz, quantity, rndVal))
++                                        if (ShouldPlaceAdjustedForOreMap(deposit, posx, posz, quantity, rndVal))
+                                         {
+-                                            subDepositsToPlace[new BlockPos(posx, posy, posz)] = childDeposits[i];
++                                            subDepositsToPlace[new BlockPos(posx, posy, posz)] = deposit;
+                                         }
+                                     }
+                                 }
+                             }
+ 
+@@ -383,10 +420,12 @@ namespace Vintagestory.ServerMods
+ 
+                         posy--;
+                     }
+                 }
+             }
++
++            // Stratum end
+         }
+ 
+         protected virtual bool shouldGenDepositHere(BlockPos depoCenterPos)
+         {
+             return true;
+@@ -404,12 +443,17 @@ namespace Vintagestory.ServerMods
+             int rdx = (pos.X / chunksize) % regionChunkSize;
+             int rdz = (pos.Z / chunksize) % regionChunkSize;
+ 
+ 
+             IMapRegion reg = heremapchunk.MapRegion;
+-            float yOffTop = reg.OreMapVerticalDistortTop.GetIntLerpedCorrectly(rdx * step + step * ((float)lx / chunksize), rdz * step + step * ((float)lz / chunksize)) - 20;
+-            float yOffBot = reg.OreMapVerticalDistortBottom.GetIntLerpedCorrectly(rdx * step + step * ((float)lx / chunksize), rdz * step + step * ((float)lz / chunksize)) - 20;
++            // Stratum start: repetitive calculations and step are moved out of parentheses for optimization
++            var numx = step * (rdx + ((float)lx / chunksize));
++            var numz = step * (rdz + ((float)lz / chunksize));
++
++            float yOffTop = reg.OreMapVerticalDistortTop.GetIntLerpedCorrectly(numx, numz) - 20;
++            float yOffBot = reg.OreMapVerticalDistortBottom.GetIntLerpedCorrectly(numx, numz) - 20;
++            // Stratum end
+ 
+             float yRel = (float)pos.Y / worldheight;
+             return yOffBot * (1 - yRel) + yOffTop * yRel;
+ 
+         }

--- a/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/5.GenDeposits/Generators/DiscGenerator.cs.patch
+++ b/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/5.GenDeposits/Generators/DiscGenerator.cs.patch
@@ -1,5 +1,5 @@
 diff --git a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/5.GenDeposits/Generators/DiscGenerator.cs b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/5.GenDeposits/Generators/DiscGenerator.cs
-index 2b6633c..90ad42e 100644
+index 2b6633c..3e511cb 100644
 --- a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/5.GenDeposits/Generators/DiscGenerator.cs
 +++ b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/5.GenDeposits/Generators/DiscGenerator.cs
 @@ -206,21 +206,56 @@ namespace Vintagestory.ServerMods
@@ -77,7 +77,7 @@ index 2b6633c..90ad42e 100644
                  lx = posx - baseX;
                  distx = posx - depoCenterPos.X;
  
-@@ -290,34 +329,32 @@ namespace Vintagestory.ServerMods
+@@ -290,34 +329,31 @@ namespace Vintagestory.ServerMods
                  {
                      posy = depoCenterPos.Y;
                      lz = posz - baseZ;
@@ -97,19 +97,21 @@ index 2b6633c..90ad42e 100644
                      posy = targetPos.Y;
                      if (posy >= worldheight) continue;
  
-+                    int posyChunksizeMod = posy % chunksize;
-+                    int posyChunksizeDiv = posy / chunksize;
- 
+-
                      // Some deposits may not appear all over cliffs
                      if (Math.Abs(depoCenterPos.Y - posy) > MaxYRoughness) continue;
- 
- 
+-
+-
++                    
                      for (int y = 0; y < hereThickness; y++)
                      {
                          if (posy <= 1) continue;
  
 -                        int index3d = ((posy % chunksize) * chunksize + lz) * chunksize + lx;
 -                        int blockId = chunks[posy / chunksize].Data.GetBlockIdUnsafe(index3d);
++                        int posyChunksizeMod = posy % chunksize;
++                        int posyChunksizeDiv = posy / chunksize;
++
 +                        int index3d = ((posyChunksizeMod) * chunksize + lz) * chunksize + lx;
 +                        int blockId = chunks[posyChunksizeDiv].Data.GetBlockIdUnsafe(index3d);
  
@@ -117,7 +119,7 @@ index 2b6633c..90ad42e 100644
                          if (!IgnoreParentTestPerBlock || !parentBlockOk)
                          {
                              parentBlockOk = placeBlockByInBlockId.TryGetValue(blockId, out resolvedPlaceBlock);
-@@ -325,37 +362,37 @@ namespace Vintagestory.ServerMods
+@@ -325,37 +361,37 @@ namespace Vintagestory.ServerMods
  
                          if (parentBlockOk && resolvedPlaceBlock.Blocks.Length > 0)
                          {
@@ -163,7 +165,7 @@ index 2b6633c..90ad42e 100644
                                  }
                              }
  
-@@ -383,10 +420,12 @@ namespace Vintagestory.ServerMods
+@@ -383,10 +419,12 @@ namespace Vintagestory.ServerMods
  
                          posy--;
                      }
@@ -176,7 +178,7 @@ index 2b6633c..90ad42e 100644
          protected virtual bool shouldGenDepositHere(BlockPos depoCenterPos)
          {
              return true;
-@@ -404,12 +443,17 @@ namespace Vintagestory.ServerMods
+@@ -404,12 +442,17 @@ namespace Vintagestory.ServerMods
              int rdx = (pos.X / chunksize) % regionChunkSize;
              int rdz = (pos.Z / chunksize) % regionChunkSize;
  


### PR DESCRIPTION
## Summary

As noted in the source code, using Perlin noise to impart non-uniformity to ore deposits is quite excessive (and slow). I propose replacing it with a faster hash function that also produces smooth noise values ​​from 0 to 1, but is calculated instantly. Visually, the ore deposits are barely distinguishable from the original ones. You can also mix in a world seed for greater uniqueness, if needed.
During testing, I regenerated chunks around me with the command **/wgen regen 10**. 

A comparison of several points produced by noise generators. The blue dots indicate the curve from the source code. The orange color is the curve of the function I proposed.
<img width="1066" height="277" alt="image" src="https://github.com/user-attachments/assets/e2a9a2be-8ceb-4f3b-8332-bb2310676dfc" />

Generation comparison. [Block Overlay](https://mods.vintagestory.at/xray) mod was used to view ores.



A refined implementation of this [PR](https://github.com/anegostudios/vssurvivalmod/pull/170)



## Type

- [ ] Bug fix
- [x] Performance
- [ ] New feature
- [ ] Refactor or cleanup
- [ ] Docs or build

## Checklist

- [x] `.\scripts\extract-patches.ps1` ran clean.
- [x] `dotnet build VintageStory.slnx -c Release` is green.
- [x] Every vanilla edit has a `// Stratum` marker.
- [x] No vanilla source committed.
- [x] Tested on a real server start, not just compilation.

## Performance numbers

Testing on 10,200 generation chunks:
- Total method execution time: decreased from 32.6 s to 9.1 s;
 - GC load: decreased from 256 MB to 198 MB.
 
Total chunk generation time decreased from 2m 20s to 2m 12s (-5.7%).

**Before**
<img width="785" height="773" alt="disc before trace" src="https://github.com/user-attachments/assets/f689e3fa-c9c7-4497-b36a-0a018b2b5933" />
<img width="1436" height="459" alt="disc before mem" src="https://github.com/user-attachments/assets/95d6c1a5-aa19-453a-abe3-20553b673ca3" />
<img width="1920" height="1017" alt="1  before" src="https://github.com/user-attachments/assets/bf6bb73e-985c-4e9d-acd6-13b7624c230a" />
<img width="1920" height="1017" alt="2 before" src="https://github.com/user-attachments/assets/b736eecf-d8c1-4540-836b-8101970047bd" />
<img width="1920" height="1017" alt="3  before" src="https://github.com/user-attachments/assets/6674f17e-99ed-48c4-a8d0-6661a59ae737" />


**After**
<img width="729" height="674" alt="disc after trace" src="https://github.com/user-attachments/assets/ecaa78ec-d431-4f66-b6fe-d1c6a106a4e2" />
<img width="1453" height="480" alt="disc after nen" src="https://github.com/user-attachments/assets/e0a3d415-3704-43bb-b689-2cf878291978" />
<img width="1920" height="1017" alt="1 after" src="https://github.com/user-attachments/assets/c5c10f97-0224-41b1-96af-b030f0371ef3" />
<img width="1920" height="1017" alt="2 after" src="https://github.com/user-attachments/assets/102656f8-4da6-4b94-9619-eb78d5ed14ac" />
<img width="1920" height="1017" alt="3 after" src="https://github.com/user-attachments/assets/d026eadf-d38e-4d0e-aae3-9b6d7b99983b" />

