### PR TITLE
Disable StratumNetworkFlush, fix client crashes on join

### DIFF
--- a/patches/VintagestoryApi/Common/Entity/Entity.cs.patch
+++ b/patches/VintagestoryApi/Common/Entity/Entity.cs.patch
@@ -1,8 +1,27 @@
 diff --git a/VintagestoryApi/Common/Entity/Entity.cs b/VintagestoryApi/Common/Entity/Entity.cs
-index aafb4f0..f084632 100644
+index aafb4f0..735ca4b 100644
 --- a/VintagestoryApi/Common/Entity/Entity.cs
 +++ b/VintagestoryApi/Common/Entity/Entity.cs
-@@ -1045,27 +1045,43 @@ namespace Vintagestory.API.Common.Entities
+@@ -577,12 +577,16 @@ namespace Vintagestory.API.Common.Entities
+                     if (World != null && Properties != null)   // The following code can crash if the entity is not yet initialised e.g. during updating from packets (see SyncedTreeAttribute.FromBytes() which calls all listeners)
+                     {
+                         float factor = Properties.Client.SizeGrowthFactor;
+                         if (factor != 0)
+                         {
+-                            var origc = World.GetEntityType(this.Code).Client;
+-                            Properties.Client.Size = origc.Size + WatchedAttributes.GetTreeAttribute("grow").GetFloat("age") * factor;
++                            var entityType = World.GetEntityType(this.Code); // Stratum: null-check, entity type may not be resolved during sync updates
++                            if (entityType != null)
++                            {
++                                var origc = entityType.Client;
++                                Properties.Client.Size = origc.Size + WatchedAttributes.GetTreeAttribute("grow").GetFloat("age") * factor;
++                            }
+                         }
+                     }
+                 });
+             }
+ 
+@@ -1045,27 +1049,43 @@ namespace Vintagestory.API.Common.Entities
  
                  // We include this check in case a mod changed the Behaviors without using .AddBehavior() or .RemoveBehavior()
                  if (Properties.Server.Behaviors.Count != ServerBehaviorsMainThread.Length + ServerBehaviorsThreadsafe.Length) CacheServerBehaviors();

--- a/patches/VintagestoryLib/Vintagestory.Server.Network/TcpNetConnection.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server.Network/TcpNetConnection.cs.patch
@@ -1,5 +1,5 @@
 diff --git a/VintagestoryLib/Vintagestory.Server.Network/TcpNetConnection.cs b/VintagestoryLib/Vintagestory.Server.Network/TcpNetConnection.cs
-index ae86835..674f19b 100644
+index ae86835..b2b0f03 100644
 --- a/VintagestoryLib/Vintagestory.Server.Network/TcpNetConnection.cs
 +++ b/VintagestoryLib/Vintagestory.Server.Network/TcpNetConnection.cs
 @@ -35,18 +35,26 @@ public class TcpNetConnection : NetConnection
@@ -43,26 +43,16 @@ index ae86835..674f19b 100644
  		catch
  		{
  			InvokeDisconnected();
-@@ -180,20 +188,65 @@ public class TcpNetConnection : NetConnection
+@@ -180,20 +188,55 @@ public class TcpNetConnection : NetConnection
  			return EnumSendResult.Disconnected;
  		}
  		try
  		{
  			NetIncomingMessage.WriteInt(dataWithLength, length | (int)((compressedFlag ? 1u : 0u) << 31));
-+			// Stratum start: keep the login path on vanilla-style direct sends. Clients that
-+			// have not yet received server assets need immediate packets; buffering them causes
-+			// a deadlock because HandleRequestJoin blocks the tick that would flush the buffer.
-+			if (client == null || !client.ServerAssetsSent)
-+			{
-+				TcpSocket.SendAsync(dataWithLength, SocketFlags.None, cts.Token);
-+				return EnumSendResult.Ok;
-+			}
-+
-+			if (StratumNetworkFlush.TryBuffer(this, dataWithLength, length, compressedFlag))
-+			{
-+				return EnumSendResult.Ok;
-+			}
-+			// Stratum end: large/compressed packet, send directly after flushing the buffer.
++			// Stratum: send all packets directly. The flush buffer (StratumNetworkFlush) causes
++			// packet ordering issues between the main thread and physics offthread that crash the
++			// client during join and early gameplay. Vanilla sends every packet via SendAsync
++			// immediately and relies on TCP ordering. Do the same.
  			TcpSocket.SendAsync(dataWithLength, SocketFlags.None, cts.Token);
  			return EnumSendResult.Ok;
  		}

--- a/patches/VintagestoryLib/Vintagestory.Server/PhysicsManager.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/PhysicsManager.cs.patch
@@ -1,5 +1,5 @@
 diff --git a/VintagestoryLib/Vintagestory.Server/PhysicsManager.cs b/VintagestoryLib/Vintagestory.Server/PhysicsManager.cs
