### PR TITLE
Skip registering disabled Stratum commands

### DIFF
--- a/sources/VintagestoryLib/Vintagestory.Server/CmdStratum.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/CmdStratum.cs
@@ -21,7 +21,6 @@ internal class CmdStratum
 	{
 		this.server = server;
 		server.api.commandapi.Create(StratumInfo.Id)
-			.WithAlias("serverinfo")
 			.WithDesc("Show Stratum server information")
 			.WithArgs(server.api.commandapi.Parsers.OptionalWord("status|version|update|health|reload|preflight|packets|performance|perf|timings|players|player|chunks|entities|queues|pathfinding|doctor|regions|violations|access|chat|pregen|get|set|save"), server.api.commandapi.Parsers.OptionalWord("argument"), server.api.commandapi.Parsers.OptionalWord("detail"), server.api.commandapi.Parsers.OptionalWord("value1"), server.api.commandapi.Parsers.OptionalWord("value2"), server.api.commandapi.Parsers.OptionalWord("value3"), server.api.commandapi.Parsers.OptionalWord("value4"))
 			.RequiresPrivilege(Privilege.controlserver)

--- a/sources/VintagestoryLib/Vintagestory.Server/CmdStratumEssentials.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/CmdStratumEssentials.cs
@@ -35,70 +35,93 @@ internal class CmdStratumEssentials
 		}
 
 		CommandArgumentParsers parsers = server.api.commandapi.Parsers;
-		server.api.commandapi.Create("spawn")
-			.WithDescription("Teleport to server spawn")
-			.RequiresPrivilege(Privilege.chat)
-			.HandleWith(HandleSpawn);
+		StratumCommandsConfig commands = StratumRuntime.Config.Commands;
+		if (StratumCommandRegistration.ShouldRegister(commands.Spawn, "/spawn", "Commands.Spawn"))
+		{
+			server.api.commandapi.Create("spawn")
+				.WithDescription("Teleport to server spawn")
+				.RequiresPrivilege(Privilege.chat)
+				.HandleWith(HandleSpawn);
+		}
 
-		server.api.commandapi.Create("setspawn")
-			.WithDescription("Set the server spawn to your position")
-			.RequiresPrivilege(Privilege.chat)
-			.HandleWith(HandleSetSpawn);
+		if (StratumCommandRegistration.ShouldRegister(commands.SetSpawn, "/setspawn", "Commands.SetSpawn"))
+		{
+			server.api.commandapi.Create("setspawn")
+				.WithDescription("Set the server spawn to your position")
+				.RequiresPrivilege(Privilege.chat)
+				.HandleWith(HandleSetSpawn);
+		}
 
-		server.api.commandapi.Create("tpa")
-			.WithDescription("Request teleport to another player, or accept/decline a request")
-			.WithArgs(parsers.OptionalWord("player|accept|decline|cancel"))
-			.RequiresPrivilege(Privilege.chat)
-			.HandleWith(HandleTpa);
+		if (StratumCommandRegistration.ShouldRegister(commands.TeleportRequests.Request, "/tpa commands", "Commands.TeleportRequests.Request"))
+		{
+			server.api.commandapi.Create("tpa")
+				.WithDescription("Request teleport to another player, or accept/decline a request")
+				.WithArgs(parsers.OptionalWord("player|accept|decline|cancel"))
+				.RequiresPrivilege(Privilege.chat)
+				.HandleWith(HandleTpa);
 
-		server.api.commandapi.Create("tpahere")
-			.WithDescription("Request another player to teleport to you")
-			.WithArgs(parsers.OptionalWord("player"))
-			.RequiresPrivilege(Privilege.chat)
-			.HandleWith(HandleTpaHere);
+			server.api.commandapi.Create("tpaccept")
+				.WithDescription("Accept a pending teleport request")
+				.RequiresPrivilege(Privilege.chat)
+				.HandleWith(HandleTpAccept);
 
-		server.api.commandapi.Create("tpaccept")
-			.WithDescription("Accept a pending teleport request")
-			.RequiresPrivilege(Privilege.chat)
-			.HandleWith(HandleTpAccept);
+			server.api.commandapi.Create("tpdeny")
+				.WithDescription("Decline a pending teleport request")
+				.RequiresPrivilege(Privilege.chat)
+				.HandleWith(HandleTpDecline);
 
-		server.api.commandapi.Create("tpdeny")
-			.WithDescription("Decline a pending teleport request")
-			.RequiresPrivilege(Privilege.chat)
-			.HandleWith(HandleTpDecline);
+			server.api.commandapi.Create("tpdecline")
+				.WithDescription("Decline a pending teleport request")
+				.RequiresPrivilege(Privilege.chat)
+				.HandleWith(HandleTpDecline);
 
-		server.api.commandapi.Create("tpdecline")
-			.WithDescription("Decline a pending teleport request")
-			.RequiresPrivilege(Privilege.chat)
-			.HandleWith(HandleTpDecline);
+			server.api.commandapi.Create("tpacancel")
+				.WithDescription("Cancel your outgoing teleport request")
+				.RequiresPrivilege(Privilege.chat)
+				.HandleWith(HandleTpCancel);
+		}
 
