### PR TITLE
Fix corrupted patch headers in EntitySimulation and GenPartial BOM

### DIFF
--- a/patches/VSEssentials/Systems/WorldGen/Standard/GenPartial.cs.patch
+++ b/patches/VSEssentials/Systems/WorldGen/Standard/GenPartial.cs.patch
@@ -1,39 +1,30 @@
 diff --git a/VSEssentials/Systems/WorldGen/Standard/GenPartial.cs b/VSEssentials/Systems/WorldGen/Standard/GenPartial.cs
-index 58aa710..14f2ccf 100644
+index 25813b8..d0c3841 100644
 --- a/VSEssentials/Systems/WorldGen/Standard/GenPartial.cs
 +++ b/VSEssentials/Systems/WorldGen/Standard/GenPartial.cs
-@@ -1,17 +1,20 @@
- using Vintagestory.API.MathTools;
+@@ -1,5 +1,6 @@
+ ﻿using Vintagestory.API.MathTools;
  using Vintagestory.API.Server;
 +using Vintagestory.ServerMods.NoObf;
  
  #nullable disable
  
- namespace Vintagestory.ServerMods
- {
-     public abstract class GenPartial : ModStdWorldGen
-     {
+@@ -10,6 +11,8 @@
          protected ICoreServerAPI api;
          protected int worldheight;
          public int airBlockId = 0;
-+        public int basaltBlockId; // Stratum: variable for basalt ID
-+        public int lavaBlockId; // Stratum: variable for lav ID
++        public int basaltBlockId; // Stratum: basalt block ID for cave gen
++        public int lavaBlockId; // Stratum: lava block ID for cave gen
  
          protected abstract int chunkRange { get; }
  
-         protected LCGRandom chunkRand;
- 
-@@ -24,10 +27,13 @@ namespace Vintagestory.ServerMods
- 
-         public virtual void initWorldGen()
+@@ -26,6 +29,9 @@
          {
              LoadGlobalConfig(api);
  
-+            basaltBlockId = gcfg.basaltBlockId; // Stratum: finding the basalt block ID
-+            lavaBlockId = gcfg.lavaBlockId;  // Stratum: finding the lsvs block ID
++            basaltBlockId = gcfg.basaltBlockId; // Stratum: resolve basalt block ID
++            lavaBlockId = gcfg.lavaBlockId; // Stratum: resolve lava block ID
 +
              worldheight = api.WorldManager.MapSizeY;
              chunkRand = new LCGRandom(api.WorldManager.Seed);
          }
- 
- 

--- a/patches/VintagestoryLib/Vintagestory.Server/ServerSystemEntitySimulation.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/ServerSystemEntitySimulation.cs.patch
@@ -16,7 +16,7 @@ index 750557a..3d902a0 100644
  using Vintagestory.API.Common.Entities;
  using Vintagestory.API.Config;
  using Vintagestory.API.Datastructures;
-@@ -22,13 +26,134 @@ public class ServerSystemEntitySimulation : ServerSystem
+@@ -22,13 +26,137 @@ public class ServerSystemEntitySimulation : ServerSystem
  
  	private Dictionary<string, List<string>> deathMessagesCache;
  
@@ -466,7 +466,7 @@ index 750557a..3d902a0 100644
  		SendEntityDespawns();
  		int count = server.DelayedSpawnQueue.Count;
  		if (count <= 0)
-@@ -185,19 +505,145 @@ public class ServerSystemEntitySimulation : ServerSystem
+@@ -185,19 +505,149 @@ public class ServerSystemEntitySimulation : ServerSystem
  		}
  	}
  
@@ -637,7 +637,7 @@ index 750557a..3d902a0 100644
  		}
  		ServerMain.FrameProfiler.Enter("despawning");
  		foreach (KeyValuePair<Entity, EntityDespawnData> item in list)
-@@ -222,27 +673,768 @@ public class ServerSystemEntitySimulation : ServerSystem
+@@ -222,27 +673,799 @@ public class ServerSystemEntitySimulation : ServerSystem
  			server.DespawnEntity(item.Key, item.Value);
  			ServerMain.FrameProfiler.Mark("despawned-", item.Key.Code.Path);
  		}


### PR DESCRIPTION
ServerSystemEntitySimulation.cs.patch had three hunks with wrong line counts after the entity filter merge (#74). Bootstrap rejected the patch at line 157 with 'patch corrompido'. Recalculated the @@ headers to match actual line counts.

GenPartial.cs.patch failed on every bootstrap because the decompiled baseline has a UTF-8 BOM (EF BB BF) that the old patch context did not include. Regenerated the patch from the actual baseline file.