### PR TITLE
Optimization of FirstCodePart and LastCodePart

### DIFF
--- a/patches/VintagestoryApi/Common/Registry/RegistryObject.cs.patch
+++ b/patches/VintagestoryApi/Common/Registry/RegistryObject.cs.patch
@@ -1,8 +1,120 @@
 diff --git a/VintagestoryApi/Common/Registry/RegistryObject.cs b/VintagestoryApi/Common/Registry/RegistryObject.cs
-index 505a304..66cc2db 100644
+index 505a304..6267f74 100644
 --- a/VintagestoryApi/Common/Registry/RegistryObject.cs
 +++ b/VintagestoryApi/Common/Registry/RegistryObject.cs
-@@ -299,26 +299,106 @@ namespace Vintagestory.API.Common
+@@ -210,29 +210,103 @@ namespace Vintagestory.API.Common
+         /// </summary>
+         /// <param name="posFromRight"></param>
+         /// <returns></returns>
+         public string LastCodePart(int posFromRight = 0)
+         {
+-            if (Code == null) return null;
+-            if (posFromRight == 0 && !Code.Path.Contains('-')) return Code.Path;
++            // Stratun start:
++            // Replacing the resource-intensive Split() with a character-by-character iteration with early exit allowed
++            // the string to be read exactly once, stopping at the required hyphen without creating intermediate arrays.
++            // This dramatically reduced the load on the garbage collector and significantly accelerated the method's execution
++            // in hot sections of code by completely eliminating unnecessary memory allocations.
++
++            // Tested on the generation of 10200 chunk columns:
++            // - GenVegetationAndPatches.genPatches method execution time: reduced from 6564 ms to 6015 ms;
++            // - GenVegetationAndPatches.genPatches GC memory allocations: reduced from 1.24 GB to 827 MB.
++
++            if (Code == null)
++                return null;
++
++            string path = Code.Path;
++            int rightBoundary = path.Length;    // Right boundary of the current found part (initially end of string)
++            int dashesSeen = -1;    // Number of dashes encountered while traversing right to left
++            int i = path.Length;    // i — current index while traversing right to left
++
++            // Traverse the string right to left searching for dashes
++            while (--i >= 0)
++            {
++                if (path[i] != '-')
++                    continue;
++
++                dashesSeen++;
++
++                // If we found the needed dash (index posFromRight), return the part between it and rightBoundary
++                if (dashesSeen == posFromRight)
++                {
++                    return path.Substring(i + 1, rightBoundary - i - 1);
++                }
++                // Otherwise shift the right boundary — now it points to the current dash
++                rightBoundary = i;
++            }
+ 
+-            string[] parts = Code.Path.Split('-');
+-            return parts.Length - 1 - posFromRight >= 0 ? parts[parts.Length - 1 - posFromRight] : null;
++            // Reached the start of the string — not enough dashes
++            // If the last part was requested
++            if (posFromRight == 0)
++                return dashesSeen == -1 ? path : null;
++
++            // If a non-last part was requested, check if there were enough dashes
++            // dashesSeen == posFromRight - 1 means there were exactly enough dashes
++            // to extract the requested part from the start of the string to the first dash
++            return dashesSeen == posFromRight - 1 ? path.Substring(0, rightBoundary) : null;
++            // Stratum end
+         }
+ 
+         /// <summary>
+         /// Returns the n-th code part. If the code contains no dash ('-') the whole code is returned. Returns null if posFromLeft is too high.
+         /// </summary>
+         /// <param name="posFromLeft"></param>
+         /// <returns></returns>
+         public string FirstCodePart(int posFromLeft = 0)
+         {
+-            if (Code == null) return null;
+-            if (posFromLeft == 0 && !Code.Path.Contains('-')) return Code.Path;
++            // Stratun start:
++            // Replacing the resource-intensive Split() with a character-by-character iteration with early exit allowed
++            // the string to be read exactly once, stopping at the required hyphen without creating intermediate arrays.
++            // This dramatically reduced the load on the garbage collector and significantly accelerated the method's execution
++            // in hot sections of code by completely eliminating unnecessary memory allocations.
++
++            if (Code == null)
++                return null;
++
++            string path = Code.Path;
++            int leftBoundary = 0;   // Left boundary of the current found part (initially start of string)
++            int dashesSeen = -1;    // Number of dashes encountered while traversing left to right
+ 
+-            string[] parts = Code.Path.Split('-');
+-            return posFromLeft <= parts.Length - 1 ? parts[posFromLeft] : null;
++            // Traverse the string left to right searching for dashes
++            for (int i = 0; i < path.Length; i++)
++            {
++                if (path[i] != '-')
++                    continue;
++
++                dashesSeen++;
++                // If we found the needed dash, return the part between leftBoundary and it
++                if (dashesSeen == posFromLeft)
++                {
++                    return path.Substring(leftBoundary, i - leftBoundary);
++                }
++                // Otherwise shift the left boundary — now it points to the position after the current dash
++                leftBoundary = i + 1;
++            }
++
++            // Reached the end of the string — not enough dashes
++            // If the first part was requested
++            if (posFromLeft == 0)
++                return dashesSeen == -1 ? path : null;
++
++            // If a non-first part was requested, check if there were enough dashes
++            // dashesSeen == posFromLeft - 1 means there were exactly enough dashes
++            // to extract the requested part from the last dash to the end of the string
++            return dashesSeen == posFromLeft - 1 ? path.Substring(leftBoundary) : null;
++            // Stratum end
+         }
+ 
+         /// <summary>
+         /// Returns true if any given wildcard matches the blocks/items code. E.g. water-* will match all water blocks
+         /// </summary>
+@@ -299,26 +373,106 @@ namespace Vintagestory.API.Common
              }
  
              return input;