-		server.api.commandapi.Create("tpacancel")
-			.WithDescription("Cancel your outgoing teleport request")
-			.RequiresPrivilege(Privilege.chat)
-			.HandleWith(HandleTpCancel);
+		if (StratumCommandRegistration.ShouldRegister(commands.TeleportRequests.Here, "/tpahere", "Commands.TeleportRequests.Here")
+			&& StratumCommandRegistration.ShouldRegister(commands.TeleportRequests.AllowTpaHere, "/tpahere", "Commands.TeleportRequests.AllowTpaHere"))
+		{
+			server.api.commandapi.Create("tpahere")
+				.WithDescription("Request another player to teleport to you")
+				.WithArgs(parsers.OptionalWord("player"))
+				.RequiresPrivilege(Privilege.chat)
+				.HandleWith(HandleTpaHere);
+		}
 
-		server.api.commandapi.Create("home")
-			.WithDescription("Teleport to one of your homes")
-			.WithArgs(parsers.OptionalWord("name"))
-			.RequiresPrivilege(Privilege.chat)
-			.HandleWith(HandleHome);
+		if (StratumCommandRegistration.ShouldRegister(commands.Homes.Home, "/home commands", "Commands.Homes.Home"))
+		{
+			server.api.commandapi.Create("home")
+				.WithDescription("Teleport to one of your homes")
+				.WithArgs(parsers.OptionalWord("name"))
+				.RequiresPrivilege(Privilege.chat)
+				.HandleWith(HandleHome);
 
-		server.api.commandapi.Create("sethome")
-			.WithDescription("Set a home at your current position")
-			.WithArgs(parsers.OptionalWord("name"))
-			.RequiresPrivilege(Privilege.chat)
-			.HandleWith(HandleSetHome);
+			server.api.commandapi.Create("homes")
+				.WithDescription("List your homes")
+				.RequiresPrivilege(Privilege.chat)
+				.HandleWith(HandleHomes);
+		}
 
-		server.api.commandapi.Create("delhome")
-			.WithDescription("Delete one of your homes")
-			.WithArgs(parsers.OptionalWord("name"))
-			.RequiresPrivilege(Privilege.chat)
-			.HandleWith(HandleDeleteHome);
+		if (StratumCommandRegistration.ShouldRegister(commands.Homes.SetHome, "/sethome", "Commands.Homes.SetHome"))
+		{
+			server.api.commandapi.Create("sethome")
+				.WithDescription("Set a home at your current position")
+				.WithArgs(parsers.OptionalWord("name"))
+				.RequiresPrivilege(Privilege.chat)
+				.HandleWith(HandleSetHome);
+		}
 
-		server.api.commandapi.Create("homes")
-			.WithDescription("List your homes")
-			.RequiresPrivilege(Privilege.chat)
-			.HandleWith(HandleHomes);
+		if (StratumCommandRegistration.ShouldRegister(commands.Homes.DeleteHome, "/delhome", "Commands.Homes.DeleteHome"))
+		{
+			server.api.commandapi.Create("delhome")
+				.WithDescription("Delete one of your homes")
+				.WithArgs(parsers.OptionalWord("name"))
+				.RequiresPrivilege(Privilege.chat)
+				.HandleWith(HandleDeleteHome);
+		}
 	}
 
 	public static void RegisterConfiguredPrivileges(ServerMain server)

