### PR TITLE
Cap RequestJoin processing to N per tick

### DIFF
--- a/StratumServer/stratum.default.json
+++ b/StratumServer/stratum.default.json
@@ -224,7 +224,8 @@
     },
     "Join": {
       "CacheStartupPackets": true,
-      "MaxQueueAdmissionsPerPass": 2
+      "MaxQueueAdmissionsPerPass": 2,
+      "MaxJoinsPerTick": 3
     }
   },
   "Commands": {

--- a/patches/VintagestoryLib/Vintagestory.Server/ServerMain.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/ServerMain.cs.patch
@@ -1,5 +1,5 @@
 diff --git a/VintagestoryLib/Vintagestory.Server/ServerMain.cs b/VintagestoryLib/Vintagestory.Server/ServerMain.cs
-index 1017be9..a819f8d 100644
+index 1017be9..a324814 100644
 --- a/VintagestoryLib/Vintagestory.Server/ServerMain.cs
 +++ b/VintagestoryLib/Vintagestory.Server/ServerMain.cs
 @@ -27,10 +27,13 @@ using VintagestoryLib.Server.Systems;
@@ -45,7 +45,7 @@ index 1017be9..a819f8d 100644
  	internal bool doNetBenchmark;
  
  	internal SortedDictionary<int, int> packetBenchmark = new SortedDictionary<int, int>();
-@@ -259,10 +277,25 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -259,10 +277,30 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  
  	private bool serverAssetsSentLocally;
  
@@ -53,6 +53,11 @@ index 1017be9..a819f8d 100644
  
 +	// Stratum: reuse large startup packets across joins while live-editable config stays unchanged.
 +	private readonly object stratumJoinPacketCacheLock = new object();
++
++	// Stratum start: per-tick RequestJoin budget
++	private readonly Queue<ReceivedClientPacket> stratumDeferredJoinQueue = new Queue<ReceivedClientPacket>();
++	private int stratumJoinsThisTick;
++	// Stratum end
 +
 +	private readonly BoxedPacket stratumWorldMetaDataPacket = new BoxedPacket();
 +
@@ -71,7 +76,7 @@ index 1017be9..a819f8d 100644
  	internal long lastCalendarFullUpdateSentToClient;
  
  	internal long lastCalendarUpdateSentToClient;
-@@ -337,11 +370,12 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -337,11 +375,12 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  
  	public string SavegameIdentifier => SaveGameData.SavegameIdentifier;
  
@@ -85,7 +90,7 @@ index 1017be9..a819f8d 100644
  	{
  		get
  		{
-@@ -413,16 +447,66 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -413,16 +452,66 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  
  	public string WorldName => SaveGameData.WorldName;
  
@@ -128,8 +133,7 @@ index 1017be9..a819f8d 100644
 +			return stratumCachedOnlinePlayers;
 +		}
 +	}
- 
--	public IPlayer[] AllPlayers => PlayersByUid.Values.ToArray();
++
 +	public IPlayer[] AllPlayers
 +	{
 +		get
@@ -139,7 +143,8 @@ index 1017be9..a819f8d 100644
 +			{
 +				return stratumCachedAllPlayers;
 +			}
-+
+ 
+-	public IPlayer[] AllPlayers => PlayersByUid.Values.ToArray();
 +			ServerPlayer[] result = new ServerPlayer[PlayersByUid.Count];
 +			int idx = 0;
 +			foreach (ServerPlayer player in PlayersByUid.Values)
@@ -157,7 +162,7 @@ index 1017be9..a819f8d 100644
  
  	IClassRegistryAPI IWorldAccessor.ClassRegistry => api.ClassRegistry;
  
-@@ -516,11 +600,14 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -516,11 +605,14 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  	{
  		ServerPlayer player = client.Player;
  		player.Entity.WatchedAttributes.MarkAllDirty();
@@ -173,7 +178,7 @@ index 1017be9..a819f8d 100644
  		string message;
  		try
  		{
-@@ -529,10 +616,11 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -529,10 +621,11 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  		catch (Exception)
  		{
  			Logger.Warning("Error formatting welcome message: \"" + text.Replace("{", "{{").Replace("}", "}}") + "\" for player " + player.PlayerName);
@@ -185,7 +190,7 @@ index 1017be9..a819f8d 100644
  		if (Config.RepairMode)
  		{
  			SendMessage(player, GlobalConstants.GeneralChatGroup, "Server is in repair mode, you are now in spectator mode. If you are not already there, fly to the area that crashes and let the chunks load, then exit the game and run in normal mode.", EnumChatType.Notification);
-@@ -730,13 +818,48 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -730,13 +823,48 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  		int num = packet.Chatline.Groupid;
  		if (num < -1)
  		{
@@ -234,7 +239,7 @@ index 1017be9..a819f8d 100644
  		IServerPlayer[] skipPlayers = ((!skipSelf) ? Array.Empty<IServerPlayer>() : new IServerPlayer[1] { ofPlayer });
  		if (ofPlayer.InventoryManager?.ActiveHotbarSlot == null)
  		{
-@@ -787,16 +910,59 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -787,16 +915,59 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  	}
  
  	private void HandleEntityPacket(Packet_Client packet, ConnectedClient client)
@@ -295,7 +300,7 @@ index 1017be9..a819f8d 100644
  		if (groupid > 0 && !PlayerDataManager.PlayerGroupsById.ContainsKey(groupid))
  		{
  			SendMessage(player, GlobalConstants.ServerInfoChatGroup, "No such group exists on this server.", EnumChatType.CommandError);
-@@ -903,71 +1069,82 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -903,71 +1074,82 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  	private void HandlePlayerIdentification(Packet_Client p, ConnectedClient client)
  	{
  		Packet_ClientIdentification identification = p.Identification;
@@ -390,7 +395,7 @@ index 1017be9..a819f8d 100644
  	}
  
  	public ServerMain(StartServerArgs serverargs, string[] cmdlineArgsRaw, ServerProgramArgs progArgs, bool isDedicatedServer = true)
-@@ -1173,15 +1350,16 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -1173,15 +1355,16 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  		if (HeartbeatSystem == null)
  		{
  			HeartbeatSystem = new ServerSystemHeartbeat(this);
@@ -408,7 +413,7 @@ index 1017be9..a819f8d 100644
  			serverSystemModHandler,
  			new ServerySystemPlayerGroups(this),
  			new ServerSystemEntitySimulation(this),
-@@ -1213,14 +1391,15 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -1213,14 +1396,15 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  		if (xPlatInterface == null)
  		{
  			xPlatInterface = XPlatformInterfaces.GetInterface();
@@ -426,7 +431,7 @@ index 1017be9..a819f8d 100644
  		if (progArgs.AddOrigin != null)
  		{
  			foreach (string item in progArgs.AddOrigin)
-@@ -1482,17 +1661,19 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -1482,17 +1666,19 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  					ServerSystem serverSystem = Systems[i];
  					long num = elapsedMilliseconds - serverSystem.millisecondsSinceStart;
  					if (num > serverSystem.GetUpdateInterval())
@@ -447,7 +452,7 @@ index 1017be9..a819f8d 100644
  				int num2 = 0;
  				while (!FrameProfilerUtil.offThreadProfiles.IsEmpty && num2++ < 25)
  				{
-@@ -1507,18 +1688,22 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -1507,18 +1693,22 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  					ServerSystem serverSystem2 = Systems[j];
  					long num = elapsedMilliseconds - serverSystem2.millisecondsSinceStart;
  					if (num > serverSystem2.GetUpdateInterval())
@@ -471,7 +476,7 @@ index 1017be9..a819f8d 100644
  			{
  				processConnectionQueue();
  				statsupdate = DateTime.UtcNow;
-@@ -1540,39 +1725,64 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -1540,42 +1730,91 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  			statsCollection.ticksTotal++;
  			statsCollection.tickTimes[statsCollection.tickTimeIndex] = elapsedMilliseconds2;
  			statsCollection.tickTimeIndex = (statsCollection.tickTimeIndex + 1) % statsCollection.tickTimes.Length;
@@ -535,9 +540,36 @@ index 1017be9..a819f8d 100644
  			FrameProfiler.Mark("mt-net-pp");
  		}
  		ReceivedClientPacket result;
++		// Stratum start: drain deferred RequestJoin packets from prior ticks (up to budget)
++		stratumJoinsThisTick = 0;
++		int stratumJoinBudget = StratumRuntime.Config.Performance.Join.MaxJoinsPerTick;
++		while (stratumJoinBudget > 0 && stratumJoinsThisTick < stratumJoinBudget && stratumDeferredJoinQueue.Count > 0)
++		{
++			ReceivedClientPacket deferred = stratumDeferredJoinQueue.Dequeue();
++			if (deferred.client.State != EnumClientState.Offline && !DisconnectedClientsThisTick.Contains(deferred.client.Id))
++			{
++				long stratumDeferredJoinTimingStart = StratumRuntime.Timings.GetTimestamp();
++				try
++				{
++					HandleRequestJoin(deferred.packet, deferred.client);
++				}
++				catch (Exception e)
++				{
++					Logger.Warning("Exception processing deferred RequestJoin for client " + deferred.client.Id + ". Disconnecting.");
++					DisconnectPlayer(deferred.client, "Threw an exception at the server", "An action you (or your client) did caused an unhandled exception");
++					Logger.Error(e);
++				}
++				StratumRuntime.Timings.RecordPacket(11, stratumDeferredJoinTimingStart);
++				stratumJoinsThisTick++;
++			}
++		}
++		// Stratum end
  		while (ClientPackets.TryDequeue(out result))
  		{
-@@ -1588,10 +1798,13 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+ 			try
+ 			{
+ 				HandleClientPacket_mainthread(result);
+@@ -1588,10 +1827,13 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  					DisconnectPlayer(result.client, "Threw an exception at the server", "An action you (or your client) did caused an unhandled exception");
  				}
  				Logger.Error(e);
@@ -551,7 +583,7 @@ index 1017be9..a819f8d 100644
  		TickPosition++;
  		foreach (KeyValuePair<Timer, Timer.Tick> timer in Timers)
  		{
-@@ -1882,10 +2095,15 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -1882,10 +2124,15 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  	}
  
  	public void Dispose()
@@ -567,7 +599,7 @@ index 1017be9..a819f8d 100644
  		if (Systems != null)
  		{
  			ServerSystem[] systems = Systems;
-@@ -1946,11 +2164,11 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -1946,11 +2193,11 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  				}
  			});
  		}
@@ -580,7 +612,7 @@ index 1017be9..a819f8d 100644
  	}
  
  	public string GetSaveFilepath()
-@@ -1970,10 +2188,15 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -1970,10 +2217,15 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  		}
  		return nextClientID++;
  	}
@@ -596,7 +628,7 @@ index 1017be9..a819f8d 100644
  		{
  			return;
  		}
-@@ -1982,17 +2205,23 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -1982,17 +2234,23 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  			lock (ConnectionQueue)
  			{
  				ConnectionQueue.RemoveAll((QueuedClient e) => e.Client.Id == client.Id);
@@ -621,7 +653,7 @@ index 1017be9..a819f8d 100644
  			{
  			}
  			Logger.Notification($"Client {client.Id} disconnected: {hisKickMessage}");
-@@ -2004,10 +2233,11 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -2004,10 +2262,11 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  			Clients.Remove(client.Id);
  			client.CloseConnection();
  		}
@@ -633,7 +665,7 @@ index 1017be9..a819f8d 100644
  				Logger.Audit("Client {0} got removed: '{1}' ({2})", client.PlayerName, othersKickmessage, hisKickMessage);
  			}
  			else
-@@ -2041,13 +2271,18 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -2041,13 +2300,18 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  			string playerName = client.PlayerName;
  			Clients.Remove(client.Id);
  			player.client = null;
@@ -655,7 +687,7 @@ index 1017be9..a819f8d 100644
  		}
  		else
  		{
-@@ -2070,10 +2305,15 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -2070,10 +2334,15 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  		{
  			SendMessageToGeneral(message, chatType, (chatType == EnumChatType.JoinLeave) ? player : null);
  		}
@@ -671,7 +703,7 @@ index 1017be9..a819f8d 100644
  		if (Config.MaxClientsInQueue <= 0 || stopped)
  		{
  			if (debugProcessConnectionQueue)
-@@ -2095,19 +2335,25 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -2095,19 +2364,25 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  			if (count > 0)
  			{
  				int maxClients = Config.MaxClients;
@@ -700,7 +732,7 @@ index 1017be9..a819f8d 100644
  					}
  					if (debugProcessConnectionQueue)
  					{
-@@ -2154,11 +2400,31 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -2154,11 +2429,31 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  		}
  	}
  
@@ -733,7 +765,7 @@ index 1017be9..a819f8d 100644
  	public int GetAllowedChunkRadius(ConnectedClient client)
  	{
  		int num = (int)Math.Ceiling((float)((client.WorldData == null) ? 128 : client.WorldData.Viewdistance) / (float)MagicNum.ServerChunkSize);
-@@ -2994,11 +3260,62 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -2994,11 +3289,62 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  		return WorldMap.GetServerChunk(entity.InChunkIndex3d)?.RemoveEntity(entity.EntityId) ?? false;
  	}
  
@@ -797,7 +829,7 @@ index 1017be9..a819f8d 100644
  	public Entity GetEntityById(long entityId)
  	{
  		LoadedEntities.TryGetValue(entityId, out var value);
-@@ -3289,20 +3606,38 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -3289,20 +3635,38 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  		return result;
  	}
  
@@ -815,24 +847,24 @@ index 1017be9..a819f8d 100644
  		float horRangeSq = horRange * horRange;
 -		foreach (ConnectedClient value in Clients.Values)
 +		try
- 		{
--			if (value.State == EnumClientState.Playing && value.Entityplayer != null && value.Position.InRangeOf(position, horRangeSq, vertRange) && (matches == null || matches(value.Player)))
++		{
 +			foreach (ConnectedClient value in Clients.Values)
- 			{
--				list.Add(value.Player);
++			{
 +				if (value.State == EnumClientState.Playing && value.Entityplayer != null && value.Position.InRangeOf(position, horRangeSq, vertRange) && (matches == null || matches(value.Player)))
 +				{
 +					list.Add(value.Player);
 +				}
- 			}
++			}
 +			return list.Count == 0 ? Array.Empty<IPlayer>() : list.ToArray();
 +		}
 +		finally
-+		{
+ 		{
+-			if (value.State == EnumClientState.Playing && value.Entityplayer != null && value.Position.InRangeOf(position, horRangeSq, vertRange) && (matches == null || matches(value.Player)))
 +			if (reuseList)
-+			{
+ 			{
+-				list.Add(value.Player);
 +				list.Clear();
-+			}
+ 			}
 +			reusablePlayersAroundDepth--;
  		}
 -		return list.ToArray();
@@ -841,7 +873,7 @@ index 1017be9..a819f8d 100644
  	public IPlayer PlayerByUid(string playerUid)
  	{
  		if (playerUid == null)
-@@ -3427,11 +3762,11 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -3427,11 +3791,11 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  			{
  				Socket = senderConnection
  			});
@@ -854,7 +886,7 @@ index 1017be9..a819f8d 100644
  		case NetworkMessageType.Data:
  		{
  			ConnectedClient client2 = msg.SenderConnection.client;
-@@ -3446,11 +3781,11 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -3446,11 +3810,11 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  		{
  			ConnectedClient client = msg.SenderConnection.client;
  			if (client != null)
@@ -867,7 +899,7 @@ index 1017be9..a819f8d 100644
  		}
  		}
  	}
-@@ -3472,13 +3807,54 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -3472,13 +3836,54 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  			DisconnectedClientsThisTick.Add(client.Id);
  			item = new ReceivedClientPacket(client, (client.Player == null) ? "" : "Network error: invalid client packet");
  		}
@@ -892,7 +924,8 @@ index 1017be9..a819f8d 100644
 +		{
 +			DisconnectedClientsThisTick.Add(client.Id);
 +			ClientPackets.Enqueue(new ReceivedClientPacket(client, disconnectReason));
-+		}
+ 		}
+-		ClientPackets.Enqueue(item);
 +	}
 +
 +	private void DispatchClientPacket_mainthread(ReceivedClientPacket pkt)
@@ -909,8 +942,7 @@ index 1017be9..a819f8d 100644
 +				DisconnectPlayer(pkt.client, "Threw an exception at the server", "An action you (or your client) did caused an unhandled exception");
 +			}
 +			Logger.Error(e);
- 		}
--		ClientPackets.Enqueue(item);
++		}
 +	}
 +
 +	private void KickForBackPressure(ConnectedClient client, string reason)
