### PR TITLE
Pool container content-stacks lists instead of allocating per call

### DIFF
--- a/patches/VSSurvivalMod/BlockEntity/BEContainer.cs.patch
+++ b/patches/VSSurvivalMod/BlockEntity/BEContainer.cs.patch
@@ -1,0 +1,49 @@
+diff --git a/VSSurvivalMod/BlockEntity/BEContainer.cs b/VSSurvivalMod/BlockEntity/BEContainer.cs
+index 4bfb9e9..4cf2cc5 100644
+--- a/VSSurvivalMod/BlockEntity/BEContainer.cs
++++ b/VSSurvivalMod/BlockEntity/BEContainer.cs
+@@ -83,21 +83,38 @@ namespace Vintagestory.GameContent
+             }
+ 
+             base.OnBlockBroken(byPlayer);
+         }
+ 
++        // Stratum start: reusable list for GetNonEmptyContentStacks, matches Block.GetDrops'
++        // pattern. Depth guard covers reentrancy from a modded override of this or any
++        // Inventory-iterating caller; falls back to a plain list on the rare reentrant call.
++        [ThreadStatic] private static List<ItemStack> stratumNonEmptyStacks;
++        [ThreadStatic] private static int stratumNonEmptyDepth;
++
+         public ItemStack[] GetNonEmptyContentStacks(bool cloned = true)
+         {
+-            List<ItemStack> stacklist = new List<ItemStack>();
+-            foreach (var slot in Inventory)
++            bool reuse = stratumNonEmptyDepth == 0;
++            stratumNonEmptyDepth++;
++            List<ItemStack> stacklist = reuse ? (stratumNonEmptyStacks ??= new List<ItemStack>()) : new List<ItemStack>();
++            if (reuse) stacklist.Clear();
++            try
+             {
+-                if (slot.Empty) continue;
+-                stacklist.Add(cloned ? slot.Itemstack.Clone() : slot.Itemstack);
+-            }
++                foreach (var slot in Inventory)
++                {
++                    if (slot.Empty) continue;
++                    stacklist.Add(cloned ? slot.Itemstack.Clone() : slot.Itemstack);
++                }
+ 
+-            return stacklist.ToArray();
++                return stacklist.ToArray();
++            }
++            finally
++            {
++                stratumNonEmptyDepth--;
++            }
+         }
++        // Stratum end
+ 
+         public ItemStack[] GetContentStacks(bool cloned = true)
+         {
+             List<ItemStack> stacklist = new List<ItemStack>();
+             foreach (var slot in Inventory)

--- a/patches/VSSurvivalMod/Systems/Cooking/BlockCookingContainer.cs.patch
+++ b/patches/VSSurvivalMod/Systems/Cooking/BlockCookingContainer.cs.patch
@@ -1,0 +1,51 @@
+diff --git a/VSSurvivalMod/Systems/Cooking/BlockCookingContainer.cs b/VSSurvivalMod/Systems/Cooking/BlockCookingContainer.cs
+index be7e48a..6c8dfa5 100644
+--- a/VSSurvivalMod/Systems/Cooking/BlockCookingContainer.cs
++++ b/VSSurvivalMod/Systems/Cooking/BlockCookingContainer.cs
+@@ -328,23 +328,39 @@ namespace Vintagestory.GameContent
+ 
+ 
+ 
+ 
+ 
++        // Stratum start: reusable list for GetCookingStacks. Same ThreadStatic + depth-guard
++        // pattern as BEContainer.GetNonEmptyContentStacks; this method has 5 call sites in this
++        // file alone plus virtual override potential, so a depth guard covers reentrancy.
++        [ThreadStatic] private static List<ItemStack> stratumCookingStacks;
++        [ThreadStatic] private static int stratumCookingStacksDepth;
++
+         public ItemStack[] GetCookingStacks(ISlotProvider cookingSlotsProvider, bool clone = true)
+         {
+-            List<ItemStack> stacks = new List<ItemStack>(4);
++            bool reuse = stratumCookingStacksDepth == 0;
++            stratumCookingStacksDepth++;
++            List<ItemStack> stacks = reuse ? (stratumCookingStacks ??= new List<ItemStack>(4)) : new List<ItemStack>(4);
++            if (reuse) stacks.Clear();
++            try
++            {
++                for (int i = 0; i < cookingSlotsProvider.Slots.Length; i++)
++                {
++                    ItemStack? stack = cookingSlotsProvider.Slots[i].Itemstack;
++                    if (stack == null) continue;
++                    stacks.Add(clone ? stack.Clone() : stack);
++                }
+ 
+-            for (int i = 0; i < cookingSlotsProvider.Slots.Length; i++)
++                return stacks.ToArray();
++            }
++            finally
+             {
+-                ItemStack? stack = cookingSlotsProvider.Slots[i].Itemstack;
+-                if (stack == null) continue;
+-                stacks.Add(clone ? stack.Clone() : stack);
++                stratumCookingStacksDepth--;
+             }
+-
+-            return stacks.ToArray();
+         }
++        // Stratum end
+ 
+         public IInFirepitRenderer GetRendererWhenInFirepit(ItemStack stack, BlockEntityFirepit firepit, bool forOutputSlot)
+         {
+             return new PotInFirepitRenderer(api as ICoreClientAPI, stack, firepit.Pos, forOutputSlot);
+         }


### PR DESCRIPTION
## Summary

`BEContainer.GetNonEmptyContentStacks` and `BlockCookingContainer.GetCookingStacks` both allocate a fresh `List<ItemStack>` per call and always return via `.ToArray()`, so the intermediate list never needs to outlive the call -- same shape as `Block.GetDrops`/`GameMain.GetEntitiesAround`/`ServerMain.GetPlayersAround`/`RecipeBase.MatchesShapeLess`, all already patched this way. Reuse the intermediate list via `[ThreadStatic]` instead of allocating it fresh.

Both methods are `public` and `virtual`/overridable by mods, so this uses a reentrancy depth guard (not a bare `ThreadStatic`): a third-party optimizer mod that tried the bare-pool version of this exact optimization on the sibling method `GetContentStacks` had to partially revert it after it broke on reentrancy from a modded override. The depth guard falls back to a plain allocation on the rare reentrant call instead of corrupting the shared buffer, and costs one field read/increment/decrement on the common path.

`GetContentStacks` itself is deliberately left untouched -- same shape, but out of scope here so a revert (if ever needed) doesn't take this PR's method down with it.

## Type

- [ ] Bug fix
- [x] Performance
- [ ] New feature
- [ ] Refactor or cleanup
- [ ] Docs or build

## Performance numbers

BenchmarkDotNet 0.14.0, .NET 10, real `ItemStack`/`Item` types (`research/benchmarks/container-cooking-reuse` in the contributions repo):

| Method | Before | After | Allocation reduction |
|---|---|---|---|
| `GetNonEmptyContentStacks` (16-slot chest, 11 full) | 3392 B | 3064 B | 10% |
| `GetCookingStacks` (4-slot pot, 2 full) | 720 B | 632 B | 12% |

Worth being upfront about the size of this: the list itself was never the dominant allocation in either method -- `ItemStack.Clone()` per non-empty slot is, and that's unchanged (it's necessary, not something to eliminate). Timing deltas were directionally consistent (~15-17% faster) but noisy on the measuring machine (bimodal distribution, high StdDev), so the allocation numbers above are the number to trust, not the raw nanosecond timings.

