### PR TITLE
Refactor TcpNetConnection and StratumNetworkFlush

### DIFF
--- a/patches/VintagestoryLib/Vintagestory.Server.Network/TcpNetConnection.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server.Network/TcpNetConnection.cs.patch
@@ -1,23 +1,17 @@
 diff --git a/VintagestoryLib/Vintagestory.Server.Network/TcpNetConnection.cs b/VintagestoryLib/Vintagestory.Server.Network/TcpNetConnection.cs
-index 7978960..c558086 100644
+index 1884990..a860d75 100644
 --- a/VintagestoryLib/Vintagestory.Server.Network/TcpNetConnection.cs
 +++ b/VintagestoryLib/Vintagestory.Server.Network/TcpNetConnection.cs
-@@ -217,11 +217,11 @@ public class TcpNetConnection : NetConnection
- 	private OnReceivedMessageDelegate m_ReceivedMessage;
+@@ -37,7 +37,7 @@ public class TcpNetConnection : NetConnection
  
- 	[CompilerGenerated]
- 	private TcpConnectionDelegate m_Disconnected;
+ 	private Memory<byte> dataRcvBuf = new byte[4096];
  
 -	private CancellationTokenSource cts;
 +	internal CancellationTokenSource cts; // Stratum: internal for StratumNetworkFlush access
  
  	public int MaxPacketSize = 5000;
  
- 	public event OnReceivedMessageDelegate ReceivedMessage
- 	{
-@@ -352,10 +352,16 @@ public class TcpNetConnection : NetConnection
- 			return EnumSendResult.Disconnected;
- 		}
+@@ -182,6 +182,12 @@ public class TcpNetConnection : NetConnection
  		try
  		{
  			NetIncomingMessage.WriteInt(dataWithLength, length | (int)((compressedFlag ? 1u : 0u) << 31));
@@ -26,9 +20,7 @@ index 7978960..c558086 100644
 +			{
 +				return EnumSendResult.Ok;
 +			}
-+			// Stratum end: large/compressed packet, send directly (buffer was flushed first).
- 			TcpSocket.SendAsync(ReadOnlyMemory<byte>.op_Implicit(dataWithLength), (SocketFlags)0, cts.Token);
++			// Stratum end: large/compressed packet, send directly after flushing the buffer.
+ 			TcpSocket.SendAsync(dataWithLength, SocketFlags.None, cts.Token);
  			return EnumSendResult.Ok;
  		}
