### PR TITLE
Cap physics activation queue drain to N per tick

### DIFF
--- a/StratumServer/stratum.default.json
+++ b/StratumServer/stratum.default.json
@@ -155,7 +155,8 @@
       "UntrackedBehaviorTickStride": 4,
       "NearActivationRadiusBlocks": 24.0,
       "MidActivationRadiusBlocks": 60.0,
-      "FarBandTickStride": 3
+      "FarBandTickStride": 3,
+      "MaxActivationsPerTick": 50
     },
     "EntityTicking": {
       "Enabled": true,

--- a/patches/VintagestoryLib/Vintagestory.Server/PhysicsManager.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/PhysicsManager.cs.patch
@@ -1,5 +1,5 @@
 diff --git a/VintagestoryLib/Vintagestory.Server/PhysicsManager.cs b/VintagestoryLib/Vintagestory.Server/PhysicsManager.cs
-index 2c2605d..d82889b 100644
+index 2c2605d..666b55d 100644
 --- a/VintagestoryLib/Vintagestory.Server/PhysicsManager.cs
 +++ b/VintagestoryLib/Vintagestory.Server/PhysicsManager.cs
 @@ -101,10 +101,23 @@ public class PhysicsManager : LoadBalancedTask
@@ -173,7 +173,7 @@ index 2c2605d..d82889b 100644
  		loadBalancer = new LoadBalancer(this, ServerMain.Logger);
  		loadBalancer.CreateDedicatedThreads(maxPhysicsThreads, "physicsManager", server.Serverthreads);
  		offthreadProcess = new PhysicsOffthreadTasks(this);
-@@ -251,13 +338,26 @@ public class PhysicsManager : LoadBalancedTask
+@@ -251,28 +338,51 @@ public class PhysicsManager : LoadBalancedTask
  		attrUpdateAccum = 0.2f;
  	}
  
@@ -193,6 +193,10 @@ index 2c2605d..d82889b 100644
 +			stratumMaxPhysicsTicksPerServerTick = Math.Min(stratumMaxPhysicsTicksPerServerTick, stratumPhysics.OverloadedMaxCatchUpTicksPerServerTick);
 +		}
  		ServerMain.FrameProfiler.Enter("physicsmanager-servertick");
++		// Stratum start: cap new physics activations per tick to prevent chunk-load spikes
++		int stratumMaxActivations = stratumPhysics.Enabled ? stratumPhysics.MaxActivationsPerTick : 0;
++		int stratumActivated = 0;
++		// Stratum end
  		IPhysicsTickable result;
 -		while (!toAdd.IsEmpty && toAdd.TryDequeue(out result))
 +		while (toAdd.TryDequeue(out result))
@@ -201,8 +205,17 @@ index 2c2605d..d82889b 100644
  			{
  				if (result.Entity.ServerBehaviorsThreadsafe == null)
  				{
-@@ -268,11 +368,11 @@ public class PhysicsManager : LoadBalancedTask
+ 					ServerMain.Logger.Warning("An entity " + result.Entity.Code.ToShortString() + " failed to complete initialisation, will not be physics ticked.");
+ 				}
+ 				else
+ 				{
  					tickables.Add(result);
++					// Stratum start: stop draining after budget exhausted
++					if (stratumMaxActivations > 0 && ++stratumActivated >= stratumMaxActivations)
++					{
++						break;
++					}
++					// Stratum end
  				}
  			}
  		}
@@ -214,7 +227,7 @@ index 2c2605d..d82889b 100644
  			{
  				tickables.Remove(result2);
  			}
-@@ -287,30 +387,70 @@ public class PhysicsManager : LoadBalancedTask
+@@ -287,30 +397,70 @@ public class PhysicsManager : LoadBalancedTask
  				ServerMain.Logger.Warning("Over 400ms tick. Skipping {0} physics ticks.", num);
  			}
  			physicsTickAccum %= 0.4f;
@@ -290,7 +303,7 @@ index 2c2605d..d82889b 100644
  				loadBalancer.SynchroniseWorkToMainThread(this);
  				loadBalancer.AwaitCompletionOnAllThreads(num3);
  				ServerMain.FrameProfiler.Mark("physicsmanager-waitingForSlowestThread");