--- a/sources/VintagestoryLib/Vintagestory.Server/CmdStratumStaffCommands.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/CmdStratumStaffCommands.cs
@@ -39,198 +39,256 @@ internal class CmdStratumStaffCommands
 		}
 
 		CommandArgumentParsers parsers = server.api.commandapi.Parsers;
-		server.api.commandapi.Create("seen")
-			.WithDescription("Show when a player was last seen")
-			.WithArgs(parsers.Word("player"))
-			.RequiresPrivilege(Privilege.chat)
-			.HandleWith(HandleSeen);
+		StratumCommandsConfig commands = StratumRuntime.Config.Commands;
+		if (StratumCommandRegistration.ShouldRegister(commands.Seen, "/seen", "Commands.Seen"))
+		{
+			server.api.commandapi.Create("seen")
+				.WithDescription("Show when a player was last seen")
+				.WithArgs(parsers.Word("player"))
+				.RequiresPrivilege(Privilege.chat)
+				.HandleWith(HandleSeen);
+		}
 
-		server.api.commandapi.Create("whois")
-			.WithDescription("Show staff investigation details for a player")
-			.WithArgs(parsers.Word("player"))
-			.RequiresPrivilege(Privilege.chat)
-			.HandleWith(HandleWhois);
+		if (StratumCommandRegistration.ShouldRegister(commands.Whois, "/whois", "Commands.Whois"))
+		{
+			server.api.commandapi.Create("whois")
+				.WithDescription("Show staff investigation details for a player")
+				.WithArgs(parsers.Word("player"))
+				.RequiresPrivilege(Privilege.chat)
+				.HandleWith(HandleWhois);
+		}
 
-		server.api.commandapi.Create("near")
-			.WithDescription("List nearby players")
-			.WithArgs(parsers.OptionalInt("radius", StratumRuntime.Config.Commands.NearDefaultRadiusBlocks))
-			.RequiresPrivilege(Privilege.chat)
-			.HandleWith(HandleNear);
+		if (StratumCommandRegistration.ShouldRegister(commands.Near, "/near", "Commands.Near"))
+		{
+			server.api.commandapi.Create("near")
+				.WithDescription("List nearby players")
+				.WithArgs(parsers.OptionalInt("radius", StratumRuntime.Config.Commands.NearDefaultRadiusBlocks))
+				.RequiresPrivilege(Privilege.chat)
+				.HandleWith(HandleNear);
+		}
 
-		server.api.commandapi.Create("back")
-			.WithDescription("Teleport back to your previous Stratum teleport or death location")
-			.RequiresPrivilege(Privilege.chat)
-			.HandleWith(HandleBack);
+		if (StratumCommandRegistration.ShouldRegister(commands.Back, "/back", "Commands.Back"))
+		{
+			server.api.commandapi.Create("back")
+				.WithDescription("Teleport back to your previous Stratum teleport or death location")
+				.RequiresPrivilege(Privilege.chat)
+				.HandleWith(HandleBack);
+		}
 
-		RegisterMessageCommand("msg", parsers);
-		RegisterMessageCommand("tell", parsers);
-		RegisterMessageCommand("w", parsers);
+		if (StratumCommandRegistration.ShouldRegister(commands.Message, "/msg commands", "Commands.Message"))
+		{
+			RegisterMessageCommand("msg", parsers);
+			RegisterMessageCommand("tell", parsers);
+			RegisterMessageCommand("w", parsers);
 
-		server.api.commandapi.Create("reply")
-			.WithAlias("r")
-			.WithDescription("Reply to your last private message")
-			.WithArgs(parsers.All("message"))
-			.RequiresPrivilege(Privilege.chat)
-			.HandleWith(HandleReply);
+			server.api.commandapi.Create("reply")
+				.WithAlias("r")
+				.WithDescription("Reply to your last private message")
+				.WithArgs(parsers.All("message"))
+				.RequiresPrivilege(Privilege.chat)
+				.HandleWith(HandleReply);
+		}
 
