### PR TITLE
Null-guard PathNode.Equals to fix NRE from node pool reuse

### DIFF
--- a/patches/VSEssentials/Entity/Pathfinding/Astar/PathNode.cs.patch
+++ b/patches/VSEssentials/Entity/Pathfinding/Astar/PathNode.cs.patch
@@ -1,0 +1,16 @@
+diff --git a/VSEssentials/Entity/Pathfinding/Astar/PathNode.cs b/VSEssentials/Entity/Pathfinding/Astar/PathNode.cs
+index e53d25c..be326f3 100644
+--- a/VSEssentials/Entity/Pathfinding/Astar/PathNode.cs
++++ b/VSEssentials/Entity/Pathfinding/Astar/PathNode.cs
+@@ -40,10 +40,11 @@ namespace Vintagestory.Essentials
+             dimension = pos.dimension;
+         }
+ 
+         public bool Equals(PathNode other)
+         {
++            if (other is null) return false; // Stratum: pool reuse can surface null in HashSet comparisons
+             return other.X == X && other.Y == Y && other.Z == Z;
+         }
+ 
+         public override bool Equals(object obj)
+         {


### PR DESCRIPTION
The node pool reuses PathNode instances across searches. HashSet bucket comparisons can pass null to PathNode.Equals during Contains/TryFindValue calls. Vanilla never hit this because it allocated fresh nodes every time. Manifests as a repeating NRE in StratumRentNode on any entity running AiTaskSeekFoodAndEat (raccoons, chickens, etc).