### PR TITLE
Fix join deadlock in SendPreparedBytes flush bypass

### DIFF
--- a/patches/VintagestoryLib/Vintagestory.Server.Network/TcpNetConnection.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server.Network/TcpNetConnection.cs.patch
@@ -1,5 +1,5 @@
 diff --git a/VintagestoryLib/Vintagestory.Server.Network/TcpNetConnection.cs b/VintagestoryLib/Vintagestory.Server.Network/TcpNetConnection.cs
-index ae86835..4b54999 100644
+index ae86835..674f19b 100644
 --- a/VintagestoryLib/Vintagestory.Server.Network/TcpNetConnection.cs
 +++ b/VintagestoryLib/Vintagestory.Server.Network/TcpNetConnection.cs
 @@ -35,18 +35,26 @@ public class TcpNetConnection : NetConnection
@@ -43,15 +43,16 @@ index ae86835..4b54999 100644
  		catch
  		{
  			InvokeDisconnected();
-@@ -180,20 +188,64 @@ public class TcpNetConnection : NetConnection
+@@ -180,20 +188,65 @@ public class TcpNetConnection : NetConnection
  			return EnumSendResult.Disconnected;
  		}
  		try
  		{
  			NetIncomingMessage.WriteInt(dataWithLength, length | (int)((compressedFlag ? 1u : 0u) << 31));
-+			// Stratum start: keep the login path on vanilla-style direct sends. New clients
-+			// need immediate handshake packets, and delaying those can leave them stuck receiving data.
-+			if (client == null || client.IsNewClient)
++			// Stratum start: keep the login path on vanilla-style direct sends. Clients that
++			// have not yet received server assets need immediate packets; buffering them causes
++			// a deadlock because HandleRequestJoin blocks the tick that would flush the buffer.
++			if (client == null || !client.ServerAssetsSent)
 +			{
 +				TcpSocket.SendAsync(dataWithLength, SocketFlags.None, cts.Token);
 +				return EnumSendResult.Ok;


### PR DESCRIPTION
The `IsNewClient` bypass in `SendPreparedBytes` (b79a776) decides whether to send directly or buffer via StratumNetworkFlush. In the delayed-join path, `IsNewClient` is set to false before `HandleRequestJoin` runs. `SendServerAssets` then buffers the ~4MB assets packet instead of sending it directly. The buffer only flushes on the next tick, but the main thread is blocked inside `HandleRequestJoin` waiting for the send to complete. Deadlock. Client sees "1kb received" for 151 seconds until the ping timeout kicks them.

Replace the condition with `!client.ServerAssetsSent`. This field stays false until `HandleRequestJoin` finishes sending assets, so all join-phase packets bypass the flush buffer regardless of the delayed-join timing.

Before: first join hangs 151s, client times out, gets kicked every time.
After: first join completes in 14s (normal for fresh world with chunk gen).