### PR TITLE
Pool bulk position packet arrays instead of allocating per batch

### DIFF
--- a/patches/VintagestoryLib/Vintagestory.Server.Systems/ServerUdpQueue.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server.Systems/ServerUdpQueue.cs.patch
@@ -1,0 +1,29 @@
+diff --git a/VintagestoryLib/Vintagestory.Server.Systems/ServerUdpQueue.cs b/VintagestoryLib/Vintagestory.Server.Systems/ServerUdpQueue.cs
+index 2f84679..b329097 100644
+--- a/VintagestoryLib/Vintagestory.Server.Systems/ServerUdpQueue.cs
++++ b/VintagestoryLib/Vintagestory.Server.Systems/ServerUdpQueue.cs
+@@ -66,10 +66,24 @@ public class ServerUdpQueue
+ 					}
+ 					catch (Exception e)
+ 					{
+ 						ServerMain.Logger.Error(e);
+ 					}
++					finally
++					{
++						// Stratum: SendPacketBlocking always finishes reading the packet
++						// before returning (serializes synchronously, no further async
++						// handoff), so it's safe to hand it back to the pool here even if
++						// the send itself threw.
++						network.physicsManager.StratumReturnBulkPositionPacket(result.packet);
++					}
++				}
++				else
++				{
++					// Stratum: TTL-dropped packet never reaches SendPacketBlocking, but it's
++					// still safe to recycle since nothing else holds a reference to it.
++					network.physicsManager.StratumReturnBulkPositionPacket(result.packet);
+ 				}
+ 			}
+ 		}
+ 	}
+ }

--- a/patches/VintagestoryLib/Vintagestory.Server.Systems/ServerUdpQueue.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server.Systems/ServerUdpQueue.cs.patch
@@ -1,8 +1,8 @@
 diff --git a/VintagestoryLib/Vintagestory.Server.Systems/ServerUdpQueue.cs b/VintagestoryLib/Vintagestory.Server.Systems/ServerUdpQueue.cs
-index 2f84679..b329097 100644
+index 2f84679..42b944a 100644
 --- a/VintagestoryLib/Vintagestory.Server.Systems/ServerUdpQueue.cs
 +++ b/VintagestoryLib/Vintagestory.Server.Systems/ServerUdpQueue.cs
-@@ -66,10 +66,24 @@ public class ServerUdpQueue
+@@ -66,10 +66,27 @@ public class ServerUdpQueue
  					}
  					catch (Exception e)
  					{
@@ -10,18 +10,21 @@ index 2f84679..b329097 100644
  					}
 +					finally
 +					{
-+						// Stratum: SendPacketBlocking always finishes reading the packet
-+						// before returning (serializes synchronously, no further async
-+						// handoff), so it's safe to hand it back to the pool here even if
-+						// the send itself threw.
-+						network.physicsManager.StratumReturnBulkPositionPacket(result.packet);
++						// Stratum: for the real UDP/TCP-fallback paths, SendPacketBlocking
++						// always finishes reading the packet before returning (serializes
++						// synchronously, no further async handoff), so it's safe to hand it
++						// back to the pool here even if the send itself threw. The
++						// single-player/dummy-network path is different -- see
++						// StratumReturnBulkPositionPacket.
++						network.physicsManager.StratumReturnBulkPositionPacket(result.packet, result.client.IsSinglePlayerClient);
 +					}
 +				}
 +				else
 +				{
 +					// Stratum: TTL-dropped packet never reaches SendPacketBlocking, but it's
-+					// still safe to recycle since nothing else holds a reference to it.
-+					network.physicsManager.StratumReturnBulkPositionPacket(result.packet);
++					// still safe to recycle (subject to the same single-player exception)
++					// since nothing else holds a reference to it.
++					network.physicsManager.StratumReturnBulkPositionPacket(result.packet, result.client.IsSinglePlayerClient);
  				}
  			}
  		}

--- a/patches/VintagestoryLib/Vintagestory.Server/PhysicsManager.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/PhysicsManager.cs.patch
@@ -1,8 +1,16 @@
 diff --git a/VintagestoryLib/Vintagestory.Server/PhysicsManager.cs b/VintagestoryLib/Vintagestory.Server/PhysicsManager.cs
-index 2c2605d..e8f049f 100644
+index 2c2605d..fb2447f 100644
 --- a/VintagestoryLib/Vintagestory.Server/PhysicsManager.cs
 +++ b/VintagestoryLib/Vintagestory.Server/PhysicsManager.cs
-@@ -101,10 +101,23 @@ public class PhysicsManager : LoadBalancedTask
+@@ -1,6 +1,7 @@
+ using System;
++using System.Buffers;
+ using System.Collections.Concurrent;
+ using System.Collections.Generic;
+ using System.IO;
+ using System.Linq;
+ using System.Threading;
+@@ -101,10 +102,23 @@ public class PhysicsManager : LoadBalancedTask
  			}
  			return true;
  		}
