### PR TITLE
Document Linux/macOS bootstrap and extract-patches scripts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,21 +9,30 @@ Stratum is a patch set over the vanilla Vintage Story server. The repo does not 
 - `patches/` is unified diffs against the decompiled vanilla baseline.
 - `sources/` is files that exist only in Stratum. No vanilla equivalent.
 - `StratumServer/` is the launcher and the first-run vanilla downloader.
-- `scripts/` holds `bootstrap.ps1` (rebuilds the working tree from `patches` and `sources`) and `extract-patches.ps1` (writes your changes back out).
-- `VintageStory.slnx` is the solution. It only opens after `bootstrap.ps1` has run.
+- `scripts/` holds `bootstrap.ps1` / `bootstrap.sh` (rebuilds the working tree from `patches` and `sources`) and `extract-patches.ps1` / `extract-patches.sh` (writes your changes back out). Use `.ps1` on Windows, `.sh` on Linux/macOS.
+- `VintageStory.slnx` is the solution. It only opens after bootstrap has run.
 
 The working tree itself is gitignored. Only `patches/` and `sources/` are tracked.
 
 ## Setting up
 
-You need the .NET 10 SDK and Windows PowerShell.
+You need the .NET 10 SDK and `git`. On Windows, PowerShell 5.1+ runs the `.ps1` scripts. On Linux/macOS, `bash` runs the `.sh` equivalents (also needs `curl`, `perl`, `python3`). macOS ships bash 3.2; the scripts require bash 4+ and GNU `coreutils` (`realpath`), both available via `brew install bash coreutils`.
+
+**Windows:**
 
 ```powershell
 .\scripts\bootstrap.ps1
 dotnet build VintageStory.slnx -c Release
 ```
 
-`bootstrap.ps1` downloads the matching vanilla server zip, decompiles the assemblies into the working tree, applies every patch, then copies `sources/` on top. After that you have a normal C# solution to edit.
+**Linux / macOS:**
+
+```bash
+./scripts/bootstrap.sh
+dotnet build VintageStory.slnx -c Release
+```
+
+`bootstrap` downloads the matching vanilla server archive, decompiles the assemblies into the working tree, applies every patch, then copies `sources/` on top. After that you have a normal C# solution to edit.
 
 If a patch fails to apply you usually want to delete the working tree and rerun bootstrap, not hand-edit the rejected hunk.
 
@@ -31,7 +40,7 @@ If a patch fails to apply you usually want to delete the working tree and rerun 
 
 1. Edit files in the working tree like any other repo.
 2. Build and test locally on a real server start. See "Testing" below.
-3. Run `.\scripts\extract-patches.ps1`. This regenerates `patches/` and `sources/` from your changes.
+3. Run `.\scripts\extract-patches.ps1` (Windows) or `./scripts/extract-patches.sh` (Linux/macOS). This regenerates `patches/` and `sources/` from your changes.
 4. `git add patches sources` and commit. Never commit the working tree itself.
 
 If you started a branch before the latest vanilla bump, rerun bootstrap against the new baseline before extracting patches. Patches that no longer apply cleanly are your problem to fix.

--- a/README.md
+++ b/README.md
@@ -72,7 +72,9 @@ Anything else is forwarded to the server (`--port`, `--dataPath`, ...).
 
 ## Build
 
-Requires the .NET 10 SDK, PowerShell 5.1+, and `git`.
+Requires the .NET 10 SDK and `git`. On Windows you also need PowerShell 5.1+; on Linux/macOS you need `bash` (4+), `curl`, `perl`, and `python3`. macOS users: `brew install bash coreutils` covers the extra dependencies.
+
+**Windows (PowerShell):**
 
 ```powershell
 git clone https://github.com/trevorftp/Stratum.git
@@ -81,14 +83,18 @@ cd Stratum
 dotnet build VintageStory.slnx -c Release
 ```
 
-`bootstrap.ps1` downloads the targeted vanilla server zip, decompiles
-`VintagestoryLib`, `VintagestoryServer` into `baseline/`,
-clones the forks pinned in [forks.json](forks.json), applies every patch in
-`patches/`, and drops Stratum-only files from `sources/` into place.
+**Linux / macOS:**
 
