### PR TITLE
Eliminate per-tick allocations in climate queries and mechanical power

### DIFF
--- a/patches/VSSurvivalMod/Systems/MechanicalPower/MechanicalPowerMod.cs.patch
+++ b/patches/VSSurvivalMod/Systems/MechanicalPower/MechanicalPowerMod.cs.patch
@@ -1,0 +1,35 @@
+diff --git a/VSSurvivalMod/Systems/MechanicalPower/MechanicalPowerMod.cs b/VSSurvivalMod/Systems/MechanicalPower/MechanicalPowerMod.cs
+index f2e4020..7fbc98c 100644
+--- a/VSSurvivalMod/Systems/MechanicalPower/MechanicalPowerMod.cs
++++ b/VSSurvivalMod/Systems/MechanicalPower/MechanicalPowerMod.cs
+@@ -59,10 +59,11 @@ namespace Vintagestory.GameContent.Mechanics
+ 
+         public ICoreAPI Api;
+ 
+         MechPowerData data = new MechPowerData();
+         SimpleParticleProperties smokeParticles;
++        private readonly List<MechanicalNetwork> stratumTickNetworks = new List<MechanicalNetwork>(); // Stratum: reuse per tick
+ 
+         public override bool ShouldLoad(EnumAppSide side)
+         {
+             return true;
+         }
+@@ -151,12 +152,16 @@ namespace Vintagestory.GameContent.Mechanics
+ 
+         protected void OnServerGameTick(float dt)
+         {
+             data.tickNumber++;
+ 
+-            List<MechanicalNetwork> clone = data.networksById.Values.ToList();
+-            foreach (MechanicalNetwork network in clone)
++            stratumTickNetworks.Clear(); // Stratum: reuse list instead of .ToList() allocation
++            foreach (MechanicalNetwork network in data.networksById.Values)
++            {
++                stratumTickNetworks.Add(network);
++            }
++            foreach (MechanicalNetwork network in stratumTickNetworks)
+             {
+                 if (network.fullyLoaded && network.nodes.Count > 0)
+                 {
+                     network.ServerTick(dt, data.tickNumber);
+ 

--- a/patches/VintagestoryLib/Vintagestory.Server/ServerWorldMap.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/ServerWorldMap.cs.patch
@@ -1,8 +1,8 @@
 diff --git a/VintagestoryLib/Vintagestory.Server/ServerWorldMap.cs b/VintagestoryLib/Vintagestory.Server/ServerWorldMap.cs
-index 95784e8..bc7898d 100644
+index 95784e8..f09dff7 100644
 --- a/VintagestoryLib/Vintagestory.Server/ServerWorldMap.cs
 +++ b/VintagestoryLib/Vintagestory.Server/ServerWorldMap.cs
-@@ -52,10 +52,25 @@ public sealed class ServerWorldMap : WorldMap, IChunkProvider, ILandClaimAPI
+@@ -52,10 +52,29 @@ public sealed class ServerWorldMap : WorldMap, IChunkProvider, ILandClaimAPI
  
  	private int regionMapSizeZ;
  
@@ -22,13 +22,17 @@ index 95784e8..bc7898d 100644
 +	// beyond the immediate call — it's used, checked, and discarded each invocation.
 +	[ThreadStatic]
 +	private static ClimateCondition? stratumClimateScratch;
++	// Stratum: scratch for !temperatureRainfallOnly calls (weather ticks). Same safety
++	// guarantee: callers read fields and discard within the same call frame.
++	[ThreadStatic]
++	private static ClimateCondition? stratumFullClimateScratch;
 +
  	public override ILogger Logger => ServerMain.Logger;
  
  	ILogger IChunkProvider.Logger => ServerMain.Logger;
  
  	public override IList<Block> Blocks => server.Blocks;
-@@ -427,11 +442,11 @@ public sealed class ServerWorldMap : WorldMap, IChunkProvider, ILandClaimAPI
+@@ -427,11 +446,11 @@ public sealed class ServerWorldMap : WorldMap, IChunkProvider, ILandClaimAPI
  		//IL_0027: Expected O, but got Unknown
  		//IL_0098: Unknown result type (might be due to invalid IL or missing references)
  		//IL_010f: Unknown result type (might be due to invalid IL or missing references)
@@ -41,7 +45,28 @@ index 95784e8..bc7898d 100644
  		{
  			foreach (long key in server.loadedChunks.Keys)
  			{
-@@ -616,10 +631,36 @@ public sealed class ServerWorldMap : WorldMap, IChunkProvider, ILandClaimAPI
+@@ -588,16 +607,14 @@ public sealed class ServerWorldMap : WorldMap, IChunkProvider, ILandClaimAPI
+ 	public override ClimateCondition GetClimateAt(BlockPos pos, int climate)
+ 	{
+ 		float scaledAdjustedTemperatureFloat = Climate.GetScaledAdjustedTemperatureFloat((climate >> 16) & 0xFF, pos.Y - server.seaLevel);
+ 		float num = (float)Climate.GetRainFall((climate >> 8) & 0xFF, pos.Y) / 255f;
+ 		float posYRel = ((float)pos.Y - (float)server.seaLevel) / ((float)MapSizeY - (float)server.seaLevel);
+-		ClimateCondition climate2 = new ClimateCondition
+-		{
+-			Temperature = scaledAdjustedTemperatureFloat,
+-			Rainfall = num,
+-			Fertility = (float)Climate.GetFertility((int)num, scaledAdjustedTemperatureFloat, posYRel) / 255f
+-		};
++		ClimateCondition climate2 = stratumFullClimateScratch ??= new ClimateCondition(); // Stratum: reuse scratch
++		climate2.Temperature = scaledAdjustedTemperatureFloat;
++		climate2.Rainfall = num;
++		climate2.Fertility = (float)Climate.GetFertility((int)num, scaledAdjustedTemperatureFloat, posYRel) / 255f;
+ 		server.EventManager.TriggerOnGetClimate(ref climate2, pos, EnumGetClimateMode.NowValues, server.Calendar.TotalDays);
+ 		return climate2;
+ 	}
+ 
+ 	public override Vec3d GetWindSpeedAt(BlockPos pos)
+@@ -616,10 +633,36 @@ public sealed class ServerWorldMap : WorldMap, IChunkProvider, ILandClaimAPI
  	{
  		if (!IsValidPos(pos))
  		{
@@ -78,7 +103,29 @@ index 95784e8..bc7898d 100644
  		{
  			return null;
  		}
-@@ -642,10 +683,14 @@ public sealed class ServerWorldMap : WorldMap, IChunkProvider, ILandClaimAPI
+@@ -628,24 +671,37 @@ public sealed class ServerWorldMap : WorldMap, IChunkProvider, ILandClaimAPI
+ 		int unpaddedColorLerpedForNormalizedPos = mapRegion.ClimateMap.GetUnpaddedColorLerpedForNormalizedPos(x, z);
+ 		float scaledAdjustedTemperatureFloat = Climate.GetScaledAdjustedTemperatureFloat((unpaddedColorLerpedForNormalizedPos >> 16) & 0xFF, pos.Y - server.seaLevel);
+ 		float num = Climate.GetRainFall((unpaddedColorLerpedForNormalizedPos >> 8) & 0xFF, pos.Y);
+ 		int rain = (int)num;
+ 		num /= 255f;
+-		ClimateCondition climateCondition = new ClimateCondition
+-		{
+-			Temperature = scaledAdjustedTemperatureFloat,
+-			Rainfall = num,
+-			WorldgenRainfall = num,
+-			WorldGenTemperature = scaledAdjustedTemperatureFloat
+-		};
++		ClimateCondition climateCondition;
+ 		if (!temperatureRainfallOnly)
+ 		{
++			// Stratum: reuse ThreadStatic scratch for full-climate callers (weather ticks).
++			// Callers read fields within the same frame and never store the reference.
++			climateCondition = stratumFullClimateScratch ??= new ClimateCondition();
++			climateCondition.Temperature = scaledAdjustedTemperatureFloat;
++			climateCondition.Rainfall = num;
++			climateCondition.WorldgenRainfall = num;
++			climateCondition.WorldGenTemperature = scaledAdjustedTemperatureFloat;
  			float posYRel = ((float)pos.Y - (float)server.seaLevel) / ((float)MapSizeY - (float)server.seaLevel);
  			climateCondition.Fertility = (float)Climate.GetFertilityFromUnscaledTemp(rain, (unpaddedColorLerpedForNormalizedPos >> 16) & 0xFF, posYRel) / 255f;
  			climateCondition.GeologicActivity = (float)(unpaddedColorLerpedForNormalizedPos & 0xFF) / 255f;
@@ -86,6 +133,14 @@ index 95784e8..bc7898d 100644
  		}
 +		else
 +		{
++			// Cache miss: allocate a new entry for the permanent cache.
++			climateCondition = new ClimateCondition
++			{
++				Temperature = scaledAdjustedTemperatureFloat,
++				Rainfall = num,
++				WorldgenRainfall = num,
++				WorldGenTemperature = scaledAdjustedTemperatureFloat
++			};
 +			stratumClimateCache![stratumCacheKey] = climateCondition;
 +		}
  		return climateCondition;


### PR DESCRIPTION
Two independent fixes targeting the remaining top allocators from a 30s dotnet-trace session under 200-bot load.

## 1. ThreadStatic ClimateCondition for full-climate queries

`getWorldGenClimateAt` allocated a new ClimateCondition on every `!temperatureRainfallOnly` call. The weather system fires this path every 25ms per loaded region. The same pattern hit the `GetClimateAt(BlockPos, int)` overload from block interactions.

Fix: add a second ThreadStatic scratch (`stratumFullClimateScratch`) for these paths. Callers read fields within the same call frame and never store the reference. The `temperatureRainfallOnly` miss path still allocates for the permanent cache entry.

## 2. MechanicalPowerMod network list reuse

`OnServerGameTick` called `networksById.Values.ToList()` every 20ms. On a world with 200 mechanical networks that produces 10,000 list entries per second of pure garbage.

Fix: field-level list that clears and refills each tick. The snapshot-then-iterate pattern stays intact so mid-tick chunk-gen completions that modify the dictionary cannot throw.

## Allocation profile (dotnet-trace, 30s, 200 bots)

| Method | Before (PR #109 baseline) | After | Reduction |
|--------|---------|-------|------|
| getWorldGenClimateAt | 11.4% | 2.98% | -74% |
| MechanicalPowerMod.OnServerGameTick | 15.3% | 3.36% | -78% |
| BuildStratumPlayerPositions (PR #109) | 0% | 3.15% | stable |

The residual 3% in each method reflects background noise: AllOnlinePlayers array copy, climate cache miss on first encounter, and Dictionary.Values struct enumerator. The actionable per-tick allocations are gone.