@@ -26,7 +34,7 @@ index 2c2605d..e8f049f 100644
  	public const float AttributesToClientsInterval = 0.2f;
  
  	private const int firstTick = 1;
-@@ -133,10 +146,12 @@ public class PhysicsManager : LoadBalancedTask
+@@ -133,10 +147,12 @@ public class PhysicsManager : LoadBalancedTask
  
  	private float physicsTickAccum;
  
@@ -39,7 +47,7 @@ index 2c2605d..e8f049f 100644
  	private ServerSystemEntitySimulation es;
  
  	private List<Packet_EntityAttributes> cliententitiesFullUpdate = new List<Packet_EntityAttributes>();
-@@ -157,23 +172,68 @@ public class PhysicsManager : LoadBalancedTask
+@@ -157,23 +173,68 @@ public class PhysicsManager : LoadBalancedTask
  
  	private ConcurrentDictionary<long, EntityTagPacket> entitiesTagPackets;
  
@@ -108,7 +116,7 @@ index 2c2605d..e8f049f 100644
  	private PhysicsOffthreadTasks offthreadProcess;
  
  	private int currentTick;
-@@ -184,24 +244,46 @@ public class PhysicsManager : LoadBalancedTask
+@@ -184,24 +245,46 @@ public class PhysicsManager : LoadBalancedTask
  
  	public PhysicsManager(ICoreServerAPI sapi, ServerUdpNetwork udpNetwork)
  	{
@@ -157,7 +165,7 @@ index 2c2605d..e8f049f 100644
  			entitiesFullUpdate[i] = new Dictionary<long, Packet_EntityAttributes>();
  		}
  		for (int j = 0; j < entitiesPartialUpdate.Length; j++)
-@@ -221,10 +303,13 @@ public class PhysicsManager : LoadBalancedTask
+@@ -221,10 +304,13 @@ public class PhysicsManager : LoadBalancedTask
  			entitiesAnimPackets[m] = new Dictionary<long, AnimationPacket>();
  		}
  		for (int n = 0; n < entitiesUpdateReusableBuffers.Length; n++)
@@ -171,7 +179,7 @@ index 2c2605d..e8f049f 100644
  		loadBalancer = new LoadBalancer(this, ServerMain.Logger);
  		loadBalancer.CreateDedicatedThreads(maxPhysicsThreads, "physicsManager", server.Serverthreads);
  		offthreadProcess = new PhysicsOffthreadTasks(this);
-@@ -251,28 +336,51 @@ public class PhysicsManager : LoadBalancedTask
+@@ -251,28 +337,51 @@ public class PhysicsManager : LoadBalancedTask
  		attrUpdateAccum = 0.2f;
  	}
  
@@ -225,7 +233,7 @@ index 2c2605d..e8f049f 100644
  			{
  				tickables.Remove(result2);
  			}
-@@ -287,30 +395,70 @@ public class PhysicsManager : LoadBalancedTask
+@@ -287,30 +396,70 @@ public class PhysicsManager : LoadBalancedTask
  				ServerMain.Logger.Warning("Over 400ms tick. Skipping {0} physics ticks.", num);
  			}
  			physicsTickAccum %= 0.4f;
@@ -301,7 +309,7 @@ index 2c2605d..e8f049f 100644
  				loadBalancer.SynchroniseWorkToMainThread(this);
  				loadBalancer.AwaitCompletionOnAllThreads(num3);
  				ServerMain.FrameProfiler.Mark("physicsmanager-waitingForSlowestThread");
-@@ -341,26 +489,31 @@ public class PhysicsManager : LoadBalancedTask
+@@ -341,26 +490,31 @@ public class PhysicsManager : LoadBalancedTask
  				{
  					ServerMain.Logger.Error(e);
  				}
@@ -339,7 +347,7 @@ index 2c2605d..e8f049f 100644
  		lock (server.EntitySpawnSendQueue)
  		{
  			List<Entity> entitySpawnSendQueue = server.EntitySpawnSendQueue;
-@@ -398,19 +551,47 @@ public class PhysicsManager : LoadBalancedTask
+@@ -398,19 +552,47 @@ public class PhysicsManager : LoadBalancedTask
  					ServerMain.spawnSendQueue--;
  				});
  			}
@@ -389,7 +397,7 @@ index 2c2605d..e8f049f 100644
  			}
  		}
  		if (positions.Length < list.Count * 3)
-@@ -462,10 +643,25 @@ public class PhysicsManager : LoadBalancedTask
+@@ -462,10 +644,25 @@ public class PhysicsManager : LoadBalancedTask
  		UpdateTrackedEntityLists(client, 1);
  	}
  
