### PR TITLE
Fixed issues with movement detection and world chunk settings

### DIFF
--- a/patches/VSEssentials/Systems/Weather/WeatherSimulationSnowAccum.cs.patch
+++ b/patches/VSEssentials/Systems/Weather/WeatherSimulationSnowAccum.cs.patch
@@ -1,0 +1,73 @@
+diff --git a/VSEssentials/Systems/Weather/WeatherSimulationSnowAccum.cs b/VSEssentials/Systems/Weather/WeatherSimulationSnowAccum.cs
+index 3c77f26..79b3d65 100644
+--- a/VSEssentials/Systems/Weather/WeatherSimulationSnowAccum.cs
++++ b/VSEssentials/Systems/Weather/WeatherSimulationSnowAccum.cs
+@@ -527,10 +527,15 @@ namespace Vintagestory.GameContent
+ 
+             int prevChunkY = -99999;
+             IWorldChunk chunk = null;
+ 
+             int maxY = sapi.World.BlockAccessor.MapSizeY - 1;
++            if (chunksCol != null)
++            {
++                maxY = Math.Min(maxY, chunksCol.Length * chunksize - 1);
++            }
++            if (maxY < 0) return null;
+ 
+             for (int i = 0; i < posIndices.Length; i++)
+             {
+                 int posIndex = posIndices[i];
+                 int posY = GameMath.Clamp(mc.RainHeightMap[posIndex], 0, maxY);
+@@ -542,11 +547,11 @@ namespace Vintagestory.GameContent
+                     chunkZ * chunksize + posIndex / chunksize
+                 );
+                 
+                 if (prevChunkY != chunkY)
+                 {
+-                    chunk = chunksCol?[chunkY] ?? sapi.WorldManager.GetChunk(chunkX, chunkY, chunkZ);
++                    chunk = GetChunkFromLoadedColumn(chunksCol, chunkX, chunkY, chunkZ);
+                     prevChunkY = chunkY;
+                 }
+                 if (chunk == null) return null;
+ 
+                 float relx = (pos.X - regionBasePosX) / (float)regionsize;
+@@ -608,16 +613,16 @@ namespace Vintagestory.GameContent
+                 float hereShouldLevel = nowAccum - GameMath.MurmurHash3Mod(pos.X, 0, pos.Z, 150) / 300f;
+ 
+                 float shouldIndexf = GameMath.Clamp(hereShouldLevel - 1.1f, -1, snowBlocksCount - 1);
+                 int shouldIndex = shouldIndexf < 0 ? -1 : (int)shouldIndexf;
+ 
+-                placePos.Set(pos.X, Math.Min(pos.Y + 1, sapi.World.BlockAccessor.MapSizeY - 1), pos.Z);
++                placePos.Set(pos.X, Math.Min(pos.Y + 1, maxY), pos.Z);
+                 chunkY = placePos.Y / chunksize;
+ 
+                 if (prevChunkY != chunkY)
+                 {
+-                    chunk = chunksCol?[chunkY] ?? sapi.WorldManager.GetChunk(chunkX, chunkY, chunkZ);
++                    chunk = GetChunkFromLoadedColumn(chunksCol, chunkX, chunkY, chunkZ);
+                     prevChunkY = chunkY;
+                 }
+                 if (chunk == null) return null;
+ 
+                 Block upBlock = chunk.GetLocalBlockAtBlockPos(sapi.World, placePos);
+@@ -665,8 +670,20 @@ namespace Vintagestory.GameContent
+ 
+ 
+             return updateChunk;
+         }
+ 
++        private IWorldChunk GetChunkFromLoadedColumn(IWorldChunk[] chunksCol, int chunkX, int chunkY, int chunkZ)
++        {
++            if (chunkY < 0) return null;
++
++            if (chunksCol != null)
++            {
++                return chunkY < chunksCol.Length ? chunksCol[chunkY] : null;
++            }
++
++            return sapi.WorldManager.GetChunk(chunkX, chunkY, chunkZ);
++        }
++
+         
+     }
+ }

--- a/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/5.GenDeposits/Generators/DiscGenerator.cs.patch
+++ b/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/5.GenDeposits/Generators/DiscGenerator.cs.patch
@@ -1,8 +1,8 @@
 diff --git a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/5.GenDeposits/Generators/DiscGenerator.cs b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/5.GenDeposits/Generators/DiscGenerator.cs
-index 2b6633c..3e511cb 100644
+index 2b6633c..328948f 100644
 --- a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/5.GenDeposits/Generators/DiscGenerator.cs
 +++ b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/5.GenDeposits/Generators/DiscGenerator.cs
