### PR TITLE
Implemented combat cheat detection and improved reach checks

### DIFF
--- a/patches/VintagestoryLib/Vintagestory.Server/ServerSystemEntitySimulation.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/ServerSystemEntitySimulation.cs.patch
@@ -1,5 +1,5 @@
 diff --git a/VintagestoryLib/Vintagestory.Server/ServerSystemEntitySimulation.cs b/VintagestoryLib/Vintagestory.Server/ServerSystemEntitySimulation.cs
-index 750557a..d7950fd 100644
+index 750557a..5cb19d7 100644
 --- a/VintagestoryLib/Vintagestory.Server/ServerSystemEntitySimulation.cs
 +++ b/VintagestoryLib/Vintagestory.Server/ServerSystemEntitySimulation.cs
 @@ -1,8 +1,12 @@
@@ -637,7 +637,7 @@ index 750557a..d7950fd 100644
  		}
  		ServerMain.FrameProfiler.Enter("despawning");
  		foreach (KeyValuePair<Entity, EntityDespawnData> item in list)
-@@ -222,27 +680,799 @@ public class ServerSystemEntitySimulation : ServerSystem
+@@ -222,27 +680,808 @@ public class ServerSystemEntitySimulation : ServerSystem
  			server.DespawnEntity(item.Key, item.Value);
  			ServerMain.FrameProfiler.Mark("despawned-", item.Key.Code.Path);
  		}
@@ -1426,6 +1426,15 @@ index 750557a..d7950fd 100644
 +			ServerMain.Logger.Debug("HandleEntityInteraction received from client " + client.PlayerName + " but no such entity found!");
 +			return;
 +		}
++		// Stratum: unified survival interaction reach (shares StratumReach with block reach).
++		if (!StratumEntityReachGuard.TryAcceptEntityInteract(server, client, entity, out string stratumEntityReachDisconnect))
++		{
++			if (stratumEntityReachDisconnect != null)
++			{
++				server.DisconnectPlayer(client, null, stratumEntityReachDisconnect);
++			}
++			return;
++		}
 +		EntityPos playerPos = player.Entity.Pos;
 +		double pickingRange = player.WorldData.PickingRange + 10f;
 +		double entityDx = entity.Pos.X - playerPos.X;
@@ -1441,7 +1450,7 @@ index 750557a..d7950fd 100644
  		ItemStack itemStack = client.Player.InventoryManager?.ActiveHotbarSlot?.Itemstack;
  		float num = itemStack?.Collectible.GetAttackRange(itemStack) ?? GlobalConstants.DefaultAttackRange;
  		double x = pos.X + client.Entityplayer.LocalEyePos.X;
-@@ -390,11 +1620,20 @@ public class ServerSystemEntitySimulation : ServerSystem
+@@ -390,11 +1629,20 @@ public class ServerSystemEntitySimulation : ServerSystem
  	{
  		if (deathMessagesCache == null)
  		{
@@ -1463,7 +1472,7 @@ index 750557a..d7950fd 100644
  			return;
  		}
  		int num = server.SaveGameData?.WorldConfiguration.GetString("playerlives", "-1").ToInt(-1) ?? (-1);
-@@ -428,10 +1667,11 @@ public class ServerSystemEntitySimulation : ServerSystem
+@@ -428,10 +1676,11 @@ public class ServerSystemEntitySimulation : ServerSystem
  			else
  			{
  				ServerMain.Logger.Audit(Lang.Get("{0} died. Death message: {1}", item.PlayerName, text));

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumAnticheatConfig.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumAnticheatConfig.cs
@@ -26,6 +26,8 @@ internal class StratumAnticheatConfig
 
 	public StratumNoFallAnticheatConfig NoFall { get; set; } = new StratumNoFallAnticheatConfig();
 
+	public StratumMultiBreakAnticheatConfig MultiBreak { get; set; } = new StratumMultiBreakAnticheatConfig();
+
 	public void EnsureSane()
 	{
 		MaxStoredViolationsPerPlayer = Math.Clamp(MaxStoredViolationsPerPlayer, 16, 2048);
@@ -37,6 +39,7 @@ internal class StratumAnticheatConfig
 		Movement ??= new StratumMovementAnticheatConfig();
 		Combat ??= new StratumCombatAnticheatConfig();
 		NoFall ??= new StratumNoFallAnticheatConfig();
+		MultiBreak ??= new StratumMultiBreakAnticheatConfig();
 		BlockEntityOutOfRange.EnsureSane();
 		BlockInteractionOutOfRange.EnsureSane();
 		EntityInteractionOutOfRange.EnsureSane();
@@ -44,6 +47,7 @@ internal class StratumAnticheatConfig
 		Movement.EnsureSane();
 		Combat.EnsureSane();
 		NoFall.EnsureSane();
+		MultiBreak.EnsureSane();
 	}
 }
 
@@ -303,5 +307,44 @@ internal class StratumNoFallAnticheatConfig : StratumAnticheatRuleConfig
 		MinDescentSpeed = Math.Clamp(MinDescentSpeed, 1.0, 30.0);
 		KickAfterViolations = Math.Clamp(KickAfterViolations, 3, 200);
 		KickMessage ??= "Disconnected by Stratum no-fall protection";
+	}
+}
+
+// Nuker / veinmine / multi-break
+internal class StratumMultiBreakAnticheatConfig : StratumAnticheatRuleConfig
+{
+	public StratumMultiBreakAnticheatConfig()
+	{
+		AlertAfterViolations = 2;
+		AlertWindowSeconds = 10;
+		RepeatAlertSeconds = 15;
+	}
+
+	public int WindowMs { get; set; } = 300;
+
+	public int MaxBreaksInWindow { get; set; } = 6;
+
+	// Cap on tracked positions per player so a huge radius nuke can't grow memory
+	public int MaxTrackedBreaks { get; set; } = 128;
+
+	// Off by default: monitor-only
+	public bool KickConfirmedCheats { get; set; } = false;
+
+	public int KickAfterViolations { get; set; } = 4;
+
+	public string KickMessage { get; set; } = "Disconnected by Stratum multi-break protection";
+
+	// when every hit lands dead-centre (0.5,0.5,0.5) can't come from a real raytrace, which always strikes a block surface. 
+	// Combined with the superhuman burst rate this is near-zero false-positive, so such a burst may kick immediately even while KickConfirmedCheats stays off.
+	public bool KickOnFingerprint { get; set; } = true;
+
+	public override void EnsureSane()
+	{
+		base.EnsureSane();
+		WindowMs = Math.Clamp(WindowMs, 50, 5000);
+		MaxBreaksInWindow = Math.Clamp(MaxBreaksInWindow, 3, 200);
+		MaxTrackedBreaks = Math.Clamp(MaxTrackedBreaks, MaxBreaksInWindow, 2048);
+		KickAfterViolations = Math.Clamp(KickAfterViolations, 2, 200);
+		KickMessage ??= "Disconnected by Stratum multi-break protection";
 	}
 }

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumAnticheatConfig.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumAnticheatConfig.cs
@@ -28,6 +28,8 @@ internal class StratumAnticheatConfig
 
 	public StratumMultiBreakAnticheatConfig MultiBreak { get; set; } = new StratumMultiBreakAnticheatConfig();
 
