### PR TITLE
Added and improved the anticheat and detections

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,7 @@
 # Keep patch files as LF so `git apply` always sees what extract-patches.ps1 wrote.
 patches/**/*.patch text eol=lf
 *.ps1 text eol=crlf
+*.cs text eol=lf
+*.csproj text eol=lf
+*.slnx text eol=lf
+*.json text eol=lf

--- a/patches/VintagestoryLib/Vintagestory.Server.Systems/ServerUdpNetwork.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server.Systems/ServerUdpNetwork.cs.patch
@@ -1,8 +1,11 @@
 diff --git a/VintagestoryLib/Vintagestory.Server.Systems/ServerUdpNetwork.cs b/VintagestoryLib/Vintagestory.Server.Systems/ServerUdpNetwork.cs
-index 719a68b..ce1a8c1 100644
+index 719a68b..4a33a0b 100644
 --- a/VintagestoryLib/Vintagestory.Server.Systems/ServerUdpNetwork.cs
 +++ b/VintagestoryLib/Vintagestory.Server.Systems/ServerUdpNetwork.cs
-@@ -7,16 +7,30 @@ using ProtoBuf;
+@@ -4,19 +4,36 @@ using System.IO;
+ using System.Linq;
+ using System.Threading.Tasks;
+ using ProtoBuf;
  using Vintagestory.API.Common;
  using Vintagestory.API.Common.Entities;
 +using Vintagestory.API.Config;
@@ -36,7 +39,7 @@ index 719a68b..ce1a8c1 100644
  
  	internal ServerUdpQueue ImmediateUdpQueue;
  
-@@ -51,10 +64,12 @@ public class ServerUdpNetwork : ServerSystem
+@@ -51,10 +68,12 @@ public class ServerUdpNetwork : ServerSystem
  			UdpPacket[] array2 = array;
  			for (int j = 0; j < array2.Length; j++)
  			{
@@ -49,7 +52,7 @@ index 719a68b..ce1a8c1 100644
  				case 1:
  					HandleConnectionRequest(udpPacket, uNetServer);
  					break;
-@@ -80,10 +95,21 @@ public class ServerUdpNetwork : ServerSystem
+@@ -80,10 +99,21 @@ public class ServerUdpNetwork : ServerSystem
  		physicsManager.Init();
  	}
  
@@ -71,7 +74,7 @@ index 719a68b..ce1a8c1 100644
  		{
  			connectingClients.Remove(keyValuePair.Key);
  		}
-@@ -167,16 +193,35 @@ public class ServerUdpNetwork : ServerSystem
+@@ -167,16 +197,34 @@ public class ServerUdpNetwork : ServerSystem
  		}
  		player.LastReceivedClientPosition = server.ElapsedMilliseconds;
  		int num2 = entity.Attributes.GetInt("tick");
@@ -106,7 +109,7 @@ index 719a68b..ce1a8c1 100644
  			if (behavior is IRemotePhysics remotePhysics)
  			{
  				remotePhysics.OnReceivedClientPos(num);
-@@ -196,22 +241,135 @@ public class ServerUdpNetwork : ServerSystem
+@@ -196,22 +244,206 @@ public class ServerUdpNetwork : ServerSystem
  		if (flag)
  		{
  			message = new AnimationPacket(entity);
@@ -171,6 +174,7 @@ index 719a68b..ce1a8c1 100644
 +
 +		if (packet.PositionVersion > serverPositionVersion)
 +		{
++			double serverDistance = Distance(packetX, packetY, packetZ, entity.Pos.X, entity.Pos.InternalY, entity.Pos.Z);
 +			double correctionDistance = Distance(packetX, packetY, packetZ, state.CorrectionX, state.CorrectionY, state.CorrectionZ);
 +			if (now <= state.CorrectionUntilMs && correctionDistance > Math.Max(0.5, config.SlackBlocks))
 +			{
@@ -185,8 +189,11 @@ index 719a68b..ce1a8c1 100644
 +				return false;
 +			}
 +
-+			RememberStratumMovement(entity, stateKey);
-+			return true;
++			if (serverDistance <= config.PositionVersionAcceptDistance)
++			{
++				RememberStratumMovement(entity, stateKey);
++				return true;
++			}
 +		}
 +
 +		double elapsedSeconds = Math.Max(0.05, (now - state.LastMs) / 1000.0);
@@ -245,6 +252,11 @@ index 719a68b..ce1a8c1 100644
 +		double walkSpeed = entityPlayer.GetWalkSpeedMultiplier(0.3);
 +		double statSpeed = GlobalConstants.BaseMoveSpeed * Math.Max(0.1, moveSpeed) * Math.Max(0.1, walkSpeed) * GlobalConstants.OverallSpeedMultiplier;
 +		double allowed = statSpeed * config.HorizontalSpeedMultiplier;
++		if (!entityPlayer.OnGround || entityPlayer.Controls?.Jump == true)
++		{
++			allowed *= config.AirborneHorizontalMultiplier;
++		}
++
 +		return Math.Min(config.MaxHorizontalBlocksPerSecond, Math.Max(config.MinimumHorizontalBlocksPerSecond, allowed));
 +	}
 +
@@ -302,12 +314,12 @@ index 719a68b..ce1a8c1 100644
 +		double dy = y - otherY;
 +		double dz = z - otherZ;
 +		return Math.Sqrt(dx * dx + dy * dy + dz * dz);
-+	}
+ 	}
  
  	private void SendSinglePositionPacket(ServerPlayer player, Entity entity, int currentTick)
  	{
  		Packet_UdpPacket packet = new Packet_UdpPacket
-@@ -240,10 +398,16 @@ public class ServerUdpNetwork : ServerSystem
+@@ -240,10 +472,16 @@ public class ServerUdpNetwork : ServerSystem
  			return;
  		}
  		int num2 = entityById.Attributes.GetInt("tick");
@@ -324,7 +336,7 @@ index 719a68b..ce1a8c1 100644
  			entityById.Api.Logger.Audit("Rejected mount position update for " + player.PlayerName + ". Client sent " + packet.X / 16384 + "," + packet.Y / 16384 + "," + packet.Z / 16384 + ", server pos was " + entityById.Pos);
  			SendSinglePositionPacket(player, entityById, num2);
  			return;
-@@ -299,10 +463,11 @@ public class ServerUdpNetwork : ServerSystem
+@@ -299,10 +537,11 @@ public class ServerUdpNetwork : ServerSystem
  			IServerNetworkChannel animationsAndTagsChannel = physicsManager.AnimationsAndTagsChannel;
  			AnimationPacket message = animationPacket;
  			IServerPlayer[] players = list.ToArray();

--- a/patches/VintagestoryLib/Vintagestory.Server.Systems/ServerUdpNetwork.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server.Systems/ServerUdpNetwork.cs.patch
@@ -1,15 +1,21 @@
 diff --git a/VintagestoryLib/Vintagestory.Server.Systems/ServerUdpNetwork.cs b/VintagestoryLib/Vintagestory.Server.Systems/ServerUdpNetwork.cs
-index 719a68b..576636f 100644
+index 719a68b..ce1a8c1 100644
 --- a/VintagestoryLib/Vintagestory.Server.Systems/ServerUdpNetwork.cs
 +++ b/VintagestoryLib/Vintagestory.Server.Systems/ServerUdpNetwork.cs
-@@ -13,10 +13,23 @@ using Vintagestory.Common.Network.Packets;
+@@ -7,16 +7,30 @@ using ProtoBuf;
+ using Vintagestory.API.Common;
+ using Vintagestory.API.Common.Entities;
++using Vintagestory.API.Config;
+ using Vintagestory.API.Server;
+ using Vintagestory.Common;
+ using Vintagestory.Common.Network.Packets;
+ 
  namespace Vintagestory.Server.Systems;
  
  public class ServerUdpNetwork : ServerSystem
  {
  	public readonly Dictionary<string, ConnectedClient> connectingClients = new Dictionary<string, ConnectedClient>();
-+	// Stratum: per-player movement tracking for the server-authoritative speed/teleport guard.
-+	// Thresholds and escalation live in Config.Anticheat.Movement (see StratumAnticheatConfig).
++	// Stratum: trusted movement state for speed, teleport, and correction checks.
 +	private readonly Dictionary<string, StratumMovementState> stratumMovementByPlayerUid = new Dictionary<string, StratumMovementState>();
 +
 +	private sealed class StratumMovementState
@@ -20,6 +26,10 @@ index 719a68b..576636f 100644
 +		public long LastMs;
 +		public long WindowStartMs;
 +		public double WindowDistance;
++		public long CorrectionUntilMs;
++		public double CorrectionX;
++		public double CorrectionY;
++		public double CorrectionZ;
 +	}
  
  	public PhysicsManager physicsManager;
