### PR TITLE
Fix CS0122 in tracking hysteresis: use public EntityPos X/Y/Z accessors

### DIFF
--- a/patches/VintagestoryLib/Vintagestory.Server/PhysicsManager.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/PhysicsManager.cs.patch
@@ -422,9 +422,9 @@ index 2c2605d..3dc5e46 100644
 +		// Stratum start: tracking hysteresis. Before despawning a tracked entity, check if it's
 +		// still within the outer radius. This prevents oscillation at the tracking boundary.
 +		double outerRangeSq = es.trackingRangeSq * StratumTrackingOuterRangeMultiplier;
-+		double clientX = client.Position.x;
-+		double clientY = client.Position.y;
-+		double clientZ = client.Position.z;
++		double clientX = client.Position.X;
++		double clientY = client.Position.Y;
++		double clientZ = client.Position.Z;
  		foreach (long item3 in trackedEntities)
  		{
 +			if (server.LoadedEntities.TryGetValue(item3, out Entity trackedEntity) && !trackedEntity.ShouldDespawn)

--- a/patches/VintagestoryLib/Vintagestory.Server/PhysicsManager.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/PhysicsManager.cs.patch
@@ -429,7 +429,7 @@ index 2c2605d..3dc5e46 100644
  		{
 +			if (server.LoadedEntities.TryGetValue(item3, out Entity trackedEntity) && !trackedEntity.ShouldDespawn)
 +			{
-+				EntityPos epos = trackedEntity.ServerPos;
++				EntityPos epos = trackedEntity.Pos;
 +				double dx = epos.X - clientX;
 +				double dy = epos.Y - clientY;
 +				double dz = epos.Z - clientZ;


### PR DESCRIPTION
The tracking hysteresis hunk added in 85da83c reads client.Position.x/y/z, but the lowercase x/y/z members of EntityPos are protected fields, so the build fails with three CS0122 errors at PhysicsManager.cs lines 750-752. This switches the reads to the public X/Y/Z accessors, matching the epos.X/Y/Z usage a few lines below in the same hunk.

Also replaces trackedEntity.ServerPos with trackedEntity.Pos in the same hunk, silencing the CS0618 warning. In the 1.22 API, Entity.ServerPos is an obsolete pass-through property that just returns Pos, so behavior is identical.

Only characters within existing lines changed, so the patch hunk headers remain valid. I scanned the full diff of both indev commits for other lowercase position field accesses and obsolete ServerPos usages and these were the only occurrences.