-index 2c2605d..8b3007c 100644
+index 2c2605d..e8f049f 100644
 --- a/VintagestoryLib/Vintagestory.Server/PhysicsManager.cs
 +++ b/VintagestoryLib/Vintagestory.Server/PhysicsManager.cs
 @@ -101,10 +101,23 @@ public class PhysicsManager : LoadBalancedTask
@@ -339,7 +339,7 @@ index 2c2605d..8b3007c 100644
  		lock (server.EntitySpawnSendQueue)
  		{
  			List<Entity> entitySpawnSendQueue = server.EntitySpawnSendQueue;
-@@ -398,16 +551,41 @@ public class PhysicsManager : LoadBalancedTask
+@@ -398,19 +551,47 @@ public class PhysicsManager : LoadBalancedTask
  					ServerMain.spawnSendQueue--;
  				});
  			}
@@ -379,10 +379,17 @@ index 2c2605d..8b3007c 100644
 +		}
  		foreach (ConnectedClient value in values)
  		{
- 			if (value.State.ConnectedOrPlaying() && value.Entityplayer != null)
+-			if (value.State.ConnectedOrPlaying() && value.Entityplayer != null)
++			// Stratum: only include fully-joined clients. Clients mid-join (Connected state)
++			// have not yet received ServerAssets. Sending entity spawns before assets arrive
++			// causes the client to deserialize entities whose types are not yet registered.
++			if (value.IsPlayingClient && value.Entityplayer != null)
  			{
  				list.Add(value);
-@@ -462,10 +640,25 @@ public class PhysicsManager : LoadBalancedTask
+ 			}
+ 		}
+ 		if (positions.Length < list.Count * 3)
+@@ -462,10 +643,25 @@ public class PhysicsManager : LoadBalancedTask
  		UpdateTrackedEntityLists(client, 1);
  	}
  
@@ -408,7 +415,7 @@ index 2c2605d..8b3007c 100644
  		double y = pos.Y;
  		double z = pos.Z;
  		double num = double.MaxValue;
-@@ -536,10 +729,15 @@ public class PhysicsManager : LoadBalancedTask
+@@ -536,10 +732,15 @@ public class PhysicsManager : LoadBalancedTask
  		List<long> list2 = alreadyTracked;
  		list2.EnsureCapacity(trackedEntities.Count);
  		List<Entity> list3 = newlyTracked;
@@ -424,7 +431,7 @@ index 2c2605d..8b3007c 100644
  			{
  				list2.Add(entityId);
  			}
-@@ -550,10 +748,15 @@ public class PhysicsManager : LoadBalancedTask
+@@ -550,10 +751,15 @@ public class PhysicsManager : LoadBalancedTask
  		}
  		for (int i = 1; i < threadCount; i++)
  		{
@@ -440,7 +447,7 @@ index 2c2605d..8b3007c 100644
  				{
  					list2.Add(entityId);
  				}
-@@ -563,19 +766,40 @@ public class PhysicsManager : LoadBalancedTask
+@@ -563,19 +769,40 @@ public class PhysicsManager : LoadBalancedTask
  				}
  				list.Add(item2);
  			}
@@ -481,7 +488,7 @@ index 2c2605d..8b3007c 100644
  		list2.Clear();
  		foreach (Entity item4 in list3)
  		{
-@@ -593,61 +817,160 @@ public class PhysicsManager : LoadBalancedTask
+@@ -593,61 +820,160 @@ public class PhysicsManager : LoadBalancedTask
  		list3.Clear();
  	}
  
@@ -668,7 +675,7 @@ index 2c2605d..8b3007c 100644
  	public void GatherUpdatePacketsFromAllThreads()
  	{
  		Dictionary<long, Packet_EntityAttributes> dict = entitiesFullUpdate[0];
-@@ -728,18 +1051,62 @@ public class PhysicsManager : LoadBalancedTask
+@@ -728,18 +1054,62 @@ public class PhysicsManager : LoadBalancedTask
  	{
  		if (entity is EntityPlayer)
  		{
@@ -733,7 +740,7 @@ index 2c2605d..8b3007c 100644
  			if (entityAgent != null)
  			{
  				entityAgent.Controls.Dirty = false;
-@@ -747,10 +1114,106 @@ public class PhysicsManager : LoadBalancedTask
+@@ -747,10 +1117,106 @@ public class PhysicsManager : LoadBalancedTask
  			entity.tagsDirty = false;
  		}
  		CompletePositionUpdate(entity);
@@ -840,7 +847,7 @@ index 2c2605d..8b3007c 100644
  		EntityTagPacket result = null;
  		SyncedTreeAttribute watchedAttributes = entity.WatchedAttributes;
  		if (watchedAttributes.AllDirty)
-@@ -781,14 +1244,24 @@ public class PhysicsManager : LoadBalancedTask
+@@ -781,14 +1247,24 @@ public class PhysicsManager : LoadBalancedTask
  		return result;
  	}
  
@@ -868,7 +875,7 @@ index 2c2605d..8b3007c 100644
  			list.Clear();
  			list2.Clear();
  			list3.Clear();
-@@ -796,65 +1269,123 @@ public class PhysicsManager : LoadBalancedTask
+@@ -796,65 +1272,123 @@ public class PhysicsManager : LoadBalancedTask
  			{
  				List<Entity> list4 = client.threadedTrackedEntities[zeroBasedThreadNum];
  				foreach (Entity item in list4)
@@ -1011,7 +1018,7 @@ index 2c2605d..8b3007c 100644
  			if (list2.Count > 0)
  			{
  				BulkAnimationPacket message = new BulkAnimationPacket
-@@ -872,35 +1403,65 @@ public class PhysicsManager : LoadBalancedTask
+@@ -872,35 +1406,65 @@ public class PhysicsManager : LoadBalancedTask
  				AnimationsAndTagsChannel.SendPacket(item2, client.Player);
  			}
  		}
@@ -1079,7 +1086,7 @@ index 2c2605d..8b3007c 100644
  					flag = true;
  				}
  			}
