### PR TITLE
Anticheat will now report violations but auto-kicking is opt-in

### DIFF
--- a/sources/VintagestoryLib/Vintagestory.Server/StratumAnticheatConfig.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumAnticheatConfig.cs
@@ -120,7 +120,7 @@ internal class StratumBlockInteractionOutOfRangeAnticheatConfig : StratumAntiche
 {
 	public double RangeSlack { get; set; } = 0.75;
 
-	public bool KickConfirmedCheats { get; set; } = true;
+	public bool KickConfirmedCheats { get; set; } = false;
 
 	public int KickAfterViolations { get; set; } = 3;
 
@@ -141,7 +141,7 @@ internal class StratumEntityInteractionOutOfRangeAnticheatConfig : StratumAntich
 {
 	public double RangeSlack { get; set; } = 1.0;
 
-	public bool KickConfirmedCheats { get; set; } = true;
+	public bool KickConfirmedCheats { get; set; } = false;
 
 	public int KickAfterViolations { get; set; } = 3;
 
@@ -158,7 +158,7 @@ internal class StratumEntityInteractionOutOfRangeAnticheatConfig : StratumAntich
 
 internal class StratumBlockBreakProgressAnticheatConfig : StratumAnticheatRuleConfig
 {
-	public bool KickConfirmedCheats { get; set; } = true;
+	public bool KickConfirmedCheats { get; set; } = false;
 
 	public int KickAfterViolations { get; set; } = 3;
 


### PR DESCRIPTION
## Summary

Anticheat will report violations but no longer kick for any cheat detections automatically.

## Type

- [ ] Bug fix
- [ ] Performance
- [ ] New feature
- [x] Refactor or cleanup
- [ ] Docs or build

## Checklist

- [x] `.\scripts\extract-patches.ps1` ran clean.
- [x] `dotnet build VintageStory.slnx -c Release` is green.
- [x] Every vanilla edit has a `// Stratum` marker.
- [x] No vanilla source committed.
- [x] Tested on a real server start, not just compilation.