## Verification

| Step | Result |
|---|---|
| `bash scripts/bootstrap.sh --refresh` | 150 patches applied, zero failures |
| `dotnet build VintageStory.slnx -c Release` | 0 errors, no new warning in either touched file |
| `scripts/extract-patches.sh` | Clean, matches the working tree exactly |
| Live server, real network path (Linux, published server, 30 protocol-level bots) | 30/30 connected/authenticated/joined, 0 bot errors, clean shutdown |
| dotnet-trace (40s, same 30-bot load) | 0 exceptions, patched classes load and execute normally under load. `GetNonEmptyContentStacks`/`GetCookingStacks` don't appear in the trace -- expected, bots don't open chests or cook, so this is a regression-safety signal, not a before/after trace comparison |
| Atlas (`research/atlas-tests/container-cooking-reuse-check`, real headless server on Windows) | Placed a real chest and a real claypot, ran 200+ repeated calls each with varying content: verified `clone: true` vs `clone: false` reference semantics (clone returns a new object, no-clone returns the live slot reference) and that the pooled buffer never leaks state between calls (an earlier call's already-returned array stays correct after a later call reuses the buffer) -- 2/2 scenarios passed |

## Checklist

- [x] `scripts/extract-patches.sh` ran clean.
- [x] `dotnet build VintageStory.slnx -c Release` is green.
- [x] Every vanilla edit has a `// Stratum` marker.
- [x] No vanilla source committed.
- [x] Tested on a real server start, not just compilation. Two real-server runs: a published Linux dedicated server under real network load with dotnet-trace attached, and a Windows in-process boot (Atlas) driving real chest/pot interaction through the actual game API.

## Related issues

None filed. Found during a Tungsten/Synergy optimization-overlap recheck.
