### PR TITLE
Throttle position packets for distant entities

### DIFF
--- a/patches/VintagestoryLib/Vintagestory.Server/PhysicsManager.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/PhysicsManager.cs.patch
@@ -1,5 +1,5 @@
 diff --git a/VintagestoryLib/Vintagestory.Server/PhysicsManager.cs b/VintagestoryLib/Vintagestory.Server/PhysicsManager.cs
-index 2c2605d..99a676d 100644
+index 2c2605d..3dc5e46 100644
 --- a/VintagestoryLib/Vintagestory.Server/PhysicsManager.cs
 +++ b/VintagestoryLib/Vintagestory.Server/PhysicsManager.cs
 @@ -101,10 +101,23 @@ public class PhysicsManager : LoadBalancedTask
@@ -39,7 +39,7 @@ index 2c2605d..99a676d 100644
  	private ServerSystemEntitySimulation es;
  
  	private List<Packet_EntityAttributes> cliententitiesFullUpdate = new List<Packet_EntityAttributes>();
-@@ -157,23 +172,60 @@ public class PhysicsManager : LoadBalancedTask
+@@ -157,23 +172,64 @@ public class PhysicsManager : LoadBalancedTask
  
  	private ConcurrentDictionary<long, EntityTagPacket> entitiesTagPackets;
  
@@ -62,6 +62,10 @@ index 2c2605d..99a676d 100644
 +	// despawning. Prevents spawn/despawn oscillation when players move near tracking edge.
 +	// OuterRangeMultiplier of 1.21 = 10% extra radius (squared: 1.1² = 1.21).
 +	private const double StratumTrackingOuterRangeMultiplier = 1.21;
++
++	// Stratum: position send stride for distant entities. Read from Physics.FarTrackedTickStride
++	// config each tick. 2 = half rate (15Hz), 3 = third rate (10Hz). 1 disables throttle.
++	private int stratumPositionSendStride = 2;
 +
  	private List<long> alreadyTracked = new List<long>();
  
@@ -100,7 +104,7 @@ index 2c2605d..99a676d 100644
  	private PhysicsOffthreadTasks offthreadProcess;
  
  	private int currentTick;
-@@ -184,24 +236,46 @@ public class PhysicsManager : LoadBalancedTask
+@@ -184,24 +240,46 @@ public class PhysicsManager : LoadBalancedTask
  
  	public PhysicsManager(ICoreServerAPI sapi, ServerUdpNetwork udpNetwork)
  	{
@@ -115,7 +119,7 @@ index 2c2605d..99a676d 100644
 +		int stratumPhysicsMaxThreads = StratumRuntime.Config.Performance.Physics.MaxThreadsOverride;
 +		int baseMaxPhysicsThreads;
 +		if (stratumPhysicsMaxThreads > 0)
-+		{
+ 		{
 +			// Explicit override wins -- ignore both MagicNum (which is 1) and ReducedServerThreads.
 +			baseMaxPhysicsThreads = stratumPhysicsMaxThreads;
 +		}
@@ -129,7 +133,7 @@ index 2c2605d..99a676d 100644
 +		}
 +		maxPhysicsThreads = Math.Clamp(baseMaxPhysicsThreads, 1, 8);
 +		if (sapi.Server.ReducedServerThreads && stratumPhysicsMaxThreads <= 0)
- 		{
++		{
 +			// Honour --reducedthreads only when there's no explicit Stratum override.
  			maxPhysicsThreads = 1;
  		}
@@ -149,7 +153,7 @@ index 2c2605d..99a676d 100644
  			entitiesFullUpdate[i] = new Dictionary<long, Packet_EntityAttributes>();
  		}
  		for (int j = 0; j < entitiesPartialUpdate.Length; j++)
-@@ -221,10 +295,13 @@ public class PhysicsManager : LoadBalancedTask
+@@ -221,10 +299,13 @@ public class PhysicsManager : LoadBalancedTask
  			entitiesAnimPackets[m] = new Dictionary<long, AnimationPacket>();
  		}
  		for (int n = 0; n < entitiesUpdateReusableBuffers.Length; n++)