@@ -32,7 +42,7 @@ index 719a68b..576636f 100644
  			{
  				UdpPacket udpPacket = array2[j];
  				server.TotalReceivedBytesUdp += udpPacket.Packet.Length;
-+				// Stratum: observe inbound UDP traffic for packet attribution reports.
++				// Stratum: feed UDP packets into the packet attribution counters.
 +				StratumRuntime.PacketLimiter.ObserveUdpPacket(udpPacket.Client, udpPacket.Packet, udpPacket.Packet.Length, server.api.networkapi);
  				switch (udpPacket.Packet.Id)
  				{
@@ -78,11 +88,10 @@ index 719a68b..576636f 100644
  			SendSinglePositionPacket(player, entity, num2);
  			return;
  		}
-+		// Stratum: server-authoritative flight / noclip validation. Runs after the packet is applied
-+		// so it can read the claimed position against the world; on a violation entity.Pos has been
-+		// reset to a safe position, so rubberband the client and kick if the reporter escalates.
++		// Stratum: check slow movement cheats after reading the claimed position.
 +		if (!StratumMovementGuard.TryAccept(server, player, entity, player.PlayerUID, out string stratumMovementKick))
 +		{
++			MarkStratumMovementCorrection(player.PlayerUID, entity, server.ElapsedMilliseconds);
 +			SendSinglePositionPacket(player, entity, num2);
 +			if (stratumMovementKick != null)
 +			{
@@ -97,17 +106,14 @@ index 719a68b..576636f 100644
  			if (behavior is IRemotePhysics remotePhysics)
  			{
  				remotePhysics.OnReceivedClientPos(num);
-@@ -196,22 +241,139 @@ public class ServerUdpNetwork : ServerSystem
+@@ -196,22 +241,135 @@ public class ServerUdpNetwork : ServerSystem
  		if (flag)
  		{
  			message = new AnimationPacket(entity);
  			entity.AnimManager.AnimationsDirty = false;
  		}
 -		foreach (ConnectedClient value in server.Clients.Values)
-+		// Stratum: batch the animation/tags TCP send across all viewers so the channel
-+		// serializes the packet ONCE instead of N times (was per-viewer SendPacket inside loop).
-+		// At ~545 player-position packets/sec * ~108 viewers, this removes ~58k redundant
-+		// serializations/sec from the main thread.
++		// Stratum: build the animation/tags packet once, then send it to every viewer.
 +		ICollection<ConnectedClient> stratumClients = server.Clients.Values;
 +		List<IServerPlayer> stratumAnimViewers = (flag && stratumClients.Count > 1) ? new List<IServerPlayer>(stratumClients.Count) : null;
 +		foreach (ConnectedClient value in stratumClients)
@@ -141,11 +147,8 @@ index 719a68b..576636f 100644
 +		StratumConfig stratumConfig = StratumRuntime.Config;
 +		stratumConfig.EnsurePopulated();
 +		StratumMovementAnticheatConfig config = stratumConfig.Anticheat.Movement;
-+		// Guard disabled, or the player is legitimately allowed to bypass physics (creative,
-+		// spectator, server-granted fly/noclip, or a teleport/mode-change just bumped the
-+		// position version). Trust the packet and reset tracking so the next delta is clean.
++		// Trust movement when Stratum checks are off or the server gave this player free movement.
 +		if (!stratumConfig.Anticheat.Enabled || !config.Enabled
-+			|| packet.PositionVersion > serverPositionVersion
 +			|| player.WorldData.CurrentGameMode == EnumGameMode.Creative
 +			|| player.WorldData.CurrentGameMode == EnumGameMode.Spectator
 +			|| player.WorldData.FreeMove
@@ -162,14 +165,27 @@ index 719a68b..576636f 100644
 +
 +		if (!stratumMovementByPlayerUid.TryGetValue(stateKey, out StratumMovementState state))
 +		{
-+			stratumMovementByPlayerUid[stateKey] = new StratumMovementState
++			RememberStratumMovement(entity, stateKey);
++			return true;
++		}
++
++		if (packet.PositionVersion > serverPositionVersion)
++		{
++			double correctionDistance = Distance(packetX, packetY, packetZ, state.CorrectionX, state.CorrectionY, state.CorrectionZ);
++			if (now <= state.CorrectionUntilMs && correctionDistance > Math.Max(0.5, config.SlackBlocks))
 +			{
-+				X = entity.Pos.X,
-+				Y = entity.Pos.InternalY,
-+				Z = entity.Pos.Z,
-+				LastMs = now,
-+				WindowStartMs = now
-+			};
++				SendSinglePositionPacket(player, entity, currentTick);
++				state.LastMs = now;
++				string reason = string.Format(System.Globalization.CultureInfo.InvariantCulture, "correction replay distance={0:0.00}", correctionDistance);
++				if (StratumAnticheatReporter.RecordMovementViolation(server, player, entity.Pos.AsBlockPos, reason, out string correctionKickReason))
++				{
++					stratumMovementByPlayerUid.Remove(stateKey);
++					server.DisconnectPlayer(player.client, null, correctionKickReason);
++				}
++				return false;
++			}
++
++			RememberStratumMovement(entity, stateKey);
 +			return true;
 +		}
 +
@@ -187,23 +203,21 @@ index 719a68b..576636f 100644
 +		}
 +		state.WindowDistance += total;
 +
-+		double maxHorizontal = config.MaxHorizontalBlocksPerSecond * elapsedSeconds + config.SlackBlocks;
++		double allowedHorizontalSpeed = GetStratumAllowedHorizontalSpeed(player, entity, config);
++		double allowedWindowDistance = Math.Min(config.MaxCumulativeBlocksPerSecond, allowedHorizontalSpeed * config.CumulativeSpeedMultiplier);
++		double maxHorizontal = allowedHorizontalSpeed * elapsedSeconds + config.SlackBlocks;
 +		double maxVerticalUp = config.MaxVerticalUpBlocksPerSecond * elapsedSeconds + config.SlackBlocks;
-+		if (horizontal > maxHorizontal || dy > maxVerticalUp || state.WindowDistance > config.MaxCumulativeBlocksPerSecond)
++		if (horizontal > maxHorizontal || dy > maxVerticalUp || state.WindowDistance > allowedWindowDistance)
 +		{
-+			// Rubberband: snap the client back to the authoritative server position.
++			double windowDistance = state.WindowDistance;
++			// Send the server position back and keep the correction window strict for a moment.
 +			SendSinglePositionPacket(player, entity, currentTick);
-+			state.X = entity.Pos.X;
-+			state.Y = entity.Pos.InternalY;
-+			state.Z = entity.Pos.Z;
++			MarkStratumMovementCorrection(state, entity, now);
 +			state.LastMs = now;
-+			state.WindowStartMs = now;
-+			state.WindowDistance = 0;
 +
-+			// Record the violation in the shared anticheat reporter for staff alerting and,
-+			// only after the player sustains many of them in the rolling window, a kick.
++			// Let the reporter handle staff alerts and kick escalation.
 +			string reason = string.Format(System.Globalization.CultureInfo.InvariantCulture,
-+				"delta h={0:0.00} up={1:0.00} window={2:0.00}/{3:0.00}", horizontal, dy, state.WindowDistance, config.MaxCumulativeBlocksPerSecond);
++				"delta h={0:0.00}/{1:0.00} up={2:0.00}/{3:0.00} window={4:0.00}/{5:0.00}", horizontal, maxHorizontal, dy, maxVerticalUp, windowDistance, allowedWindowDistance);
 +			if (StratumAnticheatReporter.RecordMovementViolation(server, player, entity.Pos.AsBlockPos, reason, out string movementKickReason))
 +			{
 +				stratumMovementByPlayerUid.Remove(stateKey);
@@ -216,7 +230,22 @@ index 719a68b..576636f 100644
 +		state.Y = packetY;
 +		state.Z = packetZ;
 +		state.LastMs = now;
++		state.CorrectionUntilMs = 0;
 +		return true;
++	}
++
++	private static double GetStratumAllowedHorizontalSpeed(ServerPlayer player, Entity entity, StratumMovementAnticheatConfig config)
++	{
++		if (!config.UseStatBasedSpeedLimits || entity is not EntityPlayer entityPlayer)
++		{
++			return config.MaxHorizontalBlocksPerSecond;
++		}
++
++		double moveSpeed = player?.WorldData?.MoveSpeedMultiplier ?? entityPlayer.Controls?.MovespeedMultiplier ?? 1.0;
++		double walkSpeed = entityPlayer.GetWalkSpeedMultiplier(0.3);
++		double statSpeed = GlobalConstants.BaseMoveSpeed * Math.Max(0.1, moveSpeed) * Math.Max(0.1, walkSpeed) * GlobalConstants.OverallSpeedMultiplier;
++		double allowed = statSpeed * config.HorizontalSpeedMultiplier;
++		return Math.Min(config.MaxHorizontalBlocksPerSecond, Math.Max(config.MinimumHorizontalBlocksPerSecond, allowed));
 +	}
 +
 +	private void RememberStratumMovement(Entity entity, string stateKey)
@@ -235,12 +264,50 @@ index 719a68b..576636f 100644
 +			LastMs = now,
 +			WindowStartMs = now
 +		};
- 	}
++	}
++
++	private static void MarkStratumMovementCorrection(StratumMovementState state, Entity entity, long now)
++	{
++		state.CorrectionUntilMs = now + 1500;
++		state.CorrectionX = entity.Pos.X;
++		state.CorrectionY = entity.Pos.InternalY;
++		state.CorrectionZ = entity.Pos.Z;
++		state.X = entity.Pos.X;
++		state.Y = entity.Pos.InternalY;
++		state.Z = entity.Pos.Z;
++		state.WindowStartMs = now;
++		state.WindowDistance = 0;
++	}
++
++	private void MarkStratumMovementCorrection(string stateKey, Entity entity, long now)
++	{
++		if (string.IsNullOrEmpty(stateKey) || entity == null)
++		{
++			return;
++		}
++
++		if (!stratumMovementByPlayerUid.TryGetValue(stateKey, out StratumMovementState state))
++		{
++			state = new StratumMovementState();
++			stratumMovementByPlayerUid[stateKey] = state;
++		}
++
++		MarkStratumMovementCorrection(state, entity, now);
++		state.LastMs = now;
++	}
++
++	private static double Distance(double x, double y, double z, double otherX, double otherY, double otherZ)
++	{
++		double dx = x - otherX;
++		double dy = y - otherY;
++		double dz = z - otherZ;
++		return Math.Sqrt(dx * dx + dy * dy + dz * dz);
++	}
  
  	private void SendSinglePositionPacket(ServerPlayer player, Entity entity, int currentTick)
  	{
  		Packet_UdpPacket packet = new Packet_UdpPacket
-@@ -240,10 +402,16 @@ public class ServerUdpNetwork : ServerSystem
+@@ -240,10 +398,16 @@ public class ServerUdpNetwork : ServerSystem
  			return;
  		}
  		int num2 = entityById.Attributes.GetInt("tick");
