### PR TITLE
Fix data loss race in StratumEntityBehaviorTimings.Drain

### DIFF
--- a/sources/VintagestoryApi/Common/Entity/StratumEntityBehaviorTimings.cs
+++ b/sources/VintagestoryApi/Common/Entity/StratumEntityBehaviorTimings.cs
@@ -86,14 +86,13 @@ namespace Vintagestory.API.Common.Entities
             List<Measurement> measurements = new List<Measurement>(buckets.Count);
             foreach (KeyValuePair<string, Bucket> entry in buckets)
             {
-                long elapsedTicks = Interlocked.Read(ref entry.Value.ElapsedTicks);
+                long elapsedTicks = Interlocked.Exchange(ref entry.Value.ElapsedTicks, 0);
                 if (elapsedTicks > 0L)
                 {
                     measurements.Add(new Measurement(entry.Key, elapsedTicks));
                 }
             }
 
-            buckets.Clear();
             return measurements;
         }
     }


### PR DESCRIPTION
## Summary

Timings reports lose ticks. Drain() reads each bucket with Interlocked.Read, then calls Clear() on the whole dict. Any Record() that lands between the read and the clear writes into a bucket that gets wiped before the next Drain sees it. Three Drain() calls per tick (PhysicsManager + EntitySimulation x2) guarantee the window opens every tick with AI entities active.

Fix: Interlocked.Exchange(ref ticks, 0) instead of Read. Captures and zeroes each bucket atomically. Remove the Clear() call since zeroed buckets are harmless and get reused by the next GetOrAdd without hitting the lambda. SetEnabled(false) still clears the dict to free memory when timings stop.

## Type

- [x] Bug fix

## Checklist

- [x] `.\scripts\extract-patches.ps1` ran clean.
- [x] `dotnet build VintageStory.slnx -c Release` is green.
- [x] Every vanilla edit has a `// Stratum` marker.
- [x] No vanilla source committed.
- [x] Tested on a real server start, not just compilation.