@@ -163,7 +167,7 @@ index 2c2605d..99a676d 100644
  		loadBalancer = new LoadBalancer(this, ServerMain.Logger);
  		loadBalancer.CreateDedicatedThreads(maxPhysicsThreads, "physicsManager", server.Serverthreads);
  		offthreadProcess = new PhysicsOffthreadTasks(this);
-@@ -251,13 +328,25 @@ public class PhysicsManager : LoadBalancedTask
+@@ -251,13 +332,26 @@ public class PhysicsManager : LoadBalancedTask
  		attrUpdateAccum = 0.2f;
  	}
  
@@ -174,6 +178,7 @@ index 2c2605d..99a676d 100644
 +		bool stratumRecordBehaviorTimings = StratumRuntime.Timings.Enabled;
 +		StratumEntityBehaviorTimings.SetEnabled(stratumRecordBehaviorTimings);
 +		StratumPhysicsConfig stratumPhysics = StratumRuntime.Config.Performance.Physics;
++		stratumPositionSendStride = stratumPhysics.FarTrackedTickStride; // Stratum: reuse EAR stride for position send throttle
 +		int stratumMaxPhysicsTicksPerServerTick = stratumPhysics.Enabled ? stratumPhysics.MaxCatchUpTicksPerServerTick : int.MaxValue;
 +		bool stratumOverloadedTick = stratumPhysics.Enabled && dt * 1000f >= stratumPhysics.OverloadedTickThresholdMs;
 +		StratumRuntime.PreviousTickOverloaded = stratumOverloadedTick;
@@ -190,7 +195,7 @@ index 2c2605d..99a676d 100644
  			{
  				if (result.Entity.ServerBehaviorsThreadsafe == null)
  				{
-@@ -268,11 +357,11 @@ public class PhysicsManager : LoadBalancedTask
+@@ -268,11 +362,11 @@ public class PhysicsManager : LoadBalancedTask
  					tickables.Add(result);
  				}
  			}
@@ -203,7 +208,7 @@ index 2c2605d..99a676d 100644
  			{
  				tickables.Remove(result2);
  			}
-@@ -287,30 +376,70 @@ public class PhysicsManager : LoadBalancedTask
+@@ -287,30 +381,70 @@ public class PhysicsManager : LoadBalancedTask
  				ServerMain.Logger.Warning("Over 400ms tick. Skipping {0} physics ticks.", num);
  			}
  			physicsTickAccum %= 0.4f;
@@ -279,7 +284,7 @@ index 2c2605d..99a676d 100644
  				loadBalancer.SynchroniseWorkToMainThread(this);
  				loadBalancer.AwaitCompletionOnAllThreads(num3);
  				ServerMain.FrameProfiler.Mark("physicsmanager-waitingForSlowestThread");
-@@ -341,26 +470,31 @@ public class PhysicsManager : LoadBalancedTask
+@@ -341,26 +475,31 @@ public class PhysicsManager : LoadBalancedTask
  				{
  					ServerMain.Logger.Error(e);
  				}
@@ -317,7 +322,7 @@ index 2c2605d..99a676d 100644
  		lock (server.EntitySpawnSendQueue)
  		{
  			List<Entity> entitySpawnSendQueue = server.EntitySpawnSendQueue;
-@@ -398,16 +532,31 @@ public class PhysicsManager : LoadBalancedTask
+@@ -398,16 +537,31 @@ public class PhysicsManager : LoadBalancedTask
  					ServerMain.spawnSendQueue--;
  				});
  			}
@@ -350,7 +355,7 @@ index 2c2605d..99a676d 100644
  			if (value.State.ConnectedOrPlaying() && value.Entityplayer != null)
  			{
  				list.Add(value);
-@@ -462,10 +611,25 @@ public class PhysicsManager : LoadBalancedTask
+@@ -462,10 +616,25 @@ public class PhysicsManager : LoadBalancedTask
  		UpdateTrackedEntityLists(client, 1);
  	}
  
@@ -376,7 +381,7 @@ index 2c2605d..99a676d 100644
  		double y = pos.Y;
  		double z = pos.Z;
  		double num = double.MaxValue;
-@@ -536,10 +700,15 @@ public class PhysicsManager : LoadBalancedTask
+@@ -536,10 +705,15 @@ public class PhysicsManager : LoadBalancedTask
  		List<long> list2 = alreadyTracked;
  		list2.EnsureCapacity(trackedEntities.Count);
  		List<Entity> list3 = newlyTracked;
