### PR TITLE
Add /stratum doctor pressure summary

### DIFF
--- a/sources/VintagestoryLib/Vintagestory.Server/CmdStratum.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/CmdStratum.cs
@@ -22,7 +22,7 @@ internal class CmdStratum
 		server.api.commandapi.Create(StratumInfo.Id)
 			.WithAlias("serverinfo")
 			.WithDesc("Show Stratum server information")
-			.WithArgs(server.api.commandapi.Parsers.OptionalWord("status|version|update|health|reload|preflight|packets|performance|perf|timings|players|player|chunks|entities|queues|violations|access|chat|pregen|get|set|save"), server.api.commandapi.Parsers.OptionalWord("argument"), server.api.commandapi.Parsers.OptionalWord("detail"), server.api.commandapi.Parsers.OptionalWord("value1"), server.api.commandapi.Parsers.OptionalWord("value2"), server.api.commandapi.Parsers.OptionalWord("value3"), server.api.commandapi.Parsers.OptionalWord("value4"))
+			.WithArgs(server.api.commandapi.Parsers.OptionalWord("status|version|update|health|reload|preflight|packets|performance|perf|timings|players|player|chunks|entities|queues|doctor|violations|access|chat|pregen|get|set|save"), server.api.commandapi.Parsers.OptionalWord("argument"), server.api.commandapi.Parsers.OptionalWord("detail"), server.api.commandapi.Parsers.OptionalWord("value1"), server.api.commandapi.Parsers.OptionalWord("value2"), server.api.commandapi.Parsers.OptionalWord("value3"), server.api.commandapi.Parsers.OptionalWord("value4"))
 			.RequiresPrivilege(Privilege.controlserver)
 			.HandleWith(HandleStratum);
 	}
@@ -43,6 +43,11 @@ internal class CmdStratum
 		if (string.Equals(action, "health", StringComparison.OrdinalIgnoreCase))
 		{
 			return HandleHealth();
+		}
+
+		if (string.Equals(action, "doctor", StringComparison.OrdinalIgnoreCase))
+		{
+			return HandleDoctor();
 		}
 
 		if (string.Equals(action, "version", StringComparison.OrdinalIgnoreCase) || string.Equals(action, "update", StringComparison.OrdinalIgnoreCase))
@@ -127,7 +132,7 @@ internal class CmdStratum
 
 		if (action != null && action.Length > 0 && !string.Equals(action, "status", StringComparison.OrdinalIgnoreCase))
 		{
-			return TextCommandResult.Error("Usage: /stratum [status|version|update|health|reload|preflight|packets|performance|timings|players|player|chunks|entities|queues|violations|access|chat|pregen|get|set|save]");
+			return TextCommandResult.Error("Usage: /stratum [status|version|update|health|doctor|reload|preflight|packets|performance|timings|players|player|chunks|entities|queues|violations|access|chat|pregen|get|set|save]");
 		}
 
 		return HandleStatus();
@@ -243,6 +248,106 @@ internal class CmdStratum
 		output.Append(StratumCommandText.Row("Preflight", StratumRuntime.LastPreflight.Summary));
 		output.Append(StratumCommandText.Row("Protection", "packets=" + (StratumRuntime.Config.Hardening.PacketMonitoring ? "on" : "off") + " blockBreak=" + (StratumRuntime.Config.Hardening.BlockBreakGuards ? "on" : "off") + " timings=" + (StratumRuntime.Timings.Enabled ? "running" : "stopped")));
 		output.Append(StratumCommandText.Row("Next", "/stratum queues, /stratum chunks, /stratum entities, /stratum players, /stratum violations"));
