### PR TITLE
Add detection for combat cheats

### DIFF
--- a/sources/VintagestoryLib/Vintagestory.Server/StratumAnticheatConfig.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumAnticheatConfig.cs
@@ -20,6 +20,8 @@ internal class StratumAnticheatConfig
 
 	public StratumMovementAnticheatConfig Movement { get; set; } = new StratumMovementAnticheatConfig();
 
+	public StratumCombatAnticheatConfig Combat { get; set; } = new StratumCombatAnticheatConfig();
+
 	public void EnsureSane()
 	{
 		MaxStoredViolationsPerPlayer = Math.Clamp(MaxStoredViolationsPerPlayer, 16, 2048);
@@ -28,10 +30,12 @@ internal class StratumAnticheatConfig
 		BlockInteractionOutOfRange ??= new StratumBlockInteractionOutOfRangeAnticheatConfig();
 		BlockBreakProgress ??= new StratumBlockBreakProgressAnticheatConfig();
 		Movement ??= new StratumMovementAnticheatConfig();
+		Combat ??= new StratumCombatAnticheatConfig();
 		BlockEntityOutOfRange.EnsureSane();
 		BlockInteractionOutOfRange.EnsureSane();
 		BlockBreakProgress.EnsureSane();
 		Movement.EnsureSane();
+		Combat.EnsureSane();
 	}
 }
 
@@ -187,5 +191,63 @@ internal class StratumMovementAnticheatConfig : StratumAnticheatRuleConfig
 		GroundContactTolerance = Math.Clamp(GroundContactTolerance, 0.005, 0.2);
 		NoclipConsecutiveTicks = Math.Clamp(NoclipConsecutiveTicks, 2, 40);
 		KickMessage ??= "Disconnected by Stratum movement protection";
+	}
+}
+
+// Server-side combat checks for kill-aura and aimbot behaviour. These sit on top of the
+// attack range checks the vanilla server already runs, so they only add signal, never remove
+// any legitimate hit. Everything here defaults to monitor-only (staff alerts, no kick) because
+// the heuristics can theoretically be nudged by heavy lag; enforcement is an opt-in per server.
+internal class StratumCombatAnticheatConfig : StratumAnticheatRuleConfig
+{
+	public StratumCombatAnticheatConfig()
+	{
+		// Aura hits arrive in fast bursts. Alert quickly but keep a little room for a burst of
+		// legitimate melee against a mob pile.
+		AlertAfterViolations = 6;
+		AlertWindowSeconds = 6;
+		RepeatAlertSeconds = 15;
+	}
+
+	// Attacking several distinct entities in a tiny window is physically impossible with a real
+	// client (one target per swing, one crosshair). This is the highest-confidence signal here.
+	public bool DetectMultiTarget { get; set; } = true;
+
+	public int MultiTargetWindowMs { get; set; } = 400;
+
+	public int MultiTargetThreshold { get; set; } = 3;
+
+	// Flags an attack whose target sits outside the player's aim cone. Kept generous so ordinary
+	// aiming plus lag never trips it; the point is to catch hits landed on entities beside or
+	// behind the player, which only an aura does.
+	public bool DetectAimCone { get; set; } = true;
+
+	public double MaxAttackAngleDegrees { get; set; } = 75.0;
+
+	// Skip the cone test when the target is basically touching the player, where the geometry of a
+	// large hitbox makes the angle meaningless.
+	public double MinAngleCheckDistance { get; set; } = 1.5;
+
+	// Combat heuristics start as monitor-only. Turn this on once a server has watched the
+	// /stratum ac combat data and is comfortable the false-positive rate is zero.
+	public bool KickConfirmedCheats { get; set; } = false;
+
+	public int KickAfterViolations { get; set; } = 12;
+
+	public string KickMessage { get; set; } = "Disconnected by Stratum combat protection";
+
+	// When on, a flagged hit is dropped instead of applied. Off by default so v1 never changes the
+	// outcome of any hit; a real client can't trigger these checks anyway.
+	public bool CancelFlaggedHits { get; set; } = false;
+
+	public override void EnsureSane()
+	{
+		base.EnsureSane();
+		MultiTargetWindowMs = Math.Clamp(MultiTargetWindowMs, 50, 5000);
+		MultiTargetThreshold = Math.Clamp(MultiTargetThreshold, 2, 20);
+		MaxAttackAngleDegrees = Math.Clamp(MaxAttackAngleDegrees, 30.0, 180.0);
+		MinAngleCheckDistance = Math.Clamp(MinAngleCheckDistance, 0.0, 8.0);
+		KickAfterViolations = Math.Clamp(KickAfterViolations, 3, 1000);
+		KickMessage ??= "Disconnected by Stratum combat protection";
 	}
 }

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumAnticheatReporter.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumAnticheatReporter.cs
@@ -16,6 +16,7 @@ internal static class StratumAnticheatReporter
 	private const string BlockInteractionOutOfRangeType = "block-interaction-range";
 	private const string BlockBreakProgressType = "block-break-progress";
 	private const string MovementType = "movement";