@@ -415,7 +423,7 @@ index 2c2605d..e8f049f 100644
  		double y = pos.Y;
  		double z = pos.Z;
  		double num = double.MaxValue;
-@@ -536,10 +732,15 @@ public class PhysicsManager : LoadBalancedTask
+@@ -536,10 +733,15 @@ public class PhysicsManager : LoadBalancedTask
  		List<long> list2 = alreadyTracked;
  		list2.EnsureCapacity(trackedEntities.Count);
  		List<Entity> list3 = newlyTracked;
@@ -431,7 +439,7 @@ index 2c2605d..e8f049f 100644
  			{
  				list2.Add(entityId);
  			}
-@@ -550,10 +751,15 @@ public class PhysicsManager : LoadBalancedTask
+@@ -550,10 +752,15 @@ public class PhysicsManager : LoadBalancedTask
  		}
  		for (int i = 1; i < threadCount; i++)
  		{
@@ -447,7 +455,7 @@ index 2c2605d..e8f049f 100644
  				{
  					list2.Add(entityId);
  				}
-@@ -563,19 +769,40 @@ public class PhysicsManager : LoadBalancedTask
+@@ -563,19 +770,40 @@ public class PhysicsManager : LoadBalancedTask
  				}
  				list.Add(item2);
  			}
@@ -488,7 +496,7 @@ index 2c2605d..e8f049f 100644
  		list2.Clear();
  		foreach (Entity item4 in list3)
  		{
-@@ -593,61 +820,160 @@ public class PhysicsManager : LoadBalancedTask
+@@ -593,61 +821,160 @@ public class PhysicsManager : LoadBalancedTask
  		list3.Clear();
  	}
  
@@ -554,11 +562,11 @@ index 2c2605d..e8f049f 100644
 +								}
 +								SendPreparedStateChangePacket(client, preparedPacket.PacketBytes, preparedPacket.Compressed);
 +							}
- 						}
++						}
 +						if (stratumRecordSectionTimings)
 +						{
 +							stratumPlayerPacketTicks += StratumRuntime.Timings.GetTimestamp() - stratumSectionStart;
-+						}
+ 						}
 +					}
 +					long entityIdForPacket = entity.EntityId;
 +					if (!entityPacketCache.TryGetValue(entityIdForPacket, out Packet_Entity entityPacket))
@@ -571,11 +579,10 @@ index 2c2605d..e8f049f 100644
 +						entityPacket = ServerPackets.GetEntityPacket(entity, fastMemoryStream, writer);
 +						entityPacketCache[entityIdForPacket] = entityPacket;
 +						if (stratumRecordSectionTimings)
- 						{
--							list.Add(new AnimationPacket(entity));
++						{
 +							stratumFullEntityBuildTicks += StratumRuntime.Timings.GetTimestamp() - stratumSectionStart;
- 						}
- 					}
++						}
++					}
 +					entityPackets.Add(entityPacket);
 +					if (entity.AnimManager != null)
 +					{
@@ -588,10 +595,11 @@ index 2c2605d..e8f049f 100644
 +						}
 +						list.Add(animationPacket);
 +						if (stratumRecordSectionTimings)