-@@ -990,11 +1551,14 @@ public class PhysicsManager : LoadBalancedTask
+@@ -990,11 +1554,14 @@ public class PhysicsManager : LoadBalancedTask
  		return ServerPackets.getEntityPositionPacket(entity.Pos, entity, 1);
  	}
  
@@ -1095,7 +1102,7 @@ index 2c2605d..8b3007c 100644
  		{
  			Id = 80,
  			EntityPosition = entityPosition
-@@ -1026,16 +1590,29 @@ public class PhysicsManager : LoadBalancedTask
+@@ -1026,16 +1593,29 @@ public class PhysicsManager : LoadBalancedTask
  		if (threadNumber == 0)
  		{
  			threadNumber = 1;
@@ -1130,7 +1137,7 @@ index 2c2605d..8b3007c 100644
  		Dictionary<long, AnimationPacket> dictionary2 = entitiesAnimPackets[threadNumber - 1];
  		dictionary.Clear();
  		dictionary2.Clear();
-@@ -1097,10 +1674,19 @@ public class PhysicsManager : LoadBalancedTask
+@@ -1097,10 +1677,19 @@ public class PhysicsManager : LoadBalancedTask
  		try
  		{
  			int num5 = -1;
@@ -1150,7 +1157,7 @@ index 2c2605d..8b3007c 100644
  				int num6 = (ticksToDo - num5 + 1) % 2;
  				num5 += num6;
  				bool flag2 = num5 == ticksToDo - 1;
-@@ -1108,20 +1694,113 @@ public class PhysicsManager : LoadBalancedTask
+@@ -1108,20 +1697,113 @@ public class PhysicsManager : LoadBalancedTask
  				bool forceUpdate = (num5 + currentTick) % 30 <= num6;
  				for (int j = num3; j < num4; j++)
  				{
@@ -1267,7 +1274,7 @@ index 2c2605d..8b3007c 100644
  						{
  							entity.PositionTicked = true;
  						}
-@@ -1196,49 +1875,153 @@ public class PhysicsManager : LoadBalancedTask
+@@ -1196,49 +1878,153 @@ public class PhysicsManager : LoadBalancedTask
  		if (doBuildAttributes)
  		{
  			eFullUpdate = entitiesFullUpdate[0];
@@ -1428,7 +1435,7 @@ index 2c2605d..8b3007c 100644
  			SendPositionsAndAnimations(dictionary, dictionary2, 0, doBuildAttributes);
  		}
  		dictionary.Clear();
-@@ -1262,11 +2045,25 @@ public class PhysicsManager : LoadBalancedTask
+@@ -1262,11 +2048,25 @@ public class PhysicsManager : LoadBalancedTask
  
  	public void StartWorkerThread(int threadNum)
  	{


### PR DESCRIPTION
StratumNetworkFlush (f0f6305, refactored in #88, patched in #96) buffers small TCP packets and flushes at tick end to reduce syscalls. This breaks packet ordering between the main thread and the physics offthread. The client receives entity data, weather snapshots, and attribute updates out of order, causing NREs on join and during early gameplay.

Tested A/B with the same client and same world type:
- Vanilla server: connects, plays, no crash.
- Stratum with flush enabled: crash within 2 seconds. WeatherSystemClient NRE, Entity.Initialize grow listener NRE, ModSystemMeasuringRope NRE.
- Stratum with flush disabled (this PR): connects, plays, no crash.

The fix sends all packets via SendAsync immediately, matching vanilla behavior. TCP preserves FIFO order. The flush buffer broke this by holding packets from one thread while another thread sent directly, causing the client to process packets out of sequence.

Also includes:
- PhysicsManager.BuildClientList: only include IsPlayingClient in the entity send loop (prevents spawn races for joining clients)
- Entity.cs grow listener: null-check GetEntityType return (defense in depth)

The flush concept still has value for syscall reduction on high-player servers. A safe reimplementation needs a single-writer queue that preserves cross-thread packet order. Leaving that for later.