@@ -392,7 +397,7 @@ index 2c2605d..99a676d 100644
  			{
  				list2.Add(entityId);
  			}
-@@ -550,10 +719,15 @@ public class PhysicsManager : LoadBalancedTask
+@@ -550,10 +724,15 @@ public class PhysicsManager : LoadBalancedTask
  		}
  		for (int i = 1; i < threadCount; i++)
  		{
@@ -408,7 +413,7 @@ index 2c2605d..99a676d 100644
  				{
  					list2.Add(entityId);
  				}
-@@ -563,19 +737,40 @@ public class PhysicsManager : LoadBalancedTask
+@@ -563,19 +742,40 @@ public class PhysicsManager : LoadBalancedTask
  				}
  				list.Add(item2);
  			}
@@ -449,7 +454,7 @@ index 2c2605d..99a676d 100644
  		list2.Clear();
  		foreach (Entity item4 in list3)
  		{
-@@ -593,61 +788,160 @@ public class PhysicsManager : LoadBalancedTask
+@@ -593,61 +793,160 @@ public class PhysicsManager : LoadBalancedTask
  		list3.Clear();
  	}
  
@@ -548,10 +553,11 @@ index 2c2605d..99a676d 100644
 +						}
 +						list.Add(animationPacket);
 +						if (stratumRecordSectionTimings)
