### PR TITLE
Remove unused RemainingSeconds field from login protection

### DIFF
--- a/sources/VintagestoryLib/Vintagestory.Server/StratumLoginProtection.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumLoginProtection.cs
@@ -51,8 +51,7 @@ internal sealed class StratumLoginProtection
 		{
 			StartX = player.Entity.Pos.X,
 			StartZ = player.Entity.Pos.Z,
-			ExpiresAtMs = server.ElapsedMilliseconds + durationMs,
-			RemainingSeconds = cfg.ProtectionSeconds
+			ExpiresAtMs = server.ElapsedMilliseconds + durationMs
 		};
 
 		if (cfg.AnnounceOnStart)
@@ -151,6 +150,5 @@ internal sealed class StratumLoginProtection
 		public double StartX;
 		public double StartZ;
 		public long ExpiresAtMs;
-		public int RemainingSeconds;
 	}
 }


### PR DESCRIPTION
## Problem

ProtectionState.RemainingSeconds is set when a player gains login protection and never read anywhere. It is dead state.

## Fix

Drop the field and its assignment.

## Verification

Searched the sources tree for other references and found none. No behavior change.