+	private const string CombatType = "combat";
 
 	private static readonly object Lock = new object();
 	private static readonly Dictionary<string, PlayerViolationState> PlayerViolations = new Dictionary<string, PlayerViolationState>(StringComparer.OrdinalIgnoreCase);
@@ -145,6 +146,40 @@ internal static class StratumAnticheatReporter
 		return false;
 	}
 
+	public static bool RecordCombatViolation(ServerMain server, ServerPlayer player, BlockPos pos, string reason, out string disconnectReason)
+	{
+		disconnectReason = null;
+		if (server == null || player == null)
+		{
+			return false;
+		}
+
+		StratumRuntime.Config.EnsurePopulated();
+		StratumAnticheatConfig config = StratumRuntime.Config.Anticheat;
+		if (!config.Enabled || !config.Combat.Enabled)
+		{
+			return false;
+		}
+
+		string detail = string.IsNullOrWhiteSpace(reason) ? "combat" : reason;
+		DateTime now = DateTime.UtcNow;
+		ViolationRecordResult result = RecordViolation(player, now, CombatType, detail, config, config.Combat);
+		if (result.ShouldAlert)
+		{
+			SendStaffAlert(server, player, "combat", pos, result.RollingCount, result.TotalCount, config.Combat.AlertWindowSeconds);
+		}
+
+		if (config.Combat.KickConfirmedCheats && result.RollingCount >= config.Combat.KickAfterViolations)
+		{
+			disconnectReason = string.IsNullOrWhiteSpace(config.Combat.KickMessage)
+				? "Disconnected by Stratum combat protection"
+				: config.Combat.KickMessage;
+			return true;
+		}
+
+		return false;
+	}
+
 	public static string BuildReport(string playerFilter, int maxEvents = 12)
 	{
 		StratumRuntime.Config.EnsurePopulated();
@@ -250,6 +285,8 @@ internal static class StratumAnticheatReporter
 				return "Block break timing";
 			case MovementType:
 				return "Movement";
+			case CombatType:
+				return "Combat";
 			default:
 				return string.IsNullOrWhiteSpace(type) ? "Unknown" : type;
 		}
