### PR TITLE
Fixed issue with windows timer overshooting with `Sleep()`

### DIFF
--- a/patches/VintagestoryLib/Vintagestory.Server/ServerMain.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/ServerMain.cs.patch
@@ -501,7 +501,7 @@ index 1017be9..0ab2741 100644
  			{
  				processConnectionQueue();
  				statsupdate = DateTime.UtcNow;
-@@ -1533,18 +1726,25 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -1533,22 +1726,29 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  				{
  					StatsCollector[StatsCollectorIndex].tickTimes[k] = 0L;
  				}
@@ -525,9 +525,16 @@ index 1017be9..0ab2741 100644
 +				Logger.Warning("Server may be overloaded. A tick took {0}ms to complete.", elapsedMilliseconds2);
  			}
  			FrameProfiler.Mark("timers-updated");
- 			int num3 = (int)Math.Max(0f, Config.TickTime - (float)elapsedMilliseconds2);
- 			if (num3 > 0)
+-			int num3 = (int)Math.Max(0f, Config.TickTime - (float)elapsedMilliseconds2);
+-			if (num3 > 0)
++			// Stratum: wait against the frame deadline so Windows sleep rounding cannot lower TPS.
++			if (elapsedMilliseconds2 < Config.TickTime)
  			{
+-				Thread.Sleep(num3);
++				StratumRuntime.WaitForNextTick(lastFramePassedTime, Config.TickTime);
+ 				FrameProfiler.Mark("sleep");
+ 			}
+ 			TickPosition++;
 @@ -1558,24 +1758,113 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  			Logger.Fatal(e);
  		}

--- a/sources/VintagestoryLib/Vintagestory.Server/ServerSystemStratum.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/ServerSystemStratum.cs
@@ -32,14 +32,17 @@ internal class ServerSystemStratum : ServerSystem
 
 		// BlockEntity stratum stagger hook requires API-side extensions not present in this build graph.
 
-		// Raise Windows multimedia timer resolution so Thread.Sleep(N) is accurate to ~1ms instead
-		// of the default ~15.6ms scheduler tick. Without this, the server's tick-sleep math
-		// (Config.TickTime - elapsed) rounds up to the next 15.6ms boundary, capping the
-		// achievable tickrate at ~25 tps on Windows regardless of how little work each tick does.
-		// Process-wide; cleaned up automatically at process exit.
+		// Windows otherwise rounds the main tick sleep up to roughly 15.6ms and keeps 30 TPS out of reach.
 		StratumTimerResolutionConfig timerCfg = StratumRuntime.Config.Performance.TimerResolution;
-		if (timerCfg != null && timerCfg.Enabled && stratumActiveTimerPeriodMs == 0
-			&& RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+		if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+		{
+			StratumRuntime.SetTimerResolutionStatus(true, "native");
+		}
+		else if (timerCfg == null || !timerCfg.Enabled)
+		{
+			StratumRuntime.SetTimerResolutionStatus(false, "disabled");
+		}
+		else if (stratumActiveTimerPeriodMs == 0)
 		{
 			uint period = (uint)Math.Max(1, timerCfg.PeriodMs);
 			try
@@ -48,17 +51,24 @@ internal class ServerSystemStratum : ServerSystem
 				if (result == 0)
 				{
 					stratumActiveTimerPeriodMs = (int)period;
+					StratumRuntime.SetTimerResolutionStatus(true, period + "ms");
 					StratumRuntime.LogInfo("timer resolution raised to " + period + "ms (was ~15.6ms default)");
 				}
 				else
 				{
-					StratumRuntime.LogWarning("timeBeginPeriod(" + period + ") returned " + result + " — timer resolution unchanged");
+					StratumRuntime.SetTimerResolutionStatus(false, "timeBeginPeriod returned " + result);
+					StratumRuntime.LogWarning("timeBeginPeriod(" + period + ") returned " + result + ": timer resolution unchanged");
 				}
 			}
 			catch (Exception ex)
 			{
+				StratumRuntime.SetTimerResolutionStatus(false, "failed: " + ex.Message);
 				StratumRuntime.LogWarning("could not raise timer resolution: " + ex.Message);
 			}
+		}
+		else
+		{
+			StratumRuntime.SetTimerResolutionStatus(true, stratumActiveTimerPeriodMs + "ms");
 		}
 
 		if (StratumRuntime.Config.Performance.Timings.EnabledOnStartup)

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumPerformanceStats.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumPerformanceStats.cs
@@ -308,6 +308,7 @@ internal sealed class StratumPerformanceStats
 		StratumSimulationDistanceConfig simulationDistance = config.Performance.SimulationDistance;
 		StratumAutoSaveConfig autoSave = config.Performance.AutoSave;
 		StratumBlockTickConfig blockTicks = config.Performance.BlockTicks;
