### PR TITLE
Normalize csproj paths to forward slashes, drop PowerShell from deploy prune

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -8,8 +8,8 @@
 	<Target Name="DeployToVSInstall" AfterTargets="Build" Condition="'$(SkipDeployToVSInstall)' != 'true' and '$(VSInstall)' != ''">
 		<PropertyGroup>
 			<_DeployRoot>$(VSInstall)</_DeployRoot>
-			<_DeployModsDir>$(VSInstall)\Mods</_DeployModsDir>
-			<_DeployLibDir>$(VSInstall)\Lib</_DeployLibDir>
+			<_DeployModsDir>$(VSInstall)/Mods</_DeployModsDir>
+			<_DeployLibDir>$(VSInstall)/Lib</_DeployLibDir>
 		</PropertyGroup>
 
 		<!-- Server runtime libs -->

--- a/StratumServer/StratumServer.csproj
+++ b/StratumServer/StratumServer.csproj
@@ -12,10 +12,10 @@
 
   <PropertyGroup>
     <!-- Prefer active decompile layout, then fall back to baseline mirrors. -->
-    <StratumInfoPath Condition="Exists('..\VintagestoryLib\Vintagestory.Server\StratumInfo.cs')">..\VintagestoryLib\Vintagestory.Server\StratumInfo.cs</StratumInfoPath>
-    <StratumInfoPath Condition="'$(StratumInfoPath)' == '' and Exists('..\VintagestoryLib\Vintagestory\Server\StratumInfo.cs')">..\VintagestoryLib\Vintagestory\Server\StratumInfo.cs</StratumInfoPath>
-    <StratumInfoPath Condition="'$(StratumInfoPath)' == '' and Exists('..\baseline\VintagestoryLib\Vintagestory.Server\StratumInfo.cs')">..\baseline\VintagestoryLib\Vintagestory.Server\StratumInfo.cs</StratumInfoPath>
-    <StratumInfoPath Condition="'$(StratumInfoPath)' == '' and Exists('..\baseline\VintagestoryLib\Vintagestory\Server\StratumInfo.cs')">..\baseline\VintagestoryLib\Vintagestory\Server\StratumInfo.cs</StratumInfoPath>
+    <StratumInfoPath Condition="Exists('../VintagestoryLib/Vintagestory.Server/StratumInfo.cs')">../VintagestoryLib/Vintagestory.Server/StratumInfo.cs</StratumInfoPath>
+    <StratumInfoPath Condition="'$(StratumInfoPath)' == '' and Exists('../VintagestoryLib/Vintagestory/Server/StratumInfo.cs')">../VintagestoryLib/Vintagestory/Server/StratumInfo.cs</StratumInfoPath>
+    <StratumInfoPath Condition="'$(StratumInfoPath)' == '' and Exists('../baseline/VintagestoryLib/Vintagestory.Server/StratumInfo.cs')">../baseline/VintagestoryLib/Vintagestory.Server/StratumInfo.cs</StratumInfoPath>
+    <StratumInfoPath Condition="'$(StratumInfoPath)' == '' and Exists('../baseline/VintagestoryLib/Vintagestory/Server/StratumInfo.cs')">../baseline/VintagestoryLib/Vintagestory/Server/StratumInfo.cs</StratumInfoPath>
   </PropertyGroup>
 
   <ItemGroup>
@@ -23,7 +23,7 @@
   </ItemGroup>
 
   <Target Name="ValidateStratumInfoPath" BeforeTargets="CoreCompile">
-    <Error Condition="'$(StratumInfoPath)' == ''" Text="StratumInfo.cs not found. Expected one of: ..\VintagestoryLib\Vintagestory.Server\StratumInfo.cs, ..\VintagestoryLib\Vintagestory\Server\StratumInfo.cs, ..\baseline\VintagestoryLib\Vintagestory.Server\StratumInfo.cs, ..\baseline\VintagestoryLib\Vintagestory\Server\StratumInfo.cs" />
+    <Error Condition="'$(StratumInfoPath)' == ''" Text="StratumInfo.cs not found. Expected one of: ../VintagestoryLib/Vintagestory.Server/StratumInfo.cs, ../VintagestoryLib/Vintagestory/Server/StratumInfo.cs, ../baseline/VintagestoryLib/Vintagestory.Server/StratumInfo.cs, ../baseline/VintagestoryLib/Vintagestory/Server/StratumInfo.cs" />
   </Target>
 
   <!--
@@ -32,35 +32,35 @@
     Logical names are read back at runtime by EmbeddedOverlay.
   -->
   <ItemGroup Condition="'$(EmbedPatchedDlls)' == 'true'">
