### PR TITLE
Skip collision resolution for stationary creatures

### DIFF
--- a/patches/VintagestoryApi/Math/CollisionTester.cs.patch
+++ b/patches/VintagestoryApi/Math/CollisionTester.cs.patch
@@ -1,0 +1,33 @@
+diff --git a/VintagestoryApi/Math/CollisionTester.cs b/VintagestoryApi/Math/CollisionTester.cs
+index b06b0dc..317d33e 100644
+--- a/VintagestoryApi/Math/CollisionTester.cs
++++ b/VintagestoryApi/Math/CollisionTester.cs
+@@ -46,10 +46,28 @@ namespace Vintagestory.API.MathTools
+         /// <param name="newPosition"></param>
+         /// <param name="stepHeight"></param>
+         /// <param name="yExtra">Default 1 for the extra high collision boxes of fences</param>
+         public void ApplyTerrainCollision(Entity entity, EntityPos entityPos, float dtFactor, ref Vec3d newPosition, float stepHeight = 1, float yExtra = 1)
+         {
++            // Stratum start: fast path for stationary entities.
++            // Zero motion means pushOutY/X/Z all return 0 and newPosition equals entityPos.
++            // Skip the block accessor scan and collision loops for idle creatures.
++            // Players excluded (client movement validation). Items excluded (ground contact rendering).
++            if (entity is not EntityPlayer && entity is not EntityItem)
++            {
++                Vec3d motion = entityPos.Motion;
++                if (motion.X == 0 && motion.Y == 0 && motion.Z == 0
++                    && !entity.FeetInLiquid && !entity.Swimming && !entity.InLava && !entity.IsOnFire)
++                {
++                    entity.CollidedVertically = false;
++                    entity.CollidedHorizontally = false;
++                    newPosition.Set(entityPos.X, entityPos.Y, entityPos.Z);
++                    return;
++                }
++            }
++            // Stratum end
++
+             minPos.SetDimension(entityPos.Dimension);
+ 
+             var worldAccessor = entity.World;
+             Vec3d pos = this.pos;           // Local copy for efficiency
+             Cuboidd entityBox = this.entityBox; // Local copy for efficiency


### PR DESCRIPTION
## Summary

Gate ApplyTerrainCollision behind a motion+environment check for non-player, non-item entities. Zero motion means pushOutY/X/Z all return 0, so the method returns entityPos unchanged. Skip the block accessor scan and collision loops for idle creatures.

## Problem

Every entity runs ApplyTerrainCollision every physics tick regardless of motion. For a stationary animal standing on flat ground, the method walks 27+ blocks through the block accessor, generates a collision box list, runs three pushOut loops, and returns the position unchanged. On a server with 200 loaded creatures, 60-80 are idle at any given moment.

## Change

Early return in ApplyTerrainCollision when all conditions hold: entity is not a player, entity is not an item, motion is exactly zero, and entity is not in liquid/lava/on fire. Sets CollidedVertically and CollidedHorizontally to false and writes entityPos into newPosition.

Players are excluded because the server validates client movement through collision. Items are excluded because the client rendering depends on CollidedVertically for ground contact detection via PassivePhysics.

## Correctness

With motion=(0,0,0): epsilon padding computes to 0, motEps is 0, the motion fed to GenerateCollisionBoxList is 0, pushOutY/X/Z with displacement 0 returns 0 for any non-intersecting entity. The method sets both Collided flags to false and writes entityPos to newPosition. The early return produces the same result.

The liquid/fire/swimming guards prevent skipping entities that have environment-driven forces about to apply (buoyancy, lava damage motion, swim corrections).

## Testing

Built Release, booted a new world, server ran and shut down cleanly. Zero collision errors in logs.