### PR TITLE
Expand timings profiler with per-type and hierarchical report

### DIFF
--- a/patches/VSEssentials/Entity/AI/AiTaskManager.cs.patch
+++ b/patches/VSEssentials/Entity/AI/AiTaskManager.cs.patch
@@ -1,5 +1,5 @@
 diff --git a/VSEssentials/Entity/AI/AiTaskManager.cs b/VSEssentials/Entity/AI/AiTaskManager.cs
-index 86955cb..c8c8c7c 100644
+index 86955cb..de8723c 100644
 --- a/VSEssentials/Entity/AI/AiTaskManager.cs
 +++ b/VSEssentials/Entity/AI/AiTaskManager.cs
 @@ -76,10 +76,21 @@ public static class AiTaskRegistry
@@ -67,8 +67,7 @@ index 86955cb..c8c8c7c 100644
 +            {
 +                tasks.Shuffle(entity.World.Rand);
 +            }
- 
--        ProcessRunningTasks(dt);
++
 +            if (StratumEntityBehaviorTimings.Enabled)
 +            {
 +                long stratumStartScanStart = StratumEntityBehaviorTimings.GetTimestamp();
@@ -86,7 +85,8 @@ index 86955cb..c8c8c7c 100644
 +                StartNewTasks();
 +            }
 +        }
-+
+ 
+-        ProcessRunningTasks(dt);
 +        if (StratumEntityBehaviorTimings.Enabled)
 +        {
 +            long stratumTaskContinueStart = StratumEntityBehaviorTimings.GetTimestamp();
@@ -139,3 +139,31 @@ index 86955cb..c8c8c7c 100644
      {
          foreach (IAiTask task in tasks)
          {
+@@ -491,16 +571,27 @@ public sealed class AiTaskManager(Entity entity)
+         {
+             IAiTask? task = activeTasksBySlot[index];
+             if (task == null) continue;
+             if (!task.CanContinueExecute()) continue;
+ 
++            // Stratum start: per-AI-task-type timing (#7)
++            long stratumTaskStart = StratumEntityBehaviorTimings.GetTimestamp();
++            // Stratum end
+             if (!task.ContinueExecute(dt))
+             {
+                 task.FinishExecute(false);
+                 OnTaskStopped?.Invoke(task);
+                 activeTasksBySlot[index] = null;
+             }
++            // Stratum start: per-AI-task-type timing (#7)
++            if (stratumTaskStart != 0L)
++            {
++                string stratumCategory = entity is EntityPlayer ? "players" : entity.IsCreature ? "creatures" : "inanimate";
++                AiTaskRegistry.TaskCodes.TryGetValue(task.GetType(), out string taskCode);
++                StratumEntityBehaviorTimings.RecordNamed("entity.ai." + stratumCategory + ".task." + (taskCode ?? "unknown"), stratumTaskStart);
++            }
++            // Stratum end
+ 
+             if (entity.World.FrameProfiler.Enabled)
+             {
+                 entity.World.FrameProfiler.Mark("task-continueexec-", AiTaskRegistry.TaskCodes[task.GetType()]);
+             }

--- a/patches/VintagestoryLib/Vintagestory.Server/ServerSystemEntitySimulation.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/ServerSystemEntitySimulation.cs.patch
@@ -1,5 +1,5 @@
 diff --git a/VintagestoryLib/Vintagestory.Server/ServerSystemEntitySimulation.cs b/VintagestoryLib/Vintagestory.Server/ServerSystemEntitySimulation.cs
-index 750557a..5265f5f 100644
+index 750557a..c899040 100644
 --- a/VintagestoryLib/Vintagestory.Server/ServerSystemEntitySimulation.cs
 +++ b/VintagestoryLib/Vintagestory.Server/ServerSystemEntitySimulation.cs
 @@ -1,8 +1,12 @@
@@ -16,7 +16,7 @@ index 750557a..5265f5f 100644
  using Vintagestory.API.Common.Entities;
  using Vintagestory.API.Config;
  using Vintagestory.API.Datastructures;
-@@ -22,13 +26,106 @@ public class ServerSystemEntitySimulation : ServerSystem
+@@ -22,13 +26,109 @@ public class ServerSystemEntitySimulation : ServerSystem
  
  	private Dictionary<string, List<string>> deathMessagesCache;
  
@@ -39,6 +39,9 @@ index 750557a..5265f5f 100644
 +	private int stratumLastPlayersTicked;
 +	private int stratumPeakRegionEntities;
 +	// Stratum end
++
++	// Stratum: cached timing bucket keys per entity code path to avoid per-tick string concat (#7)
++	private readonly ConcurrentDictionary<string, string> stratumEntityTypeTimingKeys = new ConcurrentDictionary<string, string>(StringComparer.Ordinal);
 +
 +	private List<EntityPos> stratumPlayerPositions = new List<EntityPos>();
 +
@@ -123,7 +126,7 @@ index 750557a..5265f5f 100644
  		server.RegisterGameTickListener(UpdateEvery100ms, 100);
  		server.clientAwarenessEvents[EnumClientAwarenessEvent.ChunkTransition].Add(OnPlayerLeaveChunk);
  		server.PacketHandlers[17] = HandleEntityInteraction;
-@@ -43,26 +140,33 @@ public class ServerSystemEntitySimulation : ServerSystem
+@@ -43,26 +143,33 @@ public class ServerSystemEntitySimulation : ServerSystem
  		player.Player.ItemCollectMode = packet.RuntimeSetting.ItemCollectMode;
  	}
  
@@ -160,7 +163,7 @@ index 750557a..5265f5f 100644
  	private void EventManager_OnGameWorldBeingSaved()
  	{
  		if (server.RunPhase != EnumServerRunPhase.Shutdown)
-@@ -77,66 +181,254 @@ public class ServerSystemEntitySimulation : ServerSystem
+@@ -77,66 +184,254 @@ public class ServerSystemEntitySimulation : ServerSystem
  	}
  
  	public override void OnBeginModsAndConfigReady()
@@ -435,7 +438,7 @@ index 750557a..5265f5f 100644
  		SendEntityDespawns();
  		int count = server.DelayedSpawnQueue.Count;
  		if (count <= 0)
-@@ -185,19 +477,145 @@ public class ServerSystemEntitySimulation : ServerSystem
+@@ -185,19 +480,148 @@ public class ServerSystemEntitySimulation : ServerSystem
  		}
  	}
  
@@ -564,6 +567,9 @@ index 750557a..5265f5f 100644
 +							{
 +								stratumInanimateEntityTickTicks += stratumEntityTickElapsed;
 +							}
++							// Stratum: per-entity-type timing (#7)
++							string stratumTypeKey = stratumEntityTypeTimingKeys.GetOrAdd(value.Code?.Path ?? "unknown", static k => "entity.type." + k);
++							StratumEntityBehaviorTimings.RecordNamed(stratumTypeKey, stratumEntityTickStart);
 +						}
 +					}
 +					stratumEntitiesTicked++;