-    <EmbeddedResource Include="..\baseline\VintagestoryLib\bin\$(Configuration)\$(TargetFramework)\VintagestoryLib.dll"  LogicalName="Stratum.Overlay.VintagestoryLib.dll" />
-    <EmbeddedResource Include="..\baseline\VintagestoryLib\bin\$(Configuration)\$(TargetFramework)\Nimbus.Shared.dll"   LogicalName="Stratum.Overlay.Nimbus.Shared.dll" Condition="Exists('..\baseline\VintagestoryLib\bin\$(Configuration)\$(TargetFramework)\Nimbus.Shared.dll')" />
-    <EmbeddedResource Include="..\bin\$(Configuration)\$(TargetFramework)\VintagestoryAPI.dll"                          LogicalName="Stratum.Overlay.VintagestoryAPI.dll" />
-    <EmbeddedResource Include="..\bin\$(Configuration)\$(TargetFramework)\cairo-sharp.dll"                              LogicalName="Stratum.Overlay.cairo-sharp.dll" />
-    <EmbeddedResource Include="..\bin\$(Configuration)\$(TargetFramework)\VSEssentials.dll"                             LogicalName="Stratum.OverlayMods.VSEssentials.dll" />
-    <EmbeddedResource Include="..\bin\$(Configuration)\$(TargetFramework)\VSSurvivalMod.dll"                            LogicalName="Stratum.OverlayMods.VSSurvivalMod.dll" />
+    <EmbeddedResource Include="../baseline/VintagestoryLib/bin/$(Configuration)/$(TargetFramework)/VintagestoryLib.dll"  LogicalName="Stratum.Overlay.VintagestoryLib.dll" />
+    <EmbeddedResource Include="../baseline/VintagestoryLib/bin/$(Configuration)/$(TargetFramework)/Nimbus.Shared.dll"   LogicalName="Stratum.Overlay.Nimbus.Shared.dll" Condition="Exists('../baseline/VintagestoryLib/bin/$(Configuration)/$(TargetFramework)/Nimbus.Shared.dll')" />
+    <EmbeddedResource Include="../bin/$(Configuration)/$(TargetFramework)/VintagestoryAPI.dll"                          LogicalName="Stratum.Overlay.VintagestoryAPI.dll" />
+    <EmbeddedResource Include="../bin/$(Configuration)/$(TargetFramework)/cairo-sharp.dll"                              LogicalName="Stratum.Overlay.cairo-sharp.dll" />
+    <EmbeddedResource Include="../bin/$(Configuration)/$(TargetFramework)/VSEssentials.dll"                             LogicalName="Stratum.OverlayMods.VSEssentials.dll" />
+    <EmbeddedResource Include="../bin/$(Configuration)/$(TargetFramework)/VSSurvivalMod.dll"                            LogicalName="Stratum.OverlayMods.VSSurvivalMod.dll" />
 
