### PR TITLE
Correct entity caps despawn doc comment

### DIFF
--- a/sources/VintagestoryLib/Vintagestory.Server/StratumEntityCaps.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumEntityCaps.cs
@@ -9,8 +9,8 @@ namespace Vintagestory.Server;
 /// Per-chunk-column entity cap enforcement. Runs every
 /// <see cref="StratumEntityTickingConfig.EntityCapsEnforcementIntervalSeconds"/> seconds and,
 /// for any chunk column that has more loaded creatures or ground items than the configured cap,
-/// flags the oldest excess for despawn. The simulation system's existing per-tick despawn pass
-/// picks them up; we don't call <c>DespawnEntity</c> from here.
+/// despawns the oldest excess by calling <c>server.DespawnEntity</c> with
+/// <see cref="EnumDespawnReason.Unload"/>. Excess is ordered oldest-first by <c>EntityId</c>.
 ///
 /// Creatures honor the same exempt-code-prefix list and named-entity rule as
 /// <see cref="ServerSystemEntitySimulation"/>'s hard-despawn so player livestock and tamed mobs


### PR DESCRIPTION
## Problem

The StratumEntityCaps class summary says the cap pass flags excess entities, lets the simulation despawn loop pick them up, and does not call DespawnEntity itself. Enforce does call server.DespawnEntity on the oldest excess, with EnumDespawnReason.Unload, ordered oldest-first by EntityId. The comment describes a flag-and-defer handshake the code does not use, so a reader trusting it goes looking for something that is not there.

## Fix

Rewrite the two sentences to match what Enforce does.

## Verification

Comment text only. No code path changes.
