### PR TITLE
Fix NRE in UDP fallback for clients that skip the login token query

### DIFF
--- a/patches/VintagestoryLib/Vintagestory.Server/ServerMain.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/ServerMain.cs.patch
@@ -1,5 +1,5 @@
 diff --git a/VintagestoryLib/Vintagestory.Server/ServerMain.cs b/VintagestoryLib/Vintagestory.Server/ServerMain.cs
-index 1017be9..a6c32bd 100644
+index 1017be9..d004634 100644
 --- a/VintagestoryLib/Vintagestory.Server/ServerMain.cs
 +++ b/VintagestoryLib/Vintagestory.Server/ServerMain.cs
 @@ -27,10 +27,13 @@ using VintagestoryLib.Server.Systems;
@@ -890,9 +890,11 @@ index 1017be9..a6c32bd 100644
  		float horRangeSq = horRange * horRange;
 -		foreach (ConnectedClient value in Clients.Values)
 +		try
-+		{
+ 		{
+-			if (value.State == EnumClientState.Playing && value.Entityplayer != null && value.Position.InRangeOf(position, horRangeSq, vertRange) && (matches == null || matches(value.Player)))
 +			foreach (ConnectedClient value in Clients.Values)
-+			{
+ 			{
+-				list.Add(value.Player);
 +				if (value.State == EnumClientState.Playing && value.Entityplayer != null && value.Position.InRangeOf(position, horRangeSq, vertRange) && (matches == null || matches(value.Player)))
 +				{
 +					list.Add(value.Player);
@@ -901,11 +903,9 @@ index 1017be9..a6c32bd 100644
 +			return list.Count == 0 ? Array.Empty<IPlayer>() : list.ToArray();
 +		}
 +		finally
- 		{
--			if (value.State == EnumClientState.Playing && value.Entityplayer != null && value.Position.InRangeOf(position, horRangeSq, vertRange) && (matches == null || matches(value.Player)))
++		{
 +			if (reuseList)
- 			{
--				list.Add(value.Player);
++			{
 +				list.Clear();
  			}
 +			reusablePlayersAroundDepth--;
@@ -967,7 +967,8 @@ index 1017be9..a6c32bd 100644
 +		{
 +			DisconnectedClientsThisTick.Add(client.Id);
 +			ClientPackets.Enqueue(new ReceivedClientPacket(client, disconnectReason));
-+		}
+ 		}
+-		ClientPackets.Enqueue(item);
 +	}
 +
 +	private void DispatchClientPacket_mainthread(ReceivedClientPacket pkt)
@@ -984,8 +985,7 @@ index 1017be9..a6c32bd 100644
 +				DisconnectPlayer(pkt.client, "Threw an exception at the server", "An action you (or your client) did caused an unhandled exception");
 +			}
 +			Logger.Error(e);
- 		}
--		ClientPackets.Enqueue(item);
++		}
 +	}
 +
 +	private void KickForBackPressure(ConnectedClient client, string reason)
@@ -1134,7 +1134,25 @@ index 1017be9..a6c32bd 100644
  			return;
  		}
  		if (client.Socket is TcpNetConnection tcpNetConnection)
-@@ -3773,10 +4243,20 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -3704,11 +4174,16 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+ 					{
+ 						Id = 78
+ 					};
+ 					SendPacket(client.Id, packet2);
+ 					client.FallBackToTcp = true;
+-					ServerUdpNetwork.connectingClients.Remove(client.LoginToken);
++					// Stratum start: LoginToken is only assigned when the client sends the LoginTokenQuery packet (id 33). The vanilla client sends it on connect, but a custom or hostile client can skip it, leaving the token null. Such a client was never added to connectingClients, and Dictionary.Remove throws on a null key.
++					if (client.LoginToken != null)
++					{
++						ServerUdpNetwork.connectingClients.Remove(client.LoginToken);
++					}
++					// Stratum end
+ 				}
+ 				else
+ 				{
+ 					Logger.Debug($"UDP: Client {client.Id} did send UDP");
+ 				}
+@@ -3773,10 +4248,20 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  			SendServerIdentification(client.Player);
  			SpawnPlayerRandomlyAround(client, playername, entityPos, 15);
  			client.IsNewClient = false;
@@ -1155,7 +1173,7 @@ index 1017be9..a6c32bd 100644
  			SendServerIdentification(client.Player);
  			client.Entityplayer.Pos.SetFrom(entityPos);
  			SpawnEntity(client.Entityplayer);
-@@ -3851,10 +4331,21 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -3851,10 +4336,21 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  	}
  
  	private void SpawnPlayerRandomlyAround(ConnectedClient client, string playername, EntityPos centerPos, int tries)
@@ -1177,7 +1195,7 @@ index 1017be9..a6c32bd 100644
  			EntityPos entityPos = centerPos.Copy();
  			if (pos == null)
  			{
-@@ -3869,10 +4360,38 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -3869,10 +4365,38 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  			}
  			SpawnPlayerHere(client, playername, entityPos);
  		});
@@ -1216,7 +1234,7 @@ index 1017be9..a6c32bd 100644
  		Clients.TryGetValue(client.Id, out var value);
  		if (value != null)
  		{
-@@ -4244,11 +4763,11 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -4244,11 +4768,11 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  
  	internal void BroadcastArbitraryPacket(byte[] data, params IServerPlayer[] skipPlayers)
  	{
@@ -1229,7 +1247,7 @@ index 1017be9..a6c32bd 100644
  			}
  		}
  	}