-    <EmbeddedResource Include="..\baseline\VintagestoryLib\bin\$(Configuration)\$(TargetFramework)\VintagestoryLib.pdb" LogicalName="Stratum.Overlay.VintagestoryLib.pdb" Condition="Exists('..\baseline\VintagestoryLib\bin\$(Configuration)\$(TargetFramework)\VintagestoryLib.pdb')" />
-    <EmbeddedResource Include="..\baseline\VintagestoryLib\bin\$(Configuration)\$(TargetFramework)\Nimbus.Shared.pdb"  LogicalName="Stratum.Overlay.Nimbus.Shared.pdb" Condition="Exists('..\baseline\VintagestoryLib\bin\$(Configuration)\$(TargetFramework)\Nimbus.Shared.pdb')" />
-    <EmbeddedResource Include="..\bin\$(Configuration)\$(TargetFramework)\VintagestoryAPI.pdb"                          LogicalName="Stratum.Overlay.VintagestoryAPI.pdb" Condition="Exists('..\bin\$(Configuration)\$(TargetFramework)\VintagestoryAPI.pdb')" />
-    <EmbeddedResource Include="..\bin\$(Configuration)\$(TargetFramework)\cairo-sharp.pdb"                              LogicalName="Stratum.Overlay.cairo-sharp.pdb" Condition="Exists('..\bin\$(Configuration)\$(TargetFramework)\cairo-sharp.pdb')" />
-    <EmbeddedResource Include="..\bin\$(Configuration)\$(TargetFramework)\VSEssentials.pdb"                             LogicalName="Stratum.OverlayMods.VSEssentials.pdb" Condition="Exists('..\bin\$(Configuration)\$(TargetFramework)\VSEssentials.pdb')" />
-    <EmbeddedResource Include="..\bin\$(Configuration)\$(TargetFramework)\VSSurvivalMod.pdb"                            LogicalName="Stratum.OverlayMods.VSSurvivalMod.pdb" Condition="Exists('..\bin\$(Configuration)\$(TargetFramework)\VSSurvivalMod.pdb')" />
+    <EmbeddedResource Include="../baseline/VintagestoryLib/bin/$(Configuration)/$(TargetFramework)/VintagestoryLib.pdb" LogicalName="Stratum.Overlay.VintagestoryLib.pdb" Condition="Exists('../baseline/VintagestoryLib/bin/$(Configuration)/$(TargetFramework)/VintagestoryLib.pdb')" />
+    <EmbeddedResource Include="../baseline/VintagestoryLib/bin/$(Configuration)/$(TargetFramework)/Nimbus.Shared.pdb"  LogicalName="Stratum.Overlay.Nimbus.Shared.pdb" Condition="Exists('../baseline/VintagestoryLib/bin/$(Configuration)/$(TargetFramework)/Nimbus.Shared.pdb')" />
+    <EmbeddedResource Include="../bin/$(Configuration)/$(TargetFramework)/VintagestoryAPI.pdb"                          LogicalName="Stratum.Overlay.VintagestoryAPI.pdb" Condition="Exists('../bin/$(Configuration)/$(TargetFramework)/VintagestoryAPI.pdb')" />
+    <EmbeddedResource Include="../bin/$(Configuration)/$(TargetFramework)/cairo-sharp.pdb"                              LogicalName="Stratum.Overlay.cairo-sharp.pdb" Condition="Exists('../bin/$(Configuration)/$(TargetFramework)/cairo-sharp.pdb')" />
+    <EmbeddedResource Include="../bin/$(Configuration)/$(TargetFramework)/VSEssentials.pdb"                             LogicalName="Stratum.OverlayMods.VSEssentials.pdb" Condition="Exists('../bin/$(Configuration)/$(TargetFramework)/VSEssentials.pdb')" />
+    <EmbeddedResource Include="../bin/$(Configuration)/$(TargetFramework)/VSSurvivalMod.pdb"                            LogicalName="Stratum.OverlayMods.VSSurvivalMod.pdb" Condition="Exists('../bin/$(Configuration)/$(TargetFramework)/VSSurvivalMod.pdb')" />
 
     <EmbeddedResource Include="stratum.default.json" LogicalName="Stratum.Overlay.stratum.default.json" />
   </ItemGroup>
 
   <Target Name="BuildStratumOutputs" Condition="'$(StratumDeploy)' == 'true'">
     <Message Importance="High" Text="Building Stratum server outputs" />
-    <MSBuild Projects="..\VintagestoryLib\VintagestoryLib.csproj"
+    <MSBuild Projects="../VintagestoryLib/VintagestoryLib.csproj"
              Targets="Build"
              Properties="Configuration=$(Configuration);SkipDeployToVSInstall=true" />
-    <MSBuild Projects="..\VSEssentials\VSEssentialsMod.csproj"
+    <MSBuild Projects="../VSEssentials/VSEssentialsMod.csproj"
          Targets="Build"
          Properties="Configuration=$(Configuration);SkipDeployToVSInstall=true" />
-    <MSBuild Projects="..\VSSurvivalMod\VSSurvivalMod.csproj"
+    <MSBuild Projects="../VSSurvivalMod/VSSurvivalMod.csproj"
          Targets="Build"
          Properties="Configuration=$(Configuration);SkipDeployToVSInstall=true" />
-    <MSBuild Projects="..\StratumServerGui\StratumServerGui.csproj"
+    <MSBuild Projects="../StratumServerGui/StratumServerGui.csproj"
          Targets="Build"
          Properties="Configuration=$(Configuration)"
          ContinueOnError="true" />
@@ -71,17 +71,17 @@
 
   <Target Name="DeployStratumServer" DependsOnTargets="BuildStratumOutputs" Condition="'$(StratumDeploy)' == 'true'">
     <PropertyGroup>
-      <_StratumLibOutput>..\VintagestoryLib\bin\$(Configuration)\$(TargetFramework)</_StratumLibOutput>
-      <_StratumApiOutput>..\bin\$(Configuration)\$(TargetFramework)</_StratumApiOutput>
-      <_StratumModOutput>..\bin\$(Configuration)\$(TargetFramework)</_StratumModOutput>
+      <_StratumLibOutput>../VintagestoryLib/bin/$(Configuration)/$(TargetFramework)</_StratumLibOutput>
+      <_StratumApiOutput>../bin/$(Configuration)/$(TargetFramework)</_StratumApiOutput>
+      <_StratumModOutput>../bin/$(Configuration)/$(TargetFramework)</_StratumModOutput>
 
     </PropertyGroup>
 
     <ItemGroup>
