### PR TITLE
TreeGen Optimization

### DIFF
--- a/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/8.GenVegetationAndPatches/Treegen/TreeGen.cs.patch
+++ b/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/8.GenVegetationAndPatches/Treegen/TreeGen.cs.patch
@@ -1,0 +1,80 @@
+diff --git a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/8.GenVegetationAndPatches/Treegen/TreeGen.cs b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/8.GenVegetationAndPatches/Treegen/TreeGen.cs
+index 894489e..3aa8d49 100644
+--- a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/8.GenVegetationAndPatches/Treegen/TreeGen.cs
++++ b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/8.GenVegetationAndPatches/Treegen/TreeGen.cs
+@@ -22,15 +22,30 @@ namespace Vintagestory.ServerMods
+         List<TreeGenBranch> branchesByDepth = new List<TreeGenBranch>();
+ 
+         // Tree config
+         TreeGenConfig config;
+         private readonly ForestFloorSystem forestFloor;
++        
++        private BlockPos[] posStack;    // Stratum: manual stack for block positions to avoid allocations new BlockPos()
++        private readonly BlockPos vineScratchPos;   // Stratum: field for temporary vine positions
+ 
+         public TreeGen(TreeGenConfig config, int seed, ForestFloorSystem ffs)
+         {
+             this.config = config;
+             forestFloor = ffs;
++
++            // Stratum start: 
++            // Initialize the stack and variable once when creating the generator 
++            // The maximum recursion depth in growBranch is limited by the condition depth > 30.
++            posStack = new BlockPos[32];
++            for (int i = 0; i < posStack.Length; i++)
++            {
++                posStack[i] = new BlockPos();
++            }
++
++            vineScratchPos = new BlockPos();
++            // Stratum end
+         }
+ 
+         public void GrowTree(IBlockAccessor ba, BlockPos pos, TreeGenParams treeGenParams, IRandom random)
+         {
+             int treeSubType = random.NextInt(8);
+@@ -103,12 +118,13 @@ namespace Vintagestory.ServerMods
+ 
+             float ddrag, angleVer, angleHor;
+ 
+             // we want to place around the trunk/branch => offset the coordinates when growing stuff from the base
+             float trunkOffsetX, trunkOffsetZ;
+-
+-            BlockPos currentPos = new BlockPos(basePos.dimension);
++            
++            BlockPos currentPos = posStack[depth];  // Stratum: instead of new BlockPos(...) we take an object from the stack
++            currentPos.dimension = basePos.dimension;   // Stratum: update the dimension, since the object can be reused
+ 
+             float sinAngleVer, cosAnglerHor, sinAngleHor;
+ 
+             float currentSequence;
+ 
+@@ -234,12 +250,12 @@ namespace Vintagestory.ServerMods
+         /// Place one tree block and any consequentials from that: maybe apply moss; maybe update the canopy outline for forest floor purposes; maybe place vines
+         /// </summary>
+         private void PlaceBlockEtc(int blockId, BlockPos currentPos, IRandom rand, float dx, float dz)
+         {
+             blockAccessor.SetBlock(blockId, currentPos);
+-
+-            if (blockAccessor.GetBlock(blockId).BlockMaterial == EnumBlockMaterial.Wood && treeGenParams.mossGrowthChance > 0 && config.treeBlocks.mossDecorBlock != null)
++            
++            if (treeGenParams.mossGrowthChance > 0 && config.treeBlocks.mossDecorBlock != null && blockAccessor.GetBlock(blockId).BlockMaterial == EnumBlockMaterial.Wood)  // Stratum: moving cheap conditions forward
+             {
+                 var rnd = rand.NextDouble();
+                 int faceIndex = treeGenParams.hemisphere == EnumHemisphere.North ? 0 : 2; // Prefer north face on the northern hemisphere, and south otherwise (= the shady spot)
+                 for (int i = 2; i >= 0; i--)
+                 {
+@@ -283,11 +299,12 @@ namespace Vintagestory.ServerMods
+ 
+             if (treeGenParams.vinesGrowthChance > 0 && rand.NextDouble() < treeGenParams.vinesGrowthChance && config.treeBlocks.vinesBlock != null)
+             {
+                 BlockFacing facing = BlockFacing.HORIZONTALS[rand.NextInt(4)];
+ 
+-                BlockPos vinePos = currentPos.AddCopy(facing);
++                BlockPos vinePos = vineScratchPos.Set(currentPos, currentPos.dimension).Offset(facing); // Stratum: use our field without allocations
++
+                 float cnt = 1 + rand.NextInt(11) * (treeGenParams.vinesGrowthChance + 0.2f);
+ 
+                 while (blockAccessor.GetBlockId(vinePos) == 0 && cnt-- > 0)
+                 {
+                     Block block = config.treeBlocks.vinesBlock;

--- a/patches/VintagestoryApi/Math/EvolvingNatFloat.cs.patch
+++ b/patches/VintagestoryApi/Math/EvolvingNatFloat.cs.patch
@@ -1,0 +1,33 @@
+diff --git a/VintagestoryApi/Math/EvolvingNatFloat.cs b/VintagestoryApi/Math/EvolvingNatFloat.cs
+index d7f08db..4992a13 100644
+--- a/VintagestoryApi/Math/EvolvingNatFloat.cs
++++ b/VintagestoryApi/Math/EvolvingNatFloat.cs
+@@ -154,16 +154,25 @@ namespace Vintagestory.API.MathTools
+                 factor = reader.ReadSingle()
+             };
+             return evo;
+         }
+ 
+-        public override bool Equals([NotNullWhen(true)] object obj)
++        // Stratum start:
++        // Add a typed overload 
++        // This way we avoid constant conversions of EvolvingNatFloat to object
++        public bool Equals(EvolvingNatFloat other)
+         {
+-            if (obj is not EvolvingNatFloat enf) return false;
+-            return enf.Transform == Transform && enf.factor == factor;
++            return other.Transform == Transform && other.factor == factor;
+         }
+ 
++        public override bool Equals(object obj)
++        {
++            return obj is EvolvingNatFloat other && Equals(other);
++        }
++
++        // Stratum end
++
+         public static bool operator ==(EvolvingNatFloat left, EvolvingNatFloat right)
+         {
+             return left.Equals(right);
+         }
+ 


### PR DESCRIPTION
## Summary

Added manual position pool and variable for vine positions when generating trees.
An overload has also been added to **EvolvingNatFloat**, which allows you to compare these objects without converting to object.
This significantly reduces GC pressure, since the code also works recursively.

## Type

- [ ] Bug fix
- [x] Performance
- [ ] New feature
- [ ] Refactor or cleanup
- [ ] Docs or build

## Checklist

- [x] `.\scripts\extract-patches.ps1` ran clean.
- [x] `dotnet build VintageStory.slnx -c Release` is green.
- [x] Every vanilla edit has a `// Stratum` marker.
- [x] No vanilla source committed.
- [x] Tested on a real server start, not just compilation.

## Performance numbers

Tested on the generation of 10200 chunk columns:
- TreeGen.growBranch method execution time: reduced from 3549 ms to 2607 ms;
- TreeGen.growBranch GC memory allocations: reduced from 1.14 Gb MB to 211 MB.

**Before**
<img width="690" height="655" alt="growbranch before trace" src="https://github.com/user-attachments/assets/59418472-41d7-4cea-a917-b706c563c22d" />
<img width="1802" height="701" alt="growbranch before mem" src="https://github.com/user-attachments/assets/2537be48-9119-4238-8b31-5d9c92259668" />
<img width="1920" height="1017" alt="2026-07-11_12-14-08" src="https://github.com/user-attachments/assets/41fa16cd-2f25-4102-9cfa-987b39298c8d" />
<img width="1920" height="1017" alt="2026-07-11_12-14-41" src="https://github.com/user-attachments/assets/4c5be7e4-6583-4c06-b58f-ec676c06fe91" />




**After**
<img width="670" height="569" alt="growbranch after trace" src="https://github.com/user-attachments/assets/ad93175a-0031-4ab2-8466-4a7c55b346e5" />
<img width="1755" height="501" alt="growbranch after mem" src="https://github.com/user-attachments/assets/9f0dd76b-60da-4a7a-8a17-1d132a418edf" />
<img width="1920" height="1017" alt="stratum дерево 1" src="https://github.com/user-attachments/assets/f9341491-4e84-4c7e-8dcd-dbc9c3b5a32e" />
<img width="1920" height="1017" alt="stratum дерево 2" src="https://github.com/user-attachments/assets/5febc6ee-b18e-401d-b370-9cd9e3e50aab" />




