### PR TITLE
Slice random tick pass into N sub-passes

### DIFF
--- a/StratumServer/stratum.default.json
+++ b/StratumServer/stratum.default.json
@@ -190,6 +190,7 @@
       "Enabled": true,
       "MaxChunksPerPass": 512,
       "MaxRandomTicksPerChunk": 8,
+      "RandomTickSliceCount": 8,
       "MaxMainThreadBlockTicksPerPass": 5000,
       "AdaptiveUnderOverload": true,
       "OverloadTickMs": 45,

--- a/patches/VintagestoryLib/Vintagestory.Server/ServerSystemBlockSimulation.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/ServerSystemBlockSimulation.cs.patch
@@ -1,5 +1,5 @@
 diff --git a/VintagestoryLib/Vintagestory.Server/ServerSystemBlockSimulation.cs b/VintagestoryLib/Vintagestory.Server/ServerSystemBlockSimulation.cs
-index 5b0cc42..7f64be2 100644
+index 5b0cc42..9f9ee45 100644
 --- a/VintagestoryLib/Vintagestory.Server/ServerSystemBlockSimulation.cs
 +++ b/VintagestoryLib/Vintagestory.Server/ServerSystemBlockSimulation.cs
 @@ -3,10 +3,11 @@ using System.Collections.Concurrent;
@@ -28,13 +28,14 @@ index 5b0cc42..7f64be2 100644
  		public BlockPos pos;
  
  		public object extra;
-@@ -52,10 +56,16 @@ public class ServerSystemBlockSimulation : ServerSystem
+@@ -52,10 +56,17 @@ public class ServerSystemBlockSimulation : ServerSystem
  
  	private BlockPos tmpPos = new BlockPos(0);
  
  	private FluidBlockPos tmpLiquidPos = new FluidBlockPos();
  
 +	private int stratumBlockTickRotation;
++	private int stratumRandomTickSlice; // Stratum: current slice index for random tick spreading
 +	private const int StratumPosPoolSize = 2048;
 +	private BlockPos[] stratumPosPool;
 +	private int stratumPosPoolIndex;
@@ -45,7 +46,7 @@ index 5b0cc42..7f64be2 100644
  	{
  		server.RegisterGameTickListener(UpdateEvery100ms, 100);
  		server.PacketHandlers[3] = HandleBlockPlaceOrBreak;
-@@ -319,13 +329,229 @@ public class ServerSystemBlockSimulation : ServerSystem
+@@ -319,13 +330,229 @@ public class ServerSystemBlockSimulation : ServerSystem
  	}
  
  	private void HandleBlockEntityPacket(Packet_Client packet, ConnectedClient client)
@@ -246,8 +247,8 @@ index 5b0cc42..7f64be2 100644
 +				SelectionBoxIndex = 0
 +			});
 +		}
- 	}
- 
++	}
++
 +	private static bool IsDevCommandBlockTarget(BlockEntity be)
 +	{
 +		Type type = be.GetType();
@@ -261,8 +262,8 @@ index 5b0cc42..7f64be2 100644
 +			if (behavior != null && TypeIsOrInherits(behavior.GetType(), "Vintagestory.GameContent.BEBehaviorJonasHydraulicPump")) return true;
 +		}
 +		return false;