@@ -257,7 +324,7 @@ index 719a68b..576636f 100644
  			entityById.Api.Logger.Audit("Rejected mount position update for " + player.PlayerName + ". Client sent " + packet.X / 16384 + "," + packet.Y / 16384 + "," + packet.Z / 16384 + ", server pos was " + entityById.Pos);
  			SendSinglePositionPacket(player, entityById, num2);
  			return;
-@@ -299,10 +467,11 @@ public class ServerUdpNetwork : ServerSystem
+@@ -299,10 +463,11 @@ public class ServerUdpNetwork : ServerSystem
  			IServerNetworkChannel animationsAndTagsChannel = physicsManager.AnimationsAndTagsChannel;
  			AnimationPacket message = animationPacket;
  			IServerPlayer[] players = list.ToArray();

--- a/sources/VintagestoryLib/Vintagestory.Server/CmdStratum.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/CmdStratum.cs
@@ -22,7 +22,7 @@ internal class CmdStratum
 		this.server = server;
 		server.api.commandapi.Create(StratumInfo.Id)
 			.WithDesc("Show Stratum server information")
-			.WithArgs(server.api.commandapi.Parsers.OptionalWord("status|version|update|health|reload|preflight|packets|performance|perf|timings|players|player|chunks|entities|queues|pathfinding|doctor|regions|violations|access|chat|pregen|get|set|save"), server.api.commandapi.Parsers.OptionalWord("argument"), server.api.commandapi.Parsers.OptionalWord("detail"), server.api.commandapi.Parsers.OptionalWord("value1"), server.api.commandapi.Parsers.OptionalWord("value2"), server.api.commandapi.Parsers.OptionalWord("value3"), server.api.commandapi.Parsers.OptionalWord("value4"))
+			.WithArgs(server.api.commandapi.Parsers.OptionalWord("status|version|update|health|reload|preflight|packets|performance|perf|timings|players|player|chunks|entities|queues|pathfinding|doctor|regions|violations|ac|anticheat|access|chat|pregen|get|set|save"), server.api.commandapi.Parsers.OptionalWord("argument"), server.api.commandapi.Parsers.OptionalWord("detail"), server.api.commandapi.Parsers.OptionalWord("value1"), server.api.commandapi.Parsers.OptionalWord("value2"), server.api.commandapi.Parsers.OptionalWord("value3"), server.api.commandapi.Parsers.OptionalWord("value4"))
 			.RequiresPrivilege(Privilege.controlserver)
 			.HandleWith(HandleStratum);
 	}
@@ -63,6 +63,11 @@ internal class CmdStratum
 		if (string.Equals(action, "violations", StringComparison.OrdinalIgnoreCase))
 		{
 			return HandlePackets(args[1] as string, args[2] as string);
+		}
+
+		if (string.Equals(action, "ac", StringComparison.OrdinalIgnoreCase) || string.Equals(action, "anticheat", StringComparison.OrdinalIgnoreCase))
+		{
+			return HandleAnticheat(args[1] as string);
 		}
 
 		if (string.Equals(action, "players", StringComparison.OrdinalIgnoreCase))
@@ -142,7 +147,7 @@ internal class CmdStratum
 
 		if (action != null && action.Length > 0 && !string.Equals(action, "status", StringComparison.OrdinalIgnoreCase))
 		{
-			return TextCommandResult.Error("Usage: /stratum [status|version|update|health|reload|preflight|packets|performance|timings|players|player|chunks|entities|queues|pathfinding|doctor|regions|violations|access|chat|pregen|get|set|save]");
+			return TextCommandResult.Error("Usage: /stratum [status|version|update|health|reload|preflight|packets|performance|timings|players|player|chunks|entities|queues|pathfinding|doctor|regions|violations|ac|access|chat|pregen|get|set|save]");
 		}
 
 		return HandleStatus();
@@ -234,6 +239,11 @@ internal class CmdStratum
 	private TextCommandResult HandlePackets(string mode, string detail)
 	{
 		return TextCommandResult.Success(StratumRuntime.PacketLimiter.BuildReport(mode, detail) + "\n" + StratumRuntime.PacketBackPressure.BuildReport() + "\n" + StratumRuntime.BlockBreakGuard.BuildReport());
+	}
+
+	private TextCommandResult HandleAnticheat(string playerName)
+	{
+		return TextCommandResult.Success(StratumAnticheatReporter.BuildReport(playerName));
 	}
 
 	private TextCommandResult HandleHealth()

--- a/sources/VintagestoryLib/Vintagestory.Server/CmdStratum.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/CmdStratum.cs
@@ -22,7 +22,7 @@ internal class CmdStratum
 		this.server = server;
 		server.api.commandapi.Create(StratumInfo.Id)
 			.WithDesc("Show Stratum server information")
-			.WithArgs(server.api.commandapi.Parsers.OptionalWord("status|version|update|health|reload|preflight|packets|performance|perf|timings|players|player|chunks|entities|queues|pathfinding|doctor|regions|violations|ac|anticheat|access|chat|pregen|get|set|save"), server.api.commandapi.Parsers.OptionalWord("argument"), server.api.commandapi.Parsers.OptionalWord("detail"), server.api.commandapi.Parsers.OptionalWord("value1"), server.api.commandapi.Parsers.OptionalWord("value2"), server.api.commandapi.Parsers.OptionalWord("value3"), server.api.commandapi.Parsers.OptionalWord("value4"))
+			.WithArgs(server.api.commandapi.Parsers.OptionalWord("status|version|update|health|reload|preflight|packets|performance|perf|timings|players|player|chunks|entities|queues|pathfinding|doctor|regions|ac|anticheat|access|chat|pregen|get|set|save"), server.api.commandapi.Parsers.OptionalWord("argument"), server.api.commandapi.Parsers.OptionalWord("detail"), server.api.commandapi.Parsers.OptionalWord("value1"), server.api.commandapi.Parsers.OptionalWord("value2"), server.api.commandapi.Parsers.OptionalWord("value3"), server.api.commandapi.Parsers.OptionalWord("value4"))
 			.RequiresPrivilege(Privilege.controlserver)
 			.HandleWith(HandleStratum);
 	}
@@ -56,11 +56,6 @@ internal class CmdStratum
 		}
 
 		if (string.Equals(action, "packets", StringComparison.OrdinalIgnoreCase))
-		{
-			return HandlePackets(args[1] as string, args[2] as string);
-		}
-
-		if (string.Equals(action, "violations", StringComparison.OrdinalIgnoreCase))
 		{
 			return HandlePackets(args[1] as string, args[2] as string);
 		}
@@ -147,7 +142,7 @@ internal class CmdStratum
 
 		if (action != null && action.Length > 0 && !string.Equals(action, "status", StringComparison.OrdinalIgnoreCase))
 		{
-			return TextCommandResult.Error("Usage: /stratum [status|version|update|health|reload|preflight|packets|performance|timings|players|player|chunks|entities|queues|pathfinding|doctor|regions|violations|ac|access|chat|pregen|get|set|save]");
+			return TextCommandResult.Error("Usage: /stratum [status|version|update|health|reload|preflight|packets|performance|timings|players|player|chunks|entities|queues|pathfinding|doctor|regions|ac|access|chat|pregen|get|set|save]");
 		}
 
 		return HandleStatus();
@@ -267,7 +262,7 @@ internal class CmdStratum
 		output.Append(StratumCommandText.Row("Memory", "managed=" + managedMemory + "MB process=" + processMemory + "MB"));
 		output.Append(StratumCommandText.Row("Preflight", StratumRuntime.LastPreflight.Summary));
 		output.Append(StratumCommandText.Row("Protection", "packets=" + (StratumRuntime.Config.Hardening.PacketMonitoring ? "on" : "off") + " blockBreak=" + (StratumRuntime.Config.Hardening.BlockBreakGuards ? "on" : "off") + " timings=" + (StratumRuntime.Timings.Enabled ? "running" : "stopped")));
-		output.Append(StratumCommandText.Row("Next", "/stratum queues, /stratum chunks, /stratum entities, /stratum players, /stratum violations"));
+		output.Append(StratumCommandText.Row("Next", "/stratum queues, /stratum chunks, /stratum entities, /stratum players"));
 		return TextCommandResult.Success(output.ToString());
 	}
 

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumAnticheatConfig.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumAnticheatConfig.cs
@@ -143,13 +143,9 @@ internal class StratumMovementAnticheatConfig : StratumAnticheatRuleConfig
 	// Extra cells below the real ground contact check. Keep this low unless testing proves otherwise.
 	public int FlightGroundScanDepth { get; set; } = 0;
 
-	public double FlightMinAirborneSeconds { get; set; } = 1.0;
+	public double FlightMinAirborneSeconds { get; set; } = 1.75;
 
-	public double FlightDescentResetBlocks { get; set; } = 0.08;
-
-	public int HoverConsecutiveTicks { get; set; } = 4;
-
-	public double HoverStableYBlocks { get; set; } = 0.03;
+	public double FlightRequiredDescentBlocks { get; set; } = 0.35;
 
 	// Chest-only by design. Feet collide with too many normal partial blocks.
 	public bool DetectNoclip { get; set; } = true;