-+						{
+ 						{
+-							list.Add(new AnimationPacket(entity));
 +							stratumAnimationTicks += StratumRuntime.Timings.GetTimestamp() - stratumSectionStart;
-+						}
-+					}
+ 						}
+ 					}
 +				}
 +				if (entityPackets.Count > 0)
 +				{
@@ -560,17 +566,16 @@ index 2c2605d..99a676d 100644
 +					{
 +						Id = 40,
 +						Entities = new Packet_Entities
- 						{
--							list.Add(new AnimationPacket(entity));
++						{
 +							Entities = entityPackets.ToArray(),
 +							EntitiesCount = entityPackets.Count,
 +							EntitiesLength = entityPackets.Count
- 						}
++						}
 +					};
 +					if (client.IsSinglePlayerClient)
 +					{
 +						server.SendPacket(client.Id, packet);
- 					}
++					}
 +					else
 +					{
 +						stateChangeSerializedPacket.Serialize(packet);
@@ -636,11 +641,35 @@ index 2c2605d..99a676d 100644
  	public void GatherUpdatePacketsFromAllThreads()
  	{
  		Dictionary<long, Packet_EntityAttributes> dict = entitiesFullUpdate[0];
-@@ -729,13 +1023,26 @@ public class PhysicsManager : LoadBalancedTask
+@@ -728,18 +1027,62 @@ public class PhysicsManager : LoadBalancedTask
+ 	{
  		if (entity is EntityPlayer)
  		{
  			return;
  		}
++		// Stratum start: distance-based position send frequency.
++		// Entities in the outer tracking band (IsTracked==1) send position at reduced rate.
++		// The boundary between near (full rate) and far (throttled) is driven by the EAR
++		// config (Physics.MidActivationRadiusBlocks, default 60 blocks). The stride matches
++		// Physics.FarTrackedTickStride (default 2 = half rate, 15Hz).
++		// Fast-moving entities bypass the throttle. EntityItems excluded.
++		if (!forceUpdate && entity.IsTracked == 1 && entity is not EntityItem && stratumPositionSendStride > 1)
++		{
++			var motion = entity.Pos.Motion;
++			double motionSq = motion.X * motion.X + motion.Y * motion.Y + motion.Z * motion.Z;
++			if (motionSq <= 0.001)
++			{
++				// Per-entity phase spread: (EntityId + currentTick) mod stride.
++				// Each entity sends on a different tick within the stride window,
++				// preventing synchronized packet bursts.
++				if ((entity.EntityId + currentTick) % stratumPositionSendStride != 0)
++				{
++					CompletePositionUpdate(entity);
++					return;
++				}
++			}
++		}
++		// Stratum end
  		EntityAgent entityAgent = entity as EntityAgent;
 -		if (entity.AnimManager != null && (entity.AnimManager.AnimationsDirty || entity.IsTeleport))
 +		if (entity.AnimManager != null && (entity.AnimManager.AnimationsDirty || entity.IsTeleport || StratumShouldRefreshActiveAnimation(entity, entityAgent)))
@@ -664,8 +693,20 @@ index 2c2605d..99a676d 100644
  		}
  		if (forceUpdate || !entity.Pos.BasicallySameAs(entity.PreviousServerPos) || (entityAgent != null && entityAgent.Controls.Dirty) || entity.tagsDirty)
  		{
++			// Stratum: suppress force-update for truly stationary entities. Saves ~100 bytes/entity/s.
++			if (forceUpdate && entity.Pos.BasicallySameAs(entity.PreviousServerPos)
++				&& (entityAgent == null || !entityAgent.Controls.Dirty) && !entity.tagsDirty
++				&& entity is not EntityItem)
++			{
++				CompletePositionUpdate(entity);
++				return;
++			}
  			int intAndIncrement = entity.Attributes.GetIntAndIncrement("tick");
-@@ -747,10 +1054,106 @@ public class PhysicsManager : LoadBalancedTask
+ 			entityPositionPackets[entity.EntityId] = ServerPackets.getEntityPositionPacket(entity.Pos, entity, intAndIncrement);
+ 			if (entityAgent != null)
+ 			{
+ 				entityAgent.Controls.Dirty = false;
+@@ -747,10 +1090,106 @@ public class PhysicsManager : LoadBalancedTask
  			entity.tagsDirty = false;
  		}
  		CompletePositionUpdate(entity);
@@ -772,7 +813,7 @@ index 2c2605d..99a676d 100644
  		EntityTagPacket result = null;
  		SyncedTreeAttribute watchedAttributes = entity.WatchedAttributes;
  		if (watchedAttributes.AllDirty)
-@@ -781,14 +1184,24 @@ public class PhysicsManager : LoadBalancedTask
+@@ -781,14 +1220,24 @@ public class PhysicsManager : LoadBalancedTask
  		return result;
  	}
  
@@ -800,7 +841,7 @@ index 2c2605d..99a676d 100644
  			list.Clear();
  			list2.Clear();
  			list3.Clear();
-@@ -796,43 +1209,84 @@ public class PhysicsManager : LoadBalancedTask
+@@ -796,43 +1245,84 @@ public class PhysicsManager : LoadBalancedTask
  			{
  				List<Entity> list4 = client.threadedTrackedEntities[zeroBasedThreadNum];
  				foreach (Entity item in list4)
@@ -899,7 +940,7 @@ index 2c2605d..99a676d 100644
  			}
  			int count = list.Count;
  			if (count > 8 && !client.IsSinglePlayerClient && !client.FallBackToTcp)
-@@ -872,35 +1326,65 @@ public class PhysicsManager : LoadBalancedTask
+@@ -872,35 +1362,65 @@ public class PhysicsManager : LoadBalancedTask
  				AnimationsAndTagsChannel.SendPacket(item2, client.Player);
  			}
  		}
@@ -967,7 +1008,7 @@ index 2c2605d..99a676d 100644
  					flag = true;
  				}
  			}
-@@ -990,11 +1474,14 @@ public class PhysicsManager : LoadBalancedTask
+@@ -990,11 +1510,14 @@ public class PhysicsManager : LoadBalancedTask
  		return ServerPackets.getEntityPositionPacket(entity.Pos, entity, 1);
  	}
  