- 		catch
- 		{

--- a/patches/VintagestoryLib/Vintagestory.Server/ServerSystemSendChunks.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/ServerSystemSendChunks.cs.patch
@@ -1,10 +1,8 @@
 diff --git a/VintagestoryLib/Vintagestory.Server/ServerSystemSendChunks.cs b/VintagestoryLib/Vintagestory.Server/ServerSystemSendChunks.cs
-index 277d286..e11151b 100644
+index 277d286..f19d491 100644
 --- a/VintagestoryLib/Vintagestory.Server/ServerSystemSendChunks.cs
 +++ b/VintagestoryLib/Vintagestory.Server/ServerSystemSendChunks.cs
-@@ -1,15 +1,17 @@
- using System;
- using System.Collections.Generic;
+@@ -3,11 +3,13 @@ using System.Collections.Generic;
  using System.Diagnostics;
  using System.Threading;
  using Vintagestory.API.Common;
@@ -18,11 +16,7 @@ index 277d286..e11151b 100644
  
  namespace Vintagestory.Server;
  
- internal class ServerSystemSendChunks : ServerSystem
- {
-@@ -25,10 +27,24 @@ internal class ServerSystemSendChunks : ServerSystem
- 
- 	private Dictionary<long, Packet_ServerChunk> packetsWithEntities = new Dictionary<long, Packet_ServerChunk>();
+@@ -27,6 +29,20 @@ internal class ServerSystemSendChunks : ServerSystem
  
  	private Dictionary<long, Packet_ServerChunk> packetsWithoutEntities = new Dictionary<long, Packet_ServerChunk>();
  
@@ -43,11 +37,7 @@ index 277d286..e11151b 100644
  	public override void Dispose()
  	{
  		chunkPackets = null;
- 		chunksToSend = null;
- 		mapChunksToSend = null;
-@@ -54,46 +70,218 @@ internal class ServerSystemSendChunks : ServerSystem
- 	{
- 		if (server.RunPhase != EnumServerRunPhase.RunGame)
+@@ -56,6 +72,27 @@ internal class ServerSystemSendChunks : ServerSystem
  		{
  			return;
  		}
@@ -75,7 +65,7 @@ index 277d286..e11151b 100644
  		packetsWithEntities.Clear();
  		packetsWithoutEntities.Clear();
  		IPlayer[] allOnlinePlayers = server.AllOnlinePlayers;
- 		foreach (IMiniDimension value in server.LoadedMiniDimensions.Values)
+@@ -63,15 +100,128 @@ internal class ServerSystemSendChunks : ServerSystem
  		{
  			value.CollectChunksForSending(allOnlinePlayers);
  		}
@@ -206,7 +196,7 @@ index 277d286..e11151b 100644
  	}
  
  	private void OnClientLeaveChunk(ClientStatistics clientstats)
- 	{
+@@ -79,19 +229,57 @@ internal class ServerSystemSendChunks : ServerSystem
  		clientstats.client.CurrentChunkSentRadius = 0;
  	}
  
@@ -267,11 +257,7 @@ index 277d286..e11151b 100644
  		foreach (long forceSendMapChunk in client.forceSendMapChunks)
  		{
  			Vec2i vec2i = server.WorldMap.MapChunkPosFromChunkIndex2D(forceSendMapChunk);
- 			server.loadedMapChunks.TryGetValue(forceSendMapChunk, out var value);
- 			if (value != null)
-@@ -125,18 +313,22 @@ internal class ServerSystemSendChunks : ServerSystem
- 					chunk = loadedChunk,
- 					pos = pos,
+@@ -127,6 +315,10 @@ internal class ServerSystemSendChunks : ServerSystem
  					withEntities = true
  				});
  				num2--;
@@ -282,7 +268,7 @@ index 277d286..e11151b 100644
  				toRemove.Add(forceSendChunk);
  			}
  		}
- 		foreach (long item3 in toRemove)
+@@ -134,7 +326,7 @@ internal class ServerSystemSendChunks : ServerSystem
  		{
  			client.forceSendChunks.Remove(item3);
  		}
@@ -291,11 +277,7 @@ index 277d286..e11151b 100644
  		{
  			client.CurrentChunkSentRadius++;
  		}
- 		foreach (ServerMapChunkWithCoord item4 in mapChunksToSend)
- 		{
-@@ -203,16 +395,36 @@ internal class ServerSystemSendChunks : ServerSystem
- 				server.SendPacketFast(client.Id, value3.ToPacket(vec3i.X, vec3i.Z));
- 				client.SetMapRegionSent(forceSendMapRegion);
+@@ -205,12 +397,32 @@ internal class ServerSystemSendChunks : ServerSystem
  			}
  		}
  		client.forceSendMapRegions.Clear();
@@ -330,11 +312,7 @@ index 277d286..e11151b 100644
  		int num2 = 0;
  		int num3 = dimension * 1024;
  		for (int i = 0; i < octagonPoints.Length; i++)
