### PR TITLE
Update contribution readme and solution file to unblock dev work for newcomers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -136,7 +136,7 @@ For development builds the constants are authoritative. Bump `StratumRevision` a
 
 ## Pull requests
 
-Open the PR against `main`. The template lists the checks. Don't strip them.
+Open the PR against `indev`. The template lists the checks. Don't strip them.
 
 In the description, say what changed and why. For perf work, include the numbers.
 

--- a/VintageStory.slnx
+++ b/VintageStory.slnx
@@ -7,6 +7,7 @@
   <Folder Name="/Vanilla/">
     <Project Path="Cairo/Cairo.csproj" />
     <Project Path="VintagestoryApi/VintagestoryAPI.csproj" />
+    <Project Path="baseline/VintagestoryLib/VintagestoryLib.csproj" />
   </Folder>
   <Folder Name="/Stratum/">
     <Project Path="StratumServer/StratumServer.csproj" />


### PR DESCRIPTION
## Summary

- Update CONTRIBUTING.md to specify the correct target branch for new PRs
- Add VintagestoryLib to the list of projects built when running `dotnet build VintageStory.slnx -c Release`

## Type

- [ ] Bug fix
- [ ] Performance
- [ ] New feature
- [ ] Refactor or cleanup
- [x] Docs or build

## Checklist

- [x] `.\scripts\extract-patches.ps1` ran clean.
- [x] `dotnet build VintageStory.slnx -c Release` is green.
- [x] Every vanilla edit has a `// Stratum` marker.
- [x] No vanilla source committed.
- [x] Tested on a real server start, not just compilation.