@@ -924,7 +956,7 @@ index 1017be9..a819f8d 100644
  	private void HandleClientPacket_mainthread(ReceivedClientPacket cpk)
  	{
  		ConnectedClient client = cpk.client;
-@@ -3500,15 +3876,42 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -3500,15 +3905,42 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  			{
  				Logger.Event("Client " + client.Id + " disconnected.");
  				EventManager.TriggerPlayerLeave(client.Player);
@@ -968,13 +1000,29 @@ index 1017be9..a819f8d 100644
  				FrameProfiler.Mark("net-read-", packet.Id);
  			}
  			return;
-@@ -3516,11 +3919,19 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -3516,11 +3948,35 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  		ClientPacketHandler<Packet_Client, ConnectedClient> clientPacketHandler = PacketHandlers[packet.Id];
  		if (clientPacketHandler != null && (client.Player != null || PacketHandlingOnConnectingAllowed[packet.Id]))
  		{
  			if (client.Player == null || client.Player.client == client)
  			{
 -				clientPacketHandler(packet, client);
++				// Stratum start: per-tick RequestJoin budget
++				if (packet.Id == 11)
++				{
++					int stratumJoinBudgetNow = StratumRuntime.Config.Performance.Join.MaxJoinsPerTick;
++					if (stratumJoinBudgetNow > 0 && stratumJoinsThisTick >= stratumJoinBudgetNow)
++					{
++						stratumDeferredJoinQueue.Enqueue(cpk);
++						if (FrameProfiler.Enabled)
++						{
++							FrameProfiler.Mark("net-join-deferred");
++						}
++						return;
++					}
++					stratumJoinsThisTick++;
++				}
++				// Stratum end
 +				long stratumPacketTimingStart = StratumRuntime.Timings.GetTimestamp();
 +				try
 +				{
@@ -989,7 +1037,7 @@ index 1017be9..a819f8d 100644
  					FrameProfiler.Mark("net-read-", packet.Id);
  				}
  			}
-@@ -3557,30 +3968,30 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -3557,30 +4013,30 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  						case "missingmptokenv2":
  						case "missingaccount":
  						case "banned":
@@ -1024,7 +1072,7 @@ index 1017be9..a819f8d 100644
  			if (!orCreateServerPlayerData.HasPrivilege(Privilege.controlserver, Config.RolesByCode) && !orCreateServerPlayerData.HasPrivilege("ignoremaxclients", Config.RolesByCode))
  			{
  				tryEnqueuePlayer(packet, client, entitlements, maxClients);
-@@ -3635,16 +4046,17 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -3635,16 +4091,17 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  				Logger.Notification($"Player {packet.Playername} was put into the connection queue at position {count2}");
  				SendPacket(client.Id, packet2);
  				return;
@@ -1043,7 +1091,7 @@ index 1017be9..a819f8d 100644
  			return;
  		}
  		if (client.Socket is TcpNetConnection tcpNetConnection)
-@@ -3773,10 +4185,20 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -3773,10 +4230,20 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  			SendServerIdentification(client.Player);
  			SpawnPlayerRandomlyAround(client, playername, entityPos, 15);
  			client.IsNewClient = false;
@@ -1064,7 +1112,7 @@ index 1017be9..a819f8d 100644
  			SendServerIdentification(client.Player);
  			client.Entityplayer.Pos.SetFrom(entityPos);
  			SpawnEntity(client.Entityplayer);
-@@ -3851,10 +4273,21 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -3851,10 +4318,21 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  	}
  
  	private void SpawnPlayerRandomlyAround(ConnectedClient client, string playername, EntityPos centerPos, int tries)
@@ -1086,7 +1134,7 @@ index 1017be9..a819f8d 100644
  			EntityPos entityPos = centerPos.Copy();
  			if (pos == null)
  			{
-@@ -3869,10 +4302,38 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -3869,10 +4347,38 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  			}
  			SpawnPlayerHere(client, playername, entityPos);
  		});