-		server.api.commandapi.Create("staffchat")
-			.WithDescription("Send a message to online staff")
-			.WithArgs(parsers.All("message"))
-			.RequiresPrivilege(Privilege.chat)
-			.HandleWith(HandleStaffChat);
+		if (StratumCommandRegistration.ShouldRegister(commands.StaffChat, "/staffchat", "Commands.StaffChat"))
+		{
+			server.api.commandapi.Create("staffchat")
+				.WithDescription("Send a message to online staff")
+				.WithArgs(parsers.All("message"))
+				.RequiresPrivilege(Privilege.chat)
+				.HandleWith(HandleStaffChat);
+		}
 
-		server.api.commandapi.Create("slowmode")
-			.WithDescription("Set, clear, or inspect global chat slowmode")
-			.WithArgs(parsers.OptionalWord("seconds|off|status"))
-			.RequiresPrivilege(Privilege.chat)
-			.HandleWith(HandleSlowmode);
+		if (StratumCommandRegistration.ShouldRegister(commands.ChatControl, "/chat control commands", "Commands.ChatControl"))
+		{
+			server.api.commandapi.Create("slowmode")
+				.WithDescription("Set, clear, or inspect global chat slowmode")
+				.WithArgs(parsers.OptionalWord("seconds|off|status"))
+				.RequiresPrivilege(Privilege.chat)
+				.HandleWith(HandleSlowmode);
 
-		server.api.commandapi.Create("lockchat")
-			.WithDescription("Lock or unlock global player chat")
-			.WithArgs(parsers.OptionalWordRange("mode", "on", "off", "toggle", "status"), parsers.OptionalAll("reason"))
-			.RequiresPrivilege(Privilege.chat)
-			.HandleWith(HandleLockChat);
+			server.api.commandapi.Create("lockchat")
+				.WithDescription("Lock or unlock global player chat")
+				.WithArgs(parsers.OptionalWordRange("mode", "on", "off", "toggle", "status"), parsers.OptionalAll("reason"))
+				.RequiresPrivilege(Privilege.chat)
+				.HandleWith(HandleLockChat);
 
-		server.api.commandapi.Create("chatclear")
-			.WithAlias("clearchat")
-			.WithDescription("Clear visible chat history for online players")
-			.WithArgs(parsers.OptionalInt("lines", StratumRuntime.Config.Commands.ClearChatLines))
-			.RequiresPrivilege(Privilege.chat)
-			.HandleWith(HandleClearChat);
+			server.api.commandapi.Create("chatclear")
+				.WithAlias("clearchat")
+				.WithDescription("Clear visible chat history for online players")
+				.WithArgs(parsers.OptionalInt("lines", StratumRuntime.Config.Commands.ClearChatLines))
+				.RequiresPrivilege(Privilege.chat)
+				.HandleWith(HandleClearChat);
+		}
 
-		server.api.commandapi.Create("staffbroadcast")
-			.WithAlias("sbc")
-			.WithDescription("Broadcast a highlighted staff message to the server")
-			.WithArgs(parsers.All("message"))
-			.RequiresPrivilege(Privilege.chat)
-			.HandleWith(HandleStaffBroadcast);
+		if (StratumCommandRegistration.ShouldRegister(commands.StaffBroadcast, "/staffbroadcast", "Commands.StaffBroadcast"))
+		{
+			server.api.commandapi.Create("staffbroadcast")
+				.WithAlias("sbc")
+				.WithDescription("Broadcast a highlighted staff message to the server")
+				.WithArgs(parsers.All("message"))
+				.RequiresPrivilege(Privilege.chat)
+				.HandleWith(HandleStaffBroadcast);
+		}
 