-@@ -4258,11 +4777,11 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -4258,11 +4782,11 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  		Serialize_(packet);
  		byte[] array = null;
  		bool compressed = false;
@@ -1242,7 +1260,7 @@ index 1017be9..a6c32bd 100644
  				{
  					array = client.Socket.PreparePacketForSending(reusableBuffer, Config.CompressPackets, out compressed);
  				}
-@@ -4277,17 +4796,42 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -4277,17 +4801,42 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  
  	internal void BroadcastArbitraryUdpPacket(Packet_UdpPacket data, params IServerPlayer[] skipPlayers)
  	{
@@ -1286,7 +1304,7 @@ index 1017be9..a6c32bd 100644
  		if (packetBenchmark.ContainsKey(packetId))
  		{
  			packetBenchmark[packetId]++;
-@@ -4694,15 +5238,40 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -4694,15 +5243,40 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  	}
  
  	private void SendWorldMetaData(IServerPlayer player)
@@ -1327,7 +1345,7 @@ index 1017be9..a6c32bd 100644
  		float[] array = blockLightLevels;
  		Packet_WorldMetaData packet_WorldMetaData = new Packet_WorldMetaData();
  		int[] array2 = new int[array.Length];
-@@ -4755,14 +5324,53 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -4755,14 +5329,53 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  		{
  			((DummyUdpNetServer)UdpSockets[0]).Client.Player = player;
  		}
@@ -1382,7 +1400,7 @@ index 1017be9..a6c32bd 100644
  		List<Packet_ModId> list = (from mod in api.ModLoader.Mods
  			where mod.Info.Side.IsUniversal()
  			select new Packet_ModId
-@@ -4791,15 +5399,20 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -4791,15 +5404,20 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  			RequireRemapping = ((controlServerPrivilege && requiresRemaps) ? 1 : 0)
  		};
  		Logger.Notification((Config.DisableAutoRemap ? ("Sending server identification with remap " + requiresRemaps) : "Sending server identification") + ". Server control privilege is " + controlServerPrivilege);
@@ -1405,7 +1423,7 @@ index 1017be9..a6c32bd 100644
  		}
  		return new Packet_Server
  		{
-@@ -4843,12 +5456,12 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -4843,12 +5461,12 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  				array[num] = item.Id;
  				array2[num] = (int)(1000f * item.Player.Ping);
  				num++;


### PR DESCRIPTION
## Summary

`FinalizePlayerIdentification` queues a task that waits 10 seconds for UDP from a fresh client and falls back to TCP if none arrives (`ServerMain.cs:4172`). The fallback removes the client from `ServerUdpNetwork.connectingClients`, keyed by `client.LoginToken`. `LoginToken` is only assigned when the client sends the `LoginTokenQuery` packet (id 33), in `HandleQueryClientPacket` (`ServerMain.cs:1059`). The vanilla client sends that packet unconditionally on connect, before anything else, so real players always have a token by the time this fires. A client that skips packet 33 leaves the token null, and `Dictionary.Remove(null)` throws `ArgumentNullException`.

The exception is caught by `TyronThreadPool` and logged as a warning, so nothing crashes. But a flood of tokenless connections turns into a warning plus a stack trace per join, 10 seconds later, at zero cost to whoever's sending them.

A tokenless client was never added to `connectingClients` in the first place (the UDP association keys off the token, `ServerUdpNetwork.cs:139`), so removing it is already a no-op semantically. Null-check before the call.

## Type

- [x] Bug fix
- [ ] Performance
- [ ] New feature
- [ ] Refactor or cleanup
- [ ] Docs or build

## How this was found

Turned up in the server log during an unrelated load test (#149): 300 synthetic bot clients, each producing this warning ~10s after joining. Traced it back instead of shrugging it off as load-test noise, since it fires the same way for anything speaking the wire protocol without going through the vanilla client's connect sequence.

## Is this reachable by real players?

Checked the decompiled client (`Vintagestory.Client.NoObf.ClientMain.Connect`): it sends `Packet_Client { Id = 33 }` unconditionally right after opening the socket, before identification. So no, this doesn't fire for the real client under any settings I could find. It fires for anything else on the wire: load-test tooling, third-party launchers, bots, scanners hitting the port.

## Verification

| Step | Result |
|---|---|
| `extract-patches.sh` | Clean, one file touched |
| `dotnet build VintageStory.slnx -c Release` | 0 errors |
| Reproduction: 5 protocol-level bot clients that skip packet 33, before fix | 5/5 UDP fallback lines, 5/5 exceptions |
| Same reproduction, after fix | 5/5 UDP fallback lines, 0 exceptions |
| Vanilla client path | Unchanged, `LoginToken` still gets removed normally when it's set |

## Checklist

- [x] `scripts/extract-patches.sh` ran clean.
- [x] `dotnet build VintageStory.slnx -c Release` is green.
- [x] Every vanilla edit has a `// Stratum` marker.
- [x] No vanilla source committed.
- [x] Tested on a real server start, not just compilation. Reproduced and fixed against a running server.

## Related issues

None filed. Found while investigating #149's load-test logs.