@@ -170,10 +166,8 @@ internal class StratumMovementAnticheatConfig : StratumAnticheatRuleConfig
 		SlackBlocks = Math.Clamp(SlackBlocks, 0, 32);
 		KickAfterViolations = Math.Clamp(KickAfterViolations, 3, 1000);
 		FlightGroundScanDepth = Math.Clamp(FlightGroundScanDepth, 0, 16);
-		FlightMinAirborneSeconds = Math.Clamp(FlightMinAirborneSeconds, 0.5, 10);
-		FlightDescentResetBlocks = Math.Clamp(FlightDescentResetBlocks, 0.01, 1);
-		HoverConsecutiveTicks = Math.Clamp(HoverConsecutiveTicks, 2, 40);
-		HoverStableYBlocks = Math.Clamp(HoverStableYBlocks, 0.005, 0.25);
+		FlightMinAirborneSeconds = Math.Clamp(FlightMinAirborneSeconds, 1.0, 10);
+		FlightRequiredDescentBlocks = Math.Clamp(FlightRequiredDescentBlocks, 0.05, 3);
 		WaterWalkConsecutiveTicks = Math.Clamp(WaterWalkConsecutiveTicks, 3, 40);
 		GroundContactTolerance = Math.Clamp(GroundContactTolerance, 0.005, 0.2);
 		NoclipConsecutiveTicks = Math.Clamp(NoclipConsecutiveTicks, 2, 40);

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumAnticheatConfig.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumAnticheatConfig.cs
@@ -107,7 +107,11 @@ internal class StratumMovementAnticheatConfig : StratumAnticheatRuleConfig
 
 	public double HorizontalSpeedMultiplier { get; set; } = 3.0;
 
+	public double AirborneHorizontalMultiplier { get; set; } = 1.75;
+
 	public double MinimumHorizontalBlocksPerSecond { get; set; } = 8.0;
+
+	public double PositionVersionAcceptDistance { get; set; } = 4.0;
 
 	// Fallback cap when stat-based speed limits are disabled, and hard ceiling when they are on.
 	public double MaxHorizontalBlocksPerSecond { get; set; } = 36;
@@ -132,7 +136,7 @@ internal class StratumMovementAnticheatConfig : StratumAnticheatRuleConfig
 
 	public bool DetectWaterWalk { get; set; } = true;
 
-	public int WaterWalkConsecutiveTicks { get; set; } = 5;
+	public int WaterWalkConsecutiveTicks { get; set; } = 3;
 
 	public double GroundContactTolerance { get; set; } = 0.04;
 
@@ -143,6 +147,10 @@ internal class StratumMovementAnticheatConfig : StratumAnticheatRuleConfig
 
 	public double FlightDescentResetBlocks { get; set; } = 0.08;
 
+	public int HoverConsecutiveTicks { get; set; } = 4;
+
+	public double HoverStableYBlocks { get; set; } = 0.03;
+
 	// Chest-only by design. Feet collide with too many normal partial blocks.
 	public bool DetectNoclip { get; set; } = true;
 
@@ -152,7 +160,9 @@ internal class StratumMovementAnticheatConfig : StratumAnticheatRuleConfig
 	{
 		base.EnsureSane();
 		HorizontalSpeedMultiplier = Math.Clamp(HorizontalSpeedMultiplier, 1, 20);
+		AirborneHorizontalMultiplier = Math.Clamp(AirborneHorizontalMultiplier, 1, 5);
 		MinimumHorizontalBlocksPerSecond = Math.Clamp(MinimumHorizontalBlocksPerSecond, 3, 100);
+		PositionVersionAcceptDistance = Math.Clamp(PositionVersionAcceptDistance, 0.5, 32);
 		MaxHorizontalBlocksPerSecond = Math.Clamp(MaxHorizontalBlocksPerSecond, 8, 1000);
 		MaxVerticalUpBlocksPerSecond = Math.Clamp(MaxVerticalUpBlocksPerSecond, 4, 1000);
 		CumulativeSpeedMultiplier = Math.Clamp(CumulativeSpeedMultiplier, 1, 20);
@@ -162,6 +172,8 @@ internal class StratumMovementAnticheatConfig : StratumAnticheatRuleConfig
 		FlightGroundScanDepth = Math.Clamp(FlightGroundScanDepth, 0, 16);
 		FlightMinAirborneSeconds = Math.Clamp(FlightMinAirborneSeconds, 0.5, 10);
 		FlightDescentResetBlocks = Math.Clamp(FlightDescentResetBlocks, 0.01, 1);
+		HoverConsecutiveTicks = Math.Clamp(HoverConsecutiveTicks, 2, 40);
+		HoverStableYBlocks = Math.Clamp(HoverStableYBlocks, 0.005, 0.25);
 		WaterWalkConsecutiveTicks = Math.Clamp(WaterWalkConsecutiveTicks, 3, 40);
 		GroundContactTolerance = Math.Clamp(GroundContactTolerance, 0.005, 0.2);
 		NoclipConsecutiveTicks = Math.Clamp(NoclipConsecutiveTicks, 2, 40);

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumAnticheatConfig.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumAnticheatConfig.cs
@@ -92,60 +92,58 @@ internal class StratumBlockBreakProgressAnticheatConfig : StratumAnticheatRuleCo
 	}
 }
 
-// Server-authoritative movement validation !!
-// The server can never trust client WorldData flags for this: cheat clients keep FreeMove/NoClip/MoveSpeed at the server's values and only ever lie in the position stream, so we validate the position deltas themselves. 
-// Violations are rubberbanded and, only when a player sustains many of them will it be escalated to a kick.
-// Defaults are deliberately generous will be tested with time.
+// Server-side movement checks. Defaults start generous and get tightened from testing.
 internal class StratumMovementAnticheatConfig : StratumAnticheatRuleConfig
 {
 	public StratumMovementAnticheatConfig()
 	{
-		// Movement violations cluster quickly, so use a shorter window and a high kick bar so only sustained cheating (not a lag spike) ever reaches a disconnect.
+		// Movement violations tend to come in bursts. This alerts quickly but still gives lag some room.
 		AlertAfterViolations = 6;
 		AlertWindowSeconds = 6;
 		RepeatAlertSeconds = 15;
 	}
 
-	// Max horizontal speed before a position is rejected, in blocks/second.
-	// vanilla sprint is ~6-7 b/s roughly, so this leaves wide headroom for speed potions, downhill, and minor desync. hopefully...
+	public bool UseStatBasedSpeedLimits { get; set; } = true;
+
+	public double HorizontalSpeedMultiplier { get; set; } = 3.0;
+
+	public double MinimumHorizontalBlocksPerSecond { get; set; } = 8.0;
+
+	// Fallback cap when stat-based speed limits are disabled, and hard ceiling when they are on.
 	public double MaxHorizontalBlocksPerSecond { get; set; } = 36;
 
-	// Max upward speed in blocks/second. Jumps and knockback are brief and stay under this.
 	public double MaxVerticalUpBlocksPerSecond { get; set; } = 18;
 
-	// Max total distance travelled within a rolling 1s window, in blocks. Catches teleport hacks that stay under the per-packet cap by spreading the jump across packets.
+	public double CumulativeSpeedMultiplier { get; set; } = 2.5;
+
+	// Hard ceiling for repeated smaller teleports that stay under the per-packet cap.
 	public double MaxCumulativeBlocksPerSecond { get; set; } = 64;
 
-	// Flat per-packet distance allowance added on top of the speed budgets to absorb jitter.
 	public double SlackBlocks { get; set; } = 2.5;
 
 	public bool KickConfirmedCheats { get; set; } = true;
 
-	public int KickAfterViolations { get; set; } = 25;
+	public int KickAfterViolations { get; set; } = 10;
 
 	public string KickMessage { get; set; } = "Disconnected by Stratum movement protection";
 
-	// Flight / air-walk detection. Catches the slow hover/ascent that never trips the speed caps.
-	// A survival player is "flying" when they stay unsupported (no solid within the scan depth
-	// below, not in/over liquid, not on a climbable block) yet fail to lose altitude for longer
-	// than any real jump arc. The descent rule keeps legitimate falls and paraglider descents
-	// safe - only hovering or rising is flagged.
+	// Handles slow hover and air-walk cases that never trip the speed caps.
 	public bool DetectFlight { get; set; } = true;
 
-	// Cells scanned below the feet for something to stand on. 2 means flight only triggers when
-	// the player is more than ~2 blocks above ground, so a jump apex never counts as flight.
-	public int FlightGroundScanDepth { get; set; } = 2;
+	public bool DetectWaterWalk { get; set; } = true;
 
-	// How long the player must be continuously unsupported before flight can be flagged.
-	public double FlightMinAirborneSeconds { get; set; } = 1.5;
+	public int WaterWalkConsecutiveTicks { get; set; } = 5;
 
-	// If, after that time, the player has descended less than this many blocks from where they
-	// left support, they are hovering/ascending = flight. Gravity drops a real faller far more.
-	public double FlightMaxNonDescentBlocks { get; set; } = 0.5;
+	public double GroundContactTolerance { get; set; } = 0.04;
 
-	// Noclip detection. Flags when the player's chest point sits inside a block's collision
-	// geometry for several consecutive position packets. Using the chest (not the feet) keeps
-	// slabs, snow layers, paths, and fences from ever counting.
+	// Extra cells below the real ground contact check. Keep this low unless testing proves otherwise.
+	public int FlightGroundScanDepth { get; set; } = 0;
+
+	public double FlightMinAirborneSeconds { get; set; } = 1.0;
+
+	public double FlightDescentResetBlocks { get; set; } = 0.08;
+
+	// Chest-only by design. Feet collide with too many normal partial blocks.
 	public bool DetectNoclip { get; set; } = true;
 
 	public int NoclipConsecutiveTicks { get; set; } = 3;
@@ -153,14 +151,19 @@ internal class StratumMovementAnticheatConfig : StratumAnticheatRuleConfig
 	public override void EnsureSane()
 	{
 		base.EnsureSane();
+		HorizontalSpeedMultiplier = Math.Clamp(HorizontalSpeedMultiplier, 1, 20);
+		MinimumHorizontalBlocksPerSecond = Math.Clamp(MinimumHorizontalBlocksPerSecond, 3, 100);
 		MaxHorizontalBlocksPerSecond = Math.Clamp(MaxHorizontalBlocksPerSecond, 8, 1000);
 		MaxVerticalUpBlocksPerSecond = Math.Clamp(MaxVerticalUpBlocksPerSecond, 4, 1000);
+		CumulativeSpeedMultiplier = Math.Clamp(CumulativeSpeedMultiplier, 1, 20);
 		MaxCumulativeBlocksPerSecond = Math.Clamp(MaxCumulativeBlocksPerSecond, MaxHorizontalBlocksPerSecond, 4000);
 		SlackBlocks = Math.Clamp(SlackBlocks, 0, 32);
 		KickAfterViolations = Math.Clamp(KickAfterViolations, 3, 1000);
-		FlightGroundScanDepth = Math.Clamp(FlightGroundScanDepth, 1, 16);
+		FlightGroundScanDepth = Math.Clamp(FlightGroundScanDepth, 0, 16);
 		FlightMinAirborneSeconds = Math.Clamp(FlightMinAirborneSeconds, 0.5, 10);
-		FlightMaxNonDescentBlocks = Math.Clamp(FlightMaxNonDescentBlocks, 0.1, 8);
+		FlightDescentResetBlocks = Math.Clamp(FlightDescentResetBlocks, 0.01, 1);
+		WaterWalkConsecutiveTicks = Math.Clamp(WaterWalkConsecutiveTicks, 3, 40);
+		GroundContactTolerance = Math.Clamp(GroundContactTolerance, 0.005, 0.2);
 		NoclipConsecutiveTicks = Math.Clamp(NoclipConsecutiveTicks, 2, 40);
 		KickMessage ??= "Disconnected by Stratum movement protection";
 	}

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumAnticheatReporter.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumAnticheatReporter.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Text;
 using Vintagestory.API.Common;
 using Vintagestory.API.Config;
 using Vintagestory.API.MathTools;
@@ -144,6 +145,155 @@ internal static class StratumAnticheatReporter
 		return false;
 	}
 
