### PR TITLE
Add scheduled world backup with retention pruning

### DIFF
--- a/StratumServer/stratum.default.json
+++ b/StratumServer/stratum.default.json
@@ -403,5 +403,11 @@
         "Priority": 50
       }
     }
+  },
+  "Backup": {
+    "Enabled": false,
+    "IntervalMinutes": 360,
+    "RetainCount": 5,
+    "LogBackups": true
   }
 }

--- a/patches/VSEssentials/Systems/WorldGen/Standard/GenPartial.cs.patch
+++ b/patches/VSEssentials/Systems/WorldGen/Standard/GenPartial.cs.patch
@@ -1,5 +1,4 @@
 diff --git a/VSEssentials/Systems/WorldGen/Standard/GenPartial.cs b/VSEssentials/Systems/WorldGen/Standard/GenPartial.cs
-index 25813b8..d0c3841 100644
 --- a/VSEssentials/Systems/WorldGen/Standard/GenPartial.cs
 +++ b/VSEssentials/Systems/WorldGen/Standard/GenPartial.cs
 @@ -1,5 +1,6 @@
@@ -9,17 +8,3 @@ index 25813b8..d0c3841 100644
  
  #nullable disable
  
-@@ -10,6 +11,8 @@
-         protected ICoreServerAPI api;
-         protected int worldheight;
-         public int airBlockId = 0;
- 
-         protected abstract int chunkRange { get; }
- 
-@@ -26,6 +29,9 @@
-         {
-             LoadGlobalConfig(api);
- 
-             worldheight = api.WorldManager.MapSizeY;
-             chunkRand = new LCGRandom(api.WorldManager.Seed);
-         }

--- a/sources/VintagestoryLib/Vintagestory.Server/ServerSystemStratum.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/ServerSystemStratum.cs
@@ -92,6 +92,11 @@ internal class ServerSystemStratum : ServerSystem
 		StratumPlayerPrivacy.Initialize(server);
 		StratumMetricsPublisher.Start();
 		StratumUpdateChecker.CheckOnStartup();
+		if (StratumRuntime.Config.Backup.Enabled)
+		{
+			new StratumBackupScheduler(server);
+			StratumRuntime.LogInfo("backup scheduler armed: interval=" + StratumRuntime.Config.Backup.IntervalMinutes + "min retain=" + StratumRuntime.Config.Backup.RetainCount);
+		}
 		StratumRuntime.LogInfo("runtime ready. Use /stratum health, /stratum status, and /stratum timings start.");
 	}
 

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumBackupScheduler.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumBackupScheduler.cs
@@ -1,0 +1,107 @@
+using System;
+using System.IO;
+using System.Linq;
+using Vintagestory.API.Common;
+using Vintagestory.API.Config;
+
+namespace Vintagestory.Server;
+
+/// <summary>
+/// Periodic world backup scheduler. Triggers the vanilla SQLite backup API on a configurable
+/// interval and prunes old scheduled backups beyond the configured retention count.
+/// Runs the actual I/O on the thread pool to avoid blocking the server tick.
+/// </summary>
+internal sealed class StratumBackupScheduler
+{
+	private readonly ServerMain server;
+	private long lastBackupMs;
+	private const string ScheduledPrefix = "stratum-backup-";
+
+	public StratumBackupScheduler(ServerMain server)
+	{
+		this.server = server;
+		lastBackupMs = server.ElapsedMilliseconds;
+		server.RegisterGameTickListener(OnTick, 30_000); // check every 30s
+	}
+
+	private StratumBackupConfig Cfg => StratumRuntime.Config?.Backup;
+
+	private void OnTick(float dt)
+	{
+		StratumBackupConfig cfg = Cfg;
+		if (cfg == null || !cfg.Enabled) return;
+
+		long elapsedMs = server.ElapsedMilliseconds;
+		long intervalMs = (long)cfg.IntervalMinutes * 60_000L;
+
+		if (elapsedMs - lastBackupMs < intervalMs) return;
+
+		lastBackupMs = elapsedMs;
+		RunBackup(cfg);
+	}
+
+	private void RunBackup(StratumBackupConfig cfg)
+	{
+		if (server.chunkThread.BackupInProgress)
+		{
+			if (cfg.LogBackups) StratumRuntime.LogInfo("scheduled backup skipped (backup already in progress)");
+			return;
+		}
+
+		string worldName = Path.GetFileName(server.Config.WorldConfig.SaveFileLocation).Replace(".vcdbs", "");
+		if (worldName.Length == 0) worldName = "world";
+
+		string filename = ScheduledPrefix + worldName + "-" + DateTime.Now.ToString("yyyy-MM-dd_HH-mm-ss") + ".vcdbs";
+
+		server.chunkThread.BackupInProgress = true;
+
+		if (cfg.LogBackups) StratumRuntime.LogInfo("scheduled backup started: " + filename);
+
+		TyronThreadPool.QueueTask(delegate
+		{
+			try
+			{
+				server.chunkThread.gameDatabase.CreateBackup(filename);
+			}
+			catch (Exception ex)
+			{
+				server.chunkThread.BackupInProgress = false;
+				StratumRuntime.LogWarning("scheduled backup failed: " + ex.Message);
+				return;
+			}
+
+			server.EnqueueMainThreadTask(delegate
+			{
+				server.chunkThread.BackupInProgress = false;
+				if (cfg.LogBackups) StratumRuntime.LogInfo("scheduled backup complete: " + filename);
+				PruneOldBackups(cfg);
+			});
+		}, "stratum-scheduled-backup");
+	}
+
+	private void PruneOldBackups(StratumBackupConfig cfg)
+	{
+		try
+		{
+			string backupDir = GamePaths.Backups;
+			if (!Directory.Exists(backupDir)) return;
+
+			FileInfo[] scheduled = new DirectoryInfo(backupDir)
+				.GetFiles(ScheduledPrefix + "*.vcdbs")
+				.OrderByDescending(f => f.CreationTimeUtc)
+				.ToArray();
+
+			if (scheduled.Length <= cfg.RetainCount) return;
+
+			for (int i = cfg.RetainCount; i < scheduled.Length; i++)
+			{
+				scheduled[i].Delete();
+				if (cfg.LogBackups) StratumRuntime.LogInfo("pruned old backup: " + scheduled[i].Name);
+			}
+		}
+		catch (Exception ex)
+		{
+			StratumRuntime.LogWarning("backup pruning failed: " + ex.Message);
+		}
+	}
+}

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumConfig.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumConfig.cs
@@ -43,6 +43,8 @@ internal class StratumConfig
 
 	public StratumNametagsConfig Nametags { get; set; } = new StratumNametagsConfig();
 