@@ -1125,7 +1173,7 @@ index 1017be9..a819f8d 100644
  		Clients.TryGetValue(client.Id, out var value);
  		if (value != null)
  		{
-@@ -4244,11 +4705,11 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -4244,11 +4750,11 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  
  	internal void BroadcastArbitraryPacket(byte[] data, params IServerPlayer[] skipPlayers)
  	{
@@ -1138,7 +1186,7 @@ index 1017be9..a819f8d 100644
  			}
  		}
  	}
-@@ -4258,11 +4719,11 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -4258,11 +4764,11 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  		Serialize_(packet);
  		byte[] array = null;
  		bool compressed = false;
@@ -1151,7 +1199,7 @@ index 1017be9..a819f8d 100644
  				{
  					array = client.Socket.PreparePacketForSending(reusableBuffer, Config.CompressPackets, out compressed);
  				}
-@@ -4277,17 +4738,42 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -4277,17 +4783,42 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  
  	internal void BroadcastArbitraryUdpPacket(Packet_UdpPacket data, params IServerPlayer[] skipPlayers)
  	{
@@ -1195,7 +1243,7 @@ index 1017be9..a819f8d 100644
  		if (packetBenchmark.ContainsKey(packetId))
  		{
  			packetBenchmark[packetId]++;
-@@ -4694,15 +5180,40 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -4694,15 +5225,40 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  	}
  
  	private void SendWorldMetaData(IServerPlayer player)
@@ -1236,7 +1284,7 @@ index 1017be9..a819f8d 100644
  		float[] array = blockLightLevels;
  		Packet_WorldMetaData packet_WorldMetaData = new Packet_WorldMetaData();
  		int[] array2 = new int[array.Length];
-@@ -4755,14 +5266,53 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -4755,14 +5311,53 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  		{
  			((DummyUdpNetServer)UdpSockets[0]).Client.Player = player;
  		}
@@ -1244,9 +1292,9 @@ index 1017be9..a819f8d 100644
  		{
 -			SendPacket(player, CreatePacketIdentification(player.HasPrivilege("controlserver")));
 +			SendStratumCachedServerIdentification(player);
-+		}
-+	}
-+
+ 		}
+ 	}
+ 
 +	private void SendStratumCachedServerIdentification(ServerPlayer player)
 +	{
 +		bool controlServerPrivilege = player.HasPrivilege("controlserver");
@@ -1267,9 +1315,9 @@ index 1017be9..a819f8d 100644
 +				stratumIdentificationCacheKeys[cacheIndex] = cacheKey;
 +			}
 +			SendPacket(player.ClientId, packet);