-+						{
+ 						{
+-							list.Add(new AnimationPacket(entity));
 +							stratumAnimationTicks += StratumRuntime.Timings.GetTimestamp() - stratumSectionStart;
-+						}
-+					}
+ 						}
+ 					}
 +				}
 +				if (entityPackets.Count > 0)
 +				{
@@ -675,7 +683,7 @@ index 2c2605d..e8f049f 100644
  	public void GatherUpdatePacketsFromAllThreads()
  	{
  		Dictionary<long, Packet_EntityAttributes> dict = entitiesFullUpdate[0];
-@@ -728,18 +1054,62 @@ public class PhysicsManager : LoadBalancedTask
+@@ -728,18 +1055,62 @@ public class PhysicsManager : LoadBalancedTask
  	{
  		if (entity is EntityPlayer)
  		{
@@ -740,7 +748,7 @@ index 2c2605d..e8f049f 100644
  			if (entityAgent != null)
  			{
  				entityAgent.Controls.Dirty = false;
-@@ -747,10 +1117,106 @@ public class PhysicsManager : LoadBalancedTask
+@@ -747,10 +1118,106 @@ public class PhysicsManager : LoadBalancedTask
  			entity.tagsDirty = false;
  		}
  		CompletePositionUpdate(entity);
@@ -847,10 +855,44 @@ index 2c2605d..e8f049f 100644
  		EntityTagPacket result = null;
  		SyncedTreeAttribute watchedAttributes = entity.WatchedAttributes;
  		if (watchedAttributes.AllDirty)
-@@ -781,14 +1247,24 @@ public class PhysicsManager : LoadBalancedTask
+@@ -779,16 +1246,58 @@ public class PhysicsManager : LoadBalancedTask
+ 		}
+ 		watchedAttributes.MarkClean();
  		return result;
  	}
  
++	// Stratum: rent a wrapper from the pool instead of allocating. Empty on a cold pool
++	// (server start, or a burst larger than anything seen before), same as ArrayPool.
++	// Stratum: called from ServerUdpQueue.DedicatedThreadLoop once SendPacketBlocking (or the
++	// TTL drop path) is done with a queued packet. Only Id 4 (BulkPositions) carries an
++	// ArrayPool-rented array; everything else is a no-op. The wrapper object itself
++	// (Packet_BulkEntityPosition) stays a plain per-batch `new` -- pooling it too would need a
++	// second cross-thread pool shared by every physics worker thread, and a benchmark showed
++	// that contention costs more than the ~40B/batch wrapper allocation it would save (see
++	// research/benchmarks/bulk-position-pool). The array is the actual dominant allocation
++	// (~88B/batch) and ArrayPool<T>.Shared already has a low-contention per-core fast path for
++	// this exact rent/return-from-a-different-thread shape.
++	internal void StratumReturnBulkPositionPacket(Packet_UdpPacket udpPacket)
++	{
++		if (udpPacket == null || udpPacket.Id != 4)
++		{
++			return;
++		}
++		Packet_BulkEntityPosition bulk = udpPacket.BulkPositions;
++		if (bulk == null)
++		{
++			return;
++		}
++		Packet_EntityPosition[] array = bulk.EntityPositions;
++		bulk.EntityPositions = null;
++		bulk.EntityPositionsCount = 0;
++		bulk.EntityPositionsLength = 0;
++		if (array != null)
++		{
++			ArrayPool<Packet_EntityPosition>.Shared.Return(array, clearArray: true);
++		}
++	}
++
  	public void SendPositionsAndAnimations(Dictionary<long, Packet_EntityPosition> entityPositionPackets, Dictionary<long, AnimationPacket> entityAnimPackets, int zeroBasedThreadNum, bool stateUpdateTick)
  	{
 -		List<Packet_EntityPosition> list = new List<Packet_EntityPosition>();
@@ -875,7 +917,7 @@ index 2c2605d..e8f049f 100644
  			list.Clear();
  			list2.Clear();
  			list3.Clear();
-@@ -796,65 +1272,123 @@ public class PhysicsManager : LoadBalancedTask
+@@ -796,65 +1305,126 @@ public class PhysicsManager : LoadBalancedTask
  			{
  				List<Entity> list4 = client.threadedTrackedEntities[zeroBasedThreadNum];
  				foreach (Entity item in list4)
@@ -975,10 +1017,13 @@ index 2c2605d..e8f049f 100644
  			int count = list.Count;
  			if (count > 8 && !client.IsSinglePlayerClient && !client.FallBackToTcp)
  			{
-+				// Stratum: use a local scratch array for building batches, but allocate
-+				// a fresh Packet_BulkEntityPosition + array copy per SendPacket_Threadsafe
-+				// call. The UDP thread serializes asynchronously and holds references to
-+				// the queued packet, so we must not mutate it after enqueue.
++				// Stratum: use a local scratch array for building batches, but rent the
++				// per-batch snapshot array from ArrayPool (returned by
++				// StratumReturnBulkPositionPacket once the UDP thread is done with it) and
++				// allocate a fresh, small Packet_BulkEntityPosition wrapper per
++				// SendPacket_Threadsafe call. The UDP thread serializes asynchronously and
++				// holds a reference to both, so neither may be touched or reused before that
++				// finishes.
 +				Packet_EntityPosition[] stratumBatchArray = stratumPositionBatchArray;
 +				if (stratumBatchArray == null)
 +				{
@@ -995,30 +1040,30 @@ index 2c2605d..e8f049f 100644
 -						array[j] = list[i + j];
 +						stratumBatchArray[j] = list[i + j];
  					}
-+					Packet_EntityPosition[] snapshot = new Packet_EntityPosition[batchSize];
++					Packet_EntityPosition[] snapshot = ArrayPool<Packet_EntityPosition>.Shared.Rent(batchSize);
 +					Array.Copy(stratumBatchArray, snapshot, batchSize);
  					Packet_BulkEntityPosition packet_BulkEntityPosition = new Packet_BulkEntityPosition();
 -					packet_BulkEntityPosition.SetEntityPositions(array);
-+					packet_BulkEntityPosition.SetEntityPositions(snapshot);
++					packet_BulkEntityPosition.SetEntityPositions(snapshot, batchSize, snapshot.Length);
  					udpNetwork.SendPacket_Threadsafe(client, packet_BulkEntityPosition);
  				}
  			}
  			else if (count > 0)
  			{
-+				Packet_EntityPosition[] snapshot = new Packet_EntityPosition[count];
++				Packet_EntityPosition[] snapshot = ArrayPool<Packet_EntityPosition>.Shared.Rent(count);
 +				for (int k = 0; k < count; k++)
 +				{
 +					snapshot[k] = list[k];
 +				}
  				Packet_BulkEntityPosition packet_BulkEntityPosition2 = new Packet_BulkEntityPosition();
 -				packet_BulkEntityPosition2.SetEntityPositions(list.ToArray());
-+				packet_BulkEntityPosition2.SetEntityPositions(snapshot);
++				packet_BulkEntityPosition2.SetEntityPositions(snapshot, count, snapshot.Length);
  				udpNetwork.SendPacket_Threadsafe(client, packet_BulkEntityPosition2);
  			}
  			if (list2.Count > 0)
  			{
  				BulkAnimationPacket message = new BulkAnimationPacket
-@@ -872,35 +1406,65 @@ public class PhysicsManager : LoadBalancedTask
+@@ -872,35 +1442,65 @@ public class PhysicsManager : LoadBalancedTask
  				AnimationsAndTagsChannel.SendPacket(item2, client.Player);
  			}
  		}
@@ -1086,7 +1131,7 @@ index 2c2605d..e8f049f 100644
  					flag = true;
  				}
  			}