-		server.api.commandapi.Create("rules")
-			.WithDescription("Show the server rules")
-			.RequiresPrivilege(Privilege.chat)
-			.HandleWith(HandleRules);
+		if (StratumCommandRegistration.ShouldRegister(commands.InfoCommands, "/info commands", "Commands.InfoCommands"))
+		{
+			server.api.commandapi.Create("rules")
+				.WithDescription("Show the server rules")
+				.RequiresPrivilege(Privilege.chat)
+				.HandleWith(HandleRules);
 
-		server.api.commandapi.Create("discord")
-			.WithDescription("Show the server Discord link")
-			.RequiresPrivilege(Privilege.chat)
-			.HandleWith(HandleDiscord);
+			server.api.commandapi.Create("discord")
+				.WithDescription("Show the server Discord link")
+				.RequiresPrivilege(Privilege.chat)
+				.HandleWith(HandleDiscord);
 
-		server.api.commandapi.Create("website")
-			.WithDescription("Show the server website link")
-			.RequiresPrivilege(Privilege.chat)
-			.HandleWith(HandleWebsite);
+			server.api.commandapi.Create("website")
+				.WithDescription("Show the server website link")
+				.RequiresPrivilege(Privilege.chat)
+				.HandleWith(HandleWebsite);
 
-		server.api.commandapi.Create("motd")
-			.WithDescription("Show the server message of the day")
-			.RequiresPrivilege(Privilege.chat)
-			.HandleWith(HandleMotd);
+			server.api.commandapi.Create("motd")
+				.WithDescription("Show the server message of the day")
+				.RequiresPrivilege(Privilege.chat)
+				.HandleWith(HandleMotd);
+		}
 
-		server.api.commandapi.Create("vanish")
-			.WithDescription("Toggle staff vanish")
-			.WithArgs(parsers.OptionalWordRange("mode", "on", "off", "toggle"))
-			.RequiresPrivilege(Privilege.chat)
-			.HandleWith(HandleVanish);
+		if (StratumCommandRegistration.ShouldRegister(commands.Vanish, "/vanish", "Commands.Vanish"))
+		{
+			server.api.commandapi.Create("vanish")
+				.WithDescription("Toggle staff vanish")
+				.WithArgs(parsers.OptionalWordRange("mode", "on", "off", "toggle"))
+				.RequiresPrivilege(Privilege.chat)
+				.HandleWith(HandleVanish);
+		}
 
-		server.api.commandapi.Create("pvp")
-			.WithDescription("Show or toggle global PvP")
-			.WithArgs(parsers.OptionalWordRange("mode", "on", "off", "status"))
-			.RequiresPrivilege(Privilege.chat)
-			.HandleWith(HandlePvp);
+		if (StratumCommandRegistration.ShouldRegister(commands.Pvp, "/pvp", "Commands.Pvp"))
+		{
+			server.api.commandapi.Create("pvp")
+				.WithDescription("Show or toggle global PvP")
+				.WithArgs(parsers.OptionalWordRange("mode", "on", "off", "status"))
+				.RequiresPrivilege(Privilege.chat)
+				.HandleWith(HandlePvp);
+		}
 
-		server.api.commandapi.Create("freeze")
-			.WithDescription("Freeze or unfreeze an online player")
-			.WithArgs(parsers.Word("player"), parsers.OptionalWordRange("mode", "on", "off", "toggle"))
-			.RequiresPrivilege(Privilege.chat)
-			.HandleWith(HandleFreeze);
+		if (StratumCommandRegistration.ShouldRegister(commands.Freeze, "/freeze", "Commands.Freeze"))
+		{
+			server.api.commandapi.Create("freeze")
+				.WithDescription("Freeze or unfreeze an online player")
+				.WithArgs(parsers.Word("player"), parsers.OptionalWordRange("mode", "on", "off", "toggle"))
+				.RequiresPrivilege(Privilege.chat)
+				.HandleWith(HandleFreeze);
+		}
 
-		server.api.commandapi.Create("revive")
-			.WithDescription("Revive a dead online player in place (one-life event recovery)")
-			.WithArgs(parsers.Word("player"))
-			.RequiresPrivilege(Privilege.chat)
-			.HandleWith(HandleRevive);
+		if (StratumCommandRegistration.ShouldRegister(commands.Revive, "/revive", "Commands.Revive"))
+		{
+			server.api.commandapi.Create("revive")
+				.WithDescription("Revive a dead online player in place (one-life event recovery)")
+				.WithArgs(parsers.Word("player"))
+				.RequiresPrivilege(Privilege.chat)
+				.HandleWith(HandleRevive);
+		}
 