@@ -289,6 +326,19 @@ internal static class StratumAnticheatReporter
 		if (entry.Type == BlockEntityOutOfRangeType)
 		{
 			return "sent a block entity packet too far away at " + detail;
+		}
+
+		if (entry.Type == CombatType)
+		{
+			if (detail.StartsWith("aura:", StringComparison.OrdinalIgnoreCase))
+			{
+				return "attacked several entities at once (" + detail + ")";
+			}
+
+			if (detail.StartsWith("aim:", StringComparison.OrdinalIgnoreCase))
+			{
+				return "attacked an entity outside their aim (" + detail + ")";
+			}
 		}
 
 		return detail;

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumCombatGuard.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumCombatGuard.cs
@@ -1,0 +1,192 @@
+using System;
+using System.Collections.Generic;
+using Vintagestory.API.Common;
+using Vintagestory.API.Common.Entities;
+using Vintagestory.API.MathTools;
+
+namespace Vintagestory.Server;
+
+// Kill-aura / aimbot heuristics layered on top of the vanilla attack range check. Runs only for
+// attack (left-click) interactions. Two signals, both chosen so a real vanilla client can never
+// trip them:
+//   - multi-target: a human hits one entity per swing and can only aim at one at a time, so
+//     landing attacks on several distinct entities inside a few hundred ms is not humanly possible.
+//   - aim cone: a real client raytraces from the crosshair, so the target always sits roughly in
+//     front of the player. Hitting something well to the side or behind is an aura giveaway.
+// Defaults are monitor-only: violations are recorded and staff are alerted, but no hit is dropped
+// and no one is kicked unless a server explicitly opts in.
+internal static class StratumCombatGuard
+{
+	private static readonly object gate = new object();
+	private static readonly Dictionary<string, AttackState> states = new Dictionary<string, AttackState>(StringComparer.Ordinal);
+
+	public static void ForgetPlayer(string key)
+	{
+		if (string.IsNullOrEmpty(key))
+		{
+			return;
+		}
+
+		lock (gate)
+		{
+			states.Remove(key);
+		}
+	}
+
+	// Returns false only when the guard is configured to drop the hit (or kick). Default config
+	// always returns true, so vanilla behaviour is untouched.
+	public static bool TryAcceptAttack(ServerMain server, ConnectedClient client, Entity target, Cuboidd targetBox, double eyeX, double eyeY, double eyeZ, out string disconnectReason)
+	{
+		disconnectReason = null;
+		ServerPlayer player = client?.Player;
+		if (server == null || player?.Entity == null || target == null)
+		{
+			return true;
+		}
+
+		StratumRuntime.Config.EnsurePopulated();
+		StratumAnticheatConfig anticheat = StratumRuntime.Config.Anticheat;
+		StratumCombatAnticheatConfig config = anticheat.Combat;
+		if (!anticheat.Enabled || !config.Enabled)
+		{
+			return true;
+		}
+
+		// Skip creative/spectator so staff testing or one-shotting mobs never shows up as noise.
+		EnumGameMode mode = player.WorldData.CurrentGameMode;
+		if (mode == EnumGameMode.Creative || mode == EnumGameMode.Spectator)
+		{
+			return true;
+		}
+
+		string key = !string.IsNullOrWhiteSpace(player.PlayerUID) ? player.PlayerUID : player.PlayerName;
+		if (string.IsNullOrEmpty(key))
+		{
+			return true;
+		}
+
+		long now = server.ElapsedMilliseconds;
+		string reason = null;
+
+		if (config.DetectMultiTarget)
+		{
+			int distinct = RegisterMultiTarget(key, target.EntityId, now, config);
+			if (distinct >= config.MultiTargetThreshold)
+			{
+				reason = "aura: " + distinct + " targets in " + config.MultiTargetWindowMs + "ms";
+			}
+		}
+
+		if (reason == null && config.DetectAimCone)
+		{
+			string aimReason = CheckAimCone(player.Entity, targetBox, eyeX, eyeY, eyeZ, config);
+			if (aimReason != null)
+			{
+				reason = aimReason;
+			}
+		}
+
+		if (reason == null)
+		{
+			return true;
+		}
+
+		BlockPos pos = target.Pos?.AsBlockPos;
+		bool shouldKick = StratumAnticheatReporter.RecordCombatViolation(server, player, pos, reason, out disconnectReason);
+		if (shouldKick)
+		{
+			return false;
+		}
+
+		disconnectReason = null;
+		return !config.CancelFlaggedHits;
+	}
+
+	private static int RegisterMultiTarget(string key, long entityId, long now, StratumCombatAnticheatConfig config)
+	{
+		long window = config.MultiTargetWindowMs;
+		lock (gate)
+		{
+			if (!states.TryGetValue(key, out AttackState state))
+			{
+				state = new AttackState();
+				states[key] = state;
+			}
+
+			LinkedList<AttackHit> hits = state.RecentHits;
+			hits.AddLast(new AttackHit(entityId, now));
+
+			while (hits.Count > 0 && now - hits.First.Value.WhenMs > window)
+			{
+				hits.RemoveFirst();
+			}
+
+			// Bound memory if something floods attacks inside the window.
+			while (hits.Count > 64)
+			{
+				hits.RemoveFirst();
+			}
+
+			HashSet<long> distinct = new HashSet<long>();
+			foreach (AttackHit hit in hits)
+			{
+				distinct.Add(hit.EntityId);
+			}
+
+			return distinct.Count;
+		}
+	}
+
+	private static string CheckAimCone(EntityPlayer attacker, Cuboidd targetBox, double eyeX, double eyeY, double eyeZ, StratumCombatAnticheatConfig config)
+	{
+		if (targetBox == null || attacker?.Pos == null)
+		{
+			return null;
+		}
+
+		double centerX = (targetBox.X1 + targetBox.X2) * 0.5;
+		double centerY = (targetBox.Y1 + targetBox.Y2) * 0.5;
+		double centerZ = (targetBox.Z1 + targetBox.Z2) * 0.5;
+
+		double dx = centerX - eyeX;
+		double dy = centerY - eyeY;
+		double dz = centerZ - eyeZ;
+		double length = Math.Sqrt(dx * dx + dy * dy + dz * dz);
+		if (length < config.MinAngleCheckDistance || length <= 1e-6)
+		{
+			return null;
+		}
+
+		Vec3f view = attacker.Pos.GetViewVector();
+		double invLen = 1.0 / length;
+		double cosAngle = view.X * (dx * invLen) + view.Y * (dy * invLen) + view.Z * (dz * invLen);
+		cosAngle = Math.Clamp(cosAngle, -1.0, 1.0);
+
+		double cosThreshold = Math.Cos(config.MaxAttackAngleDegrees * Math.PI / 180.0);
+		if (cosAngle >= cosThreshold)
+		{
+			return null;
+		}
+
+		double angleDeg = Math.Acos(cosAngle) * 180.0 / Math.PI;
+		return "aim: " + angleDeg.ToString("0", System.Globalization.CultureInfo.InvariantCulture) + " deg off";
+	}
+
+	private readonly struct AttackHit
+	{
+		public AttackHit(long entityId, long whenMs)
+		{
+			EntityId = entityId;
+			WhenMs = whenMs;
+		}
+
+		public long EntityId { get; }
+
+		public long WhenMs { get; }
+	}
+
+	private sealed class AttackState
+	{
+		public LinkedList<AttackHit> RecentHits { get; } = new LinkedList<AttackHit>();
+	}
+}


### PR DESCRIPTION
Detect kill aura style combat cheats, and silent aim.

## Summary

Added detection for kill-aura or silent aimbot styled combat cheats, or cheats that target multiple entities at once or behind your FoV.

## Type

- [ ] Bug fix
- [ ] Performance
- [x] New feature
- [ ] Refactor or cleanup
- [ ] Docs or build

## Checklist

- [x] `.\scripts\extract-patches.ps1` ran clean.
- [x] `dotnet build VintageStory.slnx -c Release` is green.
- [x] Every vanilla edit has a `// Stratum` marker.
- [x] No vanilla source committed.
- [x] Tested on a real server start, not just compilation.