-@@ -990,11 +1554,14 @@ public class PhysicsManager : LoadBalancedTask
+@@ -990,11 +1590,14 @@ public class PhysicsManager : LoadBalancedTask
  		return ServerPackets.getEntityPositionPacket(entity.Pos, entity, 1);
  	}
  
@@ -1102,7 +1147,7 @@ index 2c2605d..e8f049f 100644
  		{
  			Id = 80,
  			EntityPosition = entityPosition
-@@ -1026,16 +1593,29 @@ public class PhysicsManager : LoadBalancedTask
+@@ -1026,16 +1629,29 @@ public class PhysicsManager : LoadBalancedTask
  		if (threadNumber == 0)
  		{
  			threadNumber = 1;
@@ -1137,7 +1182,7 @@ index 2c2605d..e8f049f 100644
  		Dictionary<long, AnimationPacket> dictionary2 = entitiesAnimPackets[threadNumber - 1];
  		dictionary.Clear();
  		dictionary2.Clear();
-@@ -1097,10 +1677,19 @@ public class PhysicsManager : LoadBalancedTask
+@@ -1097,10 +1713,19 @@ public class PhysicsManager : LoadBalancedTask
  		try
  		{
  			int num5 = -1;
@@ -1157,7 +1202,7 @@ index 2c2605d..e8f049f 100644
  				int num6 = (ticksToDo - num5 + 1) % 2;
  				num5 += num6;
  				bool flag2 = num5 == ticksToDo - 1;
-@@ -1108,20 +1697,113 @@ public class PhysicsManager : LoadBalancedTask
+@@ -1108,20 +1733,113 @@ public class PhysicsManager : LoadBalancedTask
  				bool forceUpdate = (num5 + currentTick) % 30 <= num6;
  				for (int j = num3; j < num4; j++)
  				{
@@ -1274,7 +1319,7 @@ index 2c2605d..e8f049f 100644
  						{
  							entity.PositionTicked = true;
  						}
-@@ -1196,49 +1878,153 @@ public class PhysicsManager : LoadBalancedTask
+@@ -1196,49 +1914,153 @@ public class PhysicsManager : LoadBalancedTask
  		if (doBuildAttributes)
  		{
  			eFullUpdate = entitiesFullUpdate[0];
@@ -1435,7 +1480,7 @@ index 2c2605d..e8f049f 100644
  			SendPositionsAndAnimations(dictionary, dictionary2, 0, doBuildAttributes);
  		}
  		dictionary.Clear();
-@@ -1262,11 +2048,25 @@ public class PhysicsManager : LoadBalancedTask
+@@ -1262,11 +2084,25 @@ public class PhysicsManager : LoadBalancedTask
  
  	public void StartWorkerThread(int threadNum)
  	{

--- a/patches/VintagestoryLib/Vintagestory.Server/PhysicsManager.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/PhysicsManager.cs.patch
@@ -1,5 +1,5 @@
 diff --git a/VintagestoryLib/Vintagestory.Server/PhysicsManager.cs b/VintagestoryLib/Vintagestory.Server/PhysicsManager.cs
-index 2c2605d..fb2447f 100644
+index 2c2605d..3941bd6 100644
 --- a/VintagestoryLib/Vintagestory.Server/PhysicsManager.cs
 +++ b/VintagestoryLib/Vintagestory.Server/PhysicsManager.cs
 @@ -1,6 +1,7 @@
@@ -562,11 +562,11 @@ index 2c2605d..fb2447f 100644
 +								}
 +								SendPreparedStateChangePacket(client, preparedPacket.PacketBytes, preparedPacket.Compressed);
 +							}
-+						}
+ 						}
 +						if (stratumRecordSectionTimings)
 +						{
 +							stratumPlayerPacketTicks += StratumRuntime.Timings.GetTimestamp() - stratumSectionStart;
- 						}
++						}
 +					}
 +					long entityIdForPacket = entity.EntityId;
 +					if (!entityPacketCache.TryGetValue(entityIdForPacket, out Packet_Entity entityPacket))