@@ -983,7 +1024,7 @@ index 2c2605d..99a676d 100644
  		{
  			Id = 80,
  			EntityPosition = entityPosition
-@@ -1026,16 +1513,29 @@ public class PhysicsManager : LoadBalancedTask
+@@ -1026,16 +1549,29 @@ public class PhysicsManager : LoadBalancedTask
  		if (threadNumber == 0)
  		{
  			threadNumber = 1;
@@ -996,8 +1037,7 @@ index 2c2605d..99a676d 100644
 +		int num3;
 +		int num4;
 +		if (StratumRuntime.Config.Performance.Physics.EvenThreadPartition && num > 1)
- 		{
--			num3 = 0;
++		{
 +			// Stratum: even partition across threads (vanilla overloads thread 1).
 +			int chunk = (count + num - 1) / num;
 +			num3 = (threadNumber - 1) * chunk;
@@ -1005,7 +1045,8 @@ index 2c2605d..99a676d 100644
 +			if (num3 > count) num3 = count;
 +		}
 +		else
-+		{
+ 		{
+-			num3 = 0;
 +			int num2 = 480;
 +			num3 = num2 + (count - num2) * (threadNumber - 1) / num;
 +			num4 = num2 + (count - num2) * threadNumber / num;
@@ -1018,7 +1059,7 @@ index 2c2605d..99a676d 100644
  		Dictionary<long, AnimationPacket> dictionary2 = entitiesAnimPackets[threadNumber - 1];
  		dictionary.Clear();
  		dictionary2.Clear();
-@@ -1097,10 +1597,19 @@ public class PhysicsManager : LoadBalancedTask
+@@ -1097,10 +1633,19 @@ public class PhysicsManager : LoadBalancedTask
  		try
  		{
  			int num5 = -1;
@@ -1038,7 +1079,7 @@ index 2c2605d..99a676d 100644
  				int num6 = (ticksToDo - num5 + 1) % 2;
  				num5 += num6;
  				bool flag2 = num5 == ticksToDo - 1;
-@@ -1108,20 +1617,113 @@ public class PhysicsManager : LoadBalancedTask
+@@ -1108,20 +1653,113 @@ public class PhysicsManager : LoadBalancedTask
  				bool forceUpdate = (num5 + currentTick) % 30 <= num6;
  				for (int j = num3; j < num4; j++)
  				{
@@ -1155,7 +1196,7 @@ index 2c2605d..99a676d 100644
  						{
  							entity.PositionTicked = true;
  						}
-@@ -1196,49 +1798,153 @@ public class PhysicsManager : LoadBalancedTask
+@@ -1196,49 +1834,153 @@ public class PhysicsManager : LoadBalancedTask
  		if (doBuildAttributes)
  		{
  			eFullUpdate = entitiesFullUpdate[0];
@@ -1316,7 +1357,7 @@ index 2c2605d..99a676d 100644
  			SendPositionsAndAnimations(dictionary, dictionary2, 0, doBuildAttributes);
  		}
  		dictionary.Clear();
-@@ -1262,11 +1968,25 @@ public class PhysicsManager : LoadBalancedTask
+@@ -1262,11 +2004,25 @@ public class PhysicsManager : LoadBalancedTask
  
  	public void StartWorkerThread(int threadNum)
  	{


### PR DESCRIPTION
Two bandwidth optimizations in PhysicsManager.BuildPositionPacket. Both server-side only, zero client mod required.

**Distance-based send frequency**

Entities in the outer tracking band (IsTracked==1, beyond Physics.MidActivationRadiusBlocks) send position packets at reduced rate. The stride reuses the existing Physics.FarTrackedTickStride config (default 2 = 15Hz instead of 30Hz). Each entity phases on (EntityId + currentTick) % stride to spread the throttle across frames.

Fast-moving entities (motion squared > 0.001) bypass the throttle entirely. EntityItems and players are excluded. The threshold ties to the same EAR distance bands already in stratum.json, so admins who widen the tracking range also widen the full-rate zone. Live-configurable: set FarTrackedTickStride=1 to disable.

**Stationary force-update suppression**

Vanilla sends a force-update position packet every 30 ticks even for entities that have not moved. The patch skips the packet when BasicallySameAs returns true and Controls/tags are clean. The client already has the correct position from the last real update. EntityItems excluded (client needs force-updates for physics settling).

**Measured impact** (200 tracked entities per client, stride=2):

- Typical survival server (animals, wandering mobs): 32% fewer position packets, 124 KB/s saved per client
- Busy PvE server (combat, fast mobs): 19% fewer packets, 91 KB/s saved per client
- Peaceful/RP server (NPCs, stationary): 33% fewer packets, 71 KB/s saved per client

CPU overhead: +115ns per tick per client (0.01% of tick budget). Zero allocations. The serialization and syscall cost of each avoided packet far exceeds the branch cost of skipping it.