### PR TITLE
Skip full resync on no-op RemoveAttribute

### DIFF
--- a/patches/VintagestoryApi/Datastructures/AttributeTree/Other/SyncedTreeAttribute.cs.patch
+++ b/patches/VintagestoryApi/Datastructures/AttributeTree/Other/SyncedTreeAttribute.cs.patch
@@ -1,0 +1,17 @@
+diff --git a/VintagestoryApi/Datastructures/AttributeTree/Other/SyncedTreeAttribute.cs b/VintagestoryApi/Datastructures/AttributeTree/Other/SyncedTreeAttribute.cs
+index 7faacad..754da93 100644
+--- a/VintagestoryApi/Datastructures/AttributeTree/Other/SyncedTreeAttribute.cs
++++ b/VintagestoryApi/Datastructures/AttributeTree/Other/SyncedTreeAttribute.cs
+@@ -166,11 +166,11 @@ namespace Vintagestory.API.Datastructures
+             MarkPathDirty(key);
+         }
+ 
+         public override void RemoveAttribute(string key)
+         {
+-            base.RemoveAttribute(key);
++            if (!attributes.Remove(key)) return; // Stratum: no-op removal, skip full resync
+             MarkAllDirty();
+         }
+ 
+         #endregion
+ 


### PR DESCRIPTION
## Summary

Gate MarkAllDirty in SyncedTreeAttribute.RemoveAttribute behind the dictionary Remove return value. When the key does not exist, Remove returns false and the tree is unchanged. Skip the dirty flag that would force a full serialization and broadcast on the next sync tick.

## Problem

RemoveAttribute calls MarkAllDirty even when the key is absent. Mods call RemoveAttribute on missing keys every tick: mountedOn while dismounted, dead while alive, temporalStormImmune while not in a storm. Each no-op call schedules a full tree broadcast to all clients for data they already have.

## Change

Replace `base.RemoveAttribute(key)` (which calls `attributes.Remove(key)` and discards the return) with a direct `attributes.Remove(key)` that checks the bool. Return early when false.

## Correctness

`base.RemoveAttribute(key)` does `attributes.Remove(key)` and nothing else. The replacement is a refactor that adds a conditional on the return value. If Remove returns false, the dictionary did not change, no client needs an update, and MarkAllDirty is skipped.

## Testing

Built Release, booted a new world, server ran through RunGame and shut down clean. Zero attribute or entity errors in logs.