+	public StratumMovementAuthorityAnticheatConfig MovementAuthority { get; set; } = new StratumMovementAuthorityAnticheatConfig();
+
 	public void EnsureSane()
 	{
 		MaxStoredViolationsPerPlayer = Math.Clamp(MaxStoredViolationsPerPlayer, 16, 2048);
@@ -40,6 +42,7 @@ internal class StratumAnticheatConfig
 		Combat ??= new StratumCombatAnticheatConfig();
 		NoFall ??= new StratumNoFallAnticheatConfig();
 		MultiBreak ??= new StratumMultiBreakAnticheatConfig();
+		MovementAuthority ??= new StratumMovementAuthorityAnticheatConfig();
 		BlockEntityOutOfRange.EnsureSane();
 		BlockInteractionOutOfRange.EnsureSane();
 		EntityInteractionOutOfRange.EnsureSane();
@@ -48,6 +51,46 @@ internal class StratumAnticheatConfig
 		Combat.EnsureSane();
 		NoFall.EnsureSane();
 		MultiBreak.EnsureSane();
+		MovementAuthority.EnsureSane();
+	}
+}
+
+internal class StratumMovementAuthorityAnticheatConfig : StratumAnticheatRuleConfig
+{
+	public StratumMovementAuthorityAnticheatConfig()
+	{
+		AlertAfterViolations = 6;
+		AlertWindowSeconds = 10;
+		RepeatAlertSeconds = 15;
+	}
+
+	public bool DetectStepHeight { get; set; } = true;
+
+	public double MaxStepHeightBlocks { get; set; } = 1.3;
+
+	public double StepMaxHorizontalBlocks { get; set; } = 1.5;
+
+	public bool DetectAcceleration { get; set; } = true;
+
+	public double MaxSpeedJumpBlocksPerSecond { get; set; } = 16.0;
+
+	public double MinFlaggedSpeed { get; set; } = 12.0;
+
+	public bool KickConfirmedCheats { get; set; } = false;
+
+	public int KickAfterViolations { get; set; } = 8;
+
+	public string KickMessage { get; set; } = "Disconnected by Stratum movement protection";
+
+	public override void EnsureSane()
+	{
+		base.EnsureSane();
+		MaxStepHeightBlocks = Math.Clamp(MaxStepHeightBlocks, 1.05, 8.0);
+		StepMaxHorizontalBlocks = Math.Clamp(StepMaxHorizontalBlocks, 0.3, 8.0);
+		MaxSpeedJumpBlocksPerSecond = Math.Clamp(MaxSpeedJumpBlocksPerSecond, 4.0, 200.0);
+		MinFlaggedSpeed = Math.Clamp(MinFlaggedSpeed, 4.0, 200.0);
+		KickAfterViolations = Math.Clamp(KickAfterViolations, 3, 200);
+		KickMessage ??= "Disconnected by Stratum movement protection";
 	}
 }
 

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumAnticheatConfig.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumAnticheatConfig.cs
@@ -16,9 +16,13 @@ internal class StratumAnticheatConfig
 
 	public StratumBlockInteractionOutOfRangeAnticheatConfig BlockInteractionOutOfRange { get; set; } = new StratumBlockInteractionOutOfRangeAnticheatConfig();
 
+	public StratumEntityInteractionOutOfRangeAnticheatConfig EntityInteractionOutOfRange { get; set; } = new StratumEntityInteractionOutOfRangeAnticheatConfig();
+
 	public StratumBlockBreakProgressAnticheatConfig BlockBreakProgress { get; set; } = new StratumBlockBreakProgressAnticheatConfig();
 
 	public StratumMovementAnticheatConfig Movement { get; set; } = new StratumMovementAnticheatConfig();
+	
+	public StratumCombatAnticheatConfig Combat { get; set; } = new StratumCombatAnticheatConfig();
 
 	public void EnsureSane()
 	{
@@ -26,12 +30,16 @@ internal class StratumAnticheatConfig
 		KeepPlayerViolationsMinutes = Math.Clamp(KeepPlayerViolationsMinutes, 5, 1440);
 		BlockEntityOutOfRange ??= new StratumBlockEntityOutOfRangeAnticheatConfig();
 		BlockInteractionOutOfRange ??= new StratumBlockInteractionOutOfRangeAnticheatConfig();
+		EntityInteractionOutOfRange ??= new StratumEntityInteractionOutOfRangeAnticheatConfig();
 		BlockBreakProgress ??= new StratumBlockBreakProgressAnticheatConfig();
 		Movement ??= new StratumMovementAnticheatConfig();
+		Combat ??= new StratumCombatAnticheatConfig();
 		BlockEntityOutOfRange.EnsureSane();
 		BlockInteractionOutOfRange.EnsureSane();
+		EntityInteractionOutOfRange.EnsureSane();
 		BlockBreakProgress.EnsureSane();
 		Movement.EnsureSane();
+		Combat.EnsureSane();
 	}
 }
 
@@ -73,6 +81,27 @@ internal class StratumBlockInteractionOutOfRangeAnticheatConfig : StratumAntiche
 		RangeSlack = Math.Clamp(RangeSlack, 0, 4);
 		KickAfterViolations = Math.Clamp(KickAfterViolations, 2, 100);
 		KickMessage ??= "Disconnected by Stratum block reach protection";
+	}
+}
+
+// Reach on entity interactions (right-click: feed/trade/mount/melee). Same shape as block reach.
+// A slightly larger default slack absorbs the extra jitter of a moving target under lag.
+internal class StratumEntityInteractionOutOfRangeAnticheatConfig : StratumAnticheatRuleConfig
+{
+	public double RangeSlack { get; set; } = 1.0;
+
+	public bool KickConfirmedCheats { get; set; } = true;
+
+	public int KickAfterViolations { get; set; } = 3;
+
+	public string KickMessage { get; set; } = "Disconnected by Stratum entity reach protection";
+
+	public override void EnsureSane()
+	{
+		base.EnsureSane();
+		RangeSlack = Math.Clamp(RangeSlack, 0, 4);
+		KickAfterViolations = Math.Clamp(KickAfterViolations, 2, 100);
+		KickMessage ??= "Disconnected by Stratum entity reach protection";
 	}
 }
 
@@ -187,5 +216,59 @@ internal class StratumMovementAnticheatConfig : StratumAnticheatRuleConfig
 		GroundContactTolerance = Math.Clamp(GroundContactTolerance, 0.005, 0.2);
 		NoclipConsecutiveTicks = Math.Clamp(NoclipConsecutiveTicks, 2, 40);
 		KickMessage ??= "Disconnected by Stratum movement protection";
+	}
+}
+
+internal class StratumCombatAnticheatConfig : StratumAnticheatRuleConfig
+{
+	public StratumCombatAnticheatConfig()
+	{
+		// Aura hits arrive in fast bursts. Alert quickly but keep a little room for a burst of
+		// legitimate melee against a mob pile.
+		AlertAfterViolations = 6;
+		AlertWindowSeconds = 6;
+		RepeatAlertSeconds = 15;
+	}
+
+	// Attacking several distinct entities in a tiny window is physically impossible with a real
+	// client (one target per swing, one crosshair). This is the highest-confidence signal here.
+	public bool DetectMultiTarget { get; set; } = true;
+
+	public int MultiTargetWindowMs { get; set; } = 400;
+
+	public int MultiTargetThreshold { get; set; } = 3;
+
+	// Flags an attack whose target sits outside the player's aim cone. Kept generous so ordinary
+	// aiming plus lag never trips it; the point is to catch hits landed on entities beside or
+	// behind the player, which only an aura does.
+	public bool DetectAimCone { get; set; } = true;
+
+	public double MaxAttackAngleDegrees { get; set; } = 75.0;
+
+	// Skip the cone test when the target is basically touching the player, where the geometry of a
+	// large hitbox makes the angle meaningless.
+	public double MinAngleCheckDistance { get; set; } = 1.5;
+
+	// Combat heuristics start as monitor-only. Turn this on once a server has watched the
+	// /stratum ac combat data and is comfortable the false-positive rate is zero.
+	public bool KickConfirmedCheats { get; set; } = false;
+
+	public int KickAfterViolations { get; set; } = 12;
+
+	public string KickMessage { get; set; } = "Disconnected by Stratum combat protection";
+
+	// When on, a flagged hit is dropped instead of applied. Off by default so v1 never changes the
+	// outcome of any hit; a real client can't trigger these checks anyway.
+	public bool CancelFlaggedHits { get; set; } = false;
+
+	public override void EnsureSane()
+	{
+		base.EnsureSane();
+		MultiTargetWindowMs = Math.Clamp(MultiTargetWindowMs, 50, 5000);
+		MultiTargetThreshold = Math.Clamp(MultiTargetThreshold, 2, 20);
+		MaxAttackAngleDegrees = Math.Clamp(MaxAttackAngleDegrees, 30.0, 180.0);
+		MinAngleCheckDistance = Math.Clamp(MinAngleCheckDistance, 0.0, 8.0);
+		KickAfterViolations = Math.Clamp(KickAfterViolations, 3, 1000);
+		KickMessage ??= "Disconnected by Stratum combat protection";
 	}
 }

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumAnticheatConfig.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumAnticheatConfig.cs
@@ -21,8 +21,10 @@ internal class StratumAnticheatConfig
 	public StratumBlockBreakProgressAnticheatConfig BlockBreakProgress { get; set; } = new StratumBlockBreakProgressAnticheatConfig();
 
 	public StratumMovementAnticheatConfig Movement { get; set; } = new StratumMovementAnticheatConfig();
