### PR TITLE
Add recurring dropped item cleanup task

### DIFF
--- a/StratumServer/stratum.default.json
+++ b/StratumServer/stratum.default.json
@@ -238,6 +238,15 @@
       "OverloadDropThresholdMs": 500.0,
       "FloorChunks": 4,
       "AdjustmentIntervalSeconds": 2.0
+    },
+    "ItemCleanup": {
+      "Enabled": false,
+      "IntervalSeconds": 60,
+      "MinimumEntityAgeSeconds": 10,
+      "CleanupWarningMessage": "Cleaning up dropped items in {0} seconds.",
+      "CleanupWarningTimeOffsets": [30, 10],
+      "CleanupStartingMessage": "Cleaning up dropped items...",
+      "CleanupDoneMessage": "Cleaned up {0} items."
     }
   },
   "Commands": {

--- a/sources/VintagestoryLib/Vintagestory.Server/ServerSystemStratum.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/ServerSystemStratum.cs
@@ -99,7 +99,12 @@ internal class ServerSystemStratum : ServerSystem
 			new StratumBackupScheduler(server);
 			StratumRuntime.LogInfo("backup scheduler armed: first backup in about 1min, interval=" + StratumRuntime.Config.Backup.IntervalMinutes + "min retain=" + StratumRuntime.Config.Backup.RetainCount);
 		}
-		StratumTrimClassRegistry();
+		if (StratumRuntime.Config.Performance.ItemCleanup.Enabled)
+		{
+			new StratumItemCleanup(server);
+			StratumRuntime.LogInfo($"item cleanup scheduler armed: first cleanup in {StratumRuntime.Config.Performance.ItemCleanup.IntervalSeconds}s, interval={StratumRuntime.Config.Performance.ItemCleanup.IntervalSeconds}s");
+        }
+        StratumTrimClassRegistry();
 		StratumRuntime.LogInfo("runtime ready. Use /stratum health, /stratum status, and /stratum timings start.");
 	}
 

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumConfig.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumConfig.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using Vintagestory.API.Common.Entities;
 
 namespace Vintagestory.Server;
@@ -622,6 +623,8 @@ internal class StratumPerformanceConfig
 
 	public StratumAdaptiveRadiusConfig AdaptiveRadius { get; set; } = new StratumAdaptiveRadiusConfig();
 
+	public StratumItemCleanupConfig ItemCleanup { get; set; } = new StratumItemCleanupConfig();
+
 	public void EnsurePopulated()
 	{
 		ChunkSending ??= new StratumChunkSendingConfig();
@@ -646,6 +649,7 @@ internal class StratumPerformanceConfig
 		TimerResolution ??= new StratumTimerResolutionConfig();
 		Join ??= new StratumJoinConfig();
 		AdaptiveRadius ??= new StratumAdaptiveRadiusConfig();
+		ItemCleanup ??= new StratumItemCleanupConfig();
 		ChunkSending.EnsureSane();
 		ChunkGeneration.EnsureSane();
 		ChunkRequestManagement.EnsureSane();
@@ -668,6 +672,7 @@ internal class StratumPerformanceConfig
 		TimerResolution.EnsureSane();
 		Join.EnsureSane();
 		AdaptiveRadius.EnsureSane();
+		ItemCleanup.EnsureSane();
 	}
 }
 
@@ -715,6 +720,29 @@ internal class StratumAdaptiveRadiusConfig
 		OverloadDropThresholdMs = Math.Max(50.0, OverloadDropThresholdMs);
 		FloorChunks = Math.Max(1, FloorChunks);
 		AdjustmentIntervalSeconds = Math.Max(1.0f, AdjustmentIntervalSeconds);