@@ -584,7 +590,7 @@ index 750557a..5265f5f 100644
  				{
  					if (value is EntityPlayer entityPlayer)
  					{
-@@ -209,12 +627,17 @@ public class ServerSystemEntitySimulation : ServerSystem
+@@ -209,12 +633,17 @@ public class ServerSystemEntitySimulation : ServerSystem
  						ServerMain.Logger.Warning("Exception while ticking entity {0} ({1}) at {2}: ", value.GetName(), value.Properties?.Class, value.Pos);
  						ServerMain.Logger.Error(e);
  					}
@@ -602,7 +608,7 @@ index 750557a..5265f5f 100644
  		}
  		ServerMain.FrameProfiler.Enter("despawning");
  		foreach (KeyValuePair<Entity, EntityDespawnData> item in list)
-@@ -222,27 +645,596 @@ public class ServerSystemEntitySimulation : ServerSystem
+@@ -222,27 +651,599 @@ public class ServerSystemEntitySimulation : ServerSystem
  			server.DespawnEntity(item.Key, item.Value);
  			ServerMain.FrameProfiler.Mark("despawned-", item.Key.Code.Path);
  		}
@@ -768,6 +774,9 @@ index 750557a..5265f5f 100644
 +						long el = Stopwatch.GetTimestamp() - t0;
 +						if (isCreature) Interlocked.Add(ref creatureTicksP, el);
 +						else Interlocked.Add(ref inanimateTicksP, el);
++						// Stratum: per-entity-type timing (#7)
++						string stratumTypeKey = stratumEntityTypeTimingKeys.GetOrAdd(value.Code?.Path ?? "unknown", static k => "entity.type." + k);
++						StratumEntityBehaviorTimings.RecordNamed(stratumTypeKey, t0);
 +					}
 +					Interlocked.Increment(ref tickedP);
 +					if (isCreature) Interlocked.Increment(ref creaturesTickedP);