-After bootstrap, every patched file carries a `// Stratum:` marker so edits
-are easy to find. Edit, build, then run `.\scripts\extract-patches.ps1` to
-regenerate the diffs. Full workflow in [CONTRIBUTING.md](CONTRIBUTING.md).
+```bash
+git clone https://github.com/trevorftp/Stratum.git
+cd Stratum
+./scripts/bootstrap.sh
+dotnet build VintageStory.slnx -c Release
+```
+
+Both scripts do the same thing: download the targeted vanilla server archive, decompile `VintagestoryLib` and `VintagestoryServer` into `baseline/`, clone the forks pinned in [forks.json](forks.json), apply every patch in `patches/`, and drop Stratum-only files from `sources/` into place.
+
+After bootstrap, every patched file carries a `// Stratum:` marker so edits are easy to find. Edit, build, then run `scripts\extract-patches.ps1` (Windows) or `scripts/extract-patches.sh` (Linux/macOS) to regenerate the diffs. Full workflow in [CONTRIBUTING.md](CONTRIBUTING.md).
 
 See [SECURITY.md](SECURITY.md) for reporting exploits.
 

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -2,13 +2,24 @@
 
 ## Prerequisites
 
-* Windows 10 or later (Linux support is planned, not tested).
+**All platforms:**
 * .NET 10 SDK.
-* PowerShell 7 or later.
 * git.
 * About 2 GB of free disk space for the vanilla source tree and build output.
 
+**Windows:**
+* PowerShell 5.1+ (ships with Windows 10+).
+
+**Linux:**
+* bash, curl, perl, python3, tar.
+
+**macOS:**
+* bash 4+ and GNU coreutils (`brew install bash coreutils`).
+* curl, perl, python3.
+
 ## First build
+
+**Windows:**
 
 ```powershell
 git clone https://github.com/trevorftp/Stratum.git
@@ -17,18 +28,28 @@ cd Stratum
 dotnet build VintageStory.slnx -c Release
 ```
 
-`bootstrap.ps1` does the following:
+**Linux / macOS:**
 
-1. Downloads `vs_server_win-x64_<version>.zip` from `cdn.vintagestory.at` into
-   `.vanilla-zips/`. Cached, so re-runs are quick.
-2. Extracts the zip into `.vanilla/`.
+```bash
+git clone https://github.com/trevorftp/Stratum.git
+cd Stratum
+./scripts/bootstrap.sh
+dotnet build VintageStory.slnx -c Release
+```
+
+`bootstrap` does the following:
+
+1. Downloads the vanilla server archive (`vs_server_win-x64_<version>.zip` on Windows,
+   `vs_server_linux-x64_<version>.tar.gz` on Linux/macOS) from `cdn.vintagestory.at`
+   into `.vanilla-zips/`. Cached, so re-runs are quick.
+2. Extracts the archive into `.vanilla/`.
 3. Installs `ilspycmd` as a dotnet global tool if it is not already on PATH.
-4. Decompiles `VintagestoryLib.dll`, `VintagestoryServer.dll`, and `cairo-sharp.dll`
+4. Decompiles `VintagestoryLib.dll` and `VintagestoryServer.dll`
    into `.baseline/<project>/`.
-5. Clones the open-source Anego forks (`vsapi`, `vsessentialsmod`, `vssurvivalmod`)
-   at the commits pinned in `forks.json` into `.baseline/<project>/`.
+5. Clones the open-source Anego forks (vsapi, vsessentialsmod, vssurvivalmod, Cairo,
+   vscreativemod) at the commits pinned in `forks.json` into `.baseline/<project>/`.
 6. Copies every baseline into the matching working folder at the repo root.
-7. Applies every `.patch` file under `patches/` with `git apply --3way`.
+7. Applies every `.patch` file under `patches/` with `git apply`.
 
 After that the solution has every project it needs and `dotnet build` works.
 