@@ -579,10 +579,11 @@ index 2c2605d..fb2447f 100644
 +						entityPacket = ServerPackets.GetEntityPacket(entity, fastMemoryStream, writer);
 +						entityPacketCache[entityIdForPacket] = entityPacket;
 +						if (stratumRecordSectionTimings)
-+						{
+ 						{
+-							list.Add(new AnimationPacket(entity));
 +							stratumFullEntityBuildTicks += StratumRuntime.Timings.GetTimestamp() - stratumSectionStart;
-+						}
-+					}
+ 						}
+ 					}
 +					entityPackets.Add(entityPacket);
 +					if (entity.AnimManager != null)
 +					{
@@ -595,11 +596,10 @@ index 2c2605d..fb2447f 100644
 +						}
 +						list.Add(animationPacket);
 +						if (stratumRecordSectionTimings)
- 						{
--							list.Add(new AnimationPacket(entity));
++						{
 +							stratumAnimationTicks += StratumRuntime.Timings.GetTimestamp() - stratumSectionStart;
- 						}
- 					}
++						}
++					}
 +				}
 +				if (entityPackets.Count > 0)
 +				{
@@ -855,7 +855,7 @@ index 2c2605d..fb2447f 100644
  		EntityTagPacket result = null;
  		SyncedTreeAttribute watchedAttributes = entity.WatchedAttributes;
  		if (watchedAttributes.AllDirty)
-@@ -779,16 +1246,58 @@ public class PhysicsManager : LoadBalancedTask
+@@ -779,16 +1246,66 @@ public class PhysicsManager : LoadBalancedTask
  		}
  		watchedAttributes.MarkClean();
  		return result;
@@ -872,7 +872,15 @@ index 2c2605d..fb2447f 100644
 +	// research/benchmarks/bulk-position-pool). The array is the actual dominant allocation
 +	// (~88B/batch) and ArrayPool<T>.Shared already has a low-contention per-core fast path for
 +	// this exact rent/return-from-a-different-thread shape.
-+	internal void StratumReturnBulkPositionPacket(Packet_UdpPacket udpPacket)
++	//
++	// isSinglePlayerClient must match SendPositionsAndAnimations' own IsSinglePlayerClient
++	// check: that path (real singleplayer, or a headless test harness on the same in-memory
++	// loopback) never rents from the pool in the first place, because
++	// DummyUdpNetServer.SendToClient hands the raw packet object to a queue the client-side
++	// dummy consumer reads asynchronously, so SendPacketBlocking returning does not mean the
++	// array is done being read. Returning it to the pool here anyway would let it be handed
++	// out and overwritten mid-read. See PhysicsManager.cs.patch history.
++	internal void StratumReturnBulkPositionPacket(Packet_UdpPacket udpPacket, bool isSinglePlayerClient)
 +	{
 +		if (udpPacket == null || udpPacket.Id != 4)
 +		{
@@ -887,7 +895,7 @@ index 2c2605d..fb2447f 100644
 +		bulk.EntityPositions = null;
 +		bulk.EntityPositionsCount = 0;
 +		bulk.EntityPositionsLength = 0;
-+		if (array != null)
++		if (array != null && !isSinglePlayerClient)
 +		{
 +			ArrayPool<Packet_EntityPosition>.Shared.Return(array, clearArray: true);
 +		}
@@ -917,7 +925,7 @@ index 2c2605d..fb2447f 100644
  			list.Clear();
  			list2.Clear();
  			list3.Clear();
-@@ -796,65 +1305,126 @@ public class PhysicsManager : LoadBalancedTask
+@@ -796,65 +1313,145 @@ public class PhysicsManager : LoadBalancedTask
  			{
  				List<Entity> list4 = client.threadedTrackedEntities[zeroBasedThreadNum];
  				foreach (Entity item in list4)
@@ -1048,6 +1056,25 @@ index 2c2605d..fb2447f 100644
  					udpNetwork.SendPacket_Threadsafe(client, packet_BulkEntityPosition);
  				}
  			}
++			else if (count > 0 && client.IsSinglePlayerClient)
++			{
++				// Stratum: the dummy/local connection (real singleplayer, or a headless test
++				// harness riding the same in-memory loopback) hands the raw Packet_UdpPacket
++				// object reference into a queue the client-side dummy consumer reads
++				// asynchronously (DummyUdpNetServer.SendToClient). Unlike the real UDP and
++				// TCP-fallback paths, nothing serializes it before SendPacketBlocking
++				// returns, so pooling here would let the array be reused -- and its contents
++				// overwritten -- while the dummy consumer might still be reading it.
++				// Single-player-style connections are always low volume, so just allocate.
++				Packet_EntityPosition[] singlePlayerSnapshot = new Packet_EntityPosition[count];
++				for (int m = 0; m < count; m++)
++				{
++					singlePlayerSnapshot[m] = list[m];
++				}
++				Packet_BulkEntityPosition singlePlayerPacket = new Packet_BulkEntityPosition();
++				singlePlayerPacket.SetEntityPositions(singlePlayerSnapshot);
++				udpNetwork.SendPacket_Threadsafe(client, singlePlayerPacket);
++			}
  			else if (count > 0)
  			{
 +				Packet_EntityPosition[] snapshot = ArrayPool<Packet_EntityPosition>.Shared.Rent(count);
@@ -1063,7 +1090,7 @@ index 2c2605d..fb2447f 100644
  			if (list2.Count > 0)
  			{
  				BulkAnimationPacket message = new BulkAnimationPacket
-@@ -872,35 +1442,65 @@ public class PhysicsManager : LoadBalancedTask
+@@ -872,35 +1469,65 @@ public class PhysicsManager : LoadBalancedTask
  				AnimationsAndTagsChannel.SendPacket(item2, client.Player);
  			}
  		}
@@ -1131,7 +1158,7 @@ index 2c2605d..fb2447f 100644
  					flag = true;
  				}
  			}