- 		}
- 	}
- 
++		}
++	}
++
 +	private string GetStratumIdentificationCacheKey(bool controlServerPrivilege)
 +	{
 +		StratumClientModPolicyConfig clientModPolicy = StratumRuntime.Config.ClientModPolicy;
@@ -1291,7 +1339,7 @@ index 1017be9..a819f8d 100644
  		List<Packet_ModId> list = (from mod in api.ModLoader.Mods
  			where mod.Info.Side.IsUniversal()
  			select new Packet_ModId
-@@ -4791,15 +5341,20 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -4791,15 +5386,20 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  			RequireRemapping = ((controlServerPrivilege && requiresRemaps) ? 1 : 0)
  		};
  		Logger.Notification((Config.DisableAutoRemap ? ("Sending server identification with remap " + requiresRemaps) : "Sending server identification") + ". Server control privilege is " + controlServerPrivilege);
@@ -1314,7 +1362,7 @@ index 1017be9..a819f8d 100644
  		}
  		return new Packet_Server
  		{
-@@ -4843,12 +5398,12 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -4843,12 +5443,12 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  				array[num] = item.Id;
  				array2[num] = (int)(1000f * item.Player.Ping);
  				num++;

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumConfig.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumConfig.cs
@@ -674,9 +674,15 @@ internal class StratumJoinConfig
 	// Limits how many queued players are admitted in one queue pass. 0 = vanilla behavior.
 	public int MaxQueueAdmissionsPerPass { get; set; } = 2;
 
+	// Limits how many RequestJoin packets (Id 11) are processed per tick. Deferred joins
+	// drain on subsequent ticks. Keeps the main thread responsive during join storms.
+	// 0 = no limit (vanilla behavior).
+	public int MaxJoinsPerTick { get; set; } = 3;
+
 	public void EnsureSane()
 	{
 		MaxQueueAdmissionsPerPass = Math.Max(0, Math.Min(64, MaxQueueAdmissionsPerPass));
+		MaxJoinsPerTick = Math.Max(0, Math.Min(64, MaxJoinsPerTick));
 	}
 }
 