+	public static string BuildReport(string playerFilter, int maxEvents = 12)
+	{
+		StratumRuntime.Config.EnsurePopulated();
+		DateTime now = DateTime.UtcNow;
+		StratumAnticheatConfig config = StratumRuntime.Config.Anticheat;
+		bool showTop = string.IsNullOrWhiteSpace(playerFilter) || string.Equals(playerFilter, "top", StringComparison.OrdinalIgnoreCase);
+		List<PlayerViolationSnapshot> players;
+
+		lock (Lock)
+		{
+			PruneStalePlayers(now, config);
+			players = PlayerViolations.Values
+				.Select(state => state.ToSnapshot(maxEvents))
+				.OrderByDescending(snapshot => snapshot.TotalCount)
+				.ThenBy(snapshot => snapshot.PlayerName, StringComparer.OrdinalIgnoreCase)
+				.ToList();
+		}
+
+		if (!showTop)
+		{
+			players = players
+				.Where(snapshot => string.Equals(snapshot.PlayerName, playerFilter, StringComparison.OrdinalIgnoreCase) || string.Equals(snapshot.PlayerKey, playerFilter, StringComparison.OrdinalIgnoreCase))
+				.ToList();
+		}
+
+		StringBuilder output = new StringBuilder(StratumCommandText.Title("Stratum Anticheat"));
+		output.Append(StratumCommandText.Row("Enabled", config.Enabled ? "true" : "false"));
+		output.Append(StratumCommandText.Row("Staff alerts", config.StaffAlerts ? "true" : "false"));
+		output.Append(StratumCommandText.Row("Tracked players", players.Count.ToString(CultureInfo.InvariantCulture)));
+
+		if (players.Count == 0)
+		{
+			output.Append(StratumCommandText.Empty(showTop ? "\nNo recorded violations." : "\nNo recorded violations for " + playerFilter + "."));
+			return output.ToString();
+		}
+
+		if (showTop)
+		{
+			AppendTopReport(output, players, now);
+			output.Append(StratumCommandText.Row("Player details", "/stratum ac <player>"));
+			return output.ToString();
+		}
+
+		AppendPlayerReport(output, players[0], now);
+		output.Append(StratumCommandText.Row("Overview", "/stratum ac"));
+		return output.ToString();
+	}
+
+	private static void AppendTopReport(StringBuilder output, List<PlayerViolationSnapshot> players, DateTime now)
+	{
+		output.Append("\n").Append(StratumCommandText.Title("Top Violation Types"));
+		foreach (var entry in players
+			.SelectMany(player => player.TypeCounts)
+			.GroupBy(entry => entry.Type)
+			.Select(group => new { Type = group.Key, Count = group.Sum(entry => entry.Count) })
+			.OrderByDescending(entry => entry.Count)
+			.ThenBy(entry => FriendlyTypeName(entry.Type))
+			.Take(5))
+		{
+			output.Append(StratumCommandText.Bullet(FriendlyTypeName(entry.Type), entry.Count.ToString(CultureInfo.InvariantCulture) + " hits"));
+		}
+
+		output.Append("\n").Append(StratumCommandText.Title("Top Players"));
+		foreach (PlayerViolationSnapshot player in players.Take(8))
+		{
+			string topType = player.TypeCounts.Length == 0 ? "unknown" : FriendlyTypeName(player.TypeCounts.OrderByDescending(entry => entry.Count).First().Type);
+			output.Append(StratumCommandText.Bullet(
+				player.PlayerName,
+				player.TotalCount.ToString(CultureInfo.InvariantCulture) + " hits, mostly " + topType + ", last seen " + FormatAge(now - player.LastSeenUtc) + " ago"));
+		}
+	}
+
+	private static void AppendPlayerReport(StringBuilder output, PlayerViolationSnapshot player, DateTime now)
+	{
+		output.Append("\n").Append(StratumCommandText.Title("Player: " + player.PlayerName));
+		output.Append(StratumCommandText.Row("Total", player.TotalCount.ToString(CultureInfo.InvariantCulture) + " recorded violations"));
+		output.Append(StratumCommandText.Row("Last seen", FormatAge(now - player.LastSeenUtc) + " ago"));
+
+		output.Append("\n").Append(StratumCommandText.Title("Breakdown"));
+		foreach (ViolationTypeCount entry in player.TypeCounts.OrderByDescending(entry => entry.Count))
+		{
+			output.Append(StratumCommandText.Bullet(FriendlyTypeName(entry.Type), entry.Count.ToString(CultureInfo.InvariantCulture) + " hits"));
+		}
+
+		output.Append("\n").Append(StratumCommandText.Title("Recent"));
+		foreach (ViolationEventSnapshot entry in player.RecentEvents.Take(8))
+		{
+			output.Append(StratumCommandText.RawRow(
+				FriendlyTypeName(entry.Type),
+				StratumCommandText.Escape(FormatAge(now - entry.Utc) + " ago, " + FriendlyDetail(entry))));
+		}
+	}
+
+	private static string FriendlyTypeName(string type)
+	{
+		switch (type)
+		{
+			case BlockEntityOutOfRangeType:
+				return "Block entity out of range";
+			case BlockInteractionOutOfRangeType:
+				return "Block reach";
+			case BlockBreakProgressType:
+				return "Block break timing";
+			case MovementType:
+				return "Movement";
+			default:
+				return string.IsNullOrWhiteSpace(type) ? "Unknown" : type;
+		}
+	}
+
+	private static string FriendlyDetail(ViolationEventSnapshot entry)
+	{
+		string detail = entry.Detail ?? "";
+		if (entry.Type == MovementType)
+		{
+			if (detail.StartsWith("water walk", StringComparison.OrdinalIgnoreCase))
+			{
+				return "walking on liquid";
+			}
+
+			if (detail.StartsWith("flight:", StringComparison.OrdinalIgnoreCase))
+			{
+				return "hovering or flying without falling";
+			}
+
+			if (detail.StartsWith("noclip:", StringComparison.OrdinalIgnoreCase))
+			{
+				return "inside solid collision";
+			}
+
+			if (detail.StartsWith("correction replay", StringComparison.OrdinalIgnoreCase))
+			{
+				return "kept moving away after server correction";
+			}
+
+			if (detail.StartsWith("delta ", StringComparison.OrdinalIgnoreCase))
+			{
+				return "moved faster or farther than allowed (" + detail + ")";
+			}
+		}
+
+		if (entry.Type == BlockEntityOutOfRangeType)
+		{
+			return "sent a block entity packet too far away at " + detail;
+		}
+
+		return detail;
+	}
+
 	private static ViolationRecordResult RecordViolation(ServerPlayer player, DateTime now, string type, string detail, StratumAnticheatConfig config, StratumAnticheatRuleConfig rule)
 	{
 		int rollingCount;
@@ -165,6 +315,7 @@ internal static class StratumAnticheatReporter
 			state.LastSeenUtc = now;
 			state.TotalCount++;
 			state.Events.AddLast(new PlayerViolationEvent(type, now, detail));
+			ServerMain.Logger?.Audit("Stratum anticheat {0} player={1} detail={2}", type, player.PlayerName, detail);
 
 			while (state.Events.Count > config.MaxStoredViolationsPerPlayer)
 			{
@@ -188,6 +339,14 @@ internal static class StratumAnticheatReporter
 		}
 
 		return new ViolationRecordResult(rollingCount, totalCount, shouldAlert);
+	}
+
+	private static string FormatAge(TimeSpan age)
+	{
+		if (age.TotalSeconds < 60) return ((int)Math.Max(0, age.TotalSeconds)).ToString(CultureInfo.InvariantCulture) + "s";
+		if (age.TotalMinutes < 60) return ((int)age.TotalMinutes).ToString(CultureInfo.InvariantCulture) + "m";
+		if (age.TotalHours < 24) return ((int)age.TotalHours).ToString(CultureInfo.InvariantCulture) + "h";
+		return ((int)age.TotalDays).ToString(CultureInfo.InvariantCulture) + "d";
 	}
 
 	private static void SendStaffAlert(ServerMain server, ServerPlayer player, string label, BlockPos pos, int rollingCount, int totalCount, int windowSeconds)