-	
+
 	public StratumCombatAnticheatConfig Combat { get; set; } = new StratumCombatAnticheatConfig();
+
+	public StratumNoFallAnticheatConfig NoFall { get; set; } = new StratumNoFallAnticheatConfig();
 
 	public void EnsureSane()
 	{
@@ -34,12 +36,14 @@ internal class StratumAnticheatConfig
 		BlockBreakProgress ??= new StratumBlockBreakProgressAnticheatConfig();
 		Movement ??= new StratumMovementAnticheatConfig();
 		Combat ??= new StratumCombatAnticheatConfig();
+		NoFall ??= new StratumNoFallAnticheatConfig();
 		BlockEntityOutOfRange.EnsureSane();
 		BlockInteractionOutOfRange.EnsureSane();
 		EntityInteractionOutOfRange.EnsureSane();
 		BlockBreakProgress.EnsureSane();
 		Movement.EnsureSane();
 		Combat.EnsureSane();
+		NoFall.EnsureSane();
 	}
 }
 
@@ -270,5 +274,34 @@ internal class StratumCombatAnticheatConfig : StratumAnticheatRuleConfig
 		MinAngleCheckDistance = Math.Clamp(MinAngleCheckDistance, 0.0, 8.0);
 		KickAfterViolations = Math.Clamp(KickAfterViolations, 3, 1000);
 		KickMessage ??= "Disconnected by Stratum combat protection";
+	}
+}
+
+internal class StratumNoFallAnticheatConfig : StratumAnticheatRuleConfig
+{
+	public StratumNoFallAnticheatConfig()
+	{
+		AlertAfterViolations = 5;
+		AlertWindowSeconds = 30;
+		RepeatAlertSeconds = 30;
+	}
+
+	public double MinFallBlocks { get; set; } = 5.0;
+
+	public double MinDescentSpeed { get; set; } = 4.0;
+
+	public bool KickConfirmedCheats { get; set; } = false;
+
+	public int KickAfterViolations { get; set; } = 10;
+
+	public string KickMessage { get; set; } = "Disconnected by Stratum no-fall protection";
+
+	public override void EnsureSane()
+	{
+		base.EnsureSane();
+		MinFallBlocks = Math.Clamp(MinFallBlocks, 3.0, 64.0);
+		MinDescentSpeed = Math.Clamp(MinDescentSpeed, 1.0, 30.0);
+		KickAfterViolations = Math.Clamp(KickAfterViolations, 3, 200);
+		KickMessage ??= "Disconnected by Stratum no-fall protection";
 	}
 }

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumAnticheatReporter.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumAnticheatReporter.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.Linq;
 using System.Text;
 using Vintagestory.API.Common;
+using Vintagestory.API.Common.Entities;
 using Vintagestory.API.Config;
 using Vintagestory.API.MathTools;
 using Vintagestory.API.Server;
@@ -14,8 +15,10 @@ internal static class StratumAnticheatReporter
 {
 	private const string BlockEntityOutOfRangeType = "block-entity-range";
 	private const string BlockInteractionOutOfRangeType = "block-interaction-range";
+	private const string EntityInteractionOutOfRangeType = "entity-interaction-range";
 	private const string BlockBreakProgressType = "block-break-progress";
 	private const string MovementType = "movement";
+	private const string CombatType = "combat";
 
 	private static readonly object Lock = new object();
 	private static readonly Dictionary<string, PlayerViolationState> PlayerViolations = new Dictionary<string, PlayerViolationState>(StringComparer.OrdinalIgnoreCase);
@@ -71,6 +74,42 @@ internal static class StratumAnticheatReporter
 			disconnectReason = string.IsNullOrWhiteSpace(config.BlockInteractionOutOfRange.KickMessage)
 				? "Disconnected by Stratum block reach protection"
 				: config.BlockInteractionOutOfRange.KickMessage;
+			return true;
+		}
+
+		return false;
+	}
+
+	public static bool RecordEntityInteractionOutOfRange(ServerMain server, ServerPlayer player, Entity target, double distance, double maxRange, out string disconnectReason)
+	{
+		disconnectReason = null;
+		if (server == null || player == null || target?.Pos == null)
+		{
+			return false;
+		}
+
+		StratumRuntime.Config.EnsurePopulated();
+		StratumAnticheatConfig config = StratumRuntime.Config.Anticheat;
+		if (!config.Enabled || !config.EntityInteractionOutOfRange.Enabled)
+		{
+			return false;
+		}
+
+		BlockPos pos = target.Pos.AsBlockPos;
+		string who = target.Code?.ToString() ?? target.EntityId.ToString(CultureInfo.InvariantCulture);
+		string detail = "entity " + who + " at " + FormatBlockPos(pos) + " distance=" + distance.ToString("0.##", CultureInfo.InvariantCulture) + "/" + maxRange.ToString("0.##", CultureInfo.InvariantCulture);
+		DateTime now = DateTime.UtcNow;
+		ViolationRecordResult result = RecordViolation(player, now, EntityInteractionOutOfRangeType, detail, config, config.EntityInteractionOutOfRange);
+		if (result.ShouldAlert)
+		{
+			SendStaffAlert(server, player, "survival entity reach", pos, result.RollingCount, result.TotalCount, config.EntityInteractionOutOfRange.AlertWindowSeconds);
+		}
+
+		if (config.EntityInteractionOutOfRange.KickConfirmedCheats && result.RollingCount >= config.EntityInteractionOutOfRange.KickAfterViolations)
+		{
+			disconnectReason = string.IsNullOrWhiteSpace(config.EntityInteractionOutOfRange.KickMessage)
+				? "Disconnected by Stratum entity reach protection"
+				: config.EntityInteractionOutOfRange.KickMessage;
 			return true;
 		}
 
@@ -139,6 +178,40 @@ internal static class StratumAnticheatReporter
 			disconnectReason = string.IsNullOrWhiteSpace(config.Movement.KickMessage)
 				? "Disconnected by Stratum movement protection"
 				: config.Movement.KickMessage;
+			return true;
+		}
+
+		return false;
+	}
+
+	public static bool RecordCombatViolation(ServerMain server, ServerPlayer player, BlockPos pos, string reason, out string disconnectReason)
+	{
+		disconnectReason = null;
+		if (server == null || player == null)
+		{
+			return false;
+		}
+
+		StratumRuntime.Config.EnsurePopulated();
+		StratumAnticheatConfig config = StratumRuntime.Config.Anticheat;
+		if (!config.Enabled || !config.Combat.Enabled)
+		{
+			return false;
+		}
+
+		string detail = string.IsNullOrWhiteSpace(reason) ? "combat" : reason;
+		DateTime now = DateTime.UtcNow;
+		ViolationRecordResult result = RecordViolation(player, now, CombatType, detail, config, config.Combat);
+		if (result.ShouldAlert)
+		{
+			SendStaffAlert(server, player, "combat", pos, result.RollingCount, result.TotalCount, config.Combat.AlertWindowSeconds);
+		}
+
+		if (config.Combat.KickConfirmedCheats && result.RollingCount >= config.Combat.KickAfterViolations)
+		{
+			disconnectReason = string.IsNullOrWhiteSpace(config.Combat.KickMessage)
+				? "Disconnected by Stratum combat protection"
+				: config.Combat.KickMessage;
 			return true;
 		}
 
@@ -250,6 +323,8 @@ internal static class StratumAnticheatReporter
 				return "Block break timing";
 			case MovementType:
 				return "Movement";
+			case CombatType:
+				return "Combat";
 			default:
 				return string.IsNullOrWhiteSpace(type) ? "Unknown" : type;
 		}
