### PR TITLE
Fix corrupt hunk headers in 3 patch files

### DIFF
--- a/patches/VSEssentials/Entity/Pathfinding/PathfindingAsync.cs.patch
+++ b/patches/VSEssentials/Entity/Pathfinding/PathfindingAsync.cs.patch
@@ -142,7 +142,7 @@ index 48a886b..7b443ba 100644
  
          public int OffThreadInterval()
          {
-@@ -103,20 +205,230 @@ namespace Vintagestory.Essentials
+@@ -103,20 +205,243 @@ namespace Vintagestory.Essentials
          /// <summary>
          /// Threadsafe way of dequeueing next task
          /// </summary>

--- a/patches/VintagestoryLib/Vintagestory.Server/PhysicsManager.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/PhysicsManager.cs.patch
@@ -403,7 +403,7 @@ index 2c2605d..4a09dd1 100644
  				{
  					list2.Add(entityId);
  				}
-@@ -593,60 +762,160 @@ public class PhysicsManager : LoadBalancedTask
+@@ -593,60 +762,159 @@ public class PhysicsManager : LoadBalancedTask
  		list3.Clear();
  	}
  

--- a/patches/VintagestoryLib/Vintagestory.Server/ServerMain.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/ServerMain.cs.patch
@@ -73,7 +73,7 @@ index 1017be9..643d511 100644
  	{
  		get
  		{
-@@ -516,11 +541,11 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -516,11 +541,14 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  	{
  		ServerPlayer player = client.Player;
  		player.Entity.WatchedAttributes.MarkAllDirty();
@@ -586,7 +586,7 @@ index 1017be9..643d511 100644
  				Logger.Audit("Client {0} got removed: '{1}' ({2})", client.PlayerName, othersKickmessage, hisKickMessage);
  			}
  			else
-@@ -2041,13 +2220,14 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -2041,13 +2220,18 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  			string playerName = client.PlayerName;
  			Clients.Remove(client.Id);
  			player.client = null;


### PR DESCRIPTION
PhysicsManager.cs.patch, ServerMain.cs.patch, and PathfindingAsync.cs.patch have @@ line counts that don't match actual hunk content. git apply rejects these with 'corrupt patch' during bootstrap.

The +N values in each hunk header were wrong:
- PhysicsManager.cs.patch line 406: claimed +160, actual +159
- ServerMain.cs.patch line 76: claimed +11, actual +14
- ServerMain.cs.patch line 589: claimed +14, actual +18
- PathfindingAsync.cs.patch line 145: claimed +230, actual +243

Corrected the headers to match the real line counts. Verified all three patches apply clean against the 1.22.3 decompiled baseline.