-      <_StratumRootFiles Include="$(VSInstall)\credits.txt" Condition="Exists('$(VSInstall)\credits.txt')" />
-      <_StratumRootFiles Include="$(VSInstall)\cimgui.dll" Condition="Exists('$(VSInstall)\cimgui.dll')" />
-      <_StratumRootFiles Include="$(VSInstall)\VintagestoryAPI.xml" Condition="Exists('$(VSInstall)\VintagestoryAPI.xml')" />
-      <_StratumRootFiles Include="$(VSInstall)\VSCrashReporterLib.dll" Condition="Exists('$(VSInstall)\VSCrashReporterLib.dll')" />
+      <_StratumRootFiles Include="$(VSInstall)/credits.txt" Condition="Exists('$(VSInstall)/credits.txt')" />
+      <_StratumRootFiles Include="$(VSInstall)/cimgui.dll" Condition="Exists('$(VSInstall)/cimgui.dll')" />
+      <_StratumRootFiles Include="$(VSInstall)/VintagestoryAPI.xml" Condition="Exists('$(VSInstall)/VintagestoryAPI.xml')" />
+      <_StratumRootFiles Include="$(VSInstall)/VSCrashReporterLib.dll" Condition="Exists('$(VSInstall)/VSCrashReporterLib.dll')" />
 
       <_StratumRootFiles Include="$(TargetDir)StratumServer.exe" />
       <_StratumRootFiles Include="$(TargetDir)StratumServer.dll" />
@@ -89,56 +89,78 @@
       <_StratumRootFiles Include="$(TargetDir)StratumServer.runtimeconfig.json" />
       <_StratumRootFiles Include="$(TargetDir)StratumServer.pdb" Condition="Exists('$(TargetDir)StratumServer.pdb')" />
 
-      <_StratumLibFiles Include="$(_StratumLibOutput)\**\*" />
-      <_StratumApiFiles Include="$(_StratumApiOutput)\VintagestoryAPI.*" />
-      <_StratumApiFiles Include="$(_StratumApiOutput)\cairo-sharp.*" />
-      <_StratumRootModFiles Include="$(_StratumModOutput)\VSEssentials.dll" />
-      <_StratumRootModFiles Include="$(_StratumModOutput)\VSEssentials.pdb" Condition="Exists('$(_StratumModOutput)\VSEssentials.pdb')" />
-      <_StratumRootModFiles Include="$(_StratumModOutput)\VSSurvivalMod.dll" />
-      <_StratumRootModFiles Include="$(_StratumModOutput)\VSSurvivalMod.pdb" Condition="Exists('$(_StratumModOutput)\VSSurvivalMod.pdb')" />
+      <_StratumLibFiles Include="$(_StratumLibOutput)/**/*" />
+      <_StratumApiFiles Include="$(_StratumApiOutput)/VintagestoryAPI.*" />
+      <_StratumApiFiles Include="$(_StratumApiOutput)/cairo-sharp.*" />
+      <_StratumRootModFiles Include="$(_StratumModOutput)/VSEssentials.dll" />
+      <_StratumRootModFiles Include="$(_StratumModOutput)/VSEssentials.pdb" Condition="Exists('$(_StratumModOutput)/VSEssentials.pdb')" />
+      <_StratumRootModFiles Include="$(_StratumModOutput)/VSSurvivalMod.dll" />
+      <_StratumRootModFiles Include="$(_StratumModOutput)/VSSurvivalMod.pdb" Condition="Exists('$(_StratumModOutput)/VSSurvivalMod.pdb')" />
 
-      <_StratumGuiFiles Include="..\StratumServerGui\bin\$(Configuration)\net10.0-windows\StratumServerGui.exe" Condition="Exists('..\StratumServerGui\bin\$(Configuration)\net10.0-windows\StratumServerGui.exe')" />
-      <_StratumGuiFiles Include="..\StratumServerGui\bin\$(Configuration)\net10.0-windows\StratumServerGui.dll" Condition="Exists('..\StratumServerGui\bin\$(Configuration)\net10.0-windows\StratumServerGui.dll')" />
-      <_StratumGuiFiles Include="..\StratumServerGui\bin\$(Configuration)\net10.0-windows\StratumServerGui.runtimeconfig.json" Condition="Exists('..\StratumServerGui\bin\$(Configuration)\net10.0-windows\StratumServerGui.runtimeconfig.json')" />
-      <_StratumGuiFiles Include="..\StratumServerGui\bin\$(Configuration)\net10.0-windows\StratumServerGui.deps.json" Condition="Exists('..\StratumServerGui\bin\$(Configuration)\net10.0-windows\StratumServerGui.deps.json')" />
+      <_StratumGuiFiles Include="../StratumServerGui/bin/$(Configuration)/net10.0-windows/StratumServerGui.exe" Condition="Exists('../StratumServerGui/bin/$(Configuration)/net10.0-windows/StratumServerGui.exe')" />
+      <_StratumGuiFiles Include="../StratumServerGui/bin/$(Configuration)/net10.0-windows/StratumServerGui.dll" Condition="Exists('../StratumServerGui/bin/$(Configuration)/net10.0-windows/StratumServerGui.dll')" />
+      <_StratumGuiFiles Include="../StratumServerGui/bin/$(Configuration)/net10.0-windows/StratumServerGui.runtimeconfig.json" Condition="Exists('../StratumServerGui/bin/$(Configuration)/net10.0-windows/StratumServerGui.runtimeconfig.json')" />
+      <_StratumGuiFiles Include="../StratumServerGui/bin/$(Configuration)/net10.0-windows/StratumServerGui.deps.json" Condition="Exists('../StratumServerGui/bin/$(Configuration)/net10.0-windows/StratumServerGui.deps.json')" />
     </ItemGroup>
 
     <MakeDir Directories="$(StratumInstall)" />
