### PR TITLE
Fix block break guard false kicks on fast tool breaks

### DIFF
--- a/sources/VintagestoryLib/Vintagestory.Server/StratumBlockBreakGuard.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumBlockBreakGuard.cs
@@ -27,11 +27,27 @@ internal sealed class StratumBlockBreakGuard
 		}
 
 		BlockSelection selection = player.CurrentBlockSelection;
-		if (!player.Entity.Controls.LeftMouseDown || selection?.Position == null)
+		if (!player.Entity.Controls.LeftMouseDown)
 		{
 			ParkBreak(player.ClientId, server.ElapsedMilliseconds);
 			return;
 		}
+
+		// Stratum start: record left-click hold even when raytrace misses
+		long now = server.ElapsedMilliseconds;
+		if (selection?.Position == null)
+		{
+			lock (gate)
+			{
+				ClientBreakState state = GetOrCreateState(player.ClientId);
+				if (state.LeftMouseHeldSinceMs == 0)
+				{
+					state.LeftMouseHeldSinceMs = now;
+				}
+			}
+			return;
+		}
+		// Stratum end
 
 		Block block = GetBreakBlock(server, selection.Position);
 		if (block == null || block.Id == 0)
@@ -45,7 +61,6 @@ internal sealed class StratumBlockBreakGuard
 		float resistance = Math.Max(0f, block.GetResistance(server.BlockAccessor, selection.Position));
 		float damagePerSecond = CalculateDamagePerSecond(server, player, selection, block, activeSlot);
 		float damage = Math.Max(0f, dt) * damagePerSecond;
-		long now = server.ElapsedMilliseconds;
 
 		lock (gate)
 		{
@@ -57,6 +72,10 @@ internal sealed class StratumBlockBreakGuard
 				state.Start(selection.Position, block.Id, now, config);
 			}
 
+			if (state.LeftMouseHeldSinceMs == 0)
+			{
+				state.LeftMouseHeldSinceMs = now;
+			}
 			state.RequiredResistance = resistance;
 			state.DamagePerSecond = damagePerSecond;
 			state.ObservedDamage += damage;
@@ -109,7 +128,19 @@ internal sealed class StratumBlockBreakGuard
 			}
 			else if (!hasTrackedProgress && rememberedDamage <= 0f)
 			{
-				reason = $"no tracked mining progress for {requestedSelection.Position}";
+				// Stratum start: validate using left-click hold duration
+				// When the server raytrace misses the target block (grass cover, fluid
+				// layer, position sync lag), ObserveMining records the hold start but
+				// accumulates no damage. Use that hold duration as proof of mining intent.
+				float ratio = Math.Max(0.1f, Math.Min(1f, config.RequiredProgressRatio));
+				float requiredSeconds = expectedBreakSeconds * ratio;
+				float heldSeconds = state.LeftMouseHeldSinceMs > 0 ? (now - state.LeftMouseHeldSinceMs) / 1000f : 0f;
+				float heldWithGrace = heldSeconds + Math.Max(0f, config.GraceSeconds);
+				if (heldWithGrace < requiredSeconds)
+				{
+					reason = $"no tracked mining progress for {requestedSelection.Position}";
+				}
+				// Stratum end
 			}
 			else
 			{
@@ -191,6 +222,7 @@ internal sealed class StratumBlockBreakGuard
 			if (clients.TryGetValue(clientId, out ClientBreakState state))
 			{
 				state.ParkCurrent(nowMs, StratumRuntime.Config.BlockBreakGuards);
+				state.LeftMouseHeldSinceMs = 0;
 			}
 		}
 	}
@@ -276,6 +308,8 @@ internal sealed class StratumBlockBreakGuard
 		public float ObservedDamage { get; set; }
 
 		public long LastObservedMs { get; set; }
+
+		public long LeftMouseHeldSinceMs { get; set; } // Stratum: tracks when left-click started regardless of raytrace
 
 		public int ViolationsInWindow { get; private set; }
 


### PR DESCRIPTION
The block break guard kicks players mining soft blocks with fast tools. The guard calculates mining speed correctly (it calls GetMiningSpeed which walks all CollectibleBehaviors, including quenching and mod-injected bonuses like XSkills quality). The problem is not in speed calculation but in the tracking mechanism that validates the break.

ObserveMining runs every 20ms and uses the server raytrace (player.CurrentBlockSelection) to identify the target block. When the server raytrace disagrees with what the client targets (grass cover on clay deposits, fluid layer priority, position sync lag during movement), the guard accumulates zero ticks for the entire break duration. It rejects with "no tracked mining progress" because it never observed the player mine THAT specific block at THAT position. Three rejections in 10 seconds triggers a kick.

This happens regardless of whether speed bonuses exist. But fast tools make it worse: shorter break durations leave fewer ticks for the raytrace to align, and the old MinimumTrackedBreakSeconds threshold (150ms) only exempted sub-150ms breaks.

The fix tracks when the player started holding left-click, independent of whether the raytrace resolves a valid target. When TryAcceptBreak finds no tracked progress, it validates the elapsed hold duration: did the player hold left-click for at least (expectedBreakSeconds * RequiredProgressRatio - GraceSeconds)? The expectedBreakSeconds calculation uses the full GetMiningSpeed result, which includes quenching, XSkills, and any other CollectibleBehavior that modifies mining speed.

For the reported case: clay resistance is 4, steel shovel + quenching mines at 7.7 dps, expected break time is 519ms. The player holds left-click for that full duration. The check sees 519ms held + 250ms grace = 769ms >= 415ms required. The break passes.

With XSkills quality bonuses stacked on top (e.g. +20% from quality 10), dps rises to 9.24 and expected break time drops to 433ms. The check still works: 433ms held + 250ms grace = 683ms >= 346ms required.

A speed hack that sends the break packet without holding left-click fails because LeftMouseHeldSinceMs stays at zero (no server tick observed LeftMouseDown). The grace alone (250ms) cannot cover the required duration (415ms for clay, higher for harder blocks).

Fixes #29