### PR TITLE
Pin ilspycmd version via tool manifest

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "ilspycmd": {
+      "version": "10.1.0.8386",
+      "commands": [
+        "ilspycmd"
+      ]
+    }
+  }
+}

--- a/scripts/bootstrap.ps1
+++ b/scripts/bootstrap.ps1
@@ -112,8 +112,16 @@ try {
     }
 
     if (-not (Get-Command ilspycmd -ErrorAction SilentlyContinue)) {
-        Write-Host "Installing ilspycmd"
-        dotnet tool install -g ilspycmd | Out-Null
+        $manifest = Join-Path $PSScriptRoot "../.config/dotnet-tools.json"
+        if (Test-Path $manifest) {
+            $json = Get-Content $manifest -Raw | ConvertFrom-Json
+            $pinnedVersion = $json.tools.ilspycmd.version
+            Write-Host "Installing ilspycmd $pinnedVersion (from tool manifest)"
+            dotnet tool install -g ilspycmd --version $pinnedVersion | Out-Null
+        } else {
+            Write-Host "Installing ilspycmd (no manifest found, using latest)"
+            dotnet tool install -g ilspycmd | Out-Null
+        }
         $env:PATH += ";$env:USERPROFILE\.dotnet\tools"
     }
 

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -76,7 +76,20 @@ install_ilspycmd_if_missing() {
     return
   fi
 
-  echo "Installing ilspycmd"
+  # Install the pinned version from .config/dotnet-tools.json when available.
+  local manifest="$repo_root/.config/dotnet-tools.json"
+  if [[ -f "$manifest" ]]; then
+    local pinned_version
+    pinned_version=$(python3 -c "import json,sys;print(json.load(open(sys.argv[1]))['tools']['ilspycmd']['version'])" "$manifest" 2>/dev/null)
+    if [[ -n "$pinned_version" ]]; then
+      echo "Installing ilspycmd $pinned_version (from tool manifest)"
+      dotnet tool install -g ilspycmd --version "$pinned_version" >/dev/null
+      export PATH="$dotnet_tools:$PATH"
+      return
+    fi
+  fi
+
+  echo "Installing ilspycmd (no manifest found, using latest)"
   dotnet tool install -g ilspycmd >/dev/null
   export PATH="$dotnet_tools:$PATH"
 }


### PR DESCRIPTION
Fixes #42

Add `.config/dotnet-tools.json` pinning ilspycmd to 10.1.0.8386. Both bootstrap scripts read the pinned version from the manifest and install that exact version globally. Falls back to latest if the manifest is missing.

Without a pinned version, different ilspycmd releases produce subtly different decompiler output for the same DLL. Patches generated against one version fail to apply on machines running another. The `ClientPlatformWindows.cs` patch broke on every bootstrap using 10.0.x because of a single-character difference in an ILSpy comment (`constrained. prefix` vs `.constrained prefix`).

Tested on Linux (bash path). The PowerShell path uses the same logic via `ConvertFrom-Json` which ships with PowerShell 5.1+ on all Windows 10+ machines. Both scripts still fall back to latest when the manifest file is absent so forks that strip it keep working.