### PR TITLE
Skip per-tick JSON deserialization in jail enforcement

### DIFF
--- a/sources/VintagestoryLib/Vintagestory.Server/CmdStratumStaffCommands.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/CmdStratumStaffCommands.cs
@@ -20,6 +20,7 @@ internal class CmdStratumStaffCommands
 	private readonly ServerMain server;
 	private readonly Dictionary<string, string> lastMessagePartnerByUid = new Dictionary<string, string>(StringComparer.Ordinal);
 	private readonly Dictionary<string, long> lastVanishIndicatorMsByUid = new Dictionary<string, long>(StringComparer.Ordinal);
+	private readonly HashSet<string> stratumActiveJailUids = new HashSet<string>(StringComparer.Ordinal); // Stratum: skip per-tick JSON deserialization in EnforceJailedPlayers
 
 	public CmdStratumStaffCommands(ServerMain server)
 	{
@@ -781,6 +782,7 @@ internal class CmdStratumStaffCommands
 	{
 		StratumPositionConfig returnPosition = onlineTarget?.Player?.Entity?.Pos == null ? null : StratumPositionConfig.FromEntityPos(onlineTarget.Player.Entity.Pos);
 		StratumJailStatus status = StratumCustodyStore.JailPlayer(server, targetData, caller, reason, returnPosition);
+		stratumActiveJailUids.Add(targetData.PlayerUID); // Stratum: track in-memory for tick-path
 		if (onlineTarget?.Player?.Entity != null)
 		{
 			StratumStaffCommandState.RecordBackLocation(onlineTarget.Player);
@@ -811,6 +813,8 @@ internal class CmdStratumStaffCommands
 		{
 			return TextCommandResult.Error(targetData.LastKnownPlayername + " is not jailed.");
 		}
+
+		stratumActiveJailUids.Remove(targetData.PlayerUID); // Stratum: clear in-memory tracking
 
 		if (onlineTarget?.Player?.Entity != null)
 		{
@@ -1233,6 +1237,7 @@ internal class CmdStratumStaffCommands
 		StratumStaffCommandState.MarkSeen(server, player, "offline");
 		StratumStaffCommandState.ClearSessionState(player.PlayerUID);
 		lastVanishIndicatorMsByUid.Remove(player.PlayerUID);
+		stratumActiveJailUids.Remove(player.PlayerUID); // Stratum: re-populated on next join via ApplyJailOnJoin
 	}
 
 	private void OnPlayerDeath(IServerPlayer player, DamageSource damageSource)
@@ -1360,13 +1365,14 @@ internal class CmdStratumStaffCommands
 			return;
 		}
 
+		stratumActiveJailUids.Add(player.PlayerUID); // Stratum: track in-memory for tick-path
 		player.Entity.TeleportTo(jailPosition);
 		Send(player, "You are jailed." + FormatOptionalReason(status.Reason), EnumChatType.CommandError);
 	}
 
 	private void EnforceJailedPlayers()
 	{
-		if (!TryGetJailLocation(out EntityPos jailPosition, out _))
+		if (stratumActiveJailUids.Count == 0 || !TryGetJailLocation(out EntityPos jailPosition, out _))
 		{
 			return;
 		}
@@ -1375,7 +1381,7 @@ internal class CmdStratumStaffCommands
 		double maxDistanceSq = maxDistance * maxDistance;
 		foreach (ConnectedClient client in server.Clients.Values)
 		{
-			if (!client.State.IsAdmitted() || client.Player?.Entity?.Pos == null || !StratumCustodyStore.TryGetActiveJail(client.ServerData, out _))
+			if (!client.State.IsAdmitted() || client.Player?.Entity?.Pos == null || !stratumActiveJailUids.Contains(client.Player.PlayerUID))
 			{
 				continue;
 			}


### PR DESCRIPTION
EnforceJailedPlayers called TryGetActiveJail for every online client every 250ms. TryGetActiveJail deserializes the full StratumJailStatus JSON (3.7 KB allocation) regardless of Active state. The jail key persists after release, so every ever-jailed player paid this cost forever: 25 us and 3,768 bytes per player per tick, all discarded.

At 50 ever-jailed players online: 1.25 ms/tick (2.5% of 50ms budget), 44 MB/min allocation rate, 5 Gen0 GCs/min from this path alone. At 200: 5 ms/tick (10% budget).

Fix: maintain a HashSet<string> of actively-jailed UIDs in memory. Populated on join (ApplyJailOnJoin already loads the record once), added on /jail, removed on /unjail, cleared on disconnect. EnforceJailedPlayers checks the set (O(1), zero alloc) instead of deserializing per client.

Tested: server boots, jail/unjail works, enforcement teleports back, clean shutdown. Measured with a standalone benchmark that calls DeserializeObject<StratumJailStatus> in a loop and reports per-call allocation and timing.