### PR TITLE
Update extract-patches scripts to print what they are doing

### DIFF
--- a/scripts/extract-patches.ps1
+++ b/scripts/extract-patches.ps1
@@ -194,6 +194,8 @@ try {
         $keptBase = @{}
         $keptSrc  = @{}
 
+        Write-Host "Extracting patches for $proj" -ForegroundColor Cyan
+
         foreach ($file in Get-ProjectWorkFiles $work) {
             $rel = $file.FullName.Substring($work.Length + 1)
             $baseFile  = Join-Path $base $rel
@@ -201,6 +203,8 @@ try {
 
             if (-not (Test-Path $baseFile)) {
                 Sync-NewFile -Proj $proj -WorkRel $rel -SrcFile $file.FullName -WrittenRef ([ref]$sourcesWritten) -Kept $keptSrc
+                Write-Host "  $rel " -NoNewLine
+                Write-Host "(source)" -ForegroundColor Yellow
                 continue
             }
             $diff = Get-DiffLines $baseFile $file.FullName
@@ -209,6 +213,7 @@ try {
                 Write-Lf -Path $patchFile -Lines $headers
                 $patchesWritten++
                 $keptBase[(Resolve-Path $baseFile).Path] = $true
+                Write-Host "  $rel"
             } elseif (Test-Path $patchFile) {
                 Remove-Item $patchFile; $cleared++
             }
@@ -225,6 +230,8 @@ try {
 
         $keptBase = @{}
         $keptSrc  = @{}
+        
+        Write-Host "Extracting patches for $proj" -ForegroundColor Cyan
 
         foreach ($file in Get-ProjectWorkFiles $work) {
             $rel = $file.FullName.Substring($work.Length + 1)
@@ -233,6 +240,8 @@ try {
 
             if (-not (Test-Path $baseFile)) {
                 Sync-NewFile -Proj $proj -WorkRel $rel -SrcFile $file.FullName -WrittenRef ([ref]$sourcesWritten) -Kept $keptSrc
+                Write-Host "  $rel " -NoNewLine
+                Write-Host "(source)" -ForegroundColor Yellow
                 continue
             }
             $diff = Get-DiffLines $baseFile $file.FullName
@@ -241,6 +250,7 @@ try {
                 Write-Lf -Path $patchFile -Lines $headers
                 $patchesWritten++
                 $keptBase[(Resolve-Path $baseFile).Path] = $true
+                Write-Host "  $rel"
             } elseif (Test-Path $patchFile) {
                 Remove-Item $patchFile; $cleared++
             }

--- a/scripts/extract-patches.sh
+++ b/scripts/extract-patches.sh
@@ -78,6 +78,7 @@ write_patch() {
       -e "s#^+++ .*\$#+++ b/$rel_path#" \
       "$tmp_diff" > "$patch_file"
     ((patches_written += 1))
+    echo "  $rel_path"
   elif [[ "$status" -ne 0 ]]; then
     cat "$tmp_diff" >&2
     rm -f -- "$tmp_base" "$tmp_work" "$tmp_diff"
@@ -189,6 +190,8 @@ process_project() {
 
   [[ -d "$work_root" && -d "$base_root" ]] || return 0
 
+  echo -e "\e[36mExtracting patches for $proj\e[0m"
+
   while IFS= read -r -d '' file; do
     local rel base_file patch_file rel_patch status
     rel="${file#$work_root/}"
@@ -201,6 +204,7 @@ process_project() {
 
     if [[ ! -f "$base_file" ]]; then
       sync_new_file "$proj" "$rel" "$file"
+      echo -e "  $rel \e[1;33m(source)\e[0m"
       continue
     fi
 


### PR DESCRIPTION
## Summary

Make the extract-patches scripts print out what they're extracting instead of being completely silent for a few minutes

## Type

- [ ] Bug fix
- [ ] Performance
- [ ] New feature
- [ ] Refactor or cleanup
- [x] Docs or build

## Checklist

- [x] `.\scripts\extract-patches.ps1` ran clean.
- [ ] `dotnet build VintageStory.slnx -c Release` is green. NA
- [ ] Every vanilla edit has a `// Stratum` marker. NA
- [x] No vanilla source committed.
- [ ] Tested on a real server start, not just compilation. NA
- [x] Tested extraction

