### PR TITLE
Add smoke test and Makefile

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,16 +9,26 @@ Stratum is a patch set over the vanilla Vintage Story server. The repo does not 
 - `patches/` is unified diffs against the decompiled vanilla baseline.
 - `sources/` is files that exist only in Stratum. No vanilla equivalent.
 - `StratumServer/` is the launcher and the first-run vanilla downloader.
-- `scripts/` holds `bootstrap.ps1` (rebuilds the working tree from `patches` and `sources`) and `extract-patches.ps1` (writes your changes back out).
+- `scripts/` holds bootstrap, extract-patches, and smoke-test scripts (`.sh` for Linux/macOS, `.ps1` for Windows).
 - `VintageStory.slnx` is the solution. It only opens after `bootstrap.ps1` has run.
 
 The working tree itself is gitignored. Only `patches/` and `sources/` are tracked.
 
 ## Setting up
 
-You need the .NET 10 SDK and Windows PowerShell.
+You need the .NET 10 SDK. Linux and macOS contributors use `scripts/bootstrap.sh`; Windows contributors use `scripts/bootstrap.ps1` (PowerShell).
+
+```bash
+# Linux / macOS
+scripts/bootstrap.sh
+dotnet build VintageStory.slnx -c Release
+
+# Or use make (runs bootstrap if needed):
+make build
+```
 
 ```powershell
+# Windows
 .\scripts\bootstrap.ps1
 dotnet build VintageStory.slnx -c Release
 ```
@@ -99,7 +109,7 @@ Rules of thumb:
 Compilation is not enough. Before opening a PR:
 
 1. `dotnet build VintageStory.slnx -c Release` is green with zero warnings on files you touched.
-2. Start a server with `dotnet run --project StratumServer -c Release` against a throwaway world. Make sure it boots, accepts a connection, and shuts down cleanly.
+2. Run the smoke test: `make smoke` (or `bash scripts/smoke-test.sh` / `.\scripts\smoke-test.ps1`). It builds, boots the server, waits for RunGame, and checks for fatal errors.
 3. If your change touches a hot path (entity ticking, chunk IO, packet handling), get a before/after measurement. Server timings, frame profiler output, or a sampling profiler are all fine. "Feels faster" is not.
 
 ## Commits

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,40 @@
+# Stratum development targets.
+# Requires: .NET 10 SDK, bash, python3, git, curl.
+# Windows: use Git Bash, WSL, or run the .ps1 scripts directly.
+
+CONFIGURATION ?= Release
+VERSION ?= 1.22.3
+SERVER_ARCHIVE ?=
+CLIENT_LIB_DIR ?=
+
+BOOTSTRAP_ARGS :=
+ifneq ($(SERVER_ARCHIVE),)
+  BOOTSTRAP_ARGS += --server-archive $(SERVER_ARCHIVE)
+endif
+ifneq ($(CLIENT_LIB_DIR),)
+  BOOTSTRAP_ARGS += --client-lib-dir $(CLIENT_LIB_DIR)
+endif
+ifneq ($(VERSION),1.22.3)
+  BOOTSTRAP_ARGS += --version $(VERSION)
+endif
+
+.PHONY: bootstrap build smoke clean refresh help
+
+help: ## Show available targets
+	@grep -E '^[a-z-]+:.*##' $(MAKEFILE_LIST) | sort | awk -F ':.*## ' '{printf "  %-12s %s\n", $$1, $$2}'
+
+bootstrap: ## Download, decompile, and apply patches
+	bash scripts/bootstrap.sh $(BOOTSTRAP_ARGS)
+
+build: ## Build Release (runs bootstrap if working tree is missing)
+	@if [ ! -f VintagestoryApi/VintagestoryAPI.csproj ]; then $(MAKE) bootstrap; fi
+	dotnet build VintageStory.slnx -c $(CONFIGURATION)
+
+smoke: build ## Build and boot-test the server
+	bash scripts/smoke-test.sh
+
+clean: ## Remove intermediate build files (use refresh for full reset)
+	find . -type d -name obj -not -path './.baseline/*' -not -path './.vanilla/*' | xargs -r rm -rf
+
+refresh: ## Force full re-bootstrap from scratch
+	bash scripts/bootstrap.sh --refresh $(BOOTSTRAP_ARGS)

--- a/README.md
+++ b/README.md
@@ -88,13 +88,23 @@ Anything else is forwarded to the server, such as `--port` or `--dataPath`.
 
 ## Build
 