@@ -290,6 +365,20 @@ internal static class StratumAnticheatReporter
 		{
 			return "sent a block entity packet too far away at " + detail;
 		}
+
+				if (entry.Type == CombatType)
+		{
+			if (detail.StartsWith("aura:", StringComparison.OrdinalIgnoreCase))
+			{
+				return "attacked several entities at once (" + detail + ")";
+			}
+
+			if (detail.StartsWith("aim:", StringComparison.OrdinalIgnoreCase))
+			{
+				return "attacked an entity outside their aim (" + detail + ")";
+			}
+		}
+
 
 		return detail;
 	}

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumAnticheatReporter.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumAnticheatReporter.cs
@@ -20,6 +20,7 @@ internal static class StratumAnticheatReporter
 	private const string MovementType = "movement";
 	private const string CombatType = "combat";
 	private const string NoFallType = "no-fall";
+	private const string MultiBreakType = "multi-break";
 
 	private static readonly object Lock = new object();
 	private static readonly Dictionary<string, PlayerViolationState> PlayerViolations = new Dictionary<string, PlayerViolationState>(StringComparer.OrdinalIgnoreCase);
@@ -111,6 +112,44 @@ internal static class StratumAnticheatReporter
 			disconnectReason = string.IsNullOrWhiteSpace(config.EntityInteractionOutOfRange.KickMessage)
 				? "Disconnected by Stratum entity reach protection"
 				: config.EntityInteractionOutOfRange.KickMessage;
+			return true;
+		}
+
+		return false;
+	}
+
+	public static bool RecordMultiBreakViolation(ServerMain server, ServerPlayer player, BlockPos pos, int breaksInWindow, bool fingerprinted, out string disconnectReason)
+	{
+		disconnectReason = null;
+		if (server == null || player == null)
+		{
+			return false;
+		}
+
+		StratumRuntime.Config.EnsurePopulated();
+		StratumAnticheatConfig config = StratumRuntime.Config.Anticheat;
+		if (!config.Enabled || !config.MultiBreak.Enabled)
+		{
+			return false;
+		}
+
+		string detail = "broke " + breaksInWindow.ToString(CultureInfo.InvariantCulture) + " blocks in " + config.MultiBreak.WindowMs.ToString(CultureInfo.InvariantCulture) + "ms" + (fingerprinted ? " (all dead-centre hits)" : "") + (pos != null ? " near " + FormatBlockPos(pos) : "");
+		DateTime now = DateTime.UtcNow;
+		ViolationRecordResult result = RecordViolation(player, now, MultiBreakType, detail, config, config.MultiBreak);
+		if (result.ShouldAlert)
+		{
+			SendStaffAlert(server, player, "multi-break", pos, result.RollingCount, result.TotalCount, config.MultiBreak.AlertWindowSeconds);
+		}
+
+		// A dead-centre-hit burst is near-certain nuker, so it may kick on its own even while
+		// KickConfirmedCheats stays off; otherwise fall back to the usual monitor-first kick gate.
+		bool kickByFingerprint = fingerprinted && config.MultiBreak.KickOnFingerprint;
+		bool kickByCount = config.MultiBreak.KickConfirmedCheats && result.RollingCount >= config.MultiBreak.KickAfterViolations;
+		if (kickByFingerprint || kickByCount)
+		{
+			disconnectReason = string.IsNullOrWhiteSpace(config.MultiBreak.KickMessage)
+				? "Disconnected by Stratum multi-break protection"
+				: config.MultiBreak.KickMessage;
 			return true;
 		}
 

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumAnticheatReporter.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumAnticheatReporter.cs
@@ -21,6 +21,7 @@ internal static class StratumAnticheatReporter
 	private const string CombatType = "combat";
 	private const string NoFallType = "no-fall";
 	private const string MultiBreakType = "multi-break";
+	private const string MovementAuthorityType = "movement-authority";
 
 	private static readonly object Lock = new object();
 	private static readonly Dictionary<string, PlayerViolationState> PlayerViolations = new Dictionary<string, PlayerViolationState>(StringComparer.OrdinalIgnoreCase);
@@ -112,6 +113,45 @@ internal static class StratumAnticheatReporter
 			disconnectReason = string.IsNullOrWhiteSpace(config.EntityInteractionOutOfRange.KickMessage)
 				? "Disconnected by Stratum entity reach protection"
 				: config.EntityInteractionOutOfRange.KickMessage;
+			return true;
+		}
+
+		return false;
+	}
+
+	public static bool RecordMovementAuthorityViolation(ServerMain server, ServerPlayer player, BlockPos pos, string reason, out string disconnectReason)
+	{
+		disconnectReason = null;
+		if (server == null || player == null)
+		{
+			return false;
+		}
+
+		StratumRuntime.Config.EnsurePopulated();
+		StratumAnticheatConfig config = StratumRuntime.Config.Anticheat;
+		if (!config.Enabled || !config.MovementAuthority.Enabled)
+		{
+			return false;
+		}
+
+		string detail = string.IsNullOrWhiteSpace(reason) ? "movement authority" : reason;
+		if (pos != null)
+		{
+			detail += " at " + FormatBlockPos(pos);
+		}
+
+		DateTime now = DateTime.UtcNow;
+		ViolationRecordResult result = RecordViolation(player, now, MovementAuthorityType, detail, config, config.MovementAuthority);
+		if (result.ShouldAlert)
+		{
+			SendStaffAlert(server, player, "movement authority", pos, result.RollingCount, result.TotalCount, config.MovementAuthority.AlertWindowSeconds);
+		}
+
+		if (config.MovementAuthority.KickConfirmedCheats && result.RollingCount >= config.MovementAuthority.KickAfterViolations)
+		{
+			disconnectReason = string.IsNullOrWhiteSpace(config.MovementAuthority.KickMessage)
+				? "Disconnected by Stratum movement protection"
+				: config.MovementAuthority.KickMessage;
 			return true;
 		}
 

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumAnticheatReporter.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumAnticheatReporter.cs
@@ -19,6 +19,7 @@ internal static class StratumAnticheatReporter
 	private const string BlockBreakProgressType = "block-break-progress";
 	private const string MovementType = "movement";
 	private const string CombatType = "combat";
+	private const string NoFallType = "no-fall";
 
 	private static readonly object Lock = new object();
 	private static readonly Dictionary<string, PlayerViolationState> PlayerViolations = new Dictionary<string, PlayerViolationState>(StringComparer.OrdinalIgnoreCase);
@@ -110,6 +111,40 @@ internal static class StratumAnticheatReporter
 			disconnectReason = string.IsNullOrWhiteSpace(config.EntityInteractionOutOfRange.KickMessage)
 				? "Disconnected by Stratum entity reach protection"
 				: config.EntityInteractionOutOfRange.KickMessage;
+			return true;
+		}
+
+		return false;
+	}
+
+	public static bool RecordNoFallViolation(ServerMain server, ServerPlayer player, BlockPos pos, double fallBlocks, out string disconnectReason)
+	{
+		disconnectReason = null;
+		if (server == null || player == null)
+		{
+			return false;
+		}
+
+		StratumRuntime.Config.EnsurePopulated();
+		StratumAnticheatConfig config = StratumRuntime.Config.Anticheat;
+		if (!config.Enabled || !config.NoFall.Enabled)
+		{
+			return false;
+		}
+
+		string detail = "fell " + fallBlocks.ToString("0.#", CultureInfo.InvariantCulture) + " blocks with no fall damage" + (pos != null ? " at " + FormatBlockPos(pos) : "");
+		DateTime now = DateTime.UtcNow;
+		ViolationRecordResult result = RecordViolation(player, now, NoFallType, detail, config, config.NoFall);
+		if (result.ShouldAlert)
+		{
+			SendStaffAlert(server, player, "no-fall", pos, result.RollingCount, result.TotalCount, config.NoFall.AlertWindowSeconds);
+		}
+
+		if (config.NoFall.KickConfirmedCheats && result.RollingCount >= config.NoFall.KickAfterViolations)
+		{
+			disconnectReason = string.IsNullOrWhiteSpace(config.NoFall.KickMessage)
+				? "Disconnected by Stratum no-fall protection"
+				: config.NoFall.KickMessage;
 			return true;
 		}
 

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumBlockBreakGuard.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumBlockBreakGuard.cs
@@ -101,6 +101,15 @@ internal sealed class StratumBlockBreakGuard
 		}
 
 		ServerPlayer player = client.Player;