### PR DESCRIPTION
Adds a per-tick budget for `HandleRequestJoin` (packet Id 11). When more than `MaxJoinsPerTick` requests arrive in one tick, the excess goes into a deferred queue drained at the start of the next `ProcessMain` pass. Clients in the deferred queue stay connected and keep receiving ping/keepalive. They join on subsequent ticks without timeout.

## Problem

The existing `MaxQueueAdmissionsPerPass=2` gates how many clients get their identity confirmed per tick. But `HandleRequestJoin` itself has no cap. After a restart, 500 already-identified clients all send RequestJoin in the same tick window. Each call costs ~11 ms on the main thread (spawn entity, send world metadata, send assets, broadcast player data to all others). A 500-player restart burns 5+ seconds of main-thread time in a single tick, dropping TPS to zero.

## Fix

In `HandleClientPacket_mainthread`, when `packet.Id == 11` and `stratumJoinsThisTick >= MaxJoinsPerTick`, push the packet into `stratumDeferredJoinQueue` and return. At the start of `ProcessMain`, drain up to `MaxJoinsPerTick` from the deferred queue (skipping disconnected clients). The counter resets each tick.

Default: 3 joins per tick. At 30 TPS, a 500-player restart completes all joins in ~5.5 seconds spread across ~167 ticks instead of one catastrophic tick.

## Config

```json
{
  "Performance": {
    "Join": {
      "MaxJoinsPerTick": 3
    }
  }
}
```

Set to 0 for vanilla behavior (no limit).

## Benchmark

500-bot join storm, dotnet-trace CPU profiling, 90s:

| Metric | Vanilla | Stratum-before | Stratum-after |
|---|---|---|---|
| Bots joined | 497/500 | 500/500 | 491/500 |
| HandleRequestJoin | 14.9% (13.4s) | 14.4% (13.0s) | 14.2% (12.8s) |
| ProcessMain | 23.5% (21.2s) | 22.2% (20.0s) | 21.8% (19.6s) |
| Thread.Sleep (idle) | 72.2% | 75.0% | 74.2% |
| TickEntities | 1.1% (1.0s) | 1.1% (1.0s) | 1.8% (1.6s) |

ProcessMain dropped from 23.5% to 21.8%. TickEntities went UP from 1.1% to 1.8% because with joins spread over time, more players are alive and ticking (the server does useful work instead of burning ticks on join bursts). Thread.Sleep stays high (server maintains idle headroom during the storm).

The 9 missing bots in stratum-after are TCP connection timeouts from the ramp, not budget rejections. Every client that connects gets joined; the budget only changes when, not whether.