@@ -298,6 +457,20 @@ internal static class StratumAnticheatReporter
 			LastStaffAlertUtc = utc;
 			LastStaffAlertsByType[type] = utc;
 		}
+
+		public PlayerViolationSnapshot ToSnapshot(int maxEvents)
+		{
+			return new PlayerViolationSnapshot(
+				PlayerKey,
+				PlayerName,
+				TotalCount,
+				LastSeenUtc,
+				Events.GroupBy(entry => entry.Type)
+					.Select(group => new ViolationTypeCount(group.Key, group.Count()))
+					.OrderByDescending(entry => entry.Count)
+					.ToArray(),
+				Events.Reverse().Take(Math.Max(1, maxEvents)).Select(entry => new ViolationEventSnapshot(entry.Type, entry.Utc, entry.Detail)).ToArray());
+		}
 	}
 
 	private readonly struct PlayerViolationEvent
@@ -330,5 +503,59 @@ internal static class StratumAnticheatReporter
 		public int TotalCount { get; }
 
 		public bool ShouldAlert { get; }
+	}
+
+	private readonly struct PlayerViolationSnapshot
+	{
+		public PlayerViolationSnapshot(string playerKey, string playerName, int totalCount, DateTime lastSeenUtc, ViolationTypeCount[] typeCounts, ViolationEventSnapshot[] recentEvents)
+		{
+			PlayerKey = playerKey;
+			PlayerName = playerName;
+			TotalCount = totalCount;
+			LastSeenUtc = lastSeenUtc;
+			TypeCounts = typeCounts;
+			RecentEvents = recentEvents;
+		}
+
+		public string PlayerKey { get; }
+
+		public string PlayerName { get; }
+
+		public int TotalCount { get; }
+
+		public DateTime LastSeenUtc { get; }
+
+		public ViolationTypeCount[] TypeCounts { get; }
+
+		public ViolationEventSnapshot[] RecentEvents { get; }
+	}
+
+	private readonly struct ViolationTypeCount
+	{
+		public ViolationTypeCount(string type, int count)
+		{
+			Type = type;
+			Count = count;
+		}
+
+		public string Type { get; }
+
+		public int Count { get; }
+	}
+
+	private readonly struct ViolationEventSnapshot
+	{
+		public ViolationEventSnapshot(string type, DateTime utc, string detail)
+		{
+			Type = type;
+			Utc = utc;
+			Detail = detail;
+		}
+
+		public string Type { get; }
+
+		public DateTime Utc { get; }
+
+		public string Detail { get; }
 	}
 }

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumAnticheatReporter.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumAnticheatReporter.cs
@@ -184,7 +184,7 @@ internal static class StratumAnticheatReporter
 		if (showTop)
 		{
 			AppendTopReport(output, players, now);
-			output.Append(StratumCommandText.Row("Player details", "/stratum ac <player>"));
+			output.Append(StratumCommandText.Row("Player details", "/stratum ac &lt;player&gt;"));
 			return output.ToString();
 		}
 

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumBlockBreakGuard.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumBlockBreakGuard.cs
@@ -128,10 +128,6 @@ internal sealed class StratumBlockBreakGuard
 			}
 			else if (!hasTrackedProgress && rememberedDamage <= 0f)
 			{
-				// Stratum start: validate using left-click hold duration
-				// When the server raytrace misses the target block (grass cover, fluid
-				// layer, position sync lag), ObserveMining records the hold start but
-				// accumulates no damage. Use that hold duration as proof of mining intent.
 				float ratio = Math.Max(0.1f, Math.Min(1f, config.RequiredProgressRatio));
 				float requiredSeconds = expectedBreakSeconds * ratio;
 				float heldSeconds = state.LeftMouseHeldSinceMs > 0 ? (now - state.LeftMouseHeldSinceMs) / 1000f : 0f;
@@ -140,7 +136,6 @@ internal sealed class StratumBlockBreakGuard
 				{
 					reason = $"no tracked mining progress for {requestedSelection.Position}";
 				}
-				// Stratum end
 			}
 			else
 			{
@@ -165,8 +160,6 @@ internal sealed class StratumBlockBreakGuard
 			canLog = config.LogViolations && state.ShouldLog(now);
 		}
 
-		// updating this to go through the shared anticheat reporter so staff alerting and confirmed-cheat kicking follow the same per-player rolling window as the other signals.
-		// Called outside the gate lock since the reporter takes its own lock and may broadcast staff chat.
 		bool shouldKick = StratumAnticheatReporter.RecordBlockBreakViolation(server, player, requestedSelection.Position, reason, out disconnectReason);
 		if (shouldKick)
 		{

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumBlockBreakGuard.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumBlockBreakGuard.cs
@@ -128,6 +128,9 @@ internal sealed class StratumBlockBreakGuard
 			}
 			else if (!hasTrackedProgress && rememberedDamage <= 0f)
 			{
+				// When the server raytrace misses the target block (grass cover, fluid
+				// layer, position sync lag), ObserveMining records the hold start but
+				// accumulates no damage. Use that hold duration as proof of mining intent.
 				float ratio = Math.Max(0.1f, Math.Min(1f, config.RequiredProgressRatio));
 				float requiredSeconds = expectedBreakSeconds * ratio;
 				float heldSeconds = state.LeftMouseHeldSinceMs > 0 ? (now - state.LeftMouseHeldSinceMs) / 1000f : 0f;
@@ -136,6 +139,7 @@ internal sealed class StratumBlockBreakGuard
 				{
 					reason = $"no tracked mining progress for {requestedSelection.Position}";
 				}
+				
 			}
 			else
 			{
@@ -160,6 +164,10 @@ internal sealed class StratumBlockBreakGuard
 			canLog = config.LogViolations && state.ShouldLog(now);
 		}
 
+		// Route the violation through the shared anticheat reporter so staff alerting and
+		// confirmed-cheat kicking follow the same per-player rolling window as the other
+		// signals. Called outside the gate lock since the reporter takes its own lock and
+		// may broadcast staff chat.
 		bool shouldKick = StratumAnticheatReporter.RecordBlockBreakViolation(server, player, requestedSelection.Position, reason, out disconnectReason);
 		if (shouldKick)
 		{

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumMovementGuard.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumMovementGuard.cs
@@ -72,13 +72,16 @@ internal static class StratumMovementGuard
 			}
 		}
 