+		StratumTimerResolutionConfig timerResolution = config.Performance.TimerResolution;
 
 		lock (gate)
 		{
@@ -323,6 +324,7 @@ internal sealed class StratumPerformanceStats
 			decimal averageEntityLookedAtBlocks = totalEntitySelectionTicks <= 0 ? 0m : decimal.Round((decimal)totalEntityLookedAtBlocks / totalEntitySelectionTicks, 2);
 			decimal averageBlockTickChunks = totalBlockTickPasses <= 0 ? 0m : decimal.Round((decimal)totalBlockTickChunksTicked / totalBlockTickPasses, 2);
 			return "Stratum Performance\n" +
+				$"Timer: config={(timerResolution.Enabled ? "on" : "off")} status={StratumRuntime.TimerResolutionStatus} fineSleep={(StratumRuntime.FineSleepGranularity ? "yes" : "no")}\n" +
 				"\nChunk Pipeline\n" +
 				$"  Send: {(chunkSending.Enabled ? "on" : "off")} server={chunkSending.MaxChunksPerServerTick} client={chunkSending.MaxChunksPerClientTick} local={(chunkSending.IncludeLocalClients ? "yes" : "no")} adaptive={(chunkSending.AdaptiveUnderOverload ? "yes" : "no")} overload={chunkSending.OverloadTickMs}ms scale={chunkSending.OverloadScale:0.##}\n" +
 				$"  Last: budget={lastChunkBudget} sent={lastChunksSent} deferredClients={lastDeferredClients}\n" +

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumRuntime.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumRuntime.cs
@@ -1,6 +1,9 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
+using System.Runtime.InteropServices;
+using System.Threading;
 using Newtonsoft.Json;
 using Vintagestory.API.Config;
 
@@ -39,10 +42,50 @@ internal static class StratumRuntime
 
 	public static StratumPreflightReport LastPreflight { get; private set; } = StratumPreflightReport.NotRun();
 
+	public static bool FineSleepGranularity { get; private set; } = !RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+
+	public static string TimerResolutionStatus { get; private set; } = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "not requested" : "native";
+
 	// Updated by PhysicsManager.ServerTick each tick: true if the previous tick exceeded
 	// Performance.Physics.OverloadedTickThresholdMs. EventManager reads this to apply
 	// adaptive throttling to non-critical entity tick listeners.
 	public static volatile bool PreviousTickOverloaded;
+
+	public static void SetTimerResolutionStatus(bool fineSleepGranularity, string status)
+	{
+		FineSleepGranularity = fineSleepGranularity;
+		TimerResolutionStatus = status ?? "unknown";
+	}
+
+	public static void WaitForNextTick(Stopwatch tickTimer, float tickBudgetMs)
+	{
+		while (true)
+		{
+			double remainingMs = tickBudgetMs - tickTimer.Elapsed.TotalMilliseconds;
+			if (remainingMs <= 0)
+			{
+				return;
+			}
+
+			// Sleep once for most of the wait, then trim the last edge without another overshooting sleep.
+			double coarseMarginMs = FineSleepGranularity ? 2.0 : 17.0;
+			if (remainingMs > coarseMarginMs)
+			{
+				int sleepMs = FineSleepGranularity
+					? Math.Max(1, (int)Math.Floor(remainingMs - coarseMarginMs))
+					: 1;
+				Thread.Sleep(sleepMs);
+			}
+			else if (remainingMs > 0.5)
+			{
+				Thread.Yield();
+			}
+			else
+			{
+				Thread.SpinWait(64);
+			}
+		}
+	}
 
 	public static void InitAdaptiveRadius(ServerMain server)
 	{

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumRuntime.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumRuntime.cs
@@ -59,6 +59,19 @@ internal static class StratumRuntime
 
 	public static void WaitForNextTick(Stopwatch tickTimer, float tickBudgetMs)
 	{
+		// Without a 1ms-accurate Sleep, chasing the deadline via Yield/SpinWait means spinning
+		// a full core for the whole ~15.6ms scheduler tick instead of just the sleep overshoot.
+		// Fall back to a single coarse sleep here rather than the precise wait below.
+		if (!FineSleepGranularity)
+		{
+			double coarseRemainingMs = tickBudgetMs - tickTimer.Elapsed.TotalMilliseconds;
+			if (coarseRemainingMs > 0)
+			{
+				Thread.Sleep((int)Math.Ceiling(coarseRemainingMs));
+			}
+			return;
+		}
+
 		while (true)
 		{
 			double remainingMs = tickBudgetMs - tickTimer.Elapsed.TotalMilliseconds;
@@ -68,12 +81,10 @@ internal static class StratumRuntime
 			}
 
 			// Sleep once for most of the wait, then trim the last edge without another overshooting sleep.
-			double coarseMarginMs = FineSleepGranularity ? 2.0 : 17.0;
+			const double coarseMarginMs = 2.0;
 			if (remainingMs > coarseMarginMs)
 			{
-				int sleepMs = FineSleepGranularity
-					? Math.Max(1, (int)Math.Floor(remainingMs - coarseMarginMs))
-					: 1;
+				int sleepMs = Math.Max(1, (int)Math.Floor(remainingMs - coarseMarginMs));
 				Thread.Sleep(sleepMs);
 			}
 			else if (remainingMs > 0.5)


### PR DESCRIPTION
## Summary

This fix combines the 1ms Windows timer request with a deadline-based tick wait, so the server sleeps once for most of the remaining budget and only yields at the very edge instead of relying on one overshooting `Sleep()`

## Type

- [ ] Bug fix
- [ ] Performance
- [ ] New feature
- [x] Refactor or cleanup
- [ ] Docs or build

## Checklist

- [x] `.\scripts\extract-patches.ps1` ran clean.
- [x] `dotnet build VintageStory.slnx -c Release` is green.
- [x] Every vanilla edit has a `// Stratum` marker.
- [x] No vanilla source committed.
- [x] Tested on a real server start, not just compilation.