-Requires the .NET 10 SDK, PowerShell 5.1+, and `git`.
+Requires the .NET 10 SDK and `git`. Linux/macOS also need `bash`, `python3`, and `curl`.
+
+```bash
+# Linux / macOS
+git clone https://github.com/StratumServer/Stratum.git
+cd Stratum
+make build        # bootstrap + build in one step
+make smoke        # build + boot-test the server
+```
 
 ```powershell
+# Windows (PowerShell)
 git clone https://github.com/StratumServer/Stratum.git
 cd Stratum
 .\scripts\bootstrap.ps1
 dotnet build VintageStory.slnx -c Release
+.\scripts\smoke-test.ps1    # boot-test the server
 ```
 
 `bootstrap.ps1` downloads the targeted vanilla server zip, decompiles

--- a/scripts/smoke-test.ps1
+++ b/scripts/smoke-test.ps1
@@ -1,0 +1,166 @@
+<#
+.SYNOPSIS
+Boot-tests the Stratum server on Windows. Builds Release, starts the server,
+monitors progress through startup phases, and verifies it reaches RunGame
+without fatal errors. Detects stalls by checking log growth rather than a
+hard timeout.
+
+.PARAMETER Patience
+Seconds without log output before declaring a stall. Default: 60.
+
+.PARAMETER Port
+Server port. Default: random ephemeral.
+
+.PARAMETER DataPath
+Server dataPath. Default: temp dir, cleaned on exit.
+
+.EXAMPLE
+.\scripts\smoke-test.ps1
+.\scripts\smoke-test.ps1 -Patience 90
+#>
+
+[CmdletBinding()]
+param(
+    [int]$Patience = 60,
+    [int]$Port = 0,
+    [string]$DataPath
+)
+
+$ErrorActionPreference = 'Stop'
+$repoRoot = Split-Path -Parent $PSScriptRoot
+
+$serverDir = Join-Path $repoRoot 'StratumServer\bin\Release\net10.0'
+$serverBin = Join-Path $serverDir 'VintagestoryServer.exe'
+if (-not (Test-Path $serverBin)) {
+    $serverBin = Join-Path $serverDir 'StratumServer.exe'
+}
+
+Push-Location $repoRoot
+try {
+    # Build if binary is missing.
+    if (-not (Test-Path $serverBin)) {
+        Write-Host "Building Release..."
+        dotnet build VintageStory.slnx -c Release --verbosity quiet
+    }
+
+    if (-not (Test-Path $serverBin)) {
+        Write-Error "Server binary not found: $serverBin"
+        exit 1
+    }
+
+    # Data path.
+    $ownData = $false
+    if (-not $DataPath) {
+        $DataPath = Join-Path ([System.IO.Path]::GetTempPath()) "stratum-smoke-$([guid]::NewGuid().ToString('N').Substring(0,8))"
+        $ownData = $true
+    }
+    New-Item -ItemType Directory -Force -Path $DataPath | Out-Null
+
+    # Ephemeral port.
+    if ($Port -eq 0) {
+        $listener = [System.Net.Sockets.TcpListener]::new([System.Net.IPAddress]::Loopback, 0)
+        $listener.Start()
+        $Port = $listener.LocalEndpoint.Port
+        $listener.Stop()
+    }
+
+    Write-Host "Smoke test: port=$Port patience=${Patience}s data=$DataPath"
+
+    $logFile = Join-Path $DataPath 'smoke-test.log'
+
+    # Start server.
+    $psi = [System.Diagnostics.ProcessStartInfo]::new()
+    $psi.FileName = $serverBin
+    $psi.Arguments = "--dataPath `"$DataPath`" --port $Port"
+    $psi.RedirectStandardOutput = $false
+    $psi.RedirectStandardError = $false
+    $psi.UseShellExecute = $false
+    $psi.CreateNoWindow = $true
+
+    # Redirect output to file at the OS level to avoid .NET stream deadlocks.
+    # PowerShell's Start-Process -RedirectStandardOutput writes directly to disk,
+    # so neither stdout nor stderr can block the process.
+    $proc = Start-Process -FilePath $serverBin -ArgumentList "--dataPath `"$DataPath`" --port $Port" `
+        -RedirectStandardOutput $logFile -RedirectStandardError (Join-Path $DataPath 'smoke-test-err.log') `
+        -NoNewWindow -PassThru
+
+    $lastLineCount = 0
+    $sinceProgress = 0
+    $lastPhase = '(starting)'
+    $reachedRunGame = $false
+    $hasFatal = $false
+
+    try {
+        while (-not $proc.HasExited) {
+            Start-Sleep -Seconds 2
+
+            $content = if (Test-Path $logFile) { Get-Content $logFile -Raw -ErrorAction SilentlyContinue } else { '' }
+
+            # Reached RunGame?
+            if ($content -match 'Entering runphase RunGame') {
+                Start-Sleep -Seconds 5
+                $reachedRunGame = $true
+                break
+            }
+
+            # Fatal error?
+            if ($content -match '\[Server Fatal\]') {
+                break
+            }
+
+            # Progress detection.
+            $currentLines = if (Test-Path $logFile) { (Get-Content $logFile).Count } else { 0 }
+            if ($currentLines -gt $lastLineCount) {
+                $lastLineCount = $currentLines
+                $sinceProgress = 0
+                $phaseMatch = [regex]::Matches($content, 'Entering runphase (\S+)')
+                if ($phaseMatch.Count -gt 0) {
+                    $lastPhase = $phaseMatch[$phaseMatch.Count - 1].Groups[1].Value
+                }
+            } else {
+                $sinceProgress += 2
+            }
+
+            if ($sinceProgress -ge $Patience) {
+                Write-Warning "STALL: no log output for ${Patience}s (last phase: $lastPhase)"
+                break
+            }
+        }
+    } finally {
+        if (-not $proc.HasExited) {
+            $proc.Kill()
+            $proc.WaitForExit(5000)
+        }
+    }
+
+    # Read final log.
+    $finalLog = if (Test-Path $logFile) { Get-Content $logFile -Raw -ErrorAction SilentlyContinue } else { '' }
+
+    if (-not $reachedRunGame -and $finalLog -match 'Entering runphase RunGame') {
+        $reachedRunGame = $true
+    }
+    if ($finalLog -match 'Fatal|Unhandled exception') {
+        $hasFatal = $true
+    }
+
+    if ($reachedRunGame -and -not $hasFatal) {
+        Write-Host "PASS: server reached RunGame, no fatal errors. (last phase: $lastPhase)"
+        exit 0
+    }
+
+    Write-Error "FAIL:"
+    if (-not $reachedRunGame) {
+        Write-Error "  Server did not reach RunGame (last phase: $lastPhase)."
+    }
+    if ($hasFatal) {
+        Write-Error "  Fatal errors found in log."
+    }
+    Write-Error "  Log: $logFile"
+    exit 1
+
+} finally {
+    Pop-Location
+    if ($ownData -and (Test-Path $DataPath)) {
+        Remove-Item -Recurse -Force $DataPath -ErrorAction SilentlyContinue
+    }
+}

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Boot-tests the Stratum server. Builds Release, starts the server, monitors
+# progress through startup phases, and verifies it reaches RunGame without
+# fatal errors. Detects stalls by checking if the server made progress within
+# a patience window rather than using a hard timeout.
+#
+# Environment overrides:
+#   SMOKE_TEST_PATIENCE - seconds without progress before declaring stall (default: 60)
+#   SMOKE_TEST_PORT     - server port (default: random ephemeral)
+#   SMOKE_TEST_DATA     - server dataPath (default: temp dir, cleaned on exit)
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd -- "$script_dir/.." && pwd)"
+# Server binary: prefer VintagestoryServer (runtime entry point after first bootstrap),
+# fall back to StratumServer (first-run launcher that downloads vanilla).
+server_dir="$repo_root/StratumServer/bin/Release/net10.0"
+if [[ -f "$server_dir/VintagestoryServer" ]]; then
+  server_bin="$server_dir/VintagestoryServer"
+elif [[ -f "$server_dir/StratumServer" ]]; then
+  server_bin="$server_dir/StratumServer"
+else
+  server_bin=""
+fi
+patience="${SMOKE_TEST_PATIENCE:-60}"
+port="${SMOKE_TEST_PORT:-0}"
+
+# Data path handling.
+own_data=1
+if [[ -n "${SMOKE_TEST_DATA:-}" ]]; then
+  data_path="$SMOKE_TEST_DATA"
+  own_data=0
+else
+  data_path="$(mktemp -d)"
+fi
+mkdir -p "$data_path"
+
+cleanup() {
+  if [[ "$own_data" == "1" && -d "$data_path" ]]; then
+    rm -rf "$data_path"
+  fi
+}
+trap cleanup EXIT
+
+cd "$repo_root"
+
+# Build if binary is missing.
+if [[ -z "$server_bin" || ! -f "$server_bin" ]]; then
+  echo "Building Release..."
+  dotnet build VintageStory.slnx -c Release --verbosity quiet
+  # Re-detect after build.
+  if [[ -f "$server_dir/VintagestoryServer" ]]; then
+    server_bin="$server_dir/VintagestoryServer"
+  elif [[ -f "$server_dir/StratumServer" ]]; then
+    server_bin="$server_dir/StratumServer"
+  fi
+fi
+
+if [[ -z "$server_bin" || ! -f "$server_bin" ]]; then
+  echo "FAIL: no server binary found in $server_dir" >&2
+  exit 1
+fi
+
+# Pick an ephemeral port.
+if [[ "$port" == "0" ]]; then
+  port=$(python3 -c "import socket; s=socket.socket(); s.bind(('',0)); print(s.getsockname()[1]); s.close()")
+fi
+
+echo "Smoke test: port=$port patience=${patience}s data=$data_path"
+
+log_file="$data_path/smoke-test.log"
+"$server_bin" --dataPath "$data_path" --port "$port" >"$log_file" 2>&1 &
+server_pid=$!
+
+last_line_count=0
+since_progress=0
+last_phase="(starting)"
+
+while true; do
+  sleep 2
+
+  # Server died on its own.
+  if ! kill -0 "$server_pid" 2>/dev/null; then
+    break
+  fi
+
+  # Check if reached RunGame.
+  if grep -q "Entering runphase RunGame" "$log_file" 2>/dev/null; then
+    sleep 5
+    break
+  fi
+
+  # Check for fatal error (early exit).
+  if grep -qi "^\S.* \[Server Fatal\]" "$log_file" 2>/dev/null; then
+    break
+  fi
+
+  # Progress detection: is the log still growing?
+  current_lines=$(wc -l < "$log_file" 2>/dev/null || echo "0")
+  if [[ "$current_lines" -gt "$last_line_count" ]]; then
+    last_line_count=$current_lines
+    since_progress=0
+    # Track current phase for reporting.
+    phase=$(grep "Entering runphase" "$log_file" 2>/dev/null | tail -1 | sed 's/.*runphase //' || true)
+    if [[ -n "$phase" ]]; then
+      last_phase="$phase"
+    fi
+  else
+    ((since_progress+=2))
+  fi
+
+  # Stall detection.
+  if [[ $since_progress -ge $patience ]]; then
+    echo "STALL: no log output for ${patience}s (last phase: $last_phase)" >&2
+    break
+  fi
+done
+
+# Shut down.
+if kill -0 "$server_pid" 2>/dev/null; then
+  kill -TERM "$server_pid" 2>/dev/null || true
+  wait "$server_pid" 2>/dev/null || true
+fi
+
+# Evaluate result.
+reached_rungame=0
+has_fatal=0
+
+if grep -q "Entering runphase RunGame" "$log_file" 2>/dev/null; then
+  reached_rungame=1
+fi
+if grep -qi "Fatal\|Unhandled exception" "$log_file" 2>/dev/null; then
+  has_fatal=1
+fi
+
+if [[ "$reached_rungame" == "1" && "$has_fatal" == "0" ]]; then
+  echo "PASS: server reached RunGame, no fatal errors. (last phase: $last_phase)"
+  exit 0
+fi
+
+echo "FAIL:" >&2
+if [[ "$reached_rungame" == "0" ]]; then
+  echo "  Server did not reach RunGame (last phase: $last_phase)." >&2
+fi
+if [[ "$has_fatal" == "1" ]]; then
+  echo "  Fatal errors:" >&2
+  grep -i "Fatal\|Unhandled exception" "$log_file" | head -3 | sed 's/^/    /' >&2
+fi
+echo "  Log: $log_file" >&2
+exit 1


### PR DESCRIPTION
scripts/smoke-test.sh (Linux/macOS) and scripts/smoke-test.ps1 (Windows) build, boot, wait for RunGame, check for fatal errors. Progress-based stall detection watches log growth instead of a hard timeout.

Makefile wraps bootstrap, build, smoke, clean, refresh. Passes VERSION, SERVER_ARCHIVE, CLIENT_LIB_DIR through to bootstrap.

CONTRIBUTING.md and README.md updated with cross-platform instructions.

Replaces #65 (closed when the fork was deleted).