+		long now = server.ElapsedMilliseconds;
+
+		// Nuker / veinmine check. Runs before the per-block progress checks below so it also catches bursts of instant-break blocks
+		// Only returns false when it has escalated to a kick
+		if (CheckMultiBreak(server, client, player, requestedSelection.Position, requestedSelection.HitPosition, now, out disconnectReason))
+		{
+			return false;
+		}
+
 		ItemSlot activeSlot = player.inventoryMgr.ActiveHotbarSlot;
 		float resistance = Math.Max(0f, block.GetResistance(server.BlockAccessor, requestedSelection.Position));
 		float damagePerSecond = CalculateDamagePerSecond(server, player, requestedSelection, block, activeSlot);
@@ -113,7 +122,6 @@ internal sealed class StratumBlockBreakGuard
 
 		string reason = null;
 		bool canLog = false;
-		long now = server.ElapsedMilliseconds;
 
 		lock (gate)
 		{
@@ -245,6 +253,51 @@ internal sealed class StratumBlockBreakGuard
 		}
 	}
 
+	// Flags a burst too many distinct break positions from one client inside the configured window. 
+	// Records one violation per burst, returns true only when the reporter escalates to a kick.
+	private bool CheckMultiBreak(ServerMain server, ConnectedClient client, ServerPlayer player, BlockPos pos, Vec3d hit, long now, out string disconnectReason)
+	{
+		disconnectReason = null;
+		StratumMultiBreakAnticheatConfig mb = StratumRuntime.Config.Anticheat.MultiBreak;
+		if (mb == null || !StratumRuntime.Config.Anticheat.Enabled || !mb.Enabled)
+		{
+			return false;
+		}
+
+		bool centerHit = IsCenterHit(hit);
+		int distinct;
+		int centerHits;
+		lock (gate)
+		{
+			ClientBreakState state = GetOrCreateState(client.Id);
+			distinct = state.RegisterRecentBreak(pos, centerHit, now, Math.Max(1, mb.WindowMs), mb.MaxTrackedBreaks);
+			if (distinct <= mb.MaxBreaksInWindow || now < state.MultiBreakCooldownUntilMs)
+			{
+				return false;
+			}
+
+			centerHits = state.CountCenterHits();
+
+			// One burst one violation, cool down and clear so the rest of the wave stays quiet.
+			state.MultiBreakCooldownUntilMs = now + Math.Max(1, mb.WindowMs);
+			state.ClearRecentBreaks();
+		}
+
+		bool fingerprinted = distinct > 0 && centerHits >= distinct;
+		return StratumAnticheatReporter.RecordMultiBreakViolation(server, player, pos, distinct, fingerprinted, out disconnectReason);
+	}
+
+	private static bool IsCenterHit(Vec3d hit)
+	{
+		if (hit == null)
+		{
+			return false;
+		}
+
+		const double t = 0.02;
+		return Math.Abs(hit.X - 0.5) < t && Math.Abs(hit.Y - 0.5) < t && Math.Abs(hit.Z - 0.5) < t;
+	}
+
 	private static Block GetBreakBlock(ServerMain server, BlockPos pos)
 	{
 		Block fluidLayerBlock = server.WorldMap.RelaxedBlockAccess.GetBlock(pos, 2);
@@ -303,9 +356,12 @@ internal sealed class StratumBlockBreakGuard
 	private sealed class ClientBreakState
 	{
 		private readonly Dictionary<BreakKey, RememberedBreak> rememberedBreaks = new Dictionary<BreakKey, RememberedBreak>();
+		private readonly List<RecentBreak> recentBreaks = new List<RecentBreak>();
 		private BlockPos position;
 		private int blockId;
 		private long lastViolationLogMs = long.MinValue;
+
+		public long MultiBreakCooldownUntilMs { get; set; }
 
 		public float RequiredResistance { get; set; }
 
@@ -315,11 +371,80 @@ internal sealed class StratumBlockBreakGuard
 
 		public long LastObservedMs { get; set; }
 
-		public long LeftMouseHeldSinceMs { get; set; } // Stratum: tracks when left-click started regardless of raytrace
+		public long LeftMouseHeldSinceMs { get; set; } // tracks when left-click started regardless of raytrace
 
 		public bool IsTracking(BlockPos pos, int forBlockId)
 		{
 			return position != null && position.Equals(pos) && blockId == forBlockId;
+		}
+
+		// Registers a break at pos and returns the number of distinct block positions broken within the last windowMs
+		public int RegisterRecentBreak(BlockPos pos, bool centerHit, long nowMs, int windowMs, int maxTracked)
+		{
+			int drop = 0;
+			while (drop < recentBreaks.Count && nowMs - recentBreaks[drop].Ms > windowMs)
+			{
+				drop++;
+			}
+
+			if (drop > 0)
+			{
+				recentBreaks.RemoveRange(0, drop);
+			}
+
+			bool already = false;
+			for (int i = 0; i < recentBreaks.Count; i++)
+			{
+				if (recentBreaks[i].X == pos.X && recentBreaks[i].Y == pos.Y && recentBreaks[i].Z == pos.Z)
+				{
+					already = true;
+					break;
+				}
+			}
+
+			if (!already && recentBreaks.Count < maxTracked)
+			{
+				recentBreaks.Add(new RecentBreak(nowMs, pos.X, pos.Y, pos.Z, centerHit));
+			}
+
+			return recentBreaks.Count;
+		}
+
+		public void ClearRecentBreaks()
+		{
+			recentBreaks.Clear();
+		}
+
+		public int CountCenterHits()
+		{
+			int count = 0;
+			for (int i = 0; i < recentBreaks.Count; i++)
+			{
+				if (recentBreaks[i].Center)
+				{
+					count++;
+				}
+			}
+
+			return count;
+		}
+
+		private readonly struct RecentBreak
+		{
+			public readonly long Ms;
+			public readonly int X;
+			public readonly int Y;
+			public readonly int Z;
+			public readonly bool Center;
+
+			public RecentBreak(long ms, int x, int y, int z, bool center)
+			{
+				Ms = ms;
+				X = x;
+				Y = y;
+				Z = z;
+				Center = center;
+			}
 		}
 
 		public void Start(BlockPos pos, int forBlockId, long nowMs, StratumBlockBreakGuardsConfig config)

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumBlockReachGuard.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumBlockReachGuard.cs
@@ -33,14 +33,13 @@ internal static class StratumBlockReachGuard
 			return true;
 		}
 
-		double maxRange = Math.Max(0, player.WorldData.PickingRange) + Math.Max(0, config.RangeSlack);
-		double distanceSq = DistanceSqToBlock(player, selection.Position);
-		if (distanceSq <= maxRange * maxRange)
+		double maxRange = StratumReach.MaxReach(player, config.RangeSlack);
+		double distance = StratumReach.BlockDistance(player, selection.Position);
+		if (distance <= maxRange)
 		{
 			return true;
 		}
 
-		double distance = Math.Sqrt(distanceSq);
 		ServerMain.Logger.Audit(
 			"{0} tried to {1} a block out of survival reach {2:0.##}/{3:0.##} at {4}",
 			player.PlayerName,
@@ -57,25 +56,6 @@ internal static class StratumBlockReachGuard
 
 		disconnectReason = null;
 		return false;
-	}
-
-	private static double DistanceSqToBlock(ServerPlayer player, BlockPos pos)
-	{
-		FastVec3d eyes = player.Entity.Pos.XYZFast.Add(player.Entity.LocalEyePos);
-		double nearestX = Clamp(eyes.X, pos.X, pos.X + 1);
-		double nearestY = Clamp(eyes.Y, pos.InternalY, pos.InternalY + 1);
-		double nearestZ = Clamp(eyes.Z, pos.Z, pos.Z + 1);
-		double dx = eyes.X - nearestX;
-		double dy = eyes.Y - nearestY;
-		double dz = eyes.Z - nearestZ;
-		return dx * dx + dy * dy + dz * dz;
-	}
-
-	private static double Clamp(double value, double min, double max)
-	{
-		if (value < min) return min;
-		if (value > max) return max;
-		return value;
 	}
 
 	private static string ActionName(int mode)

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumCombatGuard.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumCombatGuard.cs
@@ -1,0 +1,192 @@
+using System;
+using System.Collections.Generic;
+using Vintagestory.API.Common;
+using Vintagestory.API.Common.Entities;
+using Vintagestory.API.MathTools;
+
+namespace Vintagestory.Server;
+
+// Kill-aura / aimbot heuristics layered on top of the vanilla attack range check. Runs only for
+// attack (left-click) interactions. Two signals, both chosen so a real vanilla client can never
+// trip them:
+//   - multi-target: a human hits one entity per swing and can only aim at one at a time, so
+//     landing attacks on several distinct entities inside a few hundred ms is not humanly possible.
+//   - aim cone: a real client raytraces from the crosshair, so the target always sits roughly in
+//     front of the player. Hitting something well to the side or behind is an aura giveaway.
+// Defaults are monitor-only: violations are recorded and staff are alerted, but no hit is dropped
+// and no one is kicked unless a server explicitly opts in.
+internal static class StratumCombatGuard
+{
+	private static readonly object gate = new object();
+	private static readonly Dictionary<string, AttackState> states = new Dictionary<string, AttackState>(StringComparer.Ordinal);
+
+	public static void ForgetPlayer(string key)
+	{
+		if (string.IsNullOrEmpty(key))
+		{
+			return;
+		}
+
+		lock (gate)
+		{
+			states.Remove(key);
+		}
+	}
+
+	// Returns false only when the guard is configured to drop the hit (or kick). Default config
+	// always returns true, so vanilla behaviour is untouched.
+	public static bool TryAcceptAttack(ServerMain server, ConnectedClient client, Entity target, Cuboidd targetBox, double eyeX, double eyeY, double eyeZ, out string disconnectReason)
+	{
+		disconnectReason = null;
+		ServerPlayer player = client?.Player;
+		if (server == null || player?.Entity == null || target == null)
+		{
+			return true;
+		}
+
+		StratumRuntime.Config.EnsurePopulated();
+		StratumAnticheatConfig anticheat = StratumRuntime.Config.Anticheat;
+		StratumCombatAnticheatConfig config = anticheat.Combat;
+		if (!anticheat.Enabled || !config.Enabled)
+		{
+			return true;
+		}
+
+		// Skip creative/spectator so staff testing or one-shotting mobs never shows up as noise.
+		EnumGameMode mode = player.WorldData.CurrentGameMode;
+		if (mode == EnumGameMode.Creative || mode == EnumGameMode.Spectator)
+		{
+			return true;
+		}
+
+		string key = !string.IsNullOrWhiteSpace(player.PlayerUID) ? player.PlayerUID : player.PlayerName;
+		if (string.IsNullOrEmpty(key))
+		{
+			return true;
+		}
+
+		long now = server.ElapsedMilliseconds;
+		string reason = null;
+
+		if (config.DetectMultiTarget)
+		{
+			int distinct = RegisterMultiTarget(key, target.EntityId, now, config);
+			if (distinct >= config.MultiTargetThreshold)
+			{
+				reason = "aura: " + distinct + " targets in " + config.MultiTargetWindowMs + "ms";
+			}
+		}
+
+		if (reason == null && config.DetectAimCone)
+		{
+			string aimReason = CheckAimCone(player.Entity, targetBox, eyeX, eyeY, eyeZ, config);
+			if (aimReason != null)
+			{
+				reason = aimReason;
+			}
+		}
+
+		if (reason == null)
+		{
+			return true;
+		}
+
+		BlockPos pos = target.Pos?.AsBlockPos;
+		bool shouldKick = StratumAnticheatReporter.RecordCombatViolation(server, player, pos, reason, out disconnectReason);
+		if (shouldKick)
+		{
+			return false;
+		}
+
+		disconnectReason = null;
+		return !config.CancelFlaggedHits;
+	}
+
+	private static int RegisterMultiTarget(string key, long entityId, long now, StratumCombatAnticheatConfig config)
+	{
+		long window = config.MultiTargetWindowMs;
+		lock (gate)
+		{
+			if (!states.TryGetValue(key, out AttackState state))
+			{
+				state = new AttackState();
+				states[key] = state;
+			}
+
+			LinkedList<AttackHit> hits = state.RecentHits;
+			hits.AddLast(new AttackHit(entityId, now));
+
+			while (hits.Count > 0 && now - hits.First.Value.WhenMs > window)
+			{
+				hits.RemoveFirst();
+			}
+
+			// Bound memory if something floods attacks inside the window.
+			while (hits.Count > 64)
+			{
+				hits.RemoveFirst();
+			}
+
+			HashSet<long> distinct = new HashSet<long>();
+			foreach (AttackHit hit in hits)
+			{
+				distinct.Add(hit.EntityId);
+			}
+
+			return distinct.Count;
+		}
+	}
+
+	private static string CheckAimCone(EntityPlayer attacker, Cuboidd targetBox, double eyeX, double eyeY, double eyeZ, StratumCombatAnticheatConfig config)
+	{
+		if (targetBox == null || attacker?.Pos == null)
+		{
+			return null;
+		}
+
+		double centerX = (targetBox.X1 + targetBox.X2) * 0.5;
+		double centerY = (targetBox.Y1 + targetBox.Y2) * 0.5;
+		double centerZ = (targetBox.Z1 + targetBox.Z2) * 0.5;
+
+		double dx = centerX - eyeX;
+		double dy = centerY - eyeY;
+		double dz = centerZ - eyeZ;
+		double length = Math.Sqrt(dx * dx + dy * dy + dz * dz);
+		if (length < config.MinAngleCheckDistance || length <= 1e-6)
+		{
+			return null;
+		}
+
+		Vec3f view = attacker.Pos.GetViewVector();
+		double invLen = 1.0 / length;
+		double cosAngle = view.X * (dx * invLen) + view.Y * (dy * invLen) + view.Z * (dz * invLen);
+		cosAngle = Math.Clamp(cosAngle, -1.0, 1.0);
+
+		double cosThreshold = Math.Cos(config.MaxAttackAngleDegrees * Math.PI / 180.0);
+		if (cosAngle >= cosThreshold)
+		{
+			return null;
+		}
+
+		double angleDeg = Math.Acos(cosAngle) * 180.0 / Math.PI;
+		return "aim: " + angleDeg.ToString("0", System.Globalization.CultureInfo.InvariantCulture) + " deg off";
+	}
+
+	private readonly struct AttackHit
+	{
+		public AttackHit(long entityId, long whenMs)
+		{
+			EntityId = entityId;
+			WhenMs = whenMs;
+		}
+
+		public long EntityId { get; }
+
+		public long WhenMs { get; }
+	}
+
+	private sealed class AttackState
+	{
+		public LinkedList<AttackHit> RecentHits { get; } = new LinkedList<AttackHit>();
+	}
+}

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumEntityReachGuard.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumEntityReachGuard.cs
@@ -1,0 +1,55 @@
+using Vintagestory.API.Common;
+using Vintagestory.API.Common.Entities;
+
+namespace Vintagestory.Server;
+
+// Survival reach check for entity interactions (right-click: feed, trade, mount, and melee).
+// Mirrors StratumBlockReachGuard and shares StratumReach, so an entity is no more reachable than a
+// block: nothing interactable beyond PickingRange + slack. Vanilla only enforces entity reach
+// loosely (a coarse horizontal range, and a stricter check gated behind server AntiAbuse), so this
+// closes the reach-hack gap uniformly.
+internal static class StratumEntityReachGuard
+{
+	// Returns true to accept. On false the caller must not process the interaction; when
+	// disconnectReason is non-null it should also disconnect the player.
+	public static bool TryAcceptEntityInteract(ServerMain server, ConnectedClient client, Entity target, out string disconnectReason)
+	{
+		disconnectReason = null;
+		ServerPlayer player = client?.Player;
+		if (server == null || player?.Entity == null || target?.Pos == null)
+		{
+			return true;
+		}
+
+		StratumRuntime.Config.EnsurePopulated();
+		StratumAnticheatConfig anticheat = StratumRuntime.Config.Anticheat;
+		StratumEntityInteractionOutOfRangeAnticheatConfig config = anticheat.EntityInteractionOutOfRange;
+		if (!anticheat.Enabled || !config.Enabled || player.WorldData.CurrentGameMode != EnumGameMode.Survival)
+		{
+			return true;
+		}
+
+		double maxRange = StratumReach.MaxReach(player, config.RangeSlack);
+		double distance = StratumReach.EntityDistance(player, target);
+		if (distance <= maxRange)
+		{
+			return true;
+		}
+
+		ServerMain.Logger.Audit(
+			"{0} tried to interact with entity {1} out of survival reach {2:0.##}/{3:0.##}",
+			player.PlayerName,
+			target.Code?.ToString() ?? target.EntityId.ToString(),
+			distance,
+			maxRange);
+
+		bool shouldKick = StratumAnticheatReporter.RecordEntityInteractionOutOfRange(server, player, target, distance, maxRange, out disconnectReason);
+		if (shouldKick)
+		{
+			return false;
+		}
+
+		disconnectReason = null;
+		return false;
+	}
+}

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumMovementGuard.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumMovementGuard.cs
@@ -163,9 +163,108 @@ internal static class StratumMovementGuard
 			}
 		}
 