-		server.api.commandapi.Create("setjail")
-			.WithDescription("Set the Stratum jail location to your current position")
-			.RequiresPrivilege(Privilege.chat)
-			.HandleWith(HandleSetJail);
+		if (StratumCommandRegistration.ShouldRegister(commands.Jail, "/jail commands", "Commands.Jail"))
+		{
+			server.api.commandapi.Create("setjail")
+				.WithDescription("Set the Stratum jail location to your current position")
+				.RequiresPrivilege(Privilege.chat)
+				.HandleWith(HandleSetJail);
 
-		server.api.commandapi.Create("jail")
-			.WithDescription("Jail a known player")
-			.WithArgs(parsers.Word("player"), parsers.OptionalAll("reason"))
-			.RequiresPrivilege(Privilege.chat)
-			.HandleWith(HandleJail);
+			server.api.commandapi.Create("jail")
+				.WithDescription("Jail a known player")
+				.WithArgs(parsers.Word("player"), parsers.OptionalAll("reason"))
+				.RequiresPrivilege(Privilege.chat)
+				.HandleWith(HandleJail);
 
-		server.api.commandapi.Create("unjail")
-			.WithDescription("Release a jailed player")
-			.WithArgs(parsers.Word("player"), parsers.OptionalAll("reason"))
-			.RequiresPrivilege(Privilege.chat)
-			.HandleWith(HandleUnjail);
+			server.api.commandapi.Create("unjail")
+				.WithDescription("Release a jailed player")
+				.WithArgs(parsers.Word("player"), parsers.OptionalAll("reason"))
+				.RequiresPrivilege(Privilege.chat)
+				.HandleWith(HandleUnjail);
 
-		server.api.commandapi.Create("jailstatus")
-			.WithDescription("Show whether a player is jailed")
-			.WithArgs(parsers.Word("player"))
-			.RequiresPrivilege(Privilege.chat)
-			.HandleWith(HandleJailStatus);
+			server.api.commandapi.Create("jailstatus")
+				.WithDescription("Show whether a player is jailed")
+				.WithArgs(parsers.Word("player"))
+				.RequiresPrivilege(Privilege.chat)
+				.HandleWith(HandleJailStatus);
+		}
 
-		server.api.commandapi.Create("warn")
-			.WithDescription("Warn a player and store the reason in moderation history")
-			.WithArgs(parsers.Word("player"), parsers.All("reason"))
-			.RequiresPrivilege(Privilege.chat)
-			.HandleWith(HandleWarn);
+		if (StratumCommandRegistration.ShouldRegister(commands.Warn, "/warn commands", "Commands.Warn"))
+		{
+			server.api.commandapi.Create("warn")
+				.WithDescription("Warn a player and store the reason in moderation history")
+				.WithArgs(parsers.Word("player"), parsers.All("reason"))
+				.RequiresPrivilege(Privilege.chat)
+				.HandleWith(HandleWarn);
 
-		server.api.commandapi.Create("warnings")
-			.WithDescription("List active warnings for a player")
-			.WithArgs(parsers.Word("player"))
-			.RequiresPrivilege(Privilege.chat)
-			.HandleWith(HandleWarnings);
+			server.api.commandapi.Create("warnings")
+				.WithDescription("List active warnings for a player")
+				.WithArgs(parsers.Word("player"))
+				.RequiresPrivilege(Privilege.chat)
+				.HandleWith(HandleWarnings);
 
-		server.api.commandapi.Create("delwarn")
-			.WithDescription("Remove an active warning from a player")
-			.WithArgs(parsers.Word("player"), parsers.Int("warning id"), parsers.OptionalAll("reason"))
-			.RequiresPrivilege(Privilege.chat)
-			.HandleWith(HandleDeleteWarning);
+			server.api.commandapi.Create("delwarn")
+				.WithDescription("Remove an active warning from a player")
+				.WithArgs(parsers.Word("player"), parsers.Int("warning id"), parsers.OptionalAll("reason"))
+				.RequiresPrivilege(Privilege.chat)
+				.HandleWith(HandleDeleteWarning);
+		}
 
