### PR TITLE
Fix NRE in EntityPlayer.SetName for first-time players

### DIFF
--- a/patches/VintagestoryApi/Common/Entity/EntityPlayer.cs.patch
+++ b/patches/VintagestoryApi/Common/Entity/EntityPlayer.cs.patch
@@ -1,0 +1,21 @@
+diff --git a/VintagestoryApi/Common/Entity/EntityPlayer.cs b/VintagestoryApi/Common/Entity/EntityPlayer.cs
+index 7279e48..7e5d1f7 100644
+--- a/VintagestoryApi/Common/Entity/EntityPlayer.cs
++++ b/VintagestoryApi/Common/Entity/EntityPlayer.cs
+@@ -1545,11 +1545,15 @@ namespace Vintagestory.API.Common
+         }
+ 
+         public void SetName(string name)
+         {
+             var tree = WatchedAttributes.GetTreeAttribute("nametag");
+-            if (tree == null) WatchedAttributes["nametag"] = new TreeAttribute();
++            if (tree == null)
++            {
++                tree = new TreeAttribute(); // Stratum: was not reassigned, caused NRE on first join
++                WatchedAttributes["nametag"] = tree;
++            }
+             tree.SetString("name", name);
+         }
+ 
+         public override string GetInfoText()
+         {


### PR DESCRIPTION
SetName calls GetTreeAttribute("nametag") and checks for null, but never reassigns the local variable after creating the new TreeAttribute. The next line dereferences null.

Every first-time player on a fresh world hits this path because EntityBehaviorNameTag initializes the nametag attribute during behavior init, which runs AFTER HandleRequestJoin calls SetName. Existing players with serialized entity data have the attribute from their save and skip the null branch.

Fix: reassign the local before calling SetString.