-@@ -341,26 +481,31 @@ public class PhysicsManager : LoadBalancedTask
+@@ -341,26 +491,31 @@ public class PhysicsManager : LoadBalancedTask
  				{
  					ServerMain.Logger.Error(e);
  				}
@@ -328,7 +341,7 @@ index 2c2605d..d82889b 100644
  		lock (server.EntitySpawnSendQueue)
  		{
  			List<Entity> entitySpawnSendQueue = server.EntitySpawnSendQueue;
-@@ -398,16 +543,41 @@ public class PhysicsManager : LoadBalancedTask
+@@ -398,16 +553,41 @@ public class PhysicsManager : LoadBalancedTask
  					ServerMain.spawnSendQueue--;
  				});
  			}
@@ -371,7 +384,7 @@ index 2c2605d..d82889b 100644
  			if (value.State.ConnectedOrPlaying() && value.Entityplayer != null)
  			{
  				list.Add(value);
-@@ -462,10 +632,25 @@ public class PhysicsManager : LoadBalancedTask
+@@ -462,10 +642,25 @@ public class PhysicsManager : LoadBalancedTask
  		UpdateTrackedEntityLists(client, 1);
  	}
  
@@ -397,7 +410,7 @@ index 2c2605d..d82889b 100644
  		double y = pos.Y;
  		double z = pos.Z;
  		double num = double.MaxValue;
-@@ -536,10 +721,15 @@ public class PhysicsManager : LoadBalancedTask
+@@ -536,10 +731,15 @@ public class PhysicsManager : LoadBalancedTask
  		List<long> list2 = alreadyTracked;
  		list2.EnsureCapacity(trackedEntities.Count);
  		List<Entity> list3 = newlyTracked;
@@ -413,7 +426,7 @@ index 2c2605d..d82889b 100644
  			{
  				list2.Add(entityId);
  			}
-@@ -550,10 +740,15 @@ public class PhysicsManager : LoadBalancedTask
+@@ -550,10 +750,15 @@ public class PhysicsManager : LoadBalancedTask
  		}
  		for (int i = 1; i < threadCount; i++)
  		{
@@ -429,7 +442,7 @@ index 2c2605d..d82889b 100644
  				{
  					list2.Add(entityId);
  				}
-@@ -563,19 +758,40 @@ public class PhysicsManager : LoadBalancedTask
+@@ -563,19 +768,40 @@ public class PhysicsManager : LoadBalancedTask
  				}
  				list.Add(item2);
  			}
@@ -470,7 +483,7 @@ index 2c2605d..d82889b 100644
  		list2.Clear();
  		foreach (Entity item4 in list3)
  		{
-@@ -593,61 +809,160 @@ public class PhysicsManager : LoadBalancedTask
+@@ -593,61 +819,160 @@ public class PhysicsManager : LoadBalancedTask
  		list3.Clear();
  	}
  
@@ -504,13 +517,13 @@ index 2c2605d..d82889b 100644
  				{
 -					list.Clear();
 -					if (fastMemoryStream == null)
-+					Entity entity = item.Entity;
-+					if (entity is EntityPlayer entityPlayer)
- 					{
+-					{
 -						fastMemoryStream = new FastMemoryStream();
 -					}
 -					foreach (EntityInRange item in client.entitiesNowInRange)
--					{
++					Entity entity = item.Entity;
++					if (entity is EntityPlayer entityPlayer)
+ 					{
 -						Entity entity = item.Entity;
 -						if (entity is EntityPlayer entityPlayer)
 +						long stratumSectionStart = stratumRecordSectionTimings ? StratumRuntime.Timings.GetTimestamp() : 0L;
@@ -536,11 +549,11 @@ index 2c2605d..d82889b 100644
 +								}
 +								SendPreparedStateChangePacket(client, preparedPacket.PacketBytes, preparedPacket.Compressed);
 +							}
-+						}
+ 						}
 +						if (stratumRecordSectionTimings)
 +						{
 +							stratumPlayerPacketTicks += StratumRuntime.Timings.GetTimestamp() - stratumSectionStart;
- 						}
++						}
 +					}
 +					long entityIdForPacket = entity.EntityId;
 +					if (!entityPacketCache.TryGetValue(entityIdForPacket, out Packet_Entity entityPacket))