-@@ -206,21 +206,56 @@ namespace Vintagestory.ServerMods
+@@ -206,24 +206,62 @@ namespace Vintagestory.ServerMods
              var rnd = new LCGRandom(Api.World.Seed);
              absAvgQuantity = GetAbsAvgQuantity(rnd);
          }
@@ -37,6 +37,8 @@ index 2b6633c..3e511cb 100644
  
          public override void GenDeposit(IBlockAccessor blockAccessor, IServerChunk[] chunks, int chunkX, int chunkZ, BlockPos depoCenterPos, ref Dictionary<BlockPos, DepositVariant> subDepositsToPlace)
          {
++            if (chunks == null || chunks.Length == 0) return;
++
              int radius = Math.Min(64, (int)Radius.nextFloat(1, DepositRand));
              if (radius <= 0) return;
  
@@ -60,9 +62,13 @@ index 2b6633c..3e511cb 100644
  
              int baseX = chunkX * chunksize;
              int baseZ = chunkZ * chunksize;
++            int maxLoadedY = chunks.Length * chunksize - 1;
  
              // No need to caluclate further if this deposit won't be part of this chunk
-@@ -277,10 +312,14 @@ namespace Vintagestory.ServerMods
+             if (
+                 depoCenterPos.X + radiusX < baseX - 6 ||
+                 depoCenterPos.Z + radiusZ < baseZ - 6 ||
+@@ -277,10 +315,14 @@ namespace Vintagestory.ServerMods
  
              float invChunkAreaSize = 1f / (chunksize * chunksize);
              double val;
@@ -77,7 +83,7 @@ index 2b6633c..3e511cb 100644
                  lx = posx - baseX;
                  distx = posx - depoCenterPos.X;
  
-@@ -290,34 +329,31 @@ namespace Vintagestory.ServerMods
+@@ -290,34 +332,36 @@ namespace Vintagestory.ServerMods
                  {
                      posy = depoCenterPos.Y;
                      lz = posz - baseZ;
@@ -106,6 +112,11 @@ index 2b6633c..3e511cb 100644
                      for (int y = 0; y < hereThickness; y++)
                      {
                          if (posy <= 1) continue;
++                        if (posy > maxLoadedY)
++                        {
++                            posy--;
++                            continue;
++                        }
  
 -                        int index3d = ((posy % chunksize) * chunksize + lz) * chunksize + lx;
 -                        int blockId = chunks[posy / chunksize].Data.GetBlockIdUnsafe(index3d);
@@ -119,7 +130,7 @@ index 2b6633c..3e511cb 100644
                          if (!IgnoreParentTestPerBlock || !parentBlockOk)
                          {
                              parentBlockOk = placeBlockByInBlockId.TryGetValue(blockId, out resolvedPlaceBlock);
-@@ -325,37 +361,37 @@ namespace Vintagestory.ServerMods
+@@ -325,37 +369,37 @@ namespace Vintagestory.ServerMods
  
                          if (parentBlockOk && resolvedPlaceBlock.Blocks.Length > 0)
                          {
@@ -165,7 +176,20 @@ index 2b6633c..3e511cb 100644
                                  }
                              }
  
-@@ -383,10 +419,12 @@ namespace Vintagestory.ServerMods
+@@ -363,11 +407,11 @@ namespace Vintagestory.ServerMods
+                             {
+                                 int surfaceY = heremapchunk.RainHeightMap[lz * chunksize + lx];
+                                 int depth = surfaceY - posy;
+                                 float seaLevelScale = 9f * (TerraGenConfig.seaLevel / 110f); // Default sea level for world height 256
+                                 float chance = SurfaceBlockChance * Math.Max(0, 1.11f - depth / seaLevelScale);
+-                                if (surfaceY < worldheight - 1 && DepositRand.NextFloat() < chance)
++                                if (surfaceY < worldheight - 1 && surfaceY + 1 <= maxLoadedY && DepositRand.NextFloat() < chance)
+                                 {
+                                     Block belowBlock = Api.World.Blocks[chunks[surfaceY / chunksize].Data.GetBlockIdUnsafe(((surfaceY % chunksize) * chunksize + lz) * chunksize + lx)];
+                                     if (belowBlock.SideSolid[BlockFacing.UP.Index])
+                                     {
+                                         index3d = (((surfaceY + 1) % chunksize) * chunksize + lz) * chunksize + lx;
+@@ -383,10 +427,12 @@ namespace Vintagestory.ServerMods
  
                          posy--;
                      }
@@ -178,7 +202,7 @@ index 2b6633c..3e511cb 100644
          protected virtual bool shouldGenDepositHere(BlockPos depoCenterPos)
          {
              return true;
-@@ -404,12 +442,17 @@ namespace Vintagestory.ServerMods
+@@ -404,12 +450,17 @@ namespace Vintagestory.ServerMods
              int rdx = (pos.X / chunksize) % regionChunkSize;
              int rdz = (pos.Z / chunksize) % regionChunkSize;
  

--- a/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/9.GenRivulets.cs.patch
+++ b/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/9.GenRivulets.cs.patch
@@ -1,0 +1,128 @@
+diff --git a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/9.GenRivulets.cs b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/9.GenRivulets.cs
+index 6e99fe9..7ee2063 100644
+--- a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/9.GenRivulets.cs
++++ b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/9.GenRivulets.cs
+@@ -57,10 +57,12 @@ namespace Vintagestory.ServerMods
+         }
+ 
+         private void OnChunkColumnGen(IChunkColumnGenerateRequest request)
+         {
+             var chunks = request.Chunks;
++            if (chunks == null || chunks.Length == 0) return;
++
+             int chunkX = request.ChunkX;
+             int chunkZ = request.ChunkZ;
+ 
+             blockAccessor.BeginColumn();
+             var mapChunk = chunks[0].MapChunk;
+@@ -127,14 +129,21 @@ namespace Vintagestory.ServerMods
+         private void tryGenRivulet(IServerChunk[] chunks, int chunkX, int chunkZ, float geoActivityYThreshold, bool lava)
+         {
+             var mapChunk = chunks[0].MapChunk;
+             int fx, fy, fz;
+             int surfaceY = (int)(TerraGenConfig.seaLevel * 1.1f);
+-            int aboveSurfaceHeight = api.WorldManager.MapSizeY - surfaceY;
++            int maxLoadedY = chunks.Length * chunksize - 1;
++            if (maxLoadedY <= 1) return;
++
++            int maxRivuletY = Math.Min(api.WorldManager.MapSizeY - 2, maxLoadedY - 1);
++            if (maxRivuletY <= 1) return;
++
++            surfaceY = Math.Min(surfaceY, maxRivuletY);
++            int aboveSurfaceHeight = Math.Max(1, maxRivuletY - surfaceY + 1);
+ 
+             int dx = 1 + rnd.NextInt(chunksize - 2);
+-            int y = Math.Min(1 + rnd.NextInt(surfaceY) + rnd.NextInt(aboveSurfaceHeight) * rnd.NextInt(aboveSurfaceHeight), api.WorldManager.MapSizeY - 2);
++            int y = Math.Min(1 + rnd.NextInt(surfaceY) + rnd.NextInt(aboveSurfaceHeight) * rnd.NextInt(aboveSurfaceHeight), maxRivuletY);
+             int dz = 1 + rnd.NextInt(chunksize - 2);
+ 
+             ushort hereSurfaceY = mapChunk.WorldGenTerrainHeightMap[dz * chunksize + dx];
+             if (y > hereSurfaceY && rnd.NextInt(2) == 0) return; // Half as common overground
+ 
+@@ -147,10 +156,11 @@ namespace Vintagestory.ServerMods
+             {
+                 BlockFacing facing = BlockFacing.ALLFACES[i];
+                 fx = dx + facing.Normali.X;
+                 fy = y + facing.Normali.Y;
+                 fz = dz + facing.Normali.Z;
++                if (!IsInLoadedColumn(chunks, fy)) return;
+ 
+                 Block block = api.World.Blocks[
+                     chunks[fy / chunksize].Data.GetBlockIdUnsafe((chunksize * (fy % chunksize) + fz) * chunksize + fx)
+                 ];
+ 
+@@ -162,10 +172,11 @@ namespace Vintagestory.ServerMods
+                 {
+                     if (facing == BlockFacing.UP) quantitySolid = 0;   // We don't place rivulets on flat ground!
+                     else if (facing == BlockFacing.DOWN)   // Nor in 1-block thick ceilings
+                     {
+                         fy = y + 1;
++                        if (!IsInLoadedColumn(chunks, fy)) return;
+                         block = api.World.Blocks[chunks[fy / chunksize].Data.GetBlockIdUnsafe((chunksize * (fy % chunksize) + fz) * chunksize + fx)];
+                         if (block.BlockMaterial != EnumBlockMaterial.Stone) quantitySolid = 0;
+                     }
+                 }
+             }
+@@ -177,10 +188,11 @@ namespace Vintagestory.ServerMods
+             {
+                 if (structuresIntersectingChunk[i].Contains(pos)) return;
+             }
+             if (GetIntersectingStructure(pos.X, pos.Z, RivuletsHashCode) != null) return;
+ 
++            if (!IsInLoadedColumn(chunks, y)) return;
+             var chunk = chunks[y / chunksize];
+             var index = (chunksize * (y % chunksize) + dz) * chunksize + dx;
+             Block existing = api.World.GetBlock(chunk.Data.GetBlockId(index, BlockLayersAccess.Solid));
+             if (existing.EntityClass != null)
+             {
+@@ -203,10 +215,11 @@ namespace Vintagestory.ServerMods
+             int dx = 4 + rnd.NextInt(chunksize - 8);
+             int dz = 4 + rnd.NextInt(chunksize - 8);
+             int y = mapChunk.WorldGenTerrainHeightMap[dz * chunksize + dx] - 2;
+ 
+             if (y < minY) return;
++            if (!IsInLoadedColumn(chunks, y)) return;
+             if (liquidBlockID == gcfg.rivuletWaterBlockId && y - TerraGenConfig.seaLevel > 20) return; // Normal rivulets only at lower heights
+ 
+             Vec3i dir = null;
+             int len = 0;
+             for (int i = 0; i < BlockFacing.HORIZONTALS.Length; i++)
+@@ -215,20 +228,22 @@ namespace Vintagestory.ServerMods
+ 
+                 // All direct neighbours need to be solid
+                 fx = dx + facing.Normali.X;
+                 fy = y;
+                 fz = dz + facing.Normali.Z;
++                if (!IsInLoadedColumn(chunks, fy)) return;
+                 Block block = api.World.Blocks[chunks[fy / chunksize].Data.GetBlockIdUnsafe((chunksize * (fy % chunksize) + fz) * chunksize + fx)];
+                 if (!block.SideSolid.All) return;
+ 
+                 // In one direction there needs to be a path towards the surface
+                 if (dir != null) continue;
+                 for (len = 1; len <= 4; len++)
+                 {
+                     fx = dx + facing.Normali.X * len;
+                     fy = y;
+                     fz = dz + facing.Normali.Z * len;
++                    if (!IsInLoadedColumn(chunks, fy) || !IsInLoadedColumn(chunks, fy - 1)) return;
+ 
+                     block = api.World.Blocks[chunks[fy / chunksize].Data.GetBlockIdUnsafe((chunksize * (fy % chunksize) + fz) * chunksize + fx)];
+                     bool belowSolid = api.World.Blocks[chunks[(fy - 1) / chunksize].Data.GetBlockIdUnsafe((chunksize * ((fy - 1) % chunksize) + fz) * chunksize + fx)].SideSolid.All;
+                     bool solid = block.SideSolid.All;
+                     if ((len < 2 && !solid) || !belowSolid) break;
+@@ -265,10 +280,15 @@ namespace Vintagestory.ServerMods
+                     blockAccessor.ScheduleBlockUpdate(pos);
+                 }
+             }
+         }
+ 
++        private bool IsInLoadedColumn(IServerChunk[] chunks, int y)
++        {
++            return y >= 0 && chunks != null && y / chunksize < chunks.Length;
++        }
++
+         private int getGeologicActivity(int posx, int posz)
+         {
+             var climateMap = blockAccessor.GetMapRegion(posx / regionsize, posz / regionsize)?.ClimateMap;
+             if (climateMap == null) return 0;
+             int regionChunkSize = regionsize / chunksize;

--- a/patches/VintagestoryLib/Vintagestory.Server.Systems/ServerUdpNetwork.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server.Systems/ServerUdpNetwork.cs.patch
@@ -1,5 +1,5 @@
 diff --git a/VintagestoryLib/Vintagestory.Server.Systems/ServerUdpNetwork.cs b/VintagestoryLib/Vintagestory.Server.Systems/ServerUdpNetwork.cs
-index 719a68b..4a33a0b 100644
+index 719a68b..d7e17c4 100644
 --- a/VintagestoryLib/Vintagestory.Server.Systems/ServerUdpNetwork.cs
 +++ b/VintagestoryLib/Vintagestory.Server.Systems/ServerUdpNetwork.cs
 @@ -4,19 +4,36 @@ using System.IO;
@@ -74,13 +74,19 @@ index 719a68b..4a33a0b 100644
  		{
  			connectingClients.Remove(keyValuePair.Key);
  		}
-@@ -167,16 +197,34 @@ public class ServerUdpNetwork : ServerSystem
+@@ -167,16 +197,40 @@ public class ServerUdpNetwork : ServerSystem
  		}
  		player.LastReceivedClientPosition = server.ElapsedMilliseconds;
  		int num2 = entity.Attributes.GetInt("tick");
  		num2++;
  		entity.Attributes.SetInt("tick", num2);
-+		if (!TryAcceptStratumMovementPacket(player, entity, packet, num, num2, player.PlayerUID))
++		bool stratumPlayerMounted = entity.MountedOn != null;
++		if (stratumPlayerMounted)
++		{
++			RememberStratumMovement(entity, player.PlayerUID);
++			StratumMovementGuard.ForgetPlayer(player.PlayerUID);
++		}
++		else if (!TryAcceptStratumMovementPacket(player, entity, packet, num, num2, player.PlayerUID, false))
 +		{
 +			return;
 +		}
@@ -92,7 +98,7 @@ index 719a68b..4a33a0b 100644
  			return;
  		}
 +		// Stratum: check slow movement cheats after reading the claimed position.
-+		if (!StratumMovementGuard.TryAccept(server, player, entity, player.PlayerUID, out string stratumMovementKick))
++		if (!stratumPlayerMounted && !StratumMovementGuard.TryAccept(server, player, entity, player.PlayerUID, out string stratumMovementKick))
 +		{
 +			MarkStratumMovementCorrection(player.PlayerUID, entity, server.ElapsedMilliseconds);
 +			SendSinglePositionPacket(player, entity, num2);
@@ -109,7 +115,7 @@ index 719a68b..4a33a0b 100644
  			if (behavior is IRemotePhysics remotePhysics)
  			{
  				remotePhysics.OnReceivedClientPos(num);
-@@ -196,22 +244,206 @@ public class ServerUdpNetwork : ServerSystem
+@@ -196,22 +250,210 @@ public class ServerUdpNetwork : ServerSystem
  		if (flag)
  		{
  			message = new AnimationPacket(entity);
@@ -140,7 +146,7 @@ index 719a68b..4a33a0b 100644
 +		RememberStratumMovement(entity, player.PlayerUID);
 +	}
 +
-+	private bool TryAcceptStratumMovementPacket(ServerPlayer player, Entity entity, Packet_EntityPosition packet, int serverPositionVersion, int currentTick, string stateKey)
++	private bool TryAcceptStratumMovementPacket(ServerPlayer player, Entity entity, Packet_EntityPosition packet, int serverPositionVersion, int currentTick, string stateKey, bool isMount)
 +	{
 +		if (player == null || entity == null || packet == null || string.IsNullOrEmpty(stateKey))
 +		{
@@ -176,7 +182,8 @@ index 719a68b..4a33a0b 100644
 +		{
 +			double serverDistance = Distance(packetX, packetY, packetZ, entity.Pos.X, entity.Pos.InternalY, entity.Pos.Z);
 +			double correctionDistance = Distance(packetX, packetY, packetZ, state.CorrectionX, state.CorrectionY, state.CorrectionZ);
-+			if (now <= state.CorrectionUntilMs && correctionDistance > Math.Max(0.5, config.SlackBlocks))
++			double correctionSlack = isMount ? config.MountSlackBlocks : config.SlackBlocks;
++			if (now <= state.CorrectionUntilMs && correctionDistance > Math.Max(0.5, correctionSlack))
 +			{
 +				SendSinglePositionPacket(player, entity, currentTick);
 +				state.LastMs = now;
@@ -196,7 +203,7 @@ index 719a68b..4a33a0b 100644
 +			}
 +		}
 +
-+		double elapsedSeconds = Math.Max(0.05, (now - state.LastMs) / 1000.0);
++		double elapsedSeconds = Math.Max(isMount ? 0.1 : 0.05, (now - state.LastMs) / 1000.0);
 +		double dx = packetX - state.X;
 +		double dy = packetY - state.Y;
 +		double dz = packetZ - state.Z;
@@ -210,10 +217,13 @@ index 719a68b..4a33a0b 100644
 +		}
 +		state.WindowDistance += total;
 +
-+		double allowedHorizontalSpeed = GetStratumAllowedHorizontalSpeed(player, entity, config);
-+		double allowedWindowDistance = Math.Min(config.MaxCumulativeBlocksPerSecond, allowedHorizontalSpeed * config.CumulativeSpeedMultiplier);
-+		double maxHorizontal = allowedHorizontalSpeed * elapsedSeconds + config.SlackBlocks;
-+		double maxVerticalUp = config.MaxVerticalUpBlocksPerSecond * elapsedSeconds + config.SlackBlocks;
++		double allowedHorizontalSpeed = isMount ? config.MountMaxHorizontalBlocksPerSecond : GetStratumAllowedHorizontalSpeed(player, entity, config);
++		double slack = isMount ? config.MountSlackBlocks : config.SlackBlocks;
++		double allowedWindowDistance = isMount
++			? config.MountMaxCumulativeBlocksPerSecond
++			: Math.Min(config.MaxCumulativeBlocksPerSecond, allowedHorizontalSpeed * config.CumulativeSpeedMultiplier);
++		double maxHorizontal = allowedHorizontalSpeed * elapsedSeconds + slack;
++		double maxVerticalUp = (isMount ? config.MountMaxVerticalUpBlocksPerSecond : config.MaxVerticalUpBlocksPerSecond) * elapsedSeconds + slack;
 +		if (horizontal > maxHorizontal || dy > maxVerticalUp || state.WindowDistance > allowedWindowDistance)
 +		{
 +			double windowDistance = state.WindowDistance;
@@ -224,7 +234,7 @@ index 719a68b..4a33a0b 100644
 +
 +			// Let the reporter handle staff alerts and kick escalation.
 +			string reason = string.Format(System.Globalization.CultureInfo.InvariantCulture,
-+				"delta h={0:0.00}/{1:0.00} up={2:0.00}/{3:0.00} window={4:0.00}/{5:0.00}", horizontal, maxHorizontal, dy, maxVerticalUp, windowDistance, allowedWindowDistance);
++				"{0}delta h={1:0.00}/{2:0.00} up={3:0.00}/{4:0.00} window={5:0.00}/{6:0.00}", isMount ? "mount " : "", horizontal, maxHorizontal, dy, maxVerticalUp, windowDistance, allowedWindowDistance);
 +			if (StratumAnticheatReporter.RecordMovementViolation(server, player, entity.Pos.AsBlockPos, reason, out string movementKickReason))
 +			{
 +				stratumMovementByPlayerUid.Remove(stateKey);
@@ -319,14 +329,14 @@ index 719a68b..4a33a0b 100644
  	private void SendSinglePositionPacket(ServerPlayer player, Entity entity, int currentTick)
  	{
  		Packet_UdpPacket packet = new Packet_UdpPacket
-@@ -240,10 +472,16 @@ public class ServerUdpNetwork : ServerSystem
+@@ -240,10 +482,16 @@ public class ServerUdpNetwork : ServerSystem
  			return;
  		}
  		int num2 = entityById.Attributes.GetInt("tick");
  		num2++;
  		entityById.Attributes.SetInt("tick", num2);
 +		string stratumMountMovementKey = player.PlayerUID + ":mount:" + entityById.EntityId;
-+		if (!TryAcceptStratumMovementPacket(player, entityById, packet, num, num2, stratumMountMovementKey))
++		if (!TryAcceptStratumMovementPacket(player, entityById, packet, num, num2, stratumMountMovementKey, true))
 +		{
 +			return;
 +		}
@@ -336,7 +346,7 @@ index 719a68b..4a33a0b 100644
  			entityById.Api.Logger.Audit("Rejected mount position update for " + player.PlayerName + ". Client sent " + packet.X / 16384 + "," + packet.Y / 16384 + "," + packet.Z / 16384 + ", server pos was " + entityById.Pos);
  			SendSinglePositionPacket(player, entityById, num2);
  			return;
-@@ -299,10 +537,11 @@ public class ServerUdpNetwork : ServerSystem
+@@ -299,10 +547,11 @@ public class ServerUdpNetwork : ServerSystem
  			IServerNetworkChannel animationsAndTagsChannel = physicsManager.AnimationsAndTagsChannel;
  			AnimationPacket message = animationPacket;
  			IServerPlayer[] players = list.ToArray();

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumAnticheatConfig.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumAnticheatConfig.cs
@@ -125,6 +125,14 @@ internal class StratumMovementAnticheatConfig : StratumAnticheatRuleConfig
 
 	public double SlackBlocks { get; set; } = 2.5;
 
+	public double MountMaxHorizontalBlocksPerSecond { get; set; } = 96;
+
+	public double MountMaxVerticalUpBlocksPerSecond { get; set; } = 36;
+
+	public double MountMaxCumulativeBlocksPerSecond { get; set; } = 160;
+
+	public double MountSlackBlocks { get; set; } = 8;
+
 	public bool KickConfirmedCheats { get; set; } = true;
 
 	public int KickAfterViolations { get; set; } = 10;
@@ -137,6 +145,8 @@ internal class StratumMovementAnticheatConfig : StratumAnticheatRuleConfig
 	public bool DetectWaterWalk { get; set; } = true;
 
 	public int WaterWalkConsecutiveTicks { get; set; } = 3;
+
+	public int WaterWalkEntryGraceMs { get; set; } = 900;
 
 	public double GroundContactTolerance { get; set; } = 0.04;
 
@@ -164,11 +174,16 @@ internal class StratumMovementAnticheatConfig : StratumAnticheatRuleConfig
 		CumulativeSpeedMultiplier = Math.Clamp(CumulativeSpeedMultiplier, 1, 20);
 		MaxCumulativeBlocksPerSecond = Math.Clamp(MaxCumulativeBlocksPerSecond, MaxHorizontalBlocksPerSecond, 4000);
 		SlackBlocks = Math.Clamp(SlackBlocks, 0, 32);
+		MountMaxHorizontalBlocksPerSecond = Math.Clamp(MountMaxHorizontalBlocksPerSecond, 16, 1000);
+		MountMaxVerticalUpBlocksPerSecond = Math.Clamp(MountMaxVerticalUpBlocksPerSecond, 8, 1000);
+		MountMaxCumulativeBlocksPerSecond = Math.Clamp(MountMaxCumulativeBlocksPerSecond, MountMaxHorizontalBlocksPerSecond, 4000);
+		MountSlackBlocks = Math.Clamp(MountSlackBlocks, 0, 64);
 		KickAfterViolations = Math.Clamp(KickAfterViolations, 3, 1000);
 		FlightGroundScanDepth = Math.Clamp(FlightGroundScanDepth, 0, 16);
 		FlightMinAirborneSeconds = Math.Clamp(FlightMinAirborneSeconds, 1.0, 10);
 		FlightRequiredDescentBlocks = Math.Clamp(FlightRequiredDescentBlocks, 0.05, 3);
 		WaterWalkConsecutiveTicks = Math.Clamp(WaterWalkConsecutiveTicks, 3, 40);
+		WaterWalkEntryGraceMs = Math.Clamp(WaterWalkEntryGraceMs, 0, 5000);
 		GroundContactTolerance = Math.Clamp(GroundContactTolerance, 0.005, 0.2);
 		NoclipConsecutiveTicks = Math.Clamp(NoclipConsecutiveTicks, 2, 40);
 		KickMessage ??= "Disconnected by Stratum movement protection";

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumInfo.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumInfo.cs
@@ -13,7 +13,7 @@ internal static class StratumInfo
 
 	// Stratum revision on top of BaseGameVersion. Increment for every public release;
 	// reset to 1 when BaseGameVersion changes.
-	public const string StratumRevision = "12";
+	public const string StratumRevision = "13";
 
 	// Optional prerelease label appended after the revision ("rc.1", "dev", "").
 	public const string PreRelease = "";

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumMovementGuard.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumMovementGuard.cs
@@ -57,11 +57,6 @@ internal static class StratumMovementGuard
 			return true;
 		}
 
-		long now = server.ElapsedMilliseconds;
-		bool supported = IsSupported(server, entity, feetCell, config);
-		bool embedded = config.DetectNoclip && IsEmbedded(server, entity, feetCell);
-		bool waterWalkCandidate = config.DetectFlight && config.DetectWaterWalk && IsWaterWalkCandidate(server, entity, feetCell, config);
-
 		MoveState state;
 		lock (gate)
 		{
@@ -70,6 +65,21 @@ internal static class StratumMovementGuard
 				state = new MoveState();
 				states[key] = state;
 			}
+		}
+
+		long now = server.ElapsedMilliseconds;
+		bool groundContact = HasGroundContact(server, entity, feetCell, config);
+		if (groundContact)
+		{
+			state.LastGroundContactMs = now;
+		}
+
+		bool supported = IsSupported(server, entity, feetCell, config, groundContact);
+		bool embedded = config.DetectNoclip && IsEmbedded(server, entity, feetCell);
+		bool waterWalkCandidate = config.DetectFlight && config.DetectWaterWalk && IsWaterWalkCandidate(server, entity, feetCell, config, groundContact);
+		if (waterWalkCandidate && now - state.LastGroundContactMs < config.WaterWalkEntryGraceMs)
+		{
+			waterWalkCandidate = false;
 		}
 
 		bool hasPreviousY = state.HasLastY;
@@ -100,9 +110,6 @@ internal static class StratumMovementGuard
 			state.SafeY = entity.Pos.Y;
 			state.SafeZ = entity.Pos.Z;
 		}
-
-		state.HasLastY = true;
-		state.LastY = entity.Pos.Y;
 
 		if (config.DetectNoclip)
 		{
@@ -199,7 +206,7 @@ internal static class StratumMovementGuard
 	}
 
 	// Unloaded blocks count as supported. Guessing wrong there would make chunk-load timing look like cheating.
-	private static bool IsSupported(ServerMain server, EntityPlayer entity, BlockPos feetCell, StratumMovementAnticheatConfig config)
+	private static bool IsSupported(ServerMain server, EntityPlayer entity, BlockPos feetCell, StratumMovementAnticheatConfig config, bool groundContact)
 	{
 		var blocks = server.WorldMap.RelaxedBlockAccess;
 		int feetY = feetCell.Y;
@@ -226,7 +233,7 @@ internal static class StratumMovementGuard
 			}
 		}
 
-		if (HasGroundContact(server, entity, feetCell, config))
+		if (groundContact)
 		{
 			return true;
 		}
@@ -281,11 +288,11 @@ internal static class StratumMovementGuard
 		return false;
 	}
 
-	private static bool IsWaterWalkCandidate(ServerMain server, EntityPlayer entity, BlockPos feetCell, StratumMovementAnticheatConfig config)
+	private static bool IsWaterWalkCandidate(ServerMain server, EntityPlayer entity, BlockPos feetCell, StratumMovementAnticheatConfig config, bool groundContact)
 	{
 		var blocks = server.WorldMap.RelaxedBlockAccess;
 
-		if (HasGroundContact(server, entity, feetCell, config))
+		if (groundContact)
 		{
 			return false;
 		}
@@ -409,6 +416,7 @@ internal static class StratumMovementGuard
 		public bool AirborneHadDescent;
 		public int EmbeddedTicks;
 		public int WaterWalkTicks;
+		public long LastGroundContactMs;
 		public bool HasLastY;
 		public double LastY;
 		public bool HasSafePos;

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumPregenManager.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumPregenManager.cs
@@ -498,6 +498,7 @@ internal sealed class StratumPregenManager
 		output.Append("Skipped: loaded=").Append(skippedLoadedColumns).Append(" invalid=").Append(skippedInvalidColumns).Append(" alreadyQueued=").Append(alreadyQueuedColumns).Append('\n');
 		output.Append("Pressure pauses: ").Append(pressurePauses).Append(" last=").Append(lastPauseReason).Append('\n');
 		output.Append("Config: rate=").Append(StratumRuntime.Config.Performance.Pregen.MaxColumnsPerSecond).Append("/s queues=").Append(StratumRuntime.Config.Performance.Pregen.MaxPendingColumnQueue).Append('/').Append(StratumRuntime.Config.Performance.Pregen.MaxWorkerColumnQueue).Append(" loadedColumns=").Append(StratumRuntime.Config.Performance.Pregen.MaxLoadedChunkColumns).Append('\n');
+		output.Append("Commands: /stratum pregen start radius &lt;radiusChunks&gt; [centerChunkX] [centerChunkZ], /stratum pregen start rect &lt;chunkX1&gt; &lt;chunkZ1&gt; &lt;chunkX2&gt; &lt;chunkZ2&gt;, /stratum pregen pause|resume|stop|status");
 		return output.ToString();
 	}
 


### PR DESCRIPTION
- Fixed issue when walking into water from level surface would sometimes trigger AC

- Fixed issue with AC not checking if you were 'mounted'
- Added config settings and different checks for mounted movement
- WorldGen checks if generated Y positions are outsided loaded chunk column to prevent incorrect or improper world height settings from causing issues.

## Summary

Movement detection was having false positives for mounted movements, such as boats or horses, and the base game had an issue with improper map sizes (numbers not divisible by 32) causing improper world gen and spamming the console.

## Type

- [x] Bug fix
- [ ] Performance
- [ ] New feature
- [x] Refactor or cleanup
- [ ] Docs or build

## Checklist

- [x] `.\scripts\extract-patches.ps1` ran clean.
- [x] `dotnet build VintageStory.slnx -c Release` is green.
- [x] Every vanilla edit has a `// Stratum` marker.
- [x] No vanilla source committed.
- [x] Tested on a real server start, not just compilation.