-		server.api.commandapi.Create("mute")
-			.WithDescription("Mute a player for a duration or permanently")
-			.WithArgs(parsers.Word("player"), parsers.Word("duration"), parsers.All("reason"))
-			.RequiresPrivilege(Privilege.chat)
-			.HandleWith(HandleMute);
+		if (StratumCommandRegistration.ShouldRegister(commands.Mute, "/mute commands", "Commands.Mute"))
+		{
+			server.api.commandapi.Create("mute")
+				.WithDescription("Mute a player for a duration or permanently")
+				.WithArgs(parsers.Word("player"), parsers.Word("duration"), parsers.All("reason"))
+				.RequiresPrivilege(Privilege.chat)
+				.HandleWith(HandleMute);
 
-		server.api.commandapi.Create("unmute")
-			.WithDescription("Remove an active mute from a player")
-			.WithArgs(parsers.Word("player"), parsers.OptionalAll("reason"))
-			.RequiresPrivilege(Privilege.chat)
-			.HandleWith(HandleUnmute);
+			server.api.commandapi.Create("unmute")
+				.WithDescription("Remove an active mute from a player")
+				.WithArgs(parsers.Word("player"), parsers.OptionalAll("reason"))
+				.RequiresPrivilege(Privilege.chat)
+				.HandleWith(HandleUnmute);
 
-		server.api.commandapi.Create("mutestatus")
-			.WithDescription("Show whether a player is muted")
-			.WithArgs(parsers.Word("player"))
-			.RequiresPrivilege(Privilege.chat)
-			.HandleWith(HandleMuteStatus);
+			server.api.commandapi.Create("mutestatus")
+				.WithDescription("Show whether a player is muted")
+				.WithArgs(parsers.Word("player"))
+				.RequiresPrivilege(Privilege.chat)
+				.HandleWith(HandleMuteStatus);
+		}
 
-		server.api.commandapi.Create("note")
-			.WithDescription("Add, list, or delete staff notes for a player")
-			.WithArgs(parsers.Word("player"), parsers.WordRange("action", "add", "list", "delete"), parsers.OptionalAll("text or id"))
-			.RequiresPrivilege(Privilege.chat)
-			.HandleWith(HandleNote);
+		if (StratumCommandRegistration.ShouldRegister(commands.Notes, "/note commands", "Commands.Notes"))
+		{
+			server.api.commandapi.Create("note")
+				.WithDescription("Add, list, or delete staff notes for a player")
+				.WithArgs(parsers.Word("player"), parsers.WordRange("action", "add", "list", "delete"), parsers.OptionalAll("text or id"))
+				.RequiresPrivilege(Privilege.chat)
+				.HandleWith(HandleNote);
 
-		server.api.commandapi.Create("notes")
-			.WithDescription("List staff notes for a player")
-			.WithArgs(parsers.Word("player"))
-			.RequiresPrivilege(Privilege.chat)
-			.HandleWith(HandleNotes);
+			server.api.commandapi.Create("notes")
+				.WithDescription("List staff notes for a player")
+				.WithArgs(parsers.Word("player"))
+				.RequiresPrivilege(Privilege.chat)
+				.HandleWith(HandleNotes);
+		}
 
-		server.api.commandapi.Create("report")
-			.WithDescription("Report a player to online staff")
-			.WithArgs(parsers.Word("player"), parsers.All("reason"))
-			.RequiresPrivilege(Privilege.chat)
-			.HandleWith(HandleReport);
+		if (StratumCommandRegistration.ShouldRegister(commands.Report, "/report", "Commands.Report"))
+		{
+			server.api.commandapi.Create("report")
+				.WithDescription("Report a player to online staff")
+				.WithArgs(parsers.Word("player"), parsers.All("reason"))
+				.RequiresPrivilege(Privilege.chat)
+				.HandleWith(HandleReport);
+		}
 