+		bool hasPreviousY = state.HasLastY;
+		double previousY = hasPreviousY ? state.LastY : entity.Pos.Y;
+
 		if (waterWalkCandidate)
 		{
-			double yDelta = state.HasLastY ? Math.Abs(entity.Pos.Y - state.LastY) : double.MaxValue;
+			double yDelta = hasPreviousY ? Math.Abs(entity.Pos.Y - previousY) : double.MaxValue;
 			state.WaterWalkTicks = yDelta <= 0.03 ? state.WaterWalkTicks + 1 : 1;
 			if (state.WaterWalkTicks >= Math.Max(3, config.WaterWalkConsecutiveTicks))
 			{
-				ResetHover(state);
+				ResetAirborne(state);
 				state.WaterWalkTicks = 0;
 				Rubberband(entity, state);
 				StratumAnticheatReporter.RecordMovementViolation(server, player, entity.Pos.AsBlockPos, "water walk: standing on liquid", out disconnectReason);
@@ -98,16 +101,13 @@ internal static class StratumMovementGuard
 			state.SafeZ = entity.Pos.Z;
 		}
 
-		state.HasLastY = true;
-		state.LastY = entity.Pos.Y;
-
 		if (config.DetectNoclip)
 		{
 			state.EmbeddedTicks = embedded ? state.EmbeddedTicks + 1 : 0;
 			if (state.EmbeddedTicks >= Math.Max(2, config.NoclipConsecutiveTicks))
 			{
 				state.EmbeddedTicks = 0;
-				ResetHover(state);
+				ResetAirborne(state);
 				Rubberband(entity, state);
 				StratumAnticheatReporter.RecordMovementViolation(server, player, entity.Pos.AsBlockPos, "noclip: chest inside solid blocks", out disconnectReason);
 				return false;
@@ -118,42 +118,47 @@ internal static class StratumMovementGuard
 		{
 			if (supported)
 			{
-				ResetHover(state);
+				ResetAirborne(state);
+			}
+			else if (!state.Airborne)
+			{
+				state.Airborne = true;
+				state.AirborneSinceMs = now;
+				state.AirborneStartY = entity.Pos.Y;
+				state.AirborneLowestY = entity.Pos.Y;
+				state.AirborneHadDescent = false;
 			}
 			else
 			{
-				bool descending = state.HasLastY && state.LastY - entity.Pos.Y >= config.FlightDescentResetBlocks;
-				if (descending)
+				state.AirborneLowestY = Math.Min(state.AirborneLowestY, entity.Pos.Y);
+				if (state.AirborneStartY - state.AirborneLowestY >= config.FlightRequiredDescentBlocks)
 				{
-					ResetHover(state);
+					state.AirborneHadDescent = true;
 				}
-				else
-				{
-					double yDelta = state.HasLastY ? Math.Abs(entity.Pos.Y - state.LastY) : double.MaxValue;
-					state.HoverTicks = yDelta <= config.HoverStableYBlocks ? state.HoverTicks + 1 : 1;
-					if (state.HoverSinceMs == 0)
-					{
-						state.HoverSinceMs = now;
-					}
 
-					if (state.HoverTicks >= config.HoverConsecutiveTicks || (now - state.HoverSinceMs) / 1000.0 >= config.FlightMinAirborneSeconds)
-					{
-						ResetHover(state);
-						Rubberband(entity, state);
-						StratumAnticheatReporter.RecordMovementViolation(server, player, entity.Pos.AsBlockPos, "flight: airborne without descent", out disconnectReason);
-						return false;
-					}
+				double airborneSeconds = (now - state.AirborneSinceMs) / 1000.0;
+				if (airborneSeconds >= config.FlightMinAirborneSeconds && !state.AirborneHadDescent)
+				{
+					ResetAirborne(state);
+					Rubberband(entity, state);
+					StratumAnticheatReporter.RecordMovementViolation(server, player, entity.Pos.AsBlockPos, "flight: airborne without descent", out disconnectReason);
+					return false;
 				}
 			}
 		}
 
+		state.HasLastY = true;
+		state.LastY = entity.Pos.Y;
 		return true;
 	}
 
-	private static void ResetHover(MoveState state)
+	private static void ResetAirborne(MoveState state)
 	{
-		state.HoverSinceMs = 0;
-		state.HoverTicks = 0;
+		state.Airborne = false;
+		state.AirborneSinceMs = 0;
+		state.AirborneStartY = 0;
+		state.AirborneLowestY = 0;
+		state.AirborneHadDescent = false;
 	}
 
 	private static void Rubberband(EntityPlayer entity, MoveState state)
@@ -178,7 +183,7 @@ internal static class StratumMovementGuard
 				states[key] = state;
 			}
 
-			ResetHover(state);
+			ResetAirborne(state);
 			state.EmbeddedTicks = 0;
 			state.WaterWalkTicks = 0;
 			state.HasLastY = true;
@@ -394,8 +399,11 @@ internal static class StratumMovementGuard
 
 	private sealed class MoveState
 	{
-		public long HoverSinceMs;
-		public int HoverTicks;
+		public bool Airborne;
+		public long AirborneSinceMs;
+		public double AirborneStartY;
+		public double AirborneLowestY;
+		public bool AirborneHadDescent;
 		public int EmbeddedTicks;
 		public int WaterWalkTicks;
 		public bool HasLastY;

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumMovementGuard.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumMovementGuard.cs
@@ -127,16 +127,22 @@ internal static class StratumMovementGuard
 				{
 					ResetHover(state);
 				}
-				else if (state.HoverSinceMs == 0)
+				else
 				{
-					state.HoverSinceMs = now;
-				}
-				else if ((now - state.HoverSinceMs) / 1000.0 >= config.FlightMinAirborneSeconds)
-				{
-					ResetHover(state);
-					Rubberband(entity, state);
-					StratumAnticheatReporter.RecordMovementViolation(server, player, entity.Pos.AsBlockPos, "flight: airborne without descent", out disconnectReason);
-					return false;
+					double yDelta = state.HasLastY ? Math.Abs(entity.Pos.Y - state.LastY) : double.MaxValue;
+					state.HoverTicks = yDelta <= config.HoverStableYBlocks ? state.HoverTicks + 1 : 1;
+					if (state.HoverSinceMs == 0)
+					{
+						state.HoverSinceMs = now;
+					}
+
+					if (state.HoverTicks >= config.HoverConsecutiveTicks || (now - state.HoverSinceMs) / 1000.0 >= config.FlightMinAirborneSeconds)
+					{
+						ResetHover(state);
+						Rubberband(entity, state);
+						StratumAnticheatReporter.RecordMovementViolation(server, player, entity.Pos.AsBlockPos, "flight: airborne without descent", out disconnectReason);
+						return false;
+					}
 				}
 			}
 		}
@@ -147,6 +153,7 @@ internal static class StratumMovementGuard
 	private static void ResetHover(MoveState state)
 	{
 		state.HoverSinceMs = 0;
+		state.HoverTicks = 0;
 	}
 
 	private static void Rubberband(EntityPlayer entity, MoveState state)
@@ -388,6 +395,7 @@ internal static class StratumMovementGuard
 	private sealed class MoveState
 	{
 		public long HoverSinceMs;
+		public int HoverTicks;
 		public int EmbeddedTicks;
 		public int WaterWalkTicks;
 		public bool HasLastY;

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumMovementGuard.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumMovementGuard.cs
@@ -6,12 +6,7 @@ using Vintagestory.API.MathTools;
 
 namespace Vintagestory.Server;
 
-// Server-authoritative flight and noclip detection. Companion to the speed/teleport guard in ServerUdpNetwork which catches fast movement,
-// but hovering / air-walk is slow and noclip moves at normal walking speed, so neither trips a speed budget so we validate against the authoritative world instead
-// is the player unsupported yet not falling (flight), or embedded in solid blocks (noclip) - rubberband them to the last known-good position
-// and escalate to a kick through the shared anticheat reporter only after sustained violations.
-//
-// some cheat clients never send a ModeChange packet so the server's WorldData flags stay clean; the only evidence is the position stream, which is what this reads.
+// Slow movement cheats need world checks, not just speed caps.
 internal static class StratumMovementGuard
 {
 	private static readonly object gate = new object();
@@ -30,8 +25,7 @@ internal static class StratumMovementGuard
 		}
 	}
 
-	// Called after the packet has already been applied to entity.Pos. Returns true to accept. On false the caller must rubberband the client (entity.Pos has been reset to a safe position)
-	// and also when disconnectReason is non-null, disconnect the player.
+	// Runs after entity.Pos was updated from the packet. False means the caller should send a correction.
 	public static bool TryAccept(ServerMain server, ServerPlayer player, EntityPlayer entity, string key, out string disconnectReason)
 	{
 		disconnectReason = null;
@@ -48,7 +42,6 @@ internal static class StratumMovementGuard
 			return true;
 		}
 
-		// Same legitimate-bypass exemptions as the speed guard: creative, spectator, and any server-granted free-move / noclip privilege.
 		if (player.WorldData.CurrentGameMode == EnumGameMode.Creative
 			|| player.WorldData.CurrentGameMode == EnumGameMode.Spectator
 			|| player.WorldData.FreeMove
@@ -67,6 +60,7 @@ internal static class StratumMovementGuard
 		long now = server.ElapsedMilliseconds;
 		bool supported = IsSupported(server, entity, feetCell, config);
 		bool embedded = config.DetectNoclip && IsEmbedded(server, entity, feetCell);
+		bool waterWalkCandidate = config.DetectFlight && config.DetectWaterWalk && IsWaterWalkCandidate(server, entity, feetCell, config);
 
 		MoveState state;
 		lock (gate)
@@ -78,8 +72,25 @@ internal static class StratumMovementGuard
 			}
 		}
 
-		// Remember the last position the player was provably standing somewhere legitimate; this is where we rubberband them back to.
-		if (supported && !embedded)
+		if (waterWalkCandidate)
+		{
+			double yDelta = state.HasLastY ? Math.Abs(entity.Pos.Y - state.LastY) : double.MaxValue;
+			state.WaterWalkTicks = yDelta <= 0.03 ? state.WaterWalkTicks + 1 : 1;
+			if (state.WaterWalkTicks >= Math.Max(3, config.WaterWalkConsecutiveTicks))
+			{
+				ResetHover(state);
+				state.WaterWalkTicks = 0;
+				Rubberband(entity, state);
+				StratumAnticheatReporter.RecordMovementViolation(server, player, entity.Pos.AsBlockPos, "water walk: standing on liquid", out disconnectReason);
+				return false;
+			}
+		}
+		else
+		{
+			state.WaterWalkTicks = 0;
+		}
+
+		if (supported && !embedded && !waterWalkCandidate && IsClearBody(server, entity, feetCell))
 		{
 			state.HasSafePos = true;
 			state.SafeX = entity.Pos.X;
@@ -87,13 +98,16 @@ internal static class StratumMovementGuard
 			state.SafeZ = entity.Pos.Z;
 		}
 