-    <MakeDir Directories="$(StratumInstall)\Mods" />
-  <MakeDir Directories="$(StratumInstall)\Data" />
-  <Copy SourceFiles="$(MSBuildProjectDirectory)\stratum.default.json"
-      DestinationFiles="$(StratumInstall)\Data\stratum.json"
-      Condition="!Exists('$(StratumInstall)\Data\stratum.json')" />
+    <MakeDir Directories="$(StratumInstall)/Mods" />
+    <MakeDir Directories="$(StratumInstall)/Data" />
+    <Copy SourceFiles="$(MSBuildProjectDirectory)/stratum.default.json"
+        DestinationFiles="$(StratumInstall)/Data/stratum.json"
+        Condition="!Exists('$(StratumInstall)/Data/stratum.json')" />
         <Message Importance="High" Text="Overlaying Stratum launcher and patched server assemblies into $(StratumInstall)" />
     <Copy SourceFiles="@(_StratumRootFiles)"
           DestinationFolder="$(StratumInstall)"
           SkipUnchangedFiles="true" />
     <Copy SourceFiles="@(_StratumLibFiles)"
-          DestinationFiles="@(_StratumLibFiles->'$(StratumInstall)\%(RecursiveDir)%(Filename)%(Extension)')"
+          DestinationFiles="@(_StratumLibFiles->'$(StratumInstall)/%(RecursiveDir)%(Filename)%(Extension)')"
           SkipUnchangedFiles="true" />
     <Copy SourceFiles="@(_StratumApiFiles)"
           DestinationFolder="$(StratumInstall)"
           SkipUnchangedFiles="true" />
         <Copy SourceFiles="@(_StratumRootModFiles)"
-          DestinationFolder="$(StratumInstall)\Mods"
+          DestinationFolder="$(StratumInstall)/Mods"
           SkipUnchangedFiles="true" />
 
     <Copy SourceFiles="@(_StratumGuiFiles)"
           DestinationFolder="$(StratumInstall)"
           SkipUnchangedFiles="true"
           Condition="'@(_StratumGuiFiles)' != ''" />
-    <Copy SourceFiles="$(MSBuildProjectDirectory)\Start-StratumServerGui.bat"
+    <Copy SourceFiles="$(MSBuildProjectDirectory)/Start-StratumServerGui.bat"
           DestinationFolder="$(StratumInstall)"
           SkipUnchangedFiles="true"
-          Condition="Exists('$(MSBuildProjectDirectory)\Start-StratumServerGui.bat')" />
+          Condition="Exists('$(MSBuildProjectDirectory)/Start-StratumServerGui.bat')" />
 
-    <!-- Prune root-level dlls that duplicate a same-size copy in Lib\. The runtime's
-         AssemblyResolver + native PATH already probe Lib\, so the duplicates in root are
+    <!-- Prune root-level dlls that duplicate a same-size copy in Lib/. The runtime's
+         AssemblyResolver + native PATH already probe Lib/, so the duplicates in root are
          pure bloat from the bulk VintagestoryLib bin copy. Size-match only, so locally
          patched libs (cairo-sharp etc.) where root differs from Lib are left alone. -->
-    <Exec Command="powershell -NoProfile -ExecutionPolicy Bypass -Command &quot;$libDir = '$(StratumInstall)\Lib'; if (Test-Path $libDir) { Get-ChildItem $libDir -File | ForEach-Object { $r = Join-Path '$(StratumInstall)' $_.Name; if ((Test-Path $r) -and (Get-Item $r).Length -eq $_.Length) { Remove-Item $r -Force; Write-Host ('  pruned root duplicate: ' + $_.Name) } } }&quot;"
-          IgnoreExitCode="true" />
+    <PruneDuplicateRootDlls InstallDir="$(StratumInstall)" />
 
-        <Message Importance="High" Text="Stratum overlay deployed to $(StratumInstall). Copy assets, Lib, and base Mods there from $(VSInstall) if they are missing or stale." />
+    <Message Importance="High" Text="Stratum overlay deployed to $(StratumInstall). Copy assets, Lib, and base Mods there from $(VSInstall) if they are missing or stale." />
   </Target>
