### PR TITLE
Cap retained closed reports to bound report store growth

### DIFF
--- a/sources/VintagestoryLib/Vintagestory.Server/StratumModerationStore.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumModerationStore.cs
@@ -238,6 +238,10 @@ internal static class StratumReportStore
 	private static readonly object StoreLock = new object();
 	private static StratumReportState state;
 
+	// Bound the report store. Save keeps the most recent MaxRetainedClosedReports closed
+	// reports and drops the rest. It never prunes open or claimed reports.
+	private const int MaxRetainedClosedReports = 200;
+
 	public static StratumReportEntry AddReport(string reporterUid, string reporterName, string targetUid, string targetName, string reason)
 	{
 		lock (StoreLock)
@@ -354,8 +358,41 @@ internal static class StratumReportStore
 
 	private static void Save()
 	{
+		PruneClosedReports();
 		GamePaths.EnsurePathExists(GamePaths.Config);
 		File.WriteAllText(StorePath, JsonConvert.SerializeObject(state, Formatting.Indented));
+	}
+
+	private static void PruneClosedReports()
+	{
+		int closedCount = 0;
+		for (int i = 0; i < state.Reports.Count; i++)
+		{
+			if (string.Equals(state.Reports[i].Status, "closed", StringComparison.OrdinalIgnoreCase))
+			{
+				closedCount++;
+			}
+		}
+
+		int toDrop = closedCount - MaxRetainedClosedReports;
+		if (toDrop <= 0)
+		{
+			return;
+		}
+
+		int index = 0;
+		while (index < state.Reports.Count && toDrop > 0)
+		{
+			if (string.Equals(state.Reports[index].Status, "closed", StringComparison.OrdinalIgnoreCase))
+			{
+				state.Reports.RemoveAt(index);
+				toDrop--;
+			}
+			else
+			{
+				index++;
+			}
+		}
 	}
 
 	private static string StorePath => Path.Combine(GamePaths.Config, "stratum.reports.json");


### PR DESCRIPTION
## Problem

StratumReportStore appends every report to state.Reports and never removes any. Closed reports stay forever, so stratum.reports.json and the load-time parse grow for the life of the world. This is the unbounded-collection pattern the block break guard already avoids with its remembered-progress cap.

## Fix

Save drops the oldest closed reports beyond the most recent 200. Open and claimed reports stay untouched. The prune runs inside the existing StoreLock on every save, so it costs two short list scans per report mutation and nothing on the read path. The cap is a constant for now; it can move to StratumConfig if admins should tune it.

## Verification

PruneClosedReports counts closed entries, and when the count passes the cap it removes oldest-first until it reaches the cap. NextId is independent of list contents, so report numbering stays stable.