@@ -70,8 +182,8 @@ index 505a304..66cc2db 100644
 +            }
 +
 +            return sb.ToString();
-+        }
-+
+         }
+ 
 +
 +        private static bool TryResolvePlaceholder(
 +            ReadOnlySpan<char> placeholder,
@@ -101,8 +213,8 @@ index 505a304..66cc2db 100644
 +
 +            value = null;
 +            return false;
-         }
- 
++        }
++
 +        // Stratum end
 +
 +


### PR DESCRIPTION
## Summary

Replacing the resource-intensive **Split()** with a character-by-character iteration with early exit allowed the string to be read exactly once, stopping at the required hyphen without creating intermediate arrays.
This dramatically reduced the load on the GC and significantly accelerated the method's execution in hot sections of code by completely eliminating unnecessary memory allocations.

## Type

- [ ] Bug fix
- [x] Performance
- [ ] New feature
- [ ] Refactor or cleanup
- [ ] Docs or build

## Checklist

- [x] `.\scripts\extract-patches.ps1` ran clean.
- [x] `dotnet build VintageStory.slnx -c Release` is green.
- [x] Every vanilla edit has a `// Stratum` marker.
- [x] No vanilla source committed.
- [x] Tested on a real server start, not just compilation.

## Performance numbers

Tested on the generation of 10200 chunk columns:
- GenVegetationAndPatches.genPatches method execution time: reduced from 6564 ms to 6015 ms;
- GenVegetationAndPatches.genPatches GC memory allocations: reduced from 1.24 GB to 827 MB.

**Before**
<img width="776" height="737" alt="registry before trace" src="https://github.com/user-attachments/assets/8ba6029f-a12b-4ac4-ac3c-60994106a0e5" />
<img width="1616" height="449" alt="registry before mem" src="https://github.com/user-attachments/assets/3141e576-466c-4939-bad3-15413af43d9c" />


**After**
<img width="769" height="714" alt="registry after trace" src="https://github.com/user-attachments/assets/f5151ca8-a099-4430-b89b-c6e168c6cffa" />
<img width="1676" height="460" alt="registry after mem" src="https://github.com/user-attachments/assets/a9d8a846-69c6-4b0b-96f5-cd0cfe42cd38" />