@@ -38,10 +59,18 @@ After that the solution has every project it needs and `dotnet build` works.
 .\scripts\bootstrap.ps1 -Version 1.22.3
 ```
 
-### Using a zip you already have
+```bash
+./scripts/bootstrap.sh --version 1.22.3
+```
+
+### Using an archive you already have
 
 ```powershell
 .\scripts\bootstrap.ps1 -ServerZip C:\downloads\vs_server_win-x64_1.22.3.zip
+```
+
+```bash
+./scripts/bootstrap.sh --server-archive ~/downloads/vs_server_linux-x64_1.22.3.tar.gz
 ```
 
 ### Re-bootstrapping after an upstream version bump
@@ -50,10 +79,14 @@ After that the solution has every project it needs and `dotnet build` works.
 .\scripts\bootstrap.ps1 -Version 1.22.4 -Refresh
 ```
 
-`-Refresh` wipes `.vanilla/` and `.baseline/` so the new release gets decompiled clean.
+```bash
+./scripts/bootstrap.sh --version 1.22.4 --refresh
+```
+
+`-Refresh` / `--refresh` wipes `.vanilla/` and `.baseline/` so the new release gets decompiled clean.
 For the open-source forks, bump the `ref` values in `forks.json` to the matching
-upstream commits before running with `-Refresh`. Expect some patches to fail. Fix them
-in the working tree and run `scripts\extract-patches.ps1` to regenerate the patch files.
+upstream commits before running with refresh. Expect some patches to fail. Fix them
+in the working tree and run `scripts\extract-patches.ps1` (Windows) or `scripts/extract-patches.sh` (Linux/macOS) to regenerate the patch files.
 
 ## Producing patches
 
@@ -63,12 +96,16 @@ After editing anything inside `VintagestoryLib/`, `VintagestoryServer/`, or `Cai
 .\scripts\extract-patches.ps1
 ```
 
+```bash
+./scripts/extract-patches.sh
+```
+
 That diffs each file against the corresponding baseline and writes or updates files
 under `patches/<project>/<relative-path>.patch`. Commit those.
 
 ## Running the server
 
-The solution outputs to `<project>\bin\Release\net10.0\`. For a real install you still
+The solution outputs to `<project>/bin/Release/net10.0/`. For a real install you still
 need the vanilla assets, native libs, and base mods. The `BuildStratumOutputs` and
 `DeployStratumServer` MSBuild targets in `StratumServer.csproj` handle that locally if
 you set `VSInstall` and `StratumInstall` in a `*.local.props` file at the repo root.
@@ -76,8 +113,8 @@ you set `VSInstall` and `StratumInstall` in a `*.local.props` file at the repo r
 ## Troubleshooting
 
 * `ilspycmd` install fails: install it manually with `dotnet tool install -g ilspycmd`
-  and make sure `%USERPROFILE%\.dotnet\tools` is on PATH.
+  and make sure `~/.dotnet/tools` (Linux/macOS) or `%USERPROFILE%\.dotnet\tools` (Windows) is on PATH.
 * A patch fails to apply: usually means upstream changed the surrounding code. Open
-  the working file, fix the conflict, then re-run `extract-patches.ps1`.
+  the working file, fix the conflict, then re-run `extract-patches`.
 * `dotnet build` reports missing types from `VintagestoryLib`: the bootstrap step did
-  not complete. Re-run `scripts\bootstrap.ps1` and watch for errors.
+  not complete. Re-run bootstrap and watch for errors.


### PR DESCRIPTION
The .sh scripts exist and work, but README, CONTRIBUTING, and docs/BUILDING.md only mention the .ps1 versions. A Linux user cloning the repo sees "You need Windows PowerShell" and has to discover bootstrap.sh on their own.

This adds side-by-side Windows/Linux/macOS instructions everywhere the .ps1 scripts appear. Also fixes three stale claims in BUILDING.md that drifted from the actual scripts:

- Step 4 listed cairo-sharp.dll as decompiled (Cairo moved to forks.json).
- Step 5 only listed three forks (now five: added Cairo and vscreativemod).
- Step 7 said `git apply --3way` (scripts use `--whitespace=nowarn`).

Doc-only change. No scripts touched.