@@ -1203,7 +1212,7 @@ index 750557a..5265f5f 100644
  		ItemStack itemStack = client.Player.InventoryManager?.ActiveHotbarSlot?.Itemstack;
  		float num = itemStack?.Collectible.GetAttackRange(itemStack) ?? GlobalConstants.DefaultAttackRange;
  		double x = pos.X + client.Entityplayer.LocalEyePos.X;
-@@ -390,11 +1382,20 @@ public class ServerSystemEntitySimulation : ServerSystem
+@@ -390,11 +1391,20 @@ public class ServerSystemEntitySimulation : ServerSystem
  	{
  		if (deathMessagesCache == null)
  		{
@@ -1225,7 +1234,7 @@ index 750557a..5265f5f 100644
  			return;
  		}
  		int num = server.SaveGameData?.WorldConfiguration.GetString("playerlives", "-1").ToInt(-1) ?? (-1);
-@@ -428,10 +1429,11 @@ public class ServerSystemEntitySimulation : ServerSystem
+@@ -428,10 +1438,11 @@ public class ServerSystemEntitySimulation : ServerSystem
  			else
  			{
  				ServerMain.Logger.Audit(Lang.Get("{0} died. Death message: {1}", item.PlayerName, text));

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumTimings.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumTimings.cs
@@ -175,6 +175,33 @@ internal sealed class StratumTimings
 			AppendTimingRow(output, row.Name, row.Calls, row.TotalTicks, row.MaxTicks, row.LastTicks, row.SlowCalls);
 		}
 
+		// Stratum start: hierarchical % breakdown (#7)
+		long grandTotalTicks = snapshot.Sum(row => row.TotalTicks);
+		if (grandTotalTicks > 0)
+		{
+			output.Append("\nHierarchy (% of total)\n");
+			Dictionary<string, long> groups = new Dictionary<string, long>(StringComparer.Ordinal);
+			foreach (var row in snapshot)
+			{
+				int dot = row.Name.IndexOf('.');
+				string prefix = dot > 0 ? row.Name.Substring(0, dot) : row.Name;
+				if (!groups.TryGetValue(prefix, out long existing)) existing = 0L;
+				groups[prefix] = existing + row.TotalTicks;
+			}
+			foreach (KeyValuePair<string, long> group in groups.OrderByDescending(g => g.Value))
+			{
+				double pct = (double)group.Value / grandTotalTicks * 100.0;
+				output.Append("  ").Append(group.Key).Append(" ").Append(TicksToMilliseconds(group.Value).ToString("0.#")).Append("ms (").Append(pct.ToString("0.#")).Append("%)\n");
+				List<(string Name, long TotalTicks)> children = snapshot.Where(row => row.Name.StartsWith(group.Key + ".", StringComparison.Ordinal)).OrderByDescending(row => row.TotalTicks).Take(5).Select(row => (row.Name, row.TotalTicks)).ToList();
+				foreach (var child in children)
+				{
+					double childPct = (double)child.TotalTicks / group.Value * 100.0;
+					output.Append("    ").Append(child.Name).Append(" ").Append(TicksToMilliseconds(child.TotalTicks).ToString("0.#")).Append("ms (").Append(childPct.ToString("0.#")).Append("%)\n");
+				}
+			}
+		}
+		// Stratum end
+
 		return output.ToString();
 	}
 


### PR DESCRIPTION
Fixes #7

Three additions to the timings subsystem:

1. Per-entity-type timing. Records `entity.type.<code>` for every ticked entity when timings run. The key string is cached in a ConcurrentDictionary per code path so the hot loop never allocates after first encounter. Shows which mob types cost the most tick time.

2. Per-AI-task-type timing. Wraps `ContinueExecute` in `ProcessRunningTasks` with `entity.ai.<category>.task.<taskCode>` recording. Shows which AI tasks dominate creature tick cost (seekfoodandeat vs wander vs meleeattack).

3. Hierarchical % breakdown in the report. Groups all buckets by first dot-segment, shows ms and % of grand total per category with top 5 children. Answers which subsystem eats the tick budget without reading a flat sorted list.

All three are gated behind `Timings.Enabled` and add zero overhead when timings are stopped.