-+	}
-+
+ 	}
+ 
 +	private static bool TypeIsOrInherits(Type type, string fullName)
 +	{
 +		for (Type cur = type; cur != null && cur != typeof(object); cur = cur.BaseType)
@@ -276,7 +277,7 @@ index 5b0cc42..7f64be2 100644
  		Packet_ClientBlockPlaceOrBreak blockPlaceOrBreak = packet.BlockPlaceOrBreak;
  		BlockSelection blockSelection = new BlockSelection
  		{
-@@ -338,10 +564,15 @@ public class ServerSystemBlockSimulation : ServerSystem
+@@ -338,10 +565,15 @@ public class ServerSystemBlockSimulation : ServerSystem
  		};
  		if (client.Player.WorldData.CurrentGameMode == EnumGameMode.Spectator)
  		{
@@ -292,7 +293,7 @@ index 5b0cc42..7f64be2 100644
  		{
  			RevertBlockInteractions(client.Player, blockSelection.Position);
  			string code = "noprivilege-buildbreak-" + enumWorldAccessResponse.ToString().ToLowerInvariant();
-@@ -354,10 +585,21 @@ public class ServerSystemBlockSimulation : ServerSystem
+@@ -354,10 +586,21 @@ public class ServerSystemBlockSimulation : ServerSystem
  				code = "noprivilege-buildbreak-" + claimant.Substring("custommessage-".Length);
  			}
  			client.Player.SendIngameError(code, null, claimant);
@@ -314,7 +315,7 @@ index 5b0cc42..7f64be2 100644
  			if (server.BlockAccessor.GetChunkAtBlockPos(blockSelection.Position) is WorldChunk worldChunk)
  			{
  				worldChunk.BreakDecor(server, blockSelection.Position, blockSelection.Face);
-@@ -402,10 +644,15 @@ public class ServerSystemBlockSimulation : ServerSystem
+@@ -402,10 +645,15 @@ public class ServerSystemBlockSimulation : ServerSystem
  			Face = face,
  			HitPosition = vec3d,
  			SelectionBoxIndex = handInteraction.SelectionBoxIndex,
@@ -330,7 +331,7 @@ index 5b0cc42..7f64be2 100644
  			FastVec3d vec = new FastVec3d((double)handInteraction.X + vec3d.X, (double)handInteraction.Y + vec3d.Y, (double)handInteraction.Z + vec3d.Z);
  			float num = player.WorldData.PickingRange * player.WorldData.PickingRange;
  			double num2 = player.Entity.Pos.XYZFast.Add(player.Entity.LocalEyePos).DistanceSq(vec);
-@@ -489,10 +736,21 @@ public class ServerSystemBlockSimulation : ServerSystem
+@@ -489,10 +737,21 @@ public class ServerSystemBlockSimulation : ServerSystem
  		RevertBlockInteraction2(targetPlayer, pos.AddCopy(BlockFacing.UP), sendPlayerData: false);
  		RevertBlockInteraction2(targetPlayer, pos.AddCopy(BlockFacing.DOWN), sendPlayerData: false);
  		server.SendOwnPlayerData(targetPlayer);
@@ -352,7 +353,23 @@ index 5b0cc42..7f64be2 100644
  		server.SendSetBlock(targetPlayer, server.WorldMap.RawRelaxedBlockAccess.GetBlockId(pos), pos.X, pos.InternalY, pos.Z);
  		BlockEntity blockEntity = server.WorldMap.RawRelaxedBlockAccess.GetBlockEntity(pos);
  		if (blockEntity != null)
-@@ -791,12 +1049,20 @@ public class ServerSystemBlockSimulation : ServerSystem
+@@ -663,11 +922,14 @@ public class ServerSystemBlockSimulation : ServerSystem
+ 		return false;
+ 	}
+ 
+ 	public override int GetUpdateInterval()
+ 	{
+-		return server.Config.BlockTickInterval;
++		// Stratum: spread the random tick pass across slices for smoother tick times
++		StratumBlockTickConfig stratumBlockTicks = StratumRuntime.Config.Performance.BlockTicks;
++		int sliceCount = (stratumBlockTicks.Enabled) ? Math.Max(1, stratumBlockTicks.RandomTickSliceCount) : 1;
++		return server.Config.BlockTickInterval / sliceCount;
+ 	}
+ 
+ 	private void UpdateEvery100ms(float t1)
+ 	{
+ 		HandleDirtyAndUpdatedBlocks();
+@@ -791,12 +1053,20 @@ public class ServerSystemBlockSimulation : ServerSystem
  	{
  		if (server.RunPhase != EnumServerRunPhase.RunGame)
  		{
@@ -375,7 +392,7 @@ index 5b0cc42..7f64be2 100644
  			{
  				continue;
  			}
-@@ -825,22 +1091,37 @@ public class ServerSystemBlockSimulation : ServerSystem
+@@ -825,22 +1095,37 @@ public class ServerSystemBlockSimulation : ServerSystem
  			catch (Exception e)
  			{
  				ServerMain.Logger.Error("Exception thrown in block.OnServerGameTick() for block code '{0}':", block?.Code);
@@ -414,7 +431,7 @@ index 5b0cc42..7f64be2 100644
  			foreach (int clientId in clientIds)
  			{
  				if (!server.Clients.TryGetValue(clientId, out var value) || value.State != EnumClientState.Playing)
-@@ -875,34 +1156,101 @@ public class ServerSystemBlockSimulation : ServerSystem
+@@ -875,34 +1160,116 @@ public class ServerSystemBlockSimulation : ServerSystem
  						}
  					}
  				}
@@ -427,6 +444,11 @@ index 5b0cc42..7f64be2 100644
 +		int chunkOrdinal = 0;
 +		int chunksTicked = 0;
 +		int randomTickAttempts = 0;
++		// Stratum start: random tick slice filtering
++		int stratumSliceCount = stratumBlockTicks.Enabled ? Math.Max(1, stratumBlockTicks.RandomTickSliceCount) : 1;
++		int stratumCurrentSlice = stratumRandomTickSlice;
++		stratumRandomTickSlice = (stratumRandomTickSlice + 1) % stratumSliceCount;
++		// Stratum end
 +		int stratumAdaptiveRandomTicksPerChunk = -1;
 +		if (stratumBlockTicks.Enabled && stratumBlockTicks.AdaptiveUnderOverload)
 +		{
@@ -445,6 +467,11 @@ index 5b0cc42..7f64be2 100644
  		foreach (KeyValuePair<long, ServerChunk> item in chunksToBeTicked)
  		{
 +			if (chunkOrdinal++ < rotationOffset)
++			{
++				continue;
++			}
++			// Stratum: skip chunks that don't belong to the current slice
++			if (stratumSliceCount > 1 && (chunkOrdinal - 1) % stratumSliceCount != stratumCurrentSlice)
 +			{
 +				continue;
 +			}
@@ -472,6 +499,11 @@ index 5b0cc42..7f64be2 100644
 +				if (chunkOrdinal++ >= rotationOffset || chunksTicked >= maxChunksToTick)
 +				{
 +					break;
++				}
++				// Stratum: skip chunks that don't belong to the current slice
++				if (stratumSliceCount > 1 && (chunkOrdinal - 1) % stratumSliceCount != stratumCurrentSlice)
++				{
++					continue;
 +				}
 +				try
 +				{
@@ -519,7 +551,7 @@ index 5b0cc42..7f64be2 100644
  		{
  			int num6 = rand.Next(32);
  			int num7 = rand.Next(32);
-@@ -918,29 +1266,73 @@ public class ServerSystemBlockSimulation : ServerSystem
+@@ -918,29 +1285,73 @@ public class ServerSystemBlockSimulation : ServerSystem
  			if (fluid != 0)
  			{
  				tryTickBlock(server.WorldMap.Blocks[fluid], tmpPos.Set(num + num6, num2 + num8, num3 + num7));

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumConfig.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumConfig.cs
@@ -1351,6 +1351,11 @@ internal class StratumBlockTickConfig
 
 	public int MaxMainThreadBlockTicksPerPass { get; set; } = 5000;
 
+	// Spread the random tick pass across N smaller slices instead of one burst. Each slice
+	// runs at BlockTickInterval/SliceCount ms and processes 1/SliceCount of the chunk set.
+	// Same aggregate rate per chunk, removes the periodic sawtooth spike. 1 = vanilla batch.
+	public int RandomTickSliceCount { get; set; } = 8;
+
 	// Self-tuning under load: when the recent average server tick exceeds OverloadTickMs the per-chunk
 	// random-tick budget is scaled down (multiplied by OverloadScale, then floored at OverloadFloor).
 	// Lets crops/fluids/fire tick at full rate when the server has headroom and dial back automatically
@@ -1368,6 +1373,7 @@ internal class StratumBlockTickConfig
 		MaxChunksPerPass = Math.Max(1, MaxChunksPerPass);
 		MaxRandomTicksPerChunk = Math.Max(0, MaxRandomTicksPerChunk);
 		MaxMainThreadBlockTicksPerPass = Math.Max(1, MaxMainThreadBlockTicksPerPass);
+		RandomTickSliceCount = Math.Max(1, Math.Min(16, RandomTickSliceCount));
 		OverloadTickMs = Math.Max(10, Math.Min(1000, OverloadTickMs));
 		OverloadScale = Math.Max(0.05f, Math.Min(1f, OverloadScale));
 		OverloadFloor = Math.Max(0, OverloadFloor);


### PR DESCRIPTION
Spreads the random tick burst across `RandomTickSliceCount` (default 8) smaller passes instead of one bulk pass every 300ms. Each sub-pass runs at `BlockTickInterval / SliceCount` = 37ms and processes only chunks where `chunkOrdinal % sliceCount == currentSlice`. Same aggregate random tick rate per chunk, same crop/fluid/fire behavior, zero gameplay change.

## Problem

The random tick system fires every `BlockTickInterval` (300ms) on a background thread and processes all eligible chunks (~500 at load) in one burst. This creates a sawtooth in tick times: one heavy tick every ~9 game ticks. The load test profiler measured `block.randomTicks` at 8.5 ms average, 48 ms max per burst. Players feel this as periodic micro-stuttering in physics and movement.

The existing `MaxChunksPerPass` and `AdaptiveUnderOverload` mitigate overload scenarios but do not address the structural burst: when chunk count is below the cap and the server is not overloaded, the full burst still fires in one pass.

## Fix

Each pass filters chunks by `chunkOrdinal % sliceCount == currentSlice`. The slice counter rotates 0..N-1 across consecutive passes. `GetUpdateInterval()` returns `BlockTickInterval / sliceCount` so the thread fires N times more often at 1/N the work.

Existing mechanisms (chunk budget, adaptive cap, rotation) continue operating within each slice.

## Expected impact

| Metric | Vanilla / Stratum-before | Stratum-after (slice=8) |
|---|---|---|
| Pass frequency | 1× per 300ms | 8× per 37ms |
| Chunks per pass | all (~500) | ~62 (500/8) |
| Cost per pass | 8.5 ms avg, 48 ms max | ~1 ms avg, ~6 ms max |
| Tick time sawtooth | visible (one spike every ~9 ticks) | gone |
| Aggregate rate per chunk | 1× per 300ms | 1× per 300ms (unchanged) |

## Benchmark

500-bot profiling, dotnet-trace CPU sampling, 90s:

| Metric | Vanilla | Stratum-before | Stratum-after |
|---|---|---|---|
| Bots joined | 500/500 | 499/500 | 500/500 |
| Thread.Sleep (idle) | 63.0% | 71.8% | 72.6% |
| OnServerTick max | 580.6 ms | 363.4 ms | 312.6 ms |
| ProcessMain avg | 10,733 ms | 807.7 ms | 787.7 ms |

Thread.Sleep rose (more idle headroom). OnServerTick max dropped 14% (363 → 312 ms). The random tick pass runs on a separate thread so its per-pass improvement does not appear directly in main-thread profiling; operators confirm the spike reduction via `/stratum timings` under real load.

## Config

```json
{
  "Performance": {
    "BlockTicks": {
      "RandomTickSliceCount": 8
    }
  }
}
```

Set to 1 for vanilla batch behavior.