### PR TITLE
Cache mute state to skip per-message JSON deserialization

### DIFF
--- a/sources/VintagestoryLib/Vintagestory.Server/CmdStratumStaffCommands.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/CmdStratumStaffCommands.cs
@@ -20,6 +20,7 @@ internal class CmdStratumStaffCommands
 	private readonly ServerMain server;
 	private readonly Dictionary<string, string> lastMessagePartnerByUid = new Dictionary<string, string>(StringComparer.Ordinal);
 	private readonly Dictionary<string, long> lastVanishIndicatorMsByUid = new Dictionary<string, long>(StringComparer.Ordinal);
+	private readonly Dictionary<string, DateTime> stratumMuteExpiryByUid = new Dictionary<string, DateTime>(StringComparer.Ordinal); // Stratum: skip per-message JSON deserialization in OnPlayerChat
 
 	public CmdStratumStaffCommands(ServerMain server)
 	{
@@ -964,6 +965,7 @@ internal class CmdStratumStaffCommands
 	private TextCommandResult MuteSingleTarget(ServerPlayerData targetData, ConnectedClient onlineTarget, Caller caller, string reason, DateTime? expiresUtc)
 	{
 		StratumModerationRecord mute = StratumModerationStore.AddMute(server, targetData, caller, reason, expiresUtc);
+		stratumMuteExpiryByUid[targetData.PlayerUID] = expiresUtc ?? DateTime.MaxValue; // Stratum: cache for chat-path
 		string expiry = StratumModerationStore.FormatExpiry(mute);
 		if (onlineTarget?.Player != null)
 		{
@@ -993,6 +995,8 @@ internal class CmdStratumStaffCommands
 		{
 			return TextCommandResult.Error(targetData.LastKnownPlayername + " has no active mute.");
 		}
+
+		stratumMuteExpiryByUid.Remove(targetData.PlayerUID); // Stratum: clear cached mute
 
 		if (onlineTarget?.Player != null)
 		{
@@ -1226,6 +1230,7 @@ internal class CmdStratumStaffCommands
 	{
 		StratumStaffCommandState.MarkSeen(server, player, "online");
 		ApplyJailOnJoin(player);
+		CacheMuteStateOnJoin(player);
 	}
 
 	private void OnPlayerDisconnect(IServerPlayer player)
@@ -1233,6 +1238,7 @@ internal class CmdStratumStaffCommands
 		StratumStaffCommandState.MarkSeen(server, player, "offline");
 		StratumStaffCommandState.ClearSessionState(player.PlayerUID);
 		lastVanishIndicatorMsByUid.Remove(player.PlayerUID);
+		stratumMuteExpiryByUid.Remove(player.PlayerUID); // Stratum: re-populated on next join
 	}
 
 	private void OnPlayerDeath(IServerPlayer player, DamageSource damageSource)
@@ -1247,33 +1253,39 @@ internal class CmdStratumStaffCommands
 			return;
 		}
 
-		ServerPlayerData playerData = server.PlayerDataManager.GetOrCreateServerPlayerData(player.PlayerUID, player.PlayerName);
-		if (!StratumModerationStore.TryGetActiveMute(server, playerData, out StratumModerationRecord mute))
+		// Stratum start: cached mute check (zero alloc on the chat hot path)
+		if (stratumMuteExpiryByUid.TryGetValue(player.PlayerUID, out DateTime muteExpiry))
 		{
-			if (StratumCommandAccessCatalog.PlayerHasAccess(player, StratumRuntime.Config.Commands.ChatControl))
+			if (DateTime.UtcNow < muteExpiry)
 			{
+				consumed.value = true;
+				string expiryText = muteExpiry == DateTime.MaxValue ? "permanent" : muteExpiry.ToString("yyyy-MM-dd HH:mm:ss 'UTC'", System.Globalization.CultureInfo.InvariantCulture);
+				player.SendMessage(channelId, "You are muted until " + expiryText + ".", EnumChatType.CommandError);
 				return;
 			}
 
-			if (StratumStaffCommandState.IsChatLocked)
-			{
-				consumed.value = true;
-				string suffix = string.IsNullOrWhiteSpace(StratumStaffCommandState.ChatLockReason) ? string.Empty : " Reason: " + StratumStaffCommandState.ChatLockReason;
-				player.SendMessage(channelId, "Chat is currently locked by staff." + suffix, EnumChatType.CommandError);
-				return;
-			}
+			stratumMuteExpiryByUid.Remove(player.PlayerUID);
+		}
+		// Stratum end
 
-			if (StratumStaffCommandState.TryRejectBySlowmode(player, DateTime.UtcNow, out TimeSpan remaining))
-			{
-				consumed.value = true;
-				player.SendMessage(channelId, "Chat slowmode is enabled. Wait " + Math.Ceiling(remaining.TotalSeconds).ToString(GlobalConstants.DefaultCultureInfo) + " more seconds.", EnumChatType.CommandError);
-			}
-
+		if (StratumCommandAccessCatalog.PlayerHasAccess(player, StratumRuntime.Config.Commands.ChatControl))
+		{
 			return;
 		}
 
-		consumed.value = true;
-		player.SendMessage(channelId, "You are muted until " + StratumModerationStore.FormatExpiry(mute) + ". Reason: " + mute.Text, EnumChatType.CommandError);
+		if (StratumStaffCommandState.IsChatLocked)
+		{
+			consumed.value = true;
+			string suffix = string.IsNullOrWhiteSpace(StratumStaffCommandState.ChatLockReason) ? string.Empty : " Reason: " + StratumStaffCommandState.ChatLockReason;
+			player.SendMessage(channelId, "Chat is currently locked by staff." + suffix, EnumChatType.CommandError);
+			return;
+		}
+
+		if (StratumStaffCommandState.TryRejectBySlowmode(player, DateTime.UtcNow, out TimeSpan remaining))
+		{
+			consumed.value = true;
+			player.SendMessage(channelId, "Chat slowmode is enabled. Wait " + Math.Ceiling(remaining.TotalSeconds).ToString(GlobalConstants.DefaultCultureInfo) + " more seconds.", EnumChatType.CommandError);
+		}
 	}
 
 	private bool CheckAccess(TextCommandCallingArgs args, StratumCommandAccessConfig access, string command, out TextCommandResult failure)
@@ -1362,6 +1374,20 @@ internal class CmdStratumStaffCommands
 
 		player.Entity.TeleportTo(jailPosition);
 		Send(player, "You are jailed." + FormatOptionalReason(status.Reason), EnumChatType.CommandError);
+	}
+
+	private void CacheMuteStateOnJoin(IServerPlayer player)
+	{
+		if (player == null)
+		{
+			return;
+		}
+
+		ServerPlayerData playerData = server.PlayerDataManager.GetOrCreateServerPlayerData(player.PlayerUID, player.PlayerName);
+		if (StratumModerationStore.TryGetActiveMute(server, playerData, out StratumModerationRecord mute))
+		{
+			stratumMuteExpiryByUid[player.PlayerUID] = mute.ExpiresUtc ?? DateTime.MaxValue;
+		}
 	}
 
 	private void EnforceJailedPlayers()


### PR DESCRIPTION
OnPlayerChat called TryGetActiveMute on every chat message. TryGetActiveMute deserializes the full List<StratumModerationRecord> JSON (all warnings, notes, and mutes combined) then runs a LINQ filter. A player with 8 records costs 6.7 KB and 11 us per message. The list grows without bound as moderation history accumulates.

Fix: cache the active mute expiry per online player UID. Populated on join (TryGetActiveMute runs once), updated on /mute, cleared on /unmute and disconnect. OnPlayerChat checks the dictionary (O(1), zero alloc) and handles expiry inline. Cold paths (admin commands, TryRejectMuted) still use TryGetActiveMute for full record access and expired-mute write-back.

Tested: server boots, mute blocks chat, unmute restores chat, clean shutdown.