+
+  <UsingTask TaskName="PruneDuplicateRootDlls" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)/Microsoft.Build.Tasks.Core.dll">
+    <ParameterGroup>
+      <InstallDir ParameterType="System.String" Required="true" />
+    </ParameterGroup>
+    <Task>
+      <Code Type="Fragment" Language="cs"><![CDATA[
+var libDir = System.IO.Path.Combine(InstallDir, "Lib");
+if (!System.IO.Directory.Exists(libDir)) return true;
+foreach (var libFile in System.IO.Directory.GetFiles(libDir, "*.dll"))
+{
+    var name = System.IO.Path.GetFileName(libFile);
+    var rootFile = System.IO.Path.Combine(InstallDir, name);
+    if (!System.IO.File.Exists(rootFile)) continue;
+    if (new System.IO.FileInfo(rootFile).Length == new System.IO.FileInfo(libFile).Length)
+    {
+        System.IO.File.Delete(rootFile);
+        Log.LogMessage(MessageImportance.Normal, "  pruned root duplicate: " + name);
+    }
+}
+]]></Code>
+    </Task>
+  </UsingTask>
 </Project>

--- a/sources/VintagestoryLib/VintagestoryLib.csproj
+++ b/sources/VintagestoryLib/VintagestoryLib.csproj
@@ -9,110 +9,105 @@
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <CheckForOverflowUnderflow>False</CheckForOverflowUnderflow>
   </PropertyGroup>
-  <PropertyGroup />
-  <PropertyGroup Condition="!Exists('$(MSBuildThisFileDirectory)..\..\.vanilla\Lib\OpenTK.Graphics.dll') Or !Exists('$(MSBuildThisFileDirectory)..\..\.vanilla\Lib\csogg.dll') Or !Exists('$(MSBuildThisFileDirectory)..\..\.vanilla\Lib\csvorbis.dll')">
+  <PropertyGroup Condition="!Exists('$(MSBuildThisFileDirectory)../../.vanilla/Lib/OpenTK.Graphics.dll') Or !Exists('$(MSBuildThisFileDirectory)../../.vanilla/Lib/csogg.dll') Or !Exists('$(MSBuildThisFileDirectory)../../.vanilla/Lib/csvorbis.dll')">
     <DefineConstants>$(DefineConstants);STRATUM_CLIENT_REF_FALLBACKS</DefineConstants>
   </PropertyGroup>
-  <ItemGroup Condition="!Exists('$(MSBuildThisFileDirectory)..\..\.vanilla\Lib\OpenTK.Graphics.dll')">
+  <ItemGroup Condition="!Exists('$(MSBuildThisFileDirectory)../../.vanilla/Lib/OpenTK.Graphics.dll')">
     <PackageReference Include="OpenTK.Graphics" Version="4.9.4" />
-  </ItemGroup>
-  <ItemGroup>
-  </ItemGroup>
-  <ItemGroup>
   </ItemGroup>
   <!-- Nimbus integration is optional. When the Nimbus.Shared project is checked
        out, define STRATUM_NIMBUS so the Nimbus/* folder and the patched baseline
        files (gated with #if STRATUM_NIMBUS) compile in. Otherwise, exclude the
        folder and skip the project reference so the lib still builds for outside
        contributors and CI. -->
-  <PropertyGroup Condition="Exists('$(MSBuildThisFileDirectory)..\..\Nimbus\Nimbus.Shared\Nimbus.Shared.csproj')">
+  <PropertyGroup Condition="Exists('$(MSBuildThisFileDirectory)../../Nimbus/Nimbus.Shared/Nimbus.Shared.csproj')">
     <DefineConstants>$(DefineConstants);STRATUM_NIMBUS</DefineConstants>
   </PropertyGroup>
-  <ItemGroup Condition="!Exists('$(MSBuildThisFileDirectory)..\..\Nimbus\Nimbus.Shared\Nimbus.Shared.csproj')">
-    <Compile Remove="Vintagestory.Server\Nimbus\**\*.cs" />
+  <ItemGroup Condition="!Exists('$(MSBuildThisFileDirectory)../../Nimbus/Nimbus.Shared/Nimbus.Shared.csproj')">
+    <Compile Remove="Vintagestory.Server/Nimbus/**/*.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\VintagestoryApi\VintagestoryAPI.csproj" />
-    <ProjectReference Include="..\..\Nimbus\Nimbus.Shared\Nimbus.Shared.csproj" Condition="Exists('$(MSBuildThisFileDirectory)..\..\Nimbus\Nimbus.Shared\Nimbus.Shared.csproj')" />
+    <ProjectReference Include="../../VintagestoryApi/VintagestoryAPI.csproj" />
+    <ProjectReference Include="../../Nimbus/Nimbus.Shared/Nimbus.Shared.csproj" Condition="Exists('$(MSBuildThisFileDirectory)../../Nimbus/Nimbus.Shared/Nimbus.Shared.csproj')" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="cairo-sharp">
-      <HintPath>..\..\.vanilla\Lib\cairo-sharp.dll</HintPath>
+      <HintPath>../../.vanilla/Lib/cairo-sharp.dll</HintPath>
     </Reference>
     <Reference Include="protobuf-net">