+		// step-height + acceleration, both position-derived
+		if (CheckMovementAuthority(server, player, entity, feetCell, state, groundContact, now, out disconnectReason))
+		{
+			return false;
+		}
+		UpdateAuthorityState(state, entity, now, groundContact);
+
 		state.HasLastY = true;
 		state.LastY = entity.Pos.Y;
 		return true;
+	}
+
+	private static bool CheckMovementAuthority(ServerMain server, ServerPlayer player, EntityPlayer entity, BlockPos feetCell, MoveState state, bool groundContact, long now, out string disconnectReason)
+	{
+		disconnectReason = null;
+		StratumMovementAuthorityAnticheatConfig cfg = StratumRuntime.Config.Anticheat.MovementAuthority;
+		if (cfg == null || !StratumRuntime.Config.Anticheat.Enabled || !cfg.Enabled || !state.HasPrevAuth || entity.MountedOn != null)
+		{
+			return false;
+		}
+
+		double dx = entity.Pos.X - state.PrevX;
+		double dy = entity.Pos.Y - state.PrevY;
+		double dz = entity.Pos.Z - state.PrevZ;
+		double horiz = Math.Sqrt(dx * dx + dz * dz);
+		double dt = Math.Max(0.02, (now - state.PrevMs) / 1000.0);
+
+		string reason = null;
+
+		// Step-height, rose more than a legal step between two consecutive on-ground packets while barely moving horizontally (stepped straight up in place, no jump)
+		if (cfg.DetectStepHeight
+			&& groundContact && state.PrevGrounded
+			&& dy > cfg.MaxStepHeightBlocks
+			&& horiz <= cfg.StepMaxHorizontalBlocks
+			&& !FeetClimbableOrLiquid(server, feetCell))
+		{
+			reason = $"step-height: rose {dy:0.##} blocks on ground, no jump";
+		}
+
+		// horizontal speed jumped suddenly to a high value in one packet, a blink that stays under the peak speed cap.
+		if (reason == null && cfg.DetectAcceleration && horiz >= 0.75)
+		{
+			double vH = horiz / dt;
+			double jump = vH - state.PrevHorizVel;
+			if (jump >= cfg.MaxSpeedJumpBlocksPerSecond && vH >= cfg.MinFlaggedSpeed)
+			{
+				reason = $"acceleration: horizontal speed jumped {jump:0.#} to {vH:0.#} b/s";
+			}
+		}
+
+		if (reason == null)
+		{
+			return false;
+		}
+
+		return StratumAnticheatReporter.RecordMovementAuthorityViolation(server, player, entity.Pos.AsBlockPos, reason, out disconnectReason);
+	}
+
+	private static void UpdateAuthorityState(MoveState state, EntityPlayer entity, long now, bool groundContact)
+	{
+		if (state.HasPrevAuth)
+		{
+			double dx = entity.Pos.X - state.PrevX;
+			double dz = entity.Pos.Z - state.PrevZ;
+			double dt = Math.Max(0.02, (now - state.PrevMs) / 1000.0);
+			state.PrevHorizVel = Math.Sqrt(dx * dx + dz * dz) / dt;
+		}
+		else
+		{
+			state.PrevHorizVel = 0;
+		}
+
+		state.PrevX = entity.Pos.X;
+		state.PrevY = entity.Pos.Y;
+		state.PrevZ = entity.Pos.Z;
+		state.PrevMs = now;
+		state.PrevGrounded = groundContact;
+		state.HasPrevAuth = true;
+	}
+
+	private static bool FeetClimbableOrLiquid(ServerMain server, BlockPos feetCell)
+	{
+		var blocks = server.WorldMap.RelaxedBlockAccess;
+		int feetY = feetCell.Y;
+		BlockPos probe = feetCell.Copy();
+		for (int d = -1; d <= 1; d++)
+		{
+			probe.Y = feetY + d;
+			Block b = blocks.GetBlock(probe);
+			if (b != null && b.Climbable)
+			{
+				return true;
+			}
+
+			Block fluid = blocks.GetBlock(probe, 2);
+			if (fluid != null && fluid.IsLiquid())
+			{
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	private static void ResetAirborne(MoveState state)
@@ -556,5 +655,14 @@ internal static class StratumMovementGuard
 		public float HealthWhenGrounded;
 		public bool TouchedLiquidSinceGround;
 		public bool TouchedGlideSinceGround;
+
+		// Movement authority (step-height / acceleration)
+		public bool HasPrevAuth;
+		public double PrevX;
+		public double PrevY;
+		public double PrevZ;
+		public long PrevMs;
+		public double PrevHorizVel;
+		public bool PrevGrounded;
 	}
 }

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumMovementGuard.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumMovementGuard.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using Vintagestory.API.Common;
 using Vintagestory.API.Common.Entities;
+using Vintagestory.API.Datastructures;
 using Vintagestory.API.MathTools;
 
 namespace Vintagestory.Server;
@@ -72,6 +73,11 @@ internal static class StratumMovementGuard
 		if (groundContact)
 		{
 			state.LastGroundContactMs = now;
+		}
+
+		if (CheckNoFall(server, player, entity, feetCell, state, groundContact, now, out disconnectReason))
+		{
+			return false;
 		}
 
 		bool supported = IsSupported(server, entity, feetCell, config, groundContact);
@@ -407,6 +413,125 @@ internal static class StratumMovementGuard
 		return false;
 	}
 
