### PR TITLE
Add /stratum pathfinding report command

### DIFF
--- a/patches/VSEssentials/Entity/Pathfinding/PathfindingAsync.cs.patch
+++ b/patches/VSEssentials/Entity/Pathfinding/PathfindingAsync.cs.patch
@@ -370,6 +370,19 @@ index 48a886b..7b443ba 100644
 +            task.Finished = true;
 +        }
 +
++        // Stratum: expose queue metrics for /stratum pathfinding.
++        public string StratumBuildReport()
++        {
++            return string.Join("\n",
++                "Workers=" + (1 + stratumExtraWorkers.Count),
++                "Queue=" + PathfinderTasks.Count + "/" + (stratumMaxQueued > 0 ? stratumMaxQueued.ToString() : "unlimited"),
++                "Priority=" + (stratumPriorityEnabled ? "on threshold=" + stratumPriorityQueueThreshold : "off"),
++                "Dropped (overflow)=" + stratumDroppedQueuedTasks,
++                "Dropped (stale)=" + stratumDroppedStaleTasks,
++                "Dropped (far)=" + stratumDroppedFarTasks,
++                "Dropped (total)=" + (stratumDroppedQueuedTasks + stratumDroppedStaleTasks + stratumDroppedFarTasks));
++        }
++
  
          public override void Dispose()
          {

--- a/sources/VintagestoryLib/Vintagestory.Server/CmdStratum.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/CmdStratum.cs
@@ -22,7 +22,7 @@ internal class CmdStratum
 		server.api.commandapi.Create(StratumInfo.Id)
 			.WithAlias("serverinfo")
 			.WithDesc("Show Stratum server information")
-			.WithArgs(server.api.commandapi.Parsers.OptionalWord("status|version|update|health|reload|preflight|packets|performance|perf|timings|players|player|chunks|entities|queues|violations|access|chat|pregen|get|set|save"), server.api.commandapi.Parsers.OptionalWord("argument"), server.api.commandapi.Parsers.OptionalWord("detail"), server.api.commandapi.Parsers.OptionalWord("value1"), server.api.commandapi.Parsers.OptionalWord("value2"), server.api.commandapi.Parsers.OptionalWord("value3"), server.api.commandapi.Parsers.OptionalWord("value4"))
+			.WithArgs(server.api.commandapi.Parsers.OptionalWord("status|version|update|health|reload|preflight|packets|performance|perf|timings|players|player|chunks|entities|queues|pathfinding|violations|access|chat|pregen|get|set|save"), server.api.commandapi.Parsers.OptionalWord("argument"), server.api.commandapi.Parsers.OptionalWord("detail"), server.api.commandapi.Parsers.OptionalWord("value1"), server.api.commandapi.Parsers.OptionalWord("value2"), server.api.commandapi.Parsers.OptionalWord("value3"), server.api.commandapi.Parsers.OptionalWord("value4"))
 			.RequiresPrivilege(Privilege.controlserver)
 			.HandleWith(HandleStratum);
 	}
@@ -100,6 +100,11 @@ internal class CmdStratum
 			return HandleQueues();
 		}
 
+		if (string.Equals(action, "pathfinding", StringComparison.OrdinalIgnoreCase))
+		{
+			return HandlePathfinding();
+		}
+
 		if (string.Equals(action, "performance", StringComparison.OrdinalIgnoreCase) || string.Equals(action, "perf", StringComparison.OrdinalIgnoreCase))
 		{
 			return HandlePerformance();
@@ -127,7 +132,7 @@ internal class CmdStratum
 
 		if (action != null && action.Length > 0 && !string.Equals(action, "status", StringComparison.OrdinalIgnoreCase))
 		{
-			return TextCommandResult.Error("Usage: /stratum [status|version|update|health|reload|preflight|packets|performance|timings|players|player|chunks|entities|queues|violations|access|chat|pregen|get|set|save]");
+			return TextCommandResult.Error("Usage: /stratum [status|version|update|health|reload|preflight|packets|performance|timings|players|player|chunks|entities|queues|pathfinding|violations|access|chat|pregen|get|set|save]");
 		}
 
 		return HandleStatus();
@@ -414,6 +419,33 @@ internal class CmdStratum
 		output.Append(StratumCommandText.Row("Chunks", "fastChunk=" + server.fastChunkQueue.Count + " requestedColumns=" + server.ChunkColumnRequested.Count + " simpleLoads=" + server.simpleLoadRequests.Count + " peeks=" + server.peekChunkColumnQueue.Count + " existsChecks=" + server.testChunkExistsQueue.Count));
 		output.Append(StratumCommandText.Row("Cleanup", "unloadedChunks=" + server.unloadedChunks.Count + " deleteColumns=" + server.deleteChunkColumns.Count + " deleteRegions=" + server.deleteMapRegions.Count));
 		output.Append(StratumCommandText.Row("Autosave smoothing", (StratumRuntime.Config.Performance.AutoSave.Enabled ? "on" : "off") + " maxDelay=" + StratumRuntime.Config.Performance.AutoSave.MaxDelaySeconds + "s"));
+		return TextCommandResult.Success(output.ToString());
+	}
+
+	private TextCommandResult HandlePathfinding()
+	{
+		var pf = server.api.ModLoader.GetModSystem("Vintagestory.Essentials.PathfindingAsync");
+		if (pf == null)
+		{
+			return TextCommandResult.Success(StratumCommandText.Title("Stratum Pathfinding") + StratumCommandText.Row("Status", "PathfindingAsync not loaded"));
+		}
+
+		var method = pf.GetType().GetMethod("StratumBuildReport");
+		if (method == null)
+		{
+			return TextCommandResult.Success(StratumCommandText.Title("Stratum Pathfinding") + StratumCommandText.Row("Status", "metrics not available"));
+		}
+
+		string report = method.Invoke(pf, null) as string ?? "";
+		StringBuilder output = new StringBuilder(StratumCommandText.Title("Stratum Pathfinding"));
+		foreach (string line in report.Split('\n'))
+		{
+			int eq = line.IndexOf('=');
+			if (eq > 0)
+			{
+				output.Append(StratumCommandText.Row(line.Substring(0, eq), line.Substring(eq + 1)));
+			}
+		}
 		return TextCommandResult.Success(output.ToString());
 	}
 


### PR DESCRIPTION
Exposes the queue metrics that PathfindingAsync already tracks but does not surface anywhere. The new /stratum pathfinding command shows worker count, current queue depth against the configured cap, priority mode state, and per-category drop counters (overflow, stale, far-entity).

The report method (StratumBuildReport) lives in the VSEssentials patch. The command handler in CmdStratum calls it via reflection since VintagestoryLib cannot reference VSEssentials at compile time. Same cross-assembly pattern that StartStratumExtraWorkers uses to read pathfinding config. Reflection cost is one invocation per admin command, zero impact on the pathfinding hot path.

Not included in this PR: solve-time tracking (needs a Stopwatch around AStar.FindPath in ProcessQueue) and queue high-water mark. Both need new instrumentation and can come as a follow-up once the baseline report is in place.

Closes #13