+	public StratumBackupConfig Backup { get; set; } = new StratumBackupConfig();
+
 	public void EnsurePopulated()
 	{
 		Diagnostics ??= new StratumDiagnosticsConfig();
@@ -62,6 +64,7 @@ internal class StratumConfig
 		LoginProtection ??= new StratumLoginProtectionConfig();
 		PlayerPrivacy ??= new StratumPlayerPrivacyConfig();
 		Nametags ??= new StratumNametagsConfig();
+		Backup ??= new StratumBackupConfig();
 		PacketLimits.EnsureSane();
 		PacketBackPressure.EnsureSane();
 		BlockBreakGuards.EnsureSane();
@@ -76,6 +79,7 @@ internal class StratumConfig
 		LoginProtection.EnsureSane();
 		PlayerPrivacy.EnsurePopulated();
 		Nametags.EnsurePopulated();
+		Backup.EnsureSane();
 		UpdateChecker.EnsureSane();
 		MigrateLegacyDefaults();
 	}
@@ -1760,5 +1764,22 @@ internal class StratumChatRolePrefixConfig
 	{
 		Tag ??= "Staff";
 		Color ??= "#ffffff";
+	}
+}
+
+internal class StratumBackupConfig
+{
+	public bool Enabled { get; set; }
+
+	public int IntervalMinutes { get; set; } = 360;
+
+	public int RetainCount { get; set; } = 5;
+
+	public bool LogBackups { get; set; } = true;
+
+	public void EnsureSane()
+	{
+		if (IntervalMinutes < 1) IntervalMinutes = 1;
+		if (RetainCount < 1) RetainCount = 1;
 	}
 }


### PR DESCRIPTION
Timer-based backup using the vanilla SQLite backup API. Runs on TyronThreadPool so it never blocks a tick. Prunes old scheduled backups beyond RetainCount, only touching `stratum-backup-*` files (manual `/genbackup` results stay untouched).

Config (in `stratum.json`):
```json
"Backup": {
  "Enabled": false,
  "IntervalMinutes": 360,
  "RetainCount": 5,
  "LogBackups": true
}
```

Disabled by default. Operators opt in.

Tested on Linux (.NET 10.0.7): server reaches RunGame, scheduler arms at boot, first backup fires on interval, completes in under a second for a fresh world with zero tick impact. Retention pruning deletes oldest files past the count.

Second commit fixes a pre-existing corrupt patch (GenPartial.cs had context-only hunks that broke `bootstrap.sh`).

Fixes #62