-		server.api.commandapi.Create("reports")
-			.WithDescription("Manage player reports")
-			.WithArgs(parsers.OptionalWordRange("action", "list", "info", "claim", "close"), parsers.OptionalWord("id or status"), parsers.OptionalAll("resolution"))
-			.RequiresPrivilege(Privilege.chat)
-			.HandleWith(HandleReports);
+		if (StratumCommandRegistration.ShouldRegister(commands.ReportManage, "/reports", "Commands.ReportManage"))
+		{
+			server.api.commandapi.Create("reports")
+				.WithDescription("Manage player reports")
+				.WithArgs(parsers.OptionalWordRange("action", "list", "info", "claim", "close"), parsers.OptionalWord("id or status"), parsers.OptionalAll("resolution"))
+				.RequiresPrivilege(Privilege.chat)
+				.HandleWith(HandleReports);
+		}
 
 		StratumTargetCommandOverrides.Register(server);
 	}

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumCommandRegistration.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumCommandRegistration.cs
@@ -1,0 +1,26 @@
+namespace Vintagestory.Server;
+
+internal static class StratumCommandRegistration
+{
+	public static bool ShouldRegister(StratumCommandAccessConfig access, string commandLabel, string configPath)
+	{
+		if (access != null && access.Enabled)
+		{
+			return true;
+		}
+
+		StratumRuntime.LogInfo("skipped " + commandLabel + " because " + configPath + ".Enabled=false");
+		return false;
+	}
+
+	public static bool ShouldRegister(bool enabled, string commandLabel, string configPath)
+	{
+		if (enabled)
+		{
+			return true;
+		}
+
+		StratumRuntime.LogInfo("skipped " + commandLabel + " because " + configPath + "=false");
+		return false;
+	}
+}


### PR DESCRIPTION
## Summary

Stratum registered its player and staff commands unconditionally, so running it next to a mod that owns the same names crashed that mod at startup. Th3Essentials is the common case. This gates each command on the config entry that already governs it, so an operator can disable a Stratum command and let the other mod take the name.

## Problem

Command registration happens in OnBeginConfiguration and never checks whether the operator turned a command off. When Th3Essentials calls Create("msg") and Stratum already registered /msg, the API throws "Command with such name already exists". That exception propagates out of Th3Essentials.StartServerSide and the whole mod fails to load, so /spawn, /home, /back and the rest silently stop working. There was no way to resolve the conflict from config.

## Change

Add StratumCommandRegistration.ShouldRegister and wrap every player and staff command registration in it. ShouldRegister reads the Commands.* entry that already exists for that command, returns false when the group is disabled, and logs the skip with the config path so the reason is visible in server-main.log. Disabling Commands.Spawn, Commands.Back, Commands.Message or Commands.Homes.* in stratum-commands.json leaves those names free for the other mod. The serverinfo alias is also removed from /stratum so Th3Essentials can own /serverinfo.

## Testing

Built Release and booted a throwaway world with Th3Essentials 2.17.1, joined, and shut down cleanly.
- Default config: /stratum answers from Stratum and /serverinfo from Th3Essentials, with no duplicate-command error at boot.
- Conflict config: disabled Commands.Spawn/Back/Message/Homes.* in stratum-commands.json and enabled the Th3Essentials equivalents. /spawn, /back, /msg, /r, /home, /home set and /home del answer from Th3Essentials, while unrelated Stratum commands /near and /seen keep working. The startup crash is gone (127 systems start, 0 errors), and each gated command logs its skip line.

## Impact

Defaults do not change. Every group ships enabled, so a server with no conflicting mod registers the same commands as before. The only visible difference without a config edit is the removed /serverinfo alias. Disabled commands are fully unregistered rather than hidden, so a name like /sethome disappears entirely when its group is off, which is the intended result when handing it to another mod.

## Decision points

1. Bootstrap dependency. This branch needs #60 to bootstrap, since main still carries the corrupt hunk headers in the entity-simulation patch. No overlap in files, but #60 should land first.
2. Mod loader resolver. While testing I found that ModAssemblyLoader.LoadAssemblyDefinition lost its Cecil assembly resolver in decompilation, which makes the built lib fail to resolve VintagestoryAPI when scanning a mod in Mods for ModSystems. It is unrelated to this change and affects any mod, so I left it out. I can open it as its own PR with the restored ReaderParameters.
3. serverinfo alias. I dropped it unconditionally rather than only when another mod claims the name. Unconditional is predictable and matches the other gates, but I can make it conditional if you prefer.

## Docs

The command config in stratum-commands.json is not documented in the README. If useful, I can add a short section on disabling a Stratum command to defer the name to another mod. Left out here to keep the PR focused.
