### PR TITLE
Add config toggles for connection chat messages

### DIFF
--- a/patches/VintagestoryLib/Vintagestory.Server/ServerMain.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/ServerMain.cs.patch
@@ -79,7 +79,10 @@ index 1017be9..bb2d35a 100644
  		client.State = EnumClientState.Connected;
  		client.MillisecsAtConnect = totalUnpausedTime.ElapsedMilliseconds;
 -		joinLeaveDeathMessage(Lang.Get("player-joined", player.PlayerName), EnumChatType.JoinLeave, player);
-+		joinLeaveDeathMessage(StratumServerTheme.PlayerJoined(player.PlayerName) ?? Lang.Get("player-joined", player.PlayerName), EnumChatType.JoinLeave, player);
++		if (StratumRuntime.Config.Chat.ShowJoinMessages)
++		{
++			joinLeaveDeathMessage(StratumServerTheme.PlayerJoined(player.PlayerName) ?? Lang.Get("player-joined", player.PlayerName), EnumChatType.JoinLeave, player);
++		}
  		Logger.Event($"{player.PlayerName} {client.Socket.RemoteEndPoint()} joins.");
  		string text = Config.WelcomeMessage.Replace("{playername}", "{0}");
  		string message;
@@ -532,7 +535,11 @@ index 1017be9..bb2d35a 100644
 -				Logger.Event(othersKickmessage);
 +				string logMessage = ((originalOthersKickMessage != null) ? string.Format(Lang.Get("Player {0} got removed. Reason: {1}", playerName, originalOthersKickMessage), default(ReadOnlySpan<object>)) : string.Format(Lang.Get("Player {0} left.", playerName), default(ReadOnlySpan<object>)));
 +				string themedMessage = originalOthersKickMessage != null ? StratumServerTheme.PlayerRemoved(playerName, originalOthersKickMessage) : StratumServerTheme.PlayerLeft(playerName);
-+				joinLeaveDeathMessage(themedMessage ?? logMessage, EnumChatType.JoinLeave, player);
++				bool showMessage = originalOthersKickMessage != null ? StratumRuntime.Config.Chat.ShowDisconnectMessages : StratumRuntime.Config.Chat.ShowLeaveMessages; // Stratum: connection message toggles
++				if (showMessage)
++				{
++					joinLeaveDeathMessage(themedMessage ?? logMessage, EnumChatType.JoinLeave, player);
++				}
 +				Logger.Event(logMessage);
  			}
  			client.CloseConnection();

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumConfig.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumConfig.cs
@@ -1646,6 +1646,14 @@ internal class StratumChatConfig
 
 	public bool LinkifyUrls { get; set; } = true;
 
+	// Stratum start: connection message toggles
+	public bool ShowJoinMessages { get; set; } = true;
+
+	public bool ShowLeaveMessages { get; set; } = true;
+
+	public bool ShowDisconnectMessages { get; set; } = true;
+	// Stratum end
+
 	// Minimum milliseconds between consecutive non-command chat lines from the same client.
 	// Messages sent faster than this are silently dropped server-side.
 	public int MinIntervalMs { get; set; } = 750;


### PR DESCRIPTION
Three new booleans in the Chat config section let server admins suppress join, leave, and disconnect/kick messages from public chat. ShowJoinMessages, ShowLeaveMessages, and ShowDisconnectMessages all default to true so nothing changes on upgrade.

The server log (Logger.Event) still records every connection event. Suppressing only affects what players see in chat. Useful for servers that restart often, run events with high player churn, or want quieter general chat during peak hours.

The issue also asked about routing messages to a separate chat tab. The built-in ServerInfoChatGroup (-1) only renders for players with controlserver privilege, so routing there would hide messages from normal players without feedback. Leaving that for a follow-up if there is a workable approach.

Closes #17