- 		{
- 			int x = octagonPoints[i].X;
-@@ -238,10 +450,18 @@ internal class ServerSystemSendChunks : ServerSystem
- 						chunksToSend.Add(new ServerChunkWithCoord
- 						{
+@@ -240,6 +452,14 @@ internal class ServerSystemSendChunks : ServerSystem
  							chunk = loadedChunk,
  							pos = new ChunkPos(x, j, y, dimension)
  						});
@@ -349,11 +327,7 @@ index 277d286..e11151b 100644
  						countChunks--;
  						if (!flag)
  						{
- 							if (!client.DidSendMapChunk(num4))
- 							{
-@@ -258,41 +478,405 @@ internal class ServerSystemSendChunks : ServerSystem
- 					}
- 					num2++;
+@@ -260,18 +480,35 @@ internal class ServerSystemSendChunks : ServerSystem
  				}
  				else
  				{
@@ -391,8 +365,7 @@ index 277d286..e11151b 100644
  					}
  					num2++;
  				}
- 			}
- 		}
+@@ -280,6 +517,245 @@ internal class ServerSystemSendChunks : ServerSystem
  		return num2;
  	}
  
@@ -437,8 +410,7 @@ index 277d286..e11151b 100644
 +			return budget;
 +		}
 +
-+		int pendingSends = tcp.PendingSendCount;
-+		long pendingBytes = tcp.PendingSendBytes;
++		StratumNetworkFlush.GetBufferedPressure(tcp, out int pendingSends, out long pendingBytes);
 +		if (pendingSends < config.OutboundPressurePendingSendsSoftLimit && pendingBytes < config.OutboundPressurePendingBytesSoftLimit)
 +		{
 +			return budget;
@@ -639,10 +611,7 @@ index 277d286..e11151b 100644
  	private Packet_ServerChunk collectChunk(ServerChunk serverChunk, int chunkX, int chunkY, int chunkZ, ConnectedClient client, bool withEntities)
  	{
  		long num = server.WorldMap.ChunkIndex3D(chunkX, chunkY, chunkZ);
- 		client.SetChunkSent(num);
- 		chunksSent++;
- 		Dictionary<long, Packet_ServerChunk> dictionary = (withEntities ? packetsWithEntities : packetsWithoutEntities);
- 		if (dictionary.TryGetValue(num, out var value))
+@@ -290,7 +766,114 @@ internal class ServerSystemSendChunks : ServerSystem
  		{
  			return value;
  		}
@@ -758,5 +727,3 @@ index 277d286..e11151b 100644
  	}
  
  	public static string performanceTest(ServerMain server)
- 	{
- 		Stopwatch stopwatch = null;

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumNetworkFlush.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumNetworkFlush.cs
@@ -68,6 +68,26 @@ internal static class StratumNetworkFlush
 		return true;
 	}
 
+	internal static void GetBufferedPressure(TcpNetConnection connection, out int pendingSends, out long pendingBytes)
+	{
+		pendingSends = 0;
+		pendingBytes = 0;
+
+		if (connection == null || !buffers.TryGetValue(connection, out ConnectionBuffer state))
+		{
+			return;
+		}
+
+		int bytes = Volatile.Read(ref state.WritePos);
+		if (bytes <= 0)
+		{
+			return;
+		}
+
+		pendingSends = 1;
+		pendingBytes = bytes;
+	}
+
 	internal static void FlushAll()
 	{
 		foreach (KeyValuePair<TcpNetConnection, ConnectionBuffer> kvp in buffers)


### PR DESCRIPTION
## Summary

- Removed the stale dependency on `TcpNetConnection.PendingSendCount/PendingSendBytes`
- Added `StratumNetworkFlush.GetBufferedPressure(...)` so chunk send pressure can read the current flush buffer instead.

## Type

- [ ] Bug fix
- [ ] Performance
- [ ] New feature
- [x] Refactor or cleanup
- [ ] Docs or build

## Checklist

- [x] `.\scripts\extract-patches.ps1` ran clean.
- [x] `dotnet build VintageStory.slnx -c Release` is green.
- [x] Every vanilla edit has a `// Stratum` marker.
- [x] No vanilla source committed.
- [x] Tested on a real server start, not just compilation.