+		state.HasLastY = true;
+		state.LastY = entity.Pos.Y;
+
 		if (config.DetectNoclip)
 		{
 			state.EmbeddedTicks = embedded ? state.EmbeddedTicks + 1 : 0;
 			if (state.EmbeddedTicks >= Math.Max(2, config.NoclipConsecutiveTicks))
 			{
 				state.EmbeddedTicks = 0;
-				state.AirborneSinceMs = 0;
+				ResetHover(state);
 				Rubberband(entity, state);
 				StratumAnticheatReporter.RecordMovementViolation(server, player, entity.Pos.AsBlockPos, "noclip: chest inside solid blocks", out disconnectReason);
 				return false;
@@ -104,20 +118,22 @@ internal static class StratumMovementGuard
 		{
 			if (supported)
 			{
-				state.AirborneSinceMs = 0;
-			}
-			else if (state.AirborneSinceMs == 0)
-			{
-				state.AirborneSinceMs = now;
-				state.AirborneStartY = entity.Pos.Y;
+				ResetHover(state);
 			}
 			else
 			{
-				double airborneSeconds = (now - state.AirborneSinceMs) / 1000.0;
-				double descended = state.AirborneStartY - entity.Pos.Y;
-				if (airborneSeconds >= config.FlightMinAirborneSeconds && descended < config.FlightMaxNonDescentBlocks)
+				bool descending = state.HasLastY && state.LastY - entity.Pos.Y >= config.FlightDescentResetBlocks;
+				if (descending)
 				{
-					state.AirborneSinceMs = 0;
+					ResetHover(state);
+				}
+				else if (state.HoverSinceMs == 0)
+				{
+					state.HoverSinceMs = now;
+				}
+				else if ((now - state.HoverSinceMs) / 1000.0 >= config.FlightMinAirborneSeconds)
+				{
+					ResetHover(state);
 					Rubberband(entity, state);
 					StratumAnticheatReporter.RecordMovementViolation(server, player, entity.Pos.AsBlockPos, "flight: airborne without descent", out disconnectReason);
 					return false;
@@ -126,6 +142,11 @@ internal static class StratumMovementGuard
 		}
 
 		return true;
+	}
+
+	private static void ResetHover(MoveState state)
+	{
+		state.HoverSinceMs = 0;
 	}
 
 	private static void Rubberband(EntityPlayer entity, MoveState state)
@@ -150,8 +171,11 @@ internal static class StratumMovementGuard
 				states[key] = state;
 			}
 
-			state.AirborneSinceMs = 0;
+			ResetHover(state);
 			state.EmbeddedTicks = 0;
+			state.WaterWalkTicks = 0;
+			state.HasLastY = true;
+			state.LastY = entity.Pos.Y;
 			state.HasSafePos = true;
 			state.SafeX = entity.Pos.X;
 			state.SafeY = entity.Pos.Y;
@@ -159,15 +183,13 @@ internal static class StratumMovementGuard
 		}
 	}
 
-	// Supported = standing on / within step range of a collidable block, or in/over liquid, or on a climbable block. Any of these is a legitimate reason to not be falling
-	// so flight is only considered when none hold. Unloaded chunks count as supported so we never flag on missing data.
+	// Unloaded blocks count as supported. Guessing wrong there would make chunk-load timing look like cheating.
 	private static bool IsSupported(ServerMain server, EntityPlayer entity, BlockPos feetCell, StratumMovementAnticheatConfig config)
 	{
 		var blocks = server.WorldMap.RelaxedBlockAccess;
 		int feetY = feetCell.Y;
 		BlockPos probe = feetCell.Copy();
 
-		// Body column (just below feet up to head): liquid or climbable surfaces.
 		for (int dy = -1; dy <= 1; dy++)
 		{
 			probe.Y = feetY + dy;
@@ -189,9 +211,13 @@ internal static class StratumMovementGuard
 			}
 		}
 
-		// Ground within the scan depth below the feet.
-		int depth = Math.Max(1, config.FlightGroundScanDepth);
-		for (int d = 0; d <= depth; d++)
+		if (HasGroundContact(server, entity, feetCell, config))
+		{
+			return true;
+		}
+
+		int depth = Math.Max(0, config.FlightGroundScanDepth);
+		for (int d = 1; d <= depth; d++)
 		{
 			probe.Y = feetY - d;
 			Block block = blocks.GetBlock(probe);
@@ -210,8 +236,65 @@ internal static class StratumMovementGuard
 		return false;
 	}
 
-	// Embedded = the player's chest point lies inside the collision geometry of the block occupying that cell. 
-	// Testing the chest (not the feet) means partial boxes a player legitimately stands in/under - slabs, snow layers, paths, fences - never count.
+	private static bool HasGroundContact(ServerMain server, EntityPlayer entity, BlockPos feetCell, StratumMovementAnticheatConfig config)
+	{
+		var blocks = server.WorldMap.RelaxedBlockAccess;
+		BlockPos groundCell = feetCell.Copy();
+		groundCell.Y--;
+
+		Block block = blocks.GetBlock(groundCell);
+		if (block == null)
+		{
+			return true;
+		}
+
+		Cuboidf[] boxes = block.GetCollisionBoxes(blocks, groundCell);
+		if (boxes == null || boxes.Length == 0)
+		{
+			return false;
+		}
+
+		double localY = entity.Pos.Y - groundCell.Y;
+		foreach (Cuboidf box in boxes)
+		{
+			if (box != null && localY >= box.Y2 && localY - box.Y2 <= config.GroundContactTolerance)
+			{
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	private static bool IsWaterWalkCandidate(ServerMain server, EntityPlayer entity, BlockPos feetCell, StratumMovementAnticheatConfig config)
+	{
+		var blocks = server.WorldMap.RelaxedBlockAccess;
+
+		if (HasGroundContact(server, entity, feetCell, config))
+		{
+			return false;
+		}
+
+		Block feetFluid = blocks.GetBlock(feetCell, 2);
+		if (feetFluid != null && feetFluid.IsLiquid())
+		{
+			double localFeetY = entity.Pos.Y - feetCell.Y;
+			return !entity.Swimming && localFeetY >= 0.92;
+		}
+
+		BlockPos belowCell = feetCell.Copy();
+		belowCell.Y--;
+		Block belowFluid = blocks.GetBlock(belowCell, 2);
+		if (belowFluid != null && belowFluid.IsLiquid())
+		{
+			double localY = entity.Pos.Y - belowCell.Y;
+			return !entity.Swimming && localY >= 0.92 && localY <= 1.2;
+		}
+
+		return false;
+	}
+
+	// Chest point only. Feet/head checks produce bad noise around normal partial blocks.
 	private static bool IsEmbedded(ServerMain server, EntityPlayer entity, BlockPos feetCell)
 	{
 		double px = entity.Pos.X;
@@ -257,11 +340,58 @@ internal static class StratumMovementGuard
 		return false;
 	}
 
+	private static bool IsClearBody(ServerMain server, EntityPlayer entity, BlockPos feetCell)
+	{
+		return !PointInsideCollision(server, entity, feetCell, 0.2)
+			&& !PointInsideCollision(server, entity, feetCell, 0.9)
+			&& !PointInsideCollision(server, entity, feetCell, 1.65);
+	}
+
+	private static bool PointInsideCollision(ServerMain server, EntityPlayer entity, BlockPos feetCell, double offsetY)
+	{
+		double px = entity.Pos.X;
+		double py = entity.Pos.Y + offsetY;
+		double pz = entity.Pos.Z;
+		int pointCellWorldY = (int)Math.Floor(py);
+		int feetCellWorldY = (int)Math.Floor(entity.Pos.Y);
+
+		BlockPos pointCell = feetCell.Copy();
+		pointCell.Y = feetCell.Y + (pointCellWorldY - feetCellWorldY);
+
+		var blocks = server.WorldMap.RelaxedBlockAccess;
+		Block block = blocks.GetBlock(pointCell);
+		if (block == null)
+		{
+			return false;
+		}
+
+		Cuboidf[] boxes = block.GetCollisionBoxes(blocks, pointCell);
+		if (boxes == null || boxes.Length == 0)
+		{
+			return false;
+		}
+
+		double lx = px - Math.Floor(px);
+		double ly = py - pointCellWorldY;
+		double lz = pz - Math.Floor(pz);
+		foreach (Cuboidf box in boxes)
+		{
+			if (box != null && lx >= box.X1 && lx <= box.X2 && ly >= box.Y1 && ly <= box.Y2 && lz >= box.Z1 && lz <= box.Z2)
+			{
+				return true;
+			}
+		}
+
+		return false;
+	}
+
 	private sealed class MoveState
 	{
-		public long AirborneSinceMs;
-		public double AirborneStartY;
+		public long HoverSinceMs;
 		public int EmbeddedTicks;
+		public int WaterWalkTicks;
+		public bool HasLastY;
+		public double LastY;
 		public bool HasSafePos;
 		public double SafeX;
 		public double SafeY;


### PR DESCRIPTION
- Added commands to easily see and view violations per player and top violations. 
- Tightened movement guards to further restrict ability to fly, noclip and use movespeed hacks
- Fixed rubberband location from potentially being updated to a location that wasn't where the player originally left from.
- Added water-walking detection to prevent players from using hacks to walk ontop of water or liquids. 
- Movement / speed detection utlizes players speed values and stats instead of just a set budget. 
- Fixed potential issue of players falling for a while being flagged.

- Tried to fix line ending stuff

## Summary

Overall I added more measures to detect movement exploits / hacks, I refined some of the existing AC stuff to prevent false positives and make the detection systems more accurate.

## Type

- [ ] Bug fix
- [ ] Performance
- [x] New feature
- [ ] Refactor or cleanup
- [ ] Docs or build

## Checklist

- [x] `.\scripts\extract-patches.ps1` ran clean.
- [x] `dotnet build VintageStory.slnx -c Release` is green.
- [x] Every vanilla edit has a `// Stratum` marker.
- [x] No vanilla source committed.
- [x] Tested on a real server start, not just compilation.

## Performance numbers

If this is a perf change, include before and after measurements. Otherwise delete this section.

## Related issues

Fixes #
