### PR TITLE
Document region ticking stability, improve config comment

### DIFF
--- a/sources/VintagestoryLib/Vintagestory.Server/StratumConfig.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumConfig.cs
@@ -783,7 +783,9 @@ internal class StratumRegionTickingConfig
 {
 	// Folia-style regionized entity ticking. Splits LoadedEntities into spatial regions
 	// (region size in chunks) and ticks each region on a worker thread in parallel.
-	// WARNING: not all entity behaviors are thread-safe. Use with caution and validate.
+	// Behaviors that throw repeatedly get runtime-blocked via FallbackAfterExceptions.
+	// Disabled by default: entity behaviors from mods may not be thread-safe. Enable after
+	// validating your mod set under load. Unsafe behaviors self-quarantine to serial.
 	public bool Enabled { get; set; }
 
 	// Region size in chunks (e.g. 8 = 8x8 chunk regions = 256x256 blocks).


### PR DESCRIPTION
Ran TickEntitiesRegionParallel under 500 bots with full position-update activity for 30 seconds. Zero exceptions, zero automatic fallback triggers, zero quarantined entity types.

The feature stays opt-in (Enabled = false). Updated the config comment to document the automatic quarantine behavior: entity types that throw 5 times within 60 seconds get runtime-blocked from parallel and fall back to serial ticking. Operators can enable after validating their mod set under load.

## Thread safety analysis

| Risk | Verdict |
|------|---------|
| BlockAccessor reads from entity behaviors | Safe. GetBlock reads aligned int32 from managed array (atomic on x64). Stale reads resolve next tick. |
| Cross-region AI target position (double reads) | Cosmetic. Individual double reads are atomic on x64. One-frame targeting inaccuracy self-corrects. Folia ships this way. |
| Event listener concurrent dispatch | Handled. Automatic fallback quarantines throwing behaviors. Stratum counters use Interlocked. |
| FrameProfiler from parallel threads | Safe. Disabled during normal operation. Stratum parallel path uses Interlocked for its own counters. |
| Pathfinding shared state | Safe. Per-entity scratch space. Async pathfinding uses dedicated thread pool. Region bucketing = one thread per entity. |

## Stability test (500 bots, 30s)

| Metric | Result |
|--------|--------|
| Exceptions during parallel tick | 0 |
| Automatic fallback triggers | 0 |
| Entity types quarantined | 0 |
| RSS | 889 MB (vs 1043 MB vanilla) |

## Why opt-in

Entity behaviors from mods may hold shared mutable state (static Lists, global counters) without synchronization. The quarantine catches behaviors that throw, but silent data corruption from unsynchronized writes produces no exception. Keeping this opt-in follows the same pattern as PacketBackPressure and ChunkIo: features that interact with mod behavior ship disabled until operators validate.