+		return TextCommandResult.Success(output.ToString());
+	}
+
+	private TextCommandResult HandleDoctor()
+	{
+		StringBuilder output = new StringBuilder(StratumCommandText.Title("Stratum Doctor"));
+
+		StatsCollection stats = server.StatsCollector[GameMath.Mod(server.StatsCollectorIndex - 1, server.StatsCollector.Length)];
+		double mspt = stats.ticksTotal > 0 ? (double)stats.tickTimeTotal / stats.ticksTotal : 0;
+		double tps = stats.ticksTotal > 0 ? (double)stats.ticksTotal / 2.0 : 0;
+		double budget = server.Config.TickTime;
+
+		// Tick: report when MSPT exceeds the configured tick budget.
+		if (budget > 0 && mspt > budget)
+		{
+			output.Append(StratumCommandText.Row("Tick", "MSPT=" + mspt.ToString("0.#") + "ms budget=" + budget + "ms TPS=" + tps.ToString("0.#") + "; inspect /stratum timings"));
+		}
+
+		// Packets: report when back-pressure deferred packets this tick.
+		var bp = StratumRuntime.PacketBackPressure.Snapshot();
+		if (bp.LastTickDeferred > 0 || bp.LastQueueDepth > 0)
+		{
+			output.Append(StratumCommandText.Row("Packets", "queue=" + bp.LastQueueDepth + " deferred=" + bp.LastTickDeferred + " peak=" + bp.PeakQueueDepth + "; inspect /stratum packets"));
+		}
+
+		// Chunks: report when the send path skipped clients due to pressure.
+		var perf = StratumRuntime.PerformanceStats.DoctorSnapshot();
+		if (perf.SkippedOutboundPressure > 0)
+		{
+			output.Append(StratumCommandText.Row("Chunk send", "skippedPressure=" + perf.SkippedOutboundPressure + " pending=" + server.ChunkColumnRequested.Count + " fastQueue=" + server.fastChunkQueue.Count + "; inspect /stratum chunks"));
+		}
+
+		// Chunk generation: report when clients had generation deferred.
+		if (perf.GenerationDeferredClients > 0)
+		{
+			output.Append(StratumCommandText.Row("Chunk gen", "deferredClients=" + perf.GenerationDeferredClients + "; inspect /stratum chunks"));
+		}
+
+		// Entities: report when throttling kicked in.
+		if (StratumRuntime.PreviousTickOverloaded || perf.EntitiesThrottled > 0)
+		{
+			output.Append(StratumCommandText.Row("Entities", "throttled=" + perf.EntitiesThrottled + " overloaded=" + StratumRuntime.PreviousTickOverloaded + "; inspect /stratum entities"));
+		}
+
+		// Block ticks: report when listeners were skipped.
+		if (perf.BlockListenersSkipped > 0)
+		{
+			output.Append(StratumCommandText.Row("Block ticks", "listenersSkipped=" + perf.BlockListenersSkipped + "; inspect /stratum perf"));
+		}
+
+		// Pathfinding: report when queue exceeds half capacity.
+		try
+		{
+			var pf = server.api.ModLoader.GetModSystem("Vintagestory.Essentials.PathfindingAsync");
+			var method = pf?.GetType().GetMethod("StratumBuildReport");
+			if (method != null)
+			{
+				string report = method.Invoke(pf, null) as string ?? "";
+				foreach (string line in report.Split('\n'))
+				{
+					if (line.StartsWith("Queue="))
+					{
+						string queueVal = line.Substring(6);
+						string[] parts = queueVal.Split('/');
+						if (parts.Length == 2 && int.TryParse(parts[0], out int depth) && int.TryParse(parts[1], out int max) && max > 0 && depth > max / 2)
+						{
+							output.Append(StratumCommandText.Row("Pathfinding", "queue=" + queueVal + "; inspect /stratum pathfinding"));
+						}
+						break;
+					}
+				}
+			}
+		}
+		catch { }
+
+		// Autosave: report when save is being delayed.
+		if (perf.AutoSaveDelayed)
+		{
+			output.Append(StratumCommandText.Row("Autosave", "delayed " + perf.AutoSaveDelaySeconds + "s; inspect /stratum perf"));
+		}
+
+		// Pregen: report when paused due to server pressure.
+		string pregenStatus = StratumRuntime.Pregen.ShortStatus;
+		if (pregenStatus == "paused")
+		{
+			output.Append(StratumCommandText.Row("Pregen", "paused; inspect /stratum pregen"));
+		}
+
+		// Join queue: report when players are waiting.
+		int connectionQueue = server.ConnectionQueue.Count;
+		if (connectionQueue > 0)
+		{
+			output.Append(StratumCommandText.Row("Join queue", connectionQueue + "/" + server.Config.MaxClientsInQueue));
+		}
+
+		if (output.Length <= StratumCommandText.Title("Stratum Doctor").Length)
+		{
+			output.Append(StratumCommandText.Row("Status", "no pressure detected"));
+		}
+
 		return TextCommandResult.Success(output.ToString());
 	}
 

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumPerformanceStats.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumPerformanceStats.cs
@@ -343,4 +343,12 @@ internal sealed class StratumPerformanceStats
 				$"  Peaks: chunksSeen={peakBlockTickChunksSeen} deferred={peakBlockTickChunksDeferred} queueAfter={peakQueuedBlockTicksAfter}";
 		}
 	}
+
+	public (bool AutoSaveDelayed, int AutoSaveDelaySeconds, int EntitiesThrottled, int SkippedOutboundPressure, int BlockListenersSkipped, int GenerationDeferredClients) DoctorSnapshot()
+	{
+		lock (gate)
+		{
+			return (lastAutoSaveWasDelayed, lastAutoSaveDelaySeconds, lastEntitiesThrottled, lastSkippedOutboundPressure, lastBlockGameTickListenersSkipped, lastGenerationDeferredClients);
+		}
+	}
 }


### PR DESCRIPTION
Single command that shows what looks bad right now during lag. Runs through each subsystem and only prints a line when that subsystem reports pressure. Each line includes the relevant /stratum sub-command to inspect next.

Checks: tick time vs configured budget, packet back-pressure (deferred count and queue depth this tick), chunk send pressure (SkippedOutboundPressure from the send path), chunk generation pressure (clients with generation deferred), entity throttle state (PreviousTickOverloaded and throttle count), block listener skips, pathfinding queue depth against its configured cap (via reflection on PathfindingAsync.StratumBuildReport, graceful no-op when unavailable or queue is uncapped), autosave delays, pregen pause state, and connection queue depth.

All thresholds are data-driven. The doctor fires on the same indicators that each subsystem uses internally to decide to throttle, skip, or defer. No hardcoded magic numbers. When no subsystem reports pressure, the output is a single "no pressure detected" line.

Adds a DoctorSnapshot() method to StratumPerformanceStats that returns the private last-tick fields the doctor needs (autosave delayed, entities throttled, skipped outbound pressure, block listeners skipped, generation deferred clients) under the existing lock.

Closes #15