-@@ -990,11 +1590,14 @@ public class PhysicsManager : LoadBalancedTask
+@@ -990,11 +1617,14 @@ public class PhysicsManager : LoadBalancedTask
  		return ServerPackets.getEntityPositionPacket(entity.Pos, entity, 1);
  	}
  
@@ -1147,7 +1174,7 @@ index 2c2605d..fb2447f 100644
  		{
  			Id = 80,
  			EntityPosition = entityPosition
-@@ -1026,16 +1629,29 @@ public class PhysicsManager : LoadBalancedTask
+@@ -1026,16 +1656,29 @@ public class PhysicsManager : LoadBalancedTask
  		if (threadNumber == 0)
  		{
  			threadNumber = 1;
@@ -1182,7 +1209,7 @@ index 2c2605d..fb2447f 100644
  		Dictionary<long, AnimationPacket> dictionary2 = entitiesAnimPackets[threadNumber - 1];
  		dictionary.Clear();
  		dictionary2.Clear();
-@@ -1097,10 +1713,19 @@ public class PhysicsManager : LoadBalancedTask
+@@ -1097,10 +1740,19 @@ public class PhysicsManager : LoadBalancedTask
  		try
  		{
  			int num5 = -1;
@@ -1202,7 +1229,7 @@ index 2c2605d..fb2447f 100644
  				int num6 = (ticksToDo - num5 + 1) % 2;
  				num5 += num6;
  				bool flag2 = num5 == ticksToDo - 1;
-@@ -1108,20 +1733,113 @@ public class PhysicsManager : LoadBalancedTask
+@@ -1108,20 +1760,113 @@ public class PhysicsManager : LoadBalancedTask
  				bool forceUpdate = (num5 + currentTick) % 30 <= num6;
  				for (int j = num3; j < num4; j++)
  				{
@@ -1319,7 +1346,7 @@ index 2c2605d..fb2447f 100644
  						{
  							entity.PositionTicked = true;
  						}
-@@ -1196,49 +1914,153 @@ public class PhysicsManager : LoadBalancedTask
+@@ -1196,49 +1941,153 @@ public class PhysicsManager : LoadBalancedTask
  		if (doBuildAttributes)
  		{
  			eFullUpdate = entitiesFullUpdate[0];
@@ -1480,7 +1507,7 @@ index 2c2605d..fb2447f 100644
  			SendPositionsAndAnimations(dictionary, dictionary2, 0, doBuildAttributes);
  		}
  		dictionary.Clear();
-@@ -1262,11 +2084,25 @@ public class PhysicsManager : LoadBalancedTask
+@@ -1262,11 +2111,25 @@ public class PhysicsManager : LoadBalancedTask
  
  	public void StartWorkerThread(int threadNum)
  	{


### PR DESCRIPTION
## Summary

`201a69e` (our own PR #135 fix) closed a real cross-client UDP position packet race: the old code reused a single `ThreadStatic` `Packet_BulkEntityPosition` (and its backing array) across every client on a physics thread, so the UDP send thread could still be serializing client A's packet when the physics thread overwrote the same shared object for client B. The fix was correct but paid for it with a fresh `Packet_EntityPosition[]` and `Packet_BulkEntityPosition` allocation on every position batch (up to 8 entities) per client per physics tick. `PhysicsManager.SendPositionsAndAnimations` runs this for every connected client every tick, so on a busy server it adds up: tsu's frame profiler showed `PhysicsManager` at 32-48% of tick time after that commit.

This rents the snapshot array from `ArrayPool<Packet_EntityPosition>.Shared` instead of `new`-ing it, and `ServerUdpQueue.DedicatedThreadLoop` returns it once `SendPacketBlocking` (or the 750ms TTL-drop path) is done with it. That's safe for the real UDP and TCP-fallback paths because both finish serializing to bytes synchronously before `SendPacketBlocking` returns, so nothing holds a reference to the array afterward.

The `Packet_BulkEntityPosition` wrapper itself stays a plain per-batch `new`. A benchmark showed pooling it too (a second `ConcurrentQueue` shared by every physics worker thread) eliminates allocation completely but costs 32% more wall-clock time from cross-thread contention. Array-only pooling gets 69% of the allocation reduction for a third of the time cost, and `ArrayPool<T>.Shared` already has a low-contention per-core fast path built for exactly this rent-on-one-thread, return-on-another shape.

**Second bug found during testing:** `IsSinglePlayerClient` connections (real singleplayer, and any headless test harness on the same in-memory loopback) route through `DummyUdpNetServer.SendToClient`, which does not serialize anything -- it hands the raw packet object reference to a queue the client-side dummy consumer reads asynchronously. `SendPacketBlocking` returning does not mean that path is done reading the packet, so the first version of this fix could have let the array be reused and overwritten while the dummy consumer was still reading it. Fixed by never renting from the pool for `IsSinglePlayerClient` connections (plain allocation, same as before this patch); those connections are always low volume so it doesn't matter for perf.

## Type

- [ ] Bug fix
- [x] Performance
- [ ] New feature
- [ ] Refactor or cleanup
- [ ] Docs or build

## How this was found

Reported by tsu (DFCN): frame profiler timings showed `PhysicsManager` eating 32-48% of tick time, with the spike appearing shortly after `201a69e`. tsu suspected the fix's snapshot-per-batch allocation and asked us to confirm and fix it -- confirmed by reading `SendPositionsAndAnimations` directly, then quantified with a benchmark.

## Performance numbers

BenchmarkDotNet 0.14.0, .NET 10, real `VintagestoryLib.dll` types, simulated 250 clients x 3 batches/tick (`research/benchmarks/bulk-position-pool` in the contributions repo):

| Method | Mean | Allocated |
|---|---|---|
| `AllocatePerBatch` (current indev) | 21.71 us | 96000 B |
| `PooledPerBatch` (array + wrapper pool) | 28.61 us (+32%) | 0 B |
| `PooledArrayOnlyPerBatch` (this PR) | 24.18 us (+11%) | 30000 B (-69%) |

## Verification

| Step | Result |
|---|---|
| `bash scripts/bootstrap.sh --refresh` | 148 patches applied, zero failures |
| `dotnet build VintageStory.slnx -c Release` | 0 errors, no new warning in either touched file |
| `scripts/extract-patches.sh` | Clean, matches the working tree exactly |
| Live server, real network path (Linux, published server, 30 protocol-level bots) | 30/30 connected/authenticated/joined, 0 bot errors, log scanned for `exception\|nullreference\|stack trace`: 0 matches, clean `SIGTERM` shutdown |
| Live server, real per-tick movement (Atlas, Windows, 12 joined test players teleporting every tick for 40 ticks) | All players still connected, final positions correct, `server-main.log` free of `Exception`/`IndexOutOfRange`/`NullReference`/`ArgumentOutOfRange` -- caught the `IsSinglePlayerClient` bug on first run, passed clean after the fix |

The Atlas run and the bot run are complementary, not redundant: Atlas's joined test players are always `IsSinglePlayerClient == true` (same dummy-network mechanism real singleplayer uses), so it validates real movement against the single-player-safe branch but never touches the `ArrayPool`-pooled branch; the bot run is real network clients (exercises pooling) but doesn't drive real per-tick movement.

## Checklist

- [x] `scripts/extract-patches.sh` ran clean.
- [x] `dotnet build VintageStory.slnx -c Release` is green.
- [x] Every vanilla edit has a `// Stratum` marker.
- [x] No vanilla source committed.
- [x] Tested on a real server start, not just compilation. Two real-server runs: a published Linux dedicated server under real network load, and a Windows in-process boot (Atlas) under real per-tick player movement.

## Related issues

Found and fixed following up on #135 / #149's load testing. No issue filed.