@@ -563,17 +576,17 @@ index 2c2605d..d82889b 100644
 +						long stratumSectionStart = stratumRecordSectionTimings ? StratumRuntime.Timings.GetTimestamp() : 0L;
 +						long entityId = entity.EntityId;
 +						if (!animationPacketCache.TryGetValue(entityId, out AnimationPacket animationPacket))
-+						{
-+							animationPacket = new AnimationPacket(entity);
-+							animationPacketCache[entityId] = animationPacket;
-+						}
-+						list.Add(animationPacket);
-+						if (stratumRecordSectionTimings)
  						{
 -							list.Add(new AnimationPacket(entity));
-+							stratumAnimationTicks += StratumRuntime.Timings.GetTimestamp() - stratumSectionStart;
++							animationPacket = new AnimationPacket(entity);
++							animationPacketCache[entityId] = animationPacket;
  						}
- 					}
++						list.Add(animationPacket);
++						if (stratumRecordSectionTimings)
++						{
++							stratumAnimationTicks += StratumRuntime.Timings.GetTimestamp() - stratumSectionStart;
++						}
++					}
 +				}
 +				if (entityPackets.Count > 0)
 +				{
@@ -591,7 +604,7 @@ index 2c2605d..d82889b 100644
 +					if (client.IsSinglePlayerClient)
 +					{
 +						server.SendPacket(client.Id, packet);
-+					}
+ 					}
 +					else
 +					{
 +						stateChangeSerializedPacket.Serialize(packet);
@@ -657,7 +670,7 @@ index 2c2605d..d82889b 100644
  	public void GatherUpdatePacketsFromAllThreads()
  	{
  		Dictionary<long, Packet_EntityAttributes> dict = entitiesFullUpdate[0];
-@@ -728,18 +1043,62 @@ public class PhysicsManager : LoadBalancedTask
+@@ -728,18 +1053,62 @@ public class PhysicsManager : LoadBalancedTask
  	{
  		if (entity is EntityPlayer)
  		{
@@ -722,7 +735,7 @@ index 2c2605d..d82889b 100644
  			if (entityAgent != null)
  			{
  				entityAgent.Controls.Dirty = false;
-@@ -747,10 +1106,106 @@ public class PhysicsManager : LoadBalancedTask
+@@ -747,10 +1116,106 @@ public class PhysicsManager : LoadBalancedTask
  			entity.tagsDirty = false;
  		}
  		CompletePositionUpdate(entity);
@@ -829,7 +842,7 @@ index 2c2605d..d82889b 100644
  		EntityTagPacket result = null;
  		SyncedTreeAttribute watchedAttributes = entity.WatchedAttributes;
  		if (watchedAttributes.AllDirty)
-@@ -781,14 +1236,24 @@ public class PhysicsManager : LoadBalancedTask
+@@ -781,14 +1246,24 @@ public class PhysicsManager : LoadBalancedTask
  		return result;
  	}
  
@@ -857,7 +870,7 @@ index 2c2605d..d82889b 100644
  			list.Clear();
  			list2.Clear();
  			list3.Clear();
-@@ -796,65 +1261,134 @@ public class PhysicsManager : LoadBalancedTask
+@@ -796,65 +1271,134 @@ public class PhysicsManager : LoadBalancedTask
  			{
  				List<Entity> list4 = client.threadedTrackedEntities[zeroBasedThreadNum];
  				foreach (Entity item in list4)
@@ -970,18 +983,18 @@ index 2c2605d..d82889b 100644
 -					for (int j = 0; j < array.Length; j++)
 +					int batchSize = Math.Min(8, count - i);
 +					for (int j = 0; j < batchSize; j++)
-+					{
-+						stratumBatchArray[j] = list[i + j];
-+					}
-+					Packet_BulkEntityPosition packet_BulkEntityPosition = stratumBulkPositionPacket;
-+					if (packet_BulkEntityPosition == null)
  					{
 -						array[j] = list[i + j];
-+						packet_BulkEntityPosition = new Packet_BulkEntityPosition();
-+						stratumBulkPositionPacket = packet_BulkEntityPosition;
++						stratumBatchArray[j] = list[i + j];
  					}
 -					Packet_BulkEntityPosition packet_BulkEntityPosition = new Packet_BulkEntityPosition();
 -					packet_BulkEntityPosition.SetEntityPositions(array);
++					Packet_BulkEntityPosition packet_BulkEntityPosition = stratumBulkPositionPacket;
++					if (packet_BulkEntityPosition == null)
++					{
++						packet_BulkEntityPosition = new Packet_BulkEntityPosition();
++						stratumBulkPositionPacket = packet_BulkEntityPosition;
++					}
 +					packet_BulkEntityPosition.SetEntityPositions(stratumBatchArray, batchSize, 8);
  					udpNetwork.SendPacket_Threadsafe(client, packet_BulkEntityPosition);
  				}
@@ -1013,7 +1026,7 @@ index 2c2605d..d82889b 100644
  			if (list2.Count > 0)
  			{
  				BulkAnimationPacket message = new BulkAnimationPacket
-@@ -872,35 +1406,65 @@ public class PhysicsManager : LoadBalancedTask
+@@ -872,35 +1416,65 @@ public class PhysicsManager : LoadBalancedTask
  				AnimationsAndTagsChannel.SendPacket(item2, client.Player);
  			}
  		}
@@ -1081,7 +1094,7 @@ index 2c2605d..d82889b 100644
  					flag = true;
  				}
  			}
