### PR TITLE
Optimize GenCaves and fix bugs

### DIFF
--- a/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves.cs.patch
+++ b/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves.cs.patch
@@ -1,0 +1,416 @@
+diff --git a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves.cs b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves.cs
+index 30f034d..2e2080a 100644
+--- a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves.cs
++++ b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves.cs
+@@ -30,11 +30,11 @@ namespace Vintagestory.ServerMods
+                 api.Event.GetWorldgenBlockAccessor(OnWorldGenBlockAccessor);
+ 
+                 api.ChatCommands.GetOrCreate("dev")
+                     .BeginSubCommand("gencaves")
+                     .WithDescription(
+-                        "Cave generator test tool. Deletes all chunks in the area and generates inverse caves around the world middle")
++                        "Cave generator test tool. Deletes all chunks in the area 10х10 and generates inverse caves around the player.") // Stratum:
+                     .RequiresPrivilege(Privilege.controlserver)
+                     .HandleWith(CmdCaveGenTest)
+                     .EndSubCommand();
+ 
+                 api.Event.MapChunkGeneration(OnMapChunkGen, "standard");
+@@ -77,16 +77,23 @@ namespace Vintagestory.ServerMods
+         private TextCommandResult CmdCaveGenTest(TextCommandCallingArgs args)
+         {
+             caveRand = new LCGRandom(api.WorldManager.Seed + 123128);
+             initWorldGen();
+ 
++            // Stratum start:
++            // Adding light recalculation for caves
++            // The cave generation command now works based on the player's coordinates.
+ 
++            // replace the air block with granite to generate inverted caves
+             airBlockId = api.World.GetBlock(new AssetLocation("rock-granite")).BlockId;
+ 
+-            int baseChunkX = api.World.BlockAccessor.MapSizeX / 2 / chunksize;
+-            int baseChunkZ = api.World.BlockAccessor.MapSizeZ / 2 / chunksize;
++            // take the player as the center
++            var player = args.Caller.Player as IServerPlayer;
++            int baseChunkX = (int)player.Entity.Pos.X / chunksize;
++            int baseChunkZ = (int)player.Entity.Pos.Z / chunksize;
+ 
++            // first check that all chunks are loaded
+             for (int dx = -5; dx <= 5; dx++)
+             {
+                 for (int dz = -5; dz <= 5; dz++)
+                 {
+                     int chunkX = baseChunkX + dx;
+@@ -96,19 +103,19 @@ namespace Vintagestory.ServerMods
+ 
+                     for (int i = 0; i < chunks.Length; i++)
+                     {
+                         if (chunks[i] == null)
+                         {
+-                            return TextCommandResult.Success( "Cannot generate 10x10 area of caves, chunks are not loaded that far yet.");
++                            return TextCommandResult.Success("Cannot generate 10x10 area of caves, chunks are not loaded that far yet.");
+                         }
+                     }
+ 
+                     OnMapChunkGen(chunks[0].MapChunk, chunkX, chunkZ);
+                 }
+             }
+ 
+-
++            // clear all chunks and start cave generation
+             for (int dx = -5; dx <= 5; dx++)
+             {
+                 for (int dz = -5; dz <= 5; dz++)
+                 {
+                     int chunkX = baseChunkX + dx;
+@@ -125,15 +132,24 @@ namespace Vintagestory.ServerMods
+                             chunkRand.InitPositionSeed(chunkX + gdx, chunkZ + gdz);
+                             GeneratePartial(chunks, chunkX, chunkZ, gdx, gdz);
+                         }
+                     }
+ 
++                    // Run lighting recalculation (like in GenLightSurvival)
++                    worldgenBlockAccessor.BeginColumn();
++                    api.WorldManager.SunFloodChunkColumnForWorldGen(chunks, chunkX, chunkZ);
++                    worldgenBlockAccessor.RunScheduledBlockLightUpdates(chunkX, chunkZ);
++
++
+                     MarkDirty(chunkX, chunkZ, chunks);
+                 }
+             }
+ 
++
++            // restore the air block id back
+             airBlockId = 0;
++            // Stratum end
+ 
+             return TextCommandResult.Success("Generated and chunks force resend flags set");
+         }
+ 
+         private IServerChunk[] GetChunkColumn(int chunkX, int chunkZ)
+@@ -506,160 +522,225 @@ namespace Vintagestory.ServerMods
+ 
+ 
+ 
+         private bool SetBlocks(IServerChunk[] chunks, float horRadius, float vertRadius, double centerX, double centerY, double centerZ, ushort[] terrainheightmap, ushort[] rainheightmap, int chunkX, int chunkZ, bool genHotSpring)
+         {
+-            IMapChunk mapchunk = chunks[0].MapChunk;
+-
+-            // One extra size for checking if we run into water
+-            horRadius++;
+-            vertRadius+=2;
+-
+-            int mindx = (int)GameMath.Clamp(centerX - horRadius, 0, chunksize - 1);
+-            int maxdx = (int)GameMath.Clamp(centerX + horRadius + 1, 0, chunksize - 1);
+-            int mindy = (int)GameMath.Clamp(centerY - vertRadius * 0.7f, 1, worldheight - 1);
+-            int maxdy = (int)GameMath.Clamp(centerY + vertRadius + 1, 1, worldheight - 1);
+-            int mindz = (int)GameMath.Clamp(centerZ - horRadius, 0, chunksize - 1);
+-            int maxdz = (int)GameMath.Clamp(centerZ + horRadius + 1, 0, chunksize - 1);
+-
+-            double xdistRel, ydistRel, zdistRel;
+-            double hRadiusSq = horRadius * horRadius;
+-            double vRadiusSq = vertRadius * vertRadius;
+-            double distortStrength = GameMath.Clamp(vertRadius / 4.0, 0, 0.1);
++            // Stratum start:
++            // Fixing incorrect cave generation in the /dev gencaves command mode
++            // We sped up the algorithm, filtered out blocks that weren't within the ellipsoid's dimensions,
++            // and checked for liquid in the same cycle as everything else.
+ 
+-            for (int lx = mindx; lx <= maxdx; lx++)
+-            {
+-                xdistRel = (lx - centerX) * (lx - centerX) / hRadiusSq;
+-
+-                for (int lz = mindz; lz <= maxdz; lz++)
+-                {
+-                    zdistRel = (lz - centerZ) * (lz - centerZ) / hRadiusSq;
+-
+-                    double heightrnd = (mapchunk.CaveHeightDistort[lz * chunksize + lx] - 127) * distortStrength;
+-
+-                    for (int y = mindy; y <= maxdy + 10; y++)
+-                    {
+-                        double yDist = y - centerY;
+-                        double heightOffFac = yDist > 0 ? heightrnd * heightrnd : 0;
+-
+-                        ydistRel = yDist * yDist / (vRadiusSq + heightOffFac);
+-
+-                        if (xdistRel + ydistRel + zdistRel > 1.0 || y > worldheight - 1) continue;
+-
+-                        int ly = y % chunksize;
+-                        var block = api.World.Blocks[chunks[y / chunksize].Data.GetFluid((ly * chunksize + lz) * chunksize + lx)];
+-                        if (block.LiquidCode != null)
+-                        {
+-                            return false;
+-                        }
+-                    }
+-                }
+-            }
++            // Testing on 10,200 generation chunks:
++            // Total method execution time: decreased from 9.2 s to 6.3 s;
+ 
++            IMapChunk mapchunk = chunks[0].MapChunk;
+ 
+-            horRadius--;
+-            vertRadius-=2;
++            // Regular generation radius
++            float genHorRadius = horRadius;
++            float genVertRadius = vertRadius;
+ 
+-            mindx = (int)GameMath.Clamp(centerX - horRadius, 0, chunksize - 1);
+-            maxdx = (int)GameMath.Clamp(centerX + horRadius + 1, 0, chunksize - 1);
+-            mindz = (int)GameMath.Clamp(centerZ - horRadius, 0, chunksize - 1);
+-            maxdz = (int)GameMath.Clamp(centerZ + horRadius + 1, 0, chunksize - 1);
++            // Increased radius for fluid checks
++            float checkHorRadius = horRadius + 1;
++            float checkVertRadius = vertRadius + 2;
+ 
+-            mindy = (int)GameMath.Clamp(centerY - vertRadius * 0.7f, 1, worldheight - 1);
+-            maxdy = (int)GameMath.Clamp(centerY + vertRadius + 1, 1, worldheight - 1);
++            // Compute common bounds for both radii
++            int mindx = (int)GameMath.Clamp(centerX - checkHorRadius, 0, chunksize - 1);
++            int maxdx = (int)GameMath.Clamp(centerX + checkHorRadius + 1, 0, chunksize - 1);
++            int mindz = (int)GameMath.Clamp(centerZ - checkHorRadius, 0, chunksize - 1);
++            int maxdz = (int)GameMath.Clamp(centerZ + checkHorRadius + 1, 0, chunksize - 1);
+ 
+-            hRadiusSq = horRadius * horRadius;
+-            vRadiusSq = vertRadius * vertRadius;
++            // For Y use the check radius because it is larger
++            int mindy = (int)GameMath.Clamp(centerY - checkVertRadius * 0.7f, 1, worldheight - 1);
++            int maxdy = (int)GameMath.Clamp(centerY + checkVertRadius + 1, 1, worldheight - 1);
+ 
++            // Precompute squared radii for fast comparisons
++            double genHorRadiusSq = genHorRadius * genHorRadius;
++            double genVertRadiusSq = genVertRadius * genVertRadius;
++            double checkHorRadiusSq = checkHorRadius * checkHorRadius;
++            double checkVertRadiusSq = checkVertRadius * checkVertRadius;
+ 
++            // Get geologic activity once
+             int geoActivity = getGeologicActivity(chunkX * chunksize + (int)centerX, chunkZ * chunksize + (int)centerZ);
+             genHotSpring &= geoActivity > 128;
+ 
+             if (genHotSpring && centerX >= 0 && centerX < 32 && centerZ >= 0 && centerZ < 32)
+             {
+                 var data = mapchunk.GetModdata<Dictionary<Vec3i, HotSpringGenData>>("hotspringlocations");
+                 if (data == null) data = new Dictionary<Vec3i, HotSpringGenData>();
+-                data[new Vec3i((int)centerX, (int)centerY, (int)centerZ)] = new HotSpringGenData() { horRadius = horRadius };
++                data[new Vec3i((int)centerX, (int)centerY, (int)centerZ)] = new HotSpringGenData() { horRadius = genHorRadius };
+                 mapchunk.SetModdata("hotspringlocations", data);
+             }
+ 
+             int yLavaStart = (geoActivity * 16) / 128;
++            int chunksizeSq = chunksize * chunksize;
+ 
+-
++            // Main loop - single pass
+             for (int lx = mindx; lx <= maxdx; lx++)
+             {
+-                xdistRel = (lx - centerX) * (lx - centerX) / hRadiusSq;
++                double dx = lx - centerX;
++                double dxSq = dx * dx;
+ 
+                 for (int lz = mindz; lz <= maxdz; lz++)
+                 {
+-                    zdistRel = (lz - centerZ) * (lz - centerZ) / hRadiusSq;
++                    double dz = lz - centerZ;
++                    double dzSq = dz * dz;
+ 
+-                    double heightrnd = (mapchunk.CaveHeightDistort[lz * chunksize + lx] - 127) * distortStrength;
+-                    int surfaceY = terrainheightmap[lz * chunksize + lx];
++                    int idx2d = lz * chunksize + lx;
+ 
+-                    for (int y = maxdy + 10; y >= mindy; y--)
+-                    {
+-                        double yDist = y - centerY;
+-                        double heightOffFac = yDist > 0 ? heightrnd * heightrnd * Math.Min(1, Math.Abs(y - surfaceY) /10.0) : 0;
++                    // Compute distortion once for the column
++                    double distortStrength = GameMath.Clamp(genVertRadius / 4.0, 0, 0.1);
++                    double heightrnd = (mapchunk.CaveHeightDistort[idx2d] - 127) * distortStrength;
++                    int surfaceY = terrainheightmap[idx2d];
+ 
+-                        ydistRel = yDist * yDist / (vRadiusSq + heightOffFac);
++                    // Compute maximum XZ distance for the check radius
++                    double checkXZDist = dxSq / checkHorRadiusSq + dzSq / checkHorRadiusSq;
++                    if (checkXZDist > 1.0) continue;
+ 
+-                        if (y > worldheight - 1 || xdistRel + ydistRel + zdistRel > 1.0) continue;
++                    // Compute Y range for the check radius
++                    double maxCheckDist = 1.0 - checkXZDist;
++                    double maxCheckYDist = Math.Sqrt(maxCheckDist * checkVertRadiusSq);
++                    int checkMindy = (int)Math.Max(mindy, centerY - maxCheckYDist);
++                    int checkMaxdy = (int)Math.Min(maxdy, centerY + maxCheckYDist);
+ 
+-                        if (terrainheightmap[lz * chunksize + lx] == y)
+-                        {
+-                            terrainheightmap[lz * chunksize + lx] = (ushort)(y - 1);
+-                            rainheightmap[lz * chunksize + lx]--;
+-                        }
++                    // Variables for tracking state
++                    bool hasLiquidInCheckRadius = false;
++                    bool needsGenInGenRadius = false;
++                    int firstGenY = -1;
+ 
+-                        IChunkBlocks chunkBlockData = chunks[y / chunksize].Data;
+-                        int index3d = ((y % chunksize) * chunksize + lz) * chunksize + lx;
++                    // Walk Y once from top down
++                    for (int y = checkMaxdy; y >= checkMindy; y--)
++                    {
++                        double dy = y - centerY;
++                        double dySq = dy * dy;
+ 
+-                        if (y == 11)
++                        // Check inclusion in check radius (for fluids)
++                        double checkYDistSq = dySq / checkVertRadiusSq;
++                        if (dxSq / checkHorRadiusSq + checkYDistSq + dzSq / checkHorRadiusSq <= 1.0)
+                         {
+-                            if (basaltNoise.Noise(chunkX * chunksize + lx, chunkZ * chunksize + lz) > 0.65)
++                            // Fluid check
++                            if (!hasLiquidInCheckRadius && y >= 1 && y < worldheight)
+                             {
+-                                chunkBlockData[index3d] = gcfg.basaltBlockId;
+-                                terrainheightmap[lz * chunksize + lx] = Math.Max(terrainheightmap[lz * chunksize + lx], (ushort)11);
+-                                rainheightmap[lz * chunksize + lx] = Math.Max(rainheightmap[lz * chunksize + lx], (ushort)11);
+-                            }
+-                            else
+-                            {
+-                                chunkBlockData[index3d] = 0;
+-                                if (y > yLavaStart)
+-                                {
+-                                    chunkBlockData[index3d] = gcfg.basaltBlockId;
+-                                } else
++                                int chunkY = y / chunksize;
++                                int localY = y % chunksize;
++                                var block = api.World.Blocks[chunks[chunkY].Data.GetFluid((localY * chunksize + lz) * chunksize + lx)];
++                                if (block.LiquidCode != null)
+                                 {
+-                                    chunkBlockData.SetFluid(index3d, gcfg.lavaBlockId);
++                                    return false; // Found fluid - exit immediately
+                                 }
+-
+-                                if (y <= yLavaStart) worldgenBlockAccessor.ScheduleBlockLightUpdate(new BlockPos(chunkX * chunksize + lx, y, chunkZ * chunksize + lz), airBlockId, gcfg.lavaBlockId);
+                             }
++                        }
+ 
++                        // Check inclusion in generation radius (for setting blocks)
++                        if (!needsGenInGenRadius)
++                        {
++                            double heightOffFac = dy > 0 ? heightrnd * heightrnd * Math.Min(1, Math.Abs(y - surfaceY) / 10.0) : 0;
++                            double genYDistSq = dySq / (genVertRadiusSq + heightOffFac);
++
++                            if (dxSq / genHorRadiusSq + genYDistSq + dzSq / genHorRadiusSq <= 1.0 && y < worldheight)
++                            {
++                                needsGenInGenRadius = true;
++                                firstGenY = y;
++                            }
+                         }
+-                        else if (y < 12)
++                    }
++
++                    // If we need to generate in this column
++                    if (needsGenInGenRadius)
++                    {
++                        // Compute precise range for generation
++                        double genXZDist = dxSq / genHorRadiusSq + dzSq / genHorRadiusSq;
++                        double maxGenDist = 1.0 - genXZDist;
++
++                        if (maxGenDist > 0)
+                         {
+-                            chunkBlockData[index3d] = 0;
+-                            if (y > yLavaStart)
++                            // For positive Y account for distortion
++                            double vertRadiusSqWithDistort = genVertRadiusSq;
++                            if (firstGenY > centerY)
+                             {
+-                                chunkBlockData[index3d] = gcfg.basaltBlockId;
++                                double heightOffFac = heightrnd * heightrnd * Math.Min(1, Math.Abs(firstGenY - surfaceY) / 10.0);
++                                vertRadiusSqWithDistort += heightOffFac;
+                             }
+-                            else
++
++                            double maxGenYDist = Math.Sqrt(maxGenDist * vertRadiusSqWithDistort);
++                            int genMindy = (int)Math.Max(mindy, centerY - maxGenYDist);
++                            int genMaxdy = (int)Math.Min(maxdy, centerY + maxGenYDist);
++
++                            // Generate blocks in the column
++                            for (int y = genMaxdy; y >= genMindy; y--)
+                             {
+-                                chunkBlockData.SetFluid(index3d, gcfg.lavaBlockId);
++                                double dy = y - centerY;
++                                double dySq = dy * dy;
++
++                                // Check inclusion in ellipsoid with distortion
++                                double heightOffFac = dy > 0 ? heightrnd * heightrnd * Math.Min(1, Math.Abs(y - surfaceY) / 10.0) : 0;
++                                if (dxSq / genHorRadiusSq + dySq / (genVertRadiusSq + heightOffFac) + dzSq / genHorRadiusSq > 1.0)
++                                    continue;
++
++                                if (y > worldheight - 1) continue;
++
++                                // Update heightmaps
++                                if (surfaceY == y)
++                                {
++                                    terrainheightmap[idx2d] = (ushort)(y - 1);
++                                    rainheightmap[idx2d]--;
++                                }
++
++                                int chunkY = y / chunksize;
++                                int localY = y % chunksize;
++                                IChunkBlocks chunkBlockData = chunks[chunkY].Data;
++                                int index3d = localY * chunksizeSq + idx2d;
++
++                                // Set block
++                                if (y == 11)
++                                {
++                                    if (basaltNoise.Noise(chunkX * chunksize + lx, chunkZ * chunksize + lz) > 0.65)
++                                    {
++                                        chunkBlockData[index3d] = basaltBlockId;
++                                        terrainheightmap[idx2d] = Math.Max(terrainheightmap[idx2d], (ushort)11);
++                                        rainheightmap[idx2d] = Math.Max(rainheightmap[idx2d], (ushort)11);
++                                    }
++                                    else
++                                    {
++                                        if (y > yLavaStart)
++                                        {
++                                            chunkBlockData[index3d] = basaltBlockId;
++                                        }
++                                        else
++                                        {
++                                            chunkBlockData.SetFluid(index3d, lavaBlockId);
++                                        }
++
++                                        if (y <= yLavaStart)
++                                            worldgenBlockAccessor.ScheduleBlockLightUpdate(
++                                                new BlockPos(chunkX * chunksize + lx, y, chunkZ * chunksize + lz),
++                                                airBlockId, lavaBlockId);
++                                    }
++                                }
++                                else if (y < 12)
++                                {
++                                    if (y > yLavaStart)
++                                    {
++                                        chunkBlockData[index3d] = basaltBlockId;
++                                    }
++                                    else
++                                    {
++                                        chunkBlockData.SetFluid(index3d, lavaBlockId);
++                                    }
++                                }
++                                else
++                                {
++                                    chunkBlockData[index3d] = airBlockId != 0 ? (ushort)airBlockId : (ushort)0;
++                                }
+                             }
+                         }
+-                        else
+-                        {
+-                            chunkBlockData.SetBlockAir(index3d);
+-                        }
+                     }
+                 }
+             }
+ 
+             return true;
++
++            // Stratum end
+         }
+ 
+         private int getGeologicActivity(int posx, int posz)
+         {
+             var climateMap = worldgenBlockAccessor.GetMapRegion(posx / regionsize, posz / regionsize)?.ClimateMap;

--- a/patches/VSEssentials/Systems/WorldGen/Standard/GenPartial.cs.patch
+++ b/patches/VSEssentials/Systems/WorldGen/Standard/GenPartial.cs.patch
@@ -1,0 +1,39 @@
+diff --git a/VSEssentials/Systems/WorldGen/Standard/GenPartial.cs b/VSEssentials/Systems/WorldGen/Standard/GenPartial.cs
+index 58aa710..14f2ccf 100644
+--- a/VSEssentials/Systems/WorldGen/Standard/GenPartial.cs
++++ b/VSEssentials/Systems/WorldGen/Standard/GenPartial.cs
+@@ -1,17 +1,20 @@
+ using Vintagestory.API.MathTools;
+ using Vintagestory.API.Server;
++using Vintagestory.ServerMods.NoObf;
+ 
+ #nullable disable
+ 
+ namespace Vintagestory.ServerMods
+ {
+     public abstract class GenPartial : ModStdWorldGen
+     {
+         protected ICoreServerAPI api;
+         protected int worldheight;
+         public int airBlockId = 0;
++        public int basaltBlockId; // Stratum: variable for basalt ID
++        public int lavaBlockId; // Stratum: variable for lav ID
+ 
+         protected abstract int chunkRange { get; }
+ 
+         protected LCGRandom chunkRand;
+ 
+@@ -24,10 +27,13 @@ namespace Vintagestory.ServerMods
+ 
+         public virtual void initWorldGen()
+         {
+             LoadGlobalConfig(api);
+ 
++            basaltBlockId = gcfg.basaltBlockId; // Stratum: finding the basalt block ID
++            lavaBlockId = gcfg.lavaBlockId;  // Stratum: finding the lsvs block ID
++
+             worldheight = api.WorldManager.MapSizeY;
+             chunkRand = new LCGRandom(api.WorldManager.Seed);
+         }
+ 
+ 


### PR DESCRIPTION
## Summary

Several fixes and improvements have been made to the cave generator:
- The **/dev gencaves** command now works as intended. It wasn't working properly before;
- The command is now applied relative to the player's position, rather than the world center;
- Light recalculation has been added for these chunks, as the caves were appearing completely black;
- The SetBlocks method algorithm has been improved, with repeated calculations moved to variables, speeding up its operation by an average of 31%.

This is the implementation of my [PR](https://github.com/anegostudios/vssurvivalmod/pull/171).
It might be added in 1.23.

## Type

- [ ] Bug fix
- [x] Performance
- [ ] New feature
- [ ] Refactor or cleanup
- [ ] Docs or build

## Checklist

- [x] `.\scripts\extract-patches.ps1` ran clean.
- [x] `dotnet build VintageStory.slnx -c Release` is green.
- [x] Every vanilla edit has a `// Stratum` marker.
- [x] No vanilla source committed.
- [x] Tested on a real server start, not just compilation.

## Performance numbers

Testing on 10,200 generation chunks:
- Total method execution time: decreased from 9.2 s to 6.3 s;

**Before**
<img width="641" height="471" alt="caves before trace" src="https://github.com/user-attachments/assets/7b380b30-c48a-45bc-a2cb-34591c2e9662" />

**After**
<img width="643" height="483" alt="caves after trace" src="https://github.com/user-attachments/assets/4d9a2ff9-158a-4086-a29c-1563bb717ed4" />

**Comparison**
<img width="1944" height="2172" alt="caves 1" src="https://github.com/user-attachments/assets/ab85862a-38ce-4f4f-b746-ba1c243851bd" />
<img width="1952" height="2132" alt="caves 2" src="https://github.com/user-attachments/assets/fdb5d830-fe55-430f-93e2-3fd25180bac8" />
<img width="1936" height="2132" alt="caves 3" src="https://github.com/user-attachments/assets/4bba2da7-10db-434e-81f5-7a5136ad52b3" />