+	}
+}
+
+internal class StratumItemCleanupConfig
+{
+	public bool Enabled { get; set; } = false;
+	public int IntervalSeconds { get; set; } = 60;
+	public int MinimumEntityAgeSeconds { get; set; } = 10;
+	public string CleanupWarningMessage { get; set; } = "Cleaning up dropped items in {0} seconds.";
+	public int[] CleanupWarningTimeOffsets { get; set; } = [30, 10];
+	public string CleanupStartingMessage { get; set; } = "Cleaning up dropped items...";
+	public string CleanupDoneMessage { get; set; } = "Cleaned up {0} items.";
+
+	public void EnsureSane()
+	{
+		IntervalSeconds = Math.Max(1, IntervalSeconds);
+		MinimumEntityAgeSeconds = Math.Max(0, MinimumEntityAgeSeconds);
+		CleanupWarningMessage ??= "";
+		CleanupStartingMessage ??= "";
+		CleanupDoneMessage ??= "";
+		CleanupWarningTimeOffsets ??= [];
+
+		CleanupWarningTimeOffsets = CleanupWarningTimeOffsets.Select(n => Math.Clamp(n, 1, IntervalSeconds)).Distinct().ToArray();
 	}
 }
 

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumItemCleanup.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumItemCleanup.cs
@@ -1,0 +1,120 @@
+using System;
+using System.Diagnostics;
+using System.Linq;
+using Vintagestory.API.Common;
+using Vintagestory.API.Common.Entities;
+
+namespace Vintagestory.Server;
+
+internal sealed class StratumItemCleanup
+{
+	private readonly ServerMain server;
+	private static StratumItemCleanupConfig Cfg => StratumRuntime.Config?.Performance?.ItemCleanup;
+	private static StratumThemeConfig Theme => StratumRuntime.Config?.Theme;
+
+	private static int CleanupIntervalMs => (Cfg?.IntervalSeconds ?? 60) * 1000;
+
+	public StratumItemCleanup(ServerMain server)
+	{
+		this.server = server;
+
+		RegisterCallbacks();
+	}
+
+	private static string ColorizeVtml(string message, string color)
+	{
+		if (string.IsNullOrWhiteSpace(color))
+		{
+			return message;
+		}
+
+		return $"<font color='{color}'>{message}</font>";
+	}
+
+	private void RegisterCallbacks()
+	{
+		var pendingEntities = GetItemEntities();
+		if (pendingEntities.Length == 0)
+		{
+			StratumRuntime.LogInfo($"No items on the ground to clean up. Waiting another {CleanupIntervalMs}ms.");
+			server.RegisterCallback((_) => RegisterCallbacks(), CleanupIntervalMs);
+
+			return;
+		}
+
+		server.RegisterCallback(DoCleanup, CleanupIntervalMs);
+
+		if (!string.IsNullOrWhiteSpace(Cfg?.CleanupWarningMessage) && Cfg?.CleanupWarningTimeOffsets != null)
+		{
+			foreach (var offset in Cfg.CleanupWarningTimeOffsets)
+			{
+				if (offset > 0 && offset < Cfg.IntervalSeconds)
+				{
+					server.RegisterCallback((_) => DoCleanupWarning(offset), CleanupIntervalMs - (offset * 1000));
+				}
+			}
+		}
+	}
+
+	private void DoCleanupWarning(int seconds)
+	{
+		StratumRuntime.LogInfo($"Cleaning up ground items in {seconds} seconds");
+		server.SendMessageToGeneral(ColorizeVtml(string.Format(Cfg.CleanupWarningMessage, seconds), Theme?.WarnColor), EnumChatType.Notification);
+	}
+
+	private void DoCleanup(float dt)
+	{
+		if (!string.IsNullOrEmpty(Cfg.CleanupStartingMessage))
+		{
+			server.SendMessageToGeneral(ColorizeVtml(Cfg.CleanupStartingMessage, Theme?.AccentColor), EnumChatType.Notification);
+		}
+		StratumRuntime.LogInfo($"Cleaning up ground items...");
+
+        try
+        {
+            var s = new Stopwatch();
+            s.Start();
+
+            var count = RemoveGroundEntities();
+
+            s.Stop();
+
+            if (!string.IsNullOrEmpty(Cfg.CleanupDoneMessage))
+            {
+                server.SendMessageToGeneral(ColorizeVtml(string.Format(Cfg.CleanupDoneMessage, count), Theme?.GoodColor), EnumChatType.Notification);
+            }
+            StratumRuntime.LogInfo($"Cleaned up {count} ground items in {s.ElapsedMilliseconds} ms");
+        }
+        catch (Exception ex)
+        {
+            StratumRuntime.LogError("Error during ground item cleanup: " + ex);
+        }
+        finally
+        {
+            RegisterCallbacks();
+        }
+    }
+
+	private Entity[] GetItemEntities()
+	{
+		// If the item is on the ground and has been around for longer than the minimum age, remove it
+		return server.LoadedEntities.Where(e => e.Value is EntityItem item
+			&& (item.OnGround || item.FeetInLiquid)
+			&& server.ElapsedMilliseconds - item.itemSpawnedMilliseconds > (Cfg?.MinimumEntityAgeSeconds ?? 1) * 1000)
+			.Select(e => e.Value)
+			.ToArray();
+	}
+
+	private int RemoveGroundEntities()
+	{
+		var entities = GetItemEntities();
+		var count = entities.Length;
+
+		foreach (var p in entities)
+		{
+			p.Die(EnumDespawnReason.Expire);
+		}
+
+		return count;
+	}
+}


### PR DESCRIPTION
## Summary

Add a scheduled item cleanup for loose items on the ground (or in the water).

Features:
- Configurable cleanup interval
- Configurable minimum item age
- Configurable warning, start, and finish messages
- Configurable warning times

## Type

- [ ] Bug fix
- [ ] Performance
- [x] New feature
- [ ] Refactor or cleanup
- [ ] Docs or build

## Checklist

- [x] `.\scripts\extract-patches.ps1` ran clean.
- [x] `dotnet build VintageStory.slnx -c Release` is green.
- [x] Every vanilla edit has a `// Stratum` marker.
- [x] No vanilla source committed.
- [x] Tested on a real server start, not just compilation.

## Related issues

Closes #102 