-      <HintPath>..\..\.vanilla\Lib\protobuf-net.dll</HintPath>
+      <HintPath>../../.vanilla/Lib/protobuf-net.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json">
-      <HintPath>..\..\.vanilla\Lib\Newtonsoft.Json.dll</HintPath>
+      <HintPath>../../.vanilla/Lib/Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="CommandLine">
-      <HintPath>..\..\.vanilla\Lib\CommandLine.dll</HintPath>
+      <HintPath>../../.vanilla/Lib/CommandLine.dll</HintPath>
     </Reference>
     <Reference Include="SkiaSharp">
-      <HintPath>..\..\.vanilla\Lib\SkiaSharp.dll</HintPath>
+      <HintPath>../../.vanilla/Lib/SkiaSharp.dll</HintPath>
     </Reference>
     <Reference Include="Open.Nat">
-      <HintPath>..\..\.vanilla\Lib\Open.Nat.dll</HintPath>
+      <HintPath>../../.vanilla/Lib/Open.Nat.dll</HintPath>
     </Reference>
     <Reference Include="Mono.Nat">
-      <HintPath>..\..\.vanilla\Lib\Mono.Nat.dll</HintPath>
+      <HintPath>../../.vanilla/Lib/Mono.Nat.dll</HintPath>
     </Reference>
     <Reference Include="Mono.Cecil">
-      <HintPath>..\..\.vanilla\Lib\Mono.Cecil.dll</HintPath>
+      <HintPath>../../.vanilla/Lib/Mono.Cecil.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis">
-      <HintPath>..\..\.vanilla\Lib\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>../../.vanilla/Lib/Microsoft.CodeAnalysis.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp">
-      <HintPath>..\..\.vanilla\Lib\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>../../.vanilla/Lib/Microsoft.CodeAnalysis.CSharp.dll</HintPath>
     </Reference>
     <Reference Include="ICSharpCode.SharpZipLib">
-      <HintPath>..\..\.vanilla\Lib\ICSharpCode.SharpZipLib.dll</HintPath>
+      <HintPath>../../.vanilla/Lib/ICSharpCode.SharpZipLib.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Data.Sqlite">
-      <HintPath>..\..\.vanilla\Lib\Microsoft.Data.Sqlite.dll</HintPath>
+      <HintPath>../../.vanilla/Lib/Microsoft.Data.Sqlite.dll</HintPath>
     </Reference>
     <Reference Include="0Harmony">
-      <HintPath>..\..\.vanilla\Lib\0Harmony.dll</HintPath>
+      <HintPath>../../.vanilla/Lib/0Harmony.dll</HintPath>
     </Reference>
     <Reference Include="OpenTK.Windowing.Desktop">
-      <HintPath>..\..\.vanilla\Lib\OpenTK.Windowing.Desktop.dll</HintPath>
+      <HintPath>../../.vanilla/Lib/OpenTK.Windowing.Desktop.dll</HintPath>
     </Reference>
     <Reference Include="OpenTK.Audio.OpenAL">
-      <HintPath>..\..\.vanilla\Lib\OpenTK.Audio.OpenAL.dll</HintPath>
+      <HintPath>../../.vanilla/Lib/OpenTK.Audio.OpenAL.dll</HintPath>
     </Reference>
     <Reference Include="OpenTK.Mathematics">
-      <HintPath>..\..\.vanilla\Lib\OpenTK.Mathematics.dll</HintPath>
+      <HintPath>../../.vanilla/Lib/OpenTK.Mathematics.dll</HintPath>
     </Reference>
     <Reference Include="OpenTK.Windowing.Common">
-      <HintPath>..\..\.vanilla\Lib\OpenTK.Windowing.Common.dll</HintPath>
+      <HintPath>../../.vanilla/Lib/OpenTK.Windowing.Common.dll</HintPath>
     </Reference>
     <Reference Include="OpenTK.Windowing.GraphicsLibraryFramework">
-      <HintPath>..\..\.vanilla\Lib\OpenTK.Windowing.GraphicsLibraryFramework.dll</HintPath>
+      <HintPath>../../.vanilla/Lib/OpenTK.Windowing.GraphicsLibraryFramework.dll</HintPath>
     </Reference>
     <Reference Include="DnsClient">