+	private static bool CheckNoFall(ServerMain server, ServerPlayer player, EntityPlayer entity, BlockPos feetCell, MoveState state, bool groundContact, long now, out string disconnectReason)
+	{
+		disconnectReason = null;
+
+		StratumNoFallAnticheatConfig config = StratumRuntime.Config.Anticheat.NoFall;
+		if (config == null || !config.Enabled || entity.Properties == null || !entity.Properties.FallDamage)
+		{
+			state.TrackingGround = false;
+			return false;
+		}
+
+		float health = ReadHealth(entity);
+
+		if (!groundContact)
+		{
+			// Airborne, track the fall peak and note anything that would legitimately cushion it.
+			if (state.TrackingGround)
+			{
+				if (entity.Pos.Y > state.FallPeakY)
+				{
+					state.FallPeakY = entity.Pos.Y;
+				}
+
+				if (entity.Controls != null && entity.Controls.Gliding)
+				{
+					state.TouchedGlideSinceGround = true;
+				}
+
+				if (!state.TouchedLiquidSinceGround && FeetInLiquid(server, feetCell))
+				{
+					state.TouchedLiquidSinceGround = true;
+				}
+			}
+
+			return false;
+		}
+
+		// Landed on solid ground, evaluate the fall that just completed, then reset the baseline.
+		bool kick = false;
+		if (state.TrackingGround)
+		{
+			double descent = state.FallPeakY - entity.Pos.Y;
+			double seconds = Math.Max(0.05, (now - state.GroundedMs) / 1000.0);
+			double speed = descent / seconds;
+			bool healthKnown = health >= 0f && state.HealthWhenGrounded >= 0f;
+			bool healthPreserved = healthKnown && health >= state.HealthWhenGrounded - 0.001f;
+
+			if (descent >= config.MinFallBlocks
+				&& speed >= config.MinDescentSpeed
+				&& !state.TouchedGlideSinceGround
+				&& !state.TouchedLiquidSinceGround
+				&& healthPreserved
+				&& !LiquidInColumn(server, entity, feetCell, state.FallPeakY))
+			{
+				kick = StratumAnticheatReporter.RecordNoFallViolation(server, player, feetCell, descent, out disconnectReason);
+			}
+		}
+
+		state.TrackingGround = true;
+		state.FallPeakY = entity.Pos.Y;
+		state.GroundedMs = now;
+		state.HealthWhenGrounded = health;
+		state.TouchedLiquidSinceGround = false;
+		state.TouchedGlideSinceGround = false;
+
+		return kick;
+	}
+
+	private static float ReadHealth(EntityPlayer entity)
+	{
+		ITreeAttribute tree = entity.WatchedAttributes?.GetTreeAttribute("health");
+		return tree?.GetFloat("currenthealth", -1f) ?? -1f;
+	}
+
+	private static bool FeetInLiquid(ServerMain server, BlockPos feetCell)
+	{
+		var blocks = server.WorldMap.RelaxedBlockAccess;
+		Block feet = blocks.GetBlock(feetCell, 2);
+		if (feet != null && feet.IsLiquid())
+		{
+			return true;
+		}
+
+		BlockPos below = feetCell.Copy();
+		below.Y--;
+		Block b = blocks.GetBlock(below, 2);
+		return b != null && b.IsLiquid();
+	}
+
+	// Any liquid in the landing column up to the fall peak means water broke the fall - exempt.
+	private static bool LiquidInColumn(ServerMain server, EntityPlayer entity, BlockPos feetCell, double peakY)
+	{
+		int count = (int)Math.Ceiling(peakY - entity.Pos.Y);
+		if (count <= 0)
+		{
+			return false;
+		}
+
+		if (count > 64)
+		{
+			count = 64;
+		}
+
+		var blocks = server.WorldMap.RelaxedBlockAccess;
+		BlockPos probe = feetCell.Copy();
+		int baseY = feetCell.Y;
+		for (int d = 0; d <= count; d++)
+		{
+			probe.Y = baseY + d;
+			Block b = blocks.GetBlock(probe, 2);
+			if (b != null && b.IsLiquid())
+			{
+				return true;
+			}
+		}
+
+		return false;
+	}
+
 	private sealed class MoveState
 	{
 		public bool Airborne;
@@ -423,5 +548,13 @@ internal static class StratumMovementGuard
 		public double SafeX;
 		public double SafeY;
 		public double SafeZ;
+
+		// NoFall tracking.
+		public bool TrackingGround;
+		public double FallPeakY;
+		public long GroundedMs;
+		public float HealthWhenGrounded;
+		public bool TouchedLiquidSinceGround;
+		public bool TouchedGlideSinceGround;
 	}
 }

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumReach.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumReach.cs
@@ -1,0 +1,59 @@
+using System;
+using Vintagestory.API.Common.Entities;
+using Vintagestory.API.MathTools;
+
+namespace Vintagestory.Server;
+
+// Shared eye-to-hitbox reach math. One place so block reach, entity-interaction reach, and (later)
+// combat reach all measure the same way: shortest distance from the player's eye to the target's
+// axis-aligned box, compared against PickingRange + a slack for lag. Nothing should be interactable
+// beyond that.
+internal static class StratumReach
+{
+	public static FastVec3d EyePos(ServerPlayer player)
+	{
+		return player.Entity.Pos.XYZFast.Add(player.Entity.LocalEyePos);
+	}
+
+	public static double MaxReach(ServerPlayer player, double slack)
+	{
+		return Math.Max(0.0, player.WorldData.PickingRange) + Math.Max(0.0, slack);
+	}
+
+	// Shortest distance from the eye to the block's unit cell AABB.
+	public static double BlockDistance(ServerPlayer player, BlockPos pos)
+	{
+		FastVec3d eyes = EyePos(player);
+		double nearestX = Clamp(eyes.X, pos.X, pos.X + 1);
+		double nearestY = Clamp(eyes.Y, pos.InternalY, pos.InternalY + 1);
+		double nearestZ = Clamp(eyes.Z, pos.Z, pos.Z + 1);
+		double dx = eyes.X - nearestX;
+		double dy = eyes.Y - nearestY;
+		double dz = eyes.Z - nearestZ;
+		return Math.Sqrt(dx * dx + dy * dy + dz * dz);
+	}
+
+	// Shortest distance from the eye to the entity's selection hitbox (falls back to the entity
+	// centre if it has no selection box).
+	public static double EntityDistance(ServerPlayer player, Entity target)
+	{
+		FastVec3d eyes = EyePos(player);
+		if (target.SelectionBox == null)
+		{
+			double dx = eyes.X - target.Pos.X;
+			double dy = eyes.Y - target.Pos.Y;
+			double dz = eyes.Z - target.Pos.Z;
+			return Math.Sqrt(dx * dx + dy * dy + dz * dz);
+		}
+
+		Cuboidd box = target.SelectionBox.ToDouble().Translate(target.Pos.X, target.Pos.Y, target.Pos.Z);
+		return box.ShortestDistanceFrom(eyes.X, eyes.Y, eyes.Z);
+	}
+
+	private static double Clamp(double value, double min, double max)
+	{
+		if (value < min) return min;
+		if (value > max) return max;
+		return value;
+	}
+}


### PR DESCRIPTION
## Summary

Added ability to detect and prevent combat related cheats, as well as improving detection for outside of block placement and breaking. Such as interacting with entities, doors, tools, etc.

## Type

- [ ] Bug fix
- [ ] Performance
- [x] New feature
- [ ] Refactor or cleanup
- [ ] Docs or build

## Checklist

- [x] `.\scripts\extract-patches.ps1` ran clean.
- [x] `dotnet build VintageStory.slnx -c Release` is green.
- [x] Every vanilla edit has a `// Stratum` marker.
- [x] No vanilla source committed.
- [x] Tested on a real server start, not just compilation.