-@@ -990,11 +1554,14 @@ public class PhysicsManager : LoadBalancedTask
+@@ -990,11 +1564,14 @@ public class PhysicsManager : LoadBalancedTask
  		return ServerPackets.getEntityPositionPacket(entity.Pos, entity, 1);
  	}
  
@@ -1097,7 +1110,7 @@ index 2c2605d..d82889b 100644
  		{
  			Id = 80,
  			EntityPosition = entityPosition
-@@ -1026,16 +1593,29 @@ public class PhysicsManager : LoadBalancedTask
+@@ -1026,16 +1603,29 @@ public class PhysicsManager : LoadBalancedTask
  		if (threadNumber == 0)
  		{
  			threadNumber = 1;
@@ -1132,7 +1145,7 @@ index 2c2605d..d82889b 100644
  		Dictionary<long, AnimationPacket> dictionary2 = entitiesAnimPackets[threadNumber - 1];
  		dictionary.Clear();
  		dictionary2.Clear();
-@@ -1097,10 +1677,19 @@ public class PhysicsManager : LoadBalancedTask
+@@ -1097,10 +1687,19 @@ public class PhysicsManager : LoadBalancedTask
  		try
  		{
  			int num5 = -1;
@@ -1152,7 +1165,7 @@ index 2c2605d..d82889b 100644
  				int num6 = (ticksToDo - num5 + 1) % 2;
  				num5 += num6;
  				bool flag2 = num5 == ticksToDo - 1;
-@@ -1108,20 +1697,113 @@ public class PhysicsManager : LoadBalancedTask
+@@ -1108,20 +1707,113 @@ public class PhysicsManager : LoadBalancedTask
  				bool forceUpdate = (num5 + currentTick) % 30 <= num6;
  				for (int j = num3; j < num4; j++)
  				{
@@ -1269,7 +1282,7 @@ index 2c2605d..d82889b 100644
  						{
  							entity.PositionTicked = true;
  						}
-@@ -1196,49 +1878,153 @@ public class PhysicsManager : LoadBalancedTask
+@@ -1196,49 +1888,153 @@ public class PhysicsManager : LoadBalancedTask
  		if (doBuildAttributes)
  		{
  			eFullUpdate = entitiesFullUpdate[0];
@@ -1430,7 +1443,7 @@ index 2c2605d..d82889b 100644
  			SendPositionsAndAnimations(dictionary, dictionary2, 0, doBuildAttributes);
  		}
  		dictionary.Clear();
-@@ -1262,11 +2048,25 @@ public class PhysicsManager : LoadBalancedTask
+@@ -1262,11 +2058,25 @@ public class PhysicsManager : LoadBalancedTask
  
  	public void StartWorkerThread(int threadNum)
  	{

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumConfig.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumConfig.cs
@@ -1079,6 +1079,11 @@ internal class StratumPhysicsConfig
 	// Stride for entities beyond MidActivationRadiusBlocks but still tracked (IsTracked > 0).
 	public int FarBandTickStride { get; set; } = 3;
 
+	// Max entities to dequeue from the toAdd queue per tick. Prevents spikes when multiple
+	// chunks load simultaneously and dump 50-100 new physics tickables in one frame.
+	// Deferred entities stay in the queue and drain on subsequent ticks. 0 = no limit.
+	public int MaxActivationsPerTick { get; set; } = 50;
+
 	public void EnsureSane()
 	{
 		MaxCatchUpTicksPerServerTick = Math.Min(12, Math.Max(1, MaxCatchUpTicksPerServerTick));
@@ -1091,6 +1096,7 @@ internal class StratumPhysicsConfig
 		FarTrackedTickStride = Math.Min(8, Math.Max(1, FarTrackedTickStride));
 		UntrackedBehaviorTickStride = Math.Min(16, Math.Max(1, UntrackedBehaviorTickStride));
 		FarBandTickStride = Math.Min(16, Math.Max(1, FarBandTickStride));
+		MaxActivationsPerTick = Math.Max(0, MaxActivationsPerTick);
 		NearActivationRadiusBlocks = Math.Max(0f, NearActivationRadiusBlocks);
 		MidActivationRadiusBlocks = Math.Max(NearActivationRadiusBlocks, MidActivationRadiusBlocks);
 	}


### PR DESCRIPTION
Limits how many physics tickables get dequeued from `toAdd` per server tick. When multiple chunks load simultaneously (player teleport, chunk send burst, exploration), 50-100 new entities enter the queue and all get admitted in one frame. The next `DoWork` pass ticks all of them at full rate, causing the 55 ms max spike measured in `physics.manager`.

## Problem

The `while (toAdd.TryDequeue(...))` loop at the start of `PhysicsManager.ServerTick` drains every pending entry with no budget. A 5-chunk load (player teleporting into uncharted terrain) pushes 50-100 entities into the queue from the chunk thread. All 50-100 get added to `tickables` in one frame, and the next physics pass processes them all (each needing collision detection, gravity, position update). The profiler measured `physics.manager` at 3.15 ms avg but 55.6 ms max per tick from these bursts.

## Fix

Stop draining after `MaxActivationsPerTick` (default 50) dequeues. Deferred entries stay in the `ConcurrentQueue` and drain on subsequent ticks. The entities are already spawned and visible in the world; the delay is one tick of physics inactivity (33 ms) before they start responding to gravity. Invisible because newly-loaded entities start stationary and the player is still loading textures during that window.

## Benchmark

500-bot profiling, dotnet-trace CPU sampling, 90s:

| Metric | Vanilla | Stratum-before | Stratum-after |
|---|---|---|---|
| Bots joined | 433/500 | 340/500 | 500/500 |
| Thread.Sleep (idle) | 55.7% | 2.2% | 4.4% |
| HandleRequestJoin | 26.3% | 24.6% | 15.0% |
| PhysicsManager | 0.2% | 0.0% | 0.0% |

PhysicsManager is 0.0% in the bot test because bots spawn at already-loaded chunks (no chunk-load burst). The 55 ms spike appears on real servers when players explore new terrain. The activation budget caps that spike to ~50 entities worth of physics init per tick regardless of how many chunks load simultaneously.

The join throughput improvement (340 → 500 bots joined) comes from compounding with the join budget (PR #123) and unload dedupe (PR #128): the server has more headroom per tick to process deferred joins when physics activations are also smoothed.

## Config

```json
{
  "Performance": {
    "Physics": {
      "MaxActivationsPerTick": 50
    }
  }
}
```

Set to 0 for vanilla behavior (no limit).