-      <HintPath>..\..\.vanilla\Lib\DnsClient.dll</HintPath>
+      <HintPath>../../.vanilla/Lib/DnsClient.dll</HintPath>
     </Reference>
-    <Reference Include="OpenTK.Graphics" Condition="Exists('$(MSBuildThisFileDirectory)..\..\.vanilla\Lib\OpenTK.Graphics.dll')">
-      <HintPath>..\..\.vanilla\Lib\OpenTK.Graphics.dll</HintPath>
+    <Reference Include="OpenTK.Graphics" Condition="Exists('$(MSBuildThisFileDirectory)../../.vanilla/Lib/OpenTK.Graphics.dll')">
+      <HintPath>../../.vanilla/Lib/OpenTK.Graphics.dll</HintPath>
     </Reference>
-    <Reference Include="OpenTK.Graphics" Condition="!Exists('$(MSBuildThisFileDirectory)..\..\.vanilla\Lib\OpenTK.Graphics.dll') And Exists('$(MSBuildThisFileDirectory)..\..\.vanilla\OpenTK.Graphics.dll')">
-      <HintPath>..\..\.vanilla\OpenTK.Graphics.dll</HintPath>
+    <Reference Include="OpenTK.Graphics" Condition="!Exists('$(MSBuildThisFileDirectory)../../.vanilla/Lib/OpenTK.Graphics.dll') And Exists('$(MSBuildThisFileDirectory)../../.vanilla/OpenTK.Graphics.dll')">
+      <HintPath>../../.vanilla/OpenTK.Graphics.dll</HintPath>
     </Reference>
-    <Reference Include="csvorbis" Condition="Exists('$(MSBuildThisFileDirectory)..\..\.vanilla\Lib\csvorbis.dll')">
-      <HintPath>..\..\.vanilla\Lib\csvorbis.dll</HintPath>
+    <Reference Include="csvorbis" Condition="Exists('$(MSBuildThisFileDirectory)../../.vanilla/Lib/csvorbis.dll')">
+      <HintPath>../../.vanilla/Lib/csvorbis.dll</HintPath>
     </Reference>
-    <Reference Include="csvorbis" Condition="!Exists('$(MSBuildThisFileDirectory)..\..\.vanilla\Lib\csvorbis.dll') And Exists('$(MSBuildThisFileDirectory)..\..\.vanilla\csvorbis.dll')">
-      <HintPath>..\..\.vanilla\csvorbis.dll</HintPath>
+    <Reference Include="csvorbis" Condition="!Exists('$(MSBuildThisFileDirectory)../../.vanilla/Lib/csvorbis.dll') And Exists('$(MSBuildThisFileDirectory)../../.vanilla/csvorbis.dll')">
+      <HintPath>../../.vanilla/csvorbis.dll</HintPath>
     </Reference>
-    <Reference Include="csogg" Condition="Exists('$(MSBuildThisFileDirectory)..\..\.vanilla\Lib\csogg.dll')">
-      <HintPath>..\..\.vanilla\Lib\csogg.dll</HintPath>
+    <Reference Include="csogg" Condition="Exists('$(MSBuildThisFileDirectory)../../.vanilla/Lib/csogg.dll')">
+      <HintPath>../../.vanilla/Lib/csogg.dll</HintPath>
     </Reference>
-    <Reference Include="csogg" Condition="!Exists('$(MSBuildThisFileDirectory)..\..\.vanilla\Lib\csogg.dll') And Exists('$(MSBuildThisFileDirectory)..\..\.vanilla\csogg.dll')">
-      <HintPath>..\..\.vanilla\csogg.dll</HintPath>
+    <Reference Include="csogg" Condition="!Exists('$(MSBuildThisFileDirectory)../../.vanilla/Lib/csogg.dll') And Exists('$(MSBuildThisFileDirectory)../../.vanilla/csogg.dll')">
+      <HintPath>../../.vanilla/csogg.dll</HintPath>
     </Reference>
     <Reference Include="xplatforminterface">
-      <HintPath>..\..\.vanilla\Lib\xplatforminterface.dll</HintPath>
+      <HintPath>../../.vanilla/Lib/xplatforminterface.dll</HintPath>
     </Reference>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Backslash path separators in StratumServer.csproj and Directory.Build.targets break Exists() checks and item globs on Linux. Switch to forward slashes. MSBuild handles both on Windows so this changes nothing for existing contributors.

The duplicate-DLL prune step in DeployStratumServer used an inline PowerShell Exec. Replace it with a RoslynCodeTaskFactory inline task that does the same size-comparison logic without requiring PowerShell on PATH.

Also remove empty PropertyGroup/ItemGroup noise from sources/VintagestoryLib/VintagestoryLib.csproj.