### PR TITLE
Add scheduled chat announcements

### DIFF
--- a/StratumServer/stratum.default.json
+++ b/StratumServer/stratum.default.json
@@ -437,5 +437,13 @@
     "IntervalMinutes": 360,
     "RetainCount": 5,
     "LogBackups": true
+  },
+  "Announcements": {
+    "Enabled": false,
+    "IntervalSeconds": 300,
+    "Messages": [],
+    "Prefix": "<strong><font color=\"orange\">",
+    "Suffix": "</font></strong>",
+    "RandomOrder": false
   }
 }

--- a/patches/VintagestoryLib/Vintagestory.Server/ServerMain.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/ServerMain.cs.patch
@@ -1,5 +1,5 @@
 diff --git a/VintagestoryLib/Vintagestory.Server/ServerMain.cs b/VintagestoryLib/Vintagestory.Server/ServerMain.cs
-index 1017be9..0ab2741 100644
+index 1017be9..8d24994 100644
 --- a/VintagestoryLib/Vintagestory.Server/ServerMain.cs
 +++ b/VintagestoryLib/Vintagestory.Server/ServerMain.cs
 @@ -27,10 +27,13 @@ using VintagestoryLib.Server.Systems;
@@ -501,7 +501,7 @@ index 1017be9..0ab2741 100644
  			{
  				processConnectionQueue();
  				statsupdate = DateTime.UtcNow;
-@@ -1533,22 +1726,29 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -1533,24 +1726,31 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  				{
  					StatsCollector[StatsCollectorIndex].tickTimes[k] = 0L;
  				}
@@ -535,6 +535,8 @@ index 1017be9..0ab2741 100644
  				FrameProfiler.Mark("sleep");
  			}
  			TickPosition++;
+ 		}
+ 		catch (Exception e)
 @@ -1558,24 +1758,113 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  			Logger.Fatal(e);
  		}

--- a/sources/VintagestoryLib/Vintagestory.Server/ServerSystemStratum.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/ServerSystemStratum.cs
@@ -114,6 +114,11 @@ internal class ServerSystemStratum : ServerSystem
 			new StratumItemCleanup(server);
 			StratumRuntime.LogInfo($"item cleanup scheduler armed: first cleanup in {StratumRuntime.Config.Performance.ItemCleanup.IntervalSeconds}s, interval={StratumRuntime.Config.Performance.ItemCleanup.IntervalSeconds}s");
         }
+		if (StratumRuntime.Config.Announcements.Enabled && StratumRuntime.Config.Announcements.Messages.Length > 0)
+		{
+			new StratumAnnouncementScheduler(server);
+			StratumRuntime.LogInfo("announcements armed: " + StratumRuntime.Config.Announcements.Messages.Length + " messages, interval=" + StratumRuntime.Config.Announcements.IntervalSeconds + "s");
+		}
         StratumTrimClassRegistry();
 		StratumRuntime.LogInfo("runtime ready. Use /stratum health, /stratum status, and /stratum timings start.");
 	}

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumAnnouncementScheduler.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumAnnouncementScheduler.cs
@@ -1,0 +1,61 @@
+using System;
+using Vintagestory.API.Common;
+
+namespace Vintagestory.Server;
+
+/// <summary>
+/// Broadcasts configured messages to all players at a fixed interval.
+/// Messages rotate sequentially. Skips broadcast when no players are online.
+/// </summary>
+internal sealed class StratumAnnouncementScheduler
+{
+	private readonly ServerMain server;
+	private long lastBroadcastMs;
+	private int nextIndex;
+
+	public StratumAnnouncementScheduler(ServerMain server)
+	{
+		this.server = server;
+		lastBroadcastMs = server.ElapsedMilliseconds;
+		server.RegisterGameTickListener(OnTick, 10_000);
+	}
+
+	private void OnTick(float dt)
+	{
+		StratumAnnouncementsConfig cfg = StratumRuntime.Config.Announcements;
+		if (cfg == null || !cfg.Enabled || cfg.Messages == null || cfg.Messages.Length == 0)
+		{
+			return;
+		}
+
+		if (server.AllOnlinePlayers.Length == 0)
+		{
+			return;
+		}
+
+		long elapsedMs = server.ElapsedMilliseconds;
+		long intervalMs = (long)Math.Max(10, cfg.IntervalSeconds) * 1000L;
+
+		if (elapsedMs - lastBroadcastMs < intervalMs)
+		{
+			return;
+		}
+
+		lastBroadcastMs = elapsedMs;
+
+		if (cfg.RandomOrder)
+		{
+			nextIndex = server.rand.Value.Next(cfg.Messages.Length);
+		}
+
+		string message = cfg.Messages[nextIndex % cfg.Messages.Length];
+
+		if (!cfg.RandomOrder)
+		{
+			nextIndex = (nextIndex + 1) % cfg.Messages.Length;
+		}
+
+		string formatted = cfg.Prefix + message + cfg.Suffix;
+		server.BroadcastMessageToAllGroups(formatted, EnumChatType.Notification);
+	}
+}

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumConfig.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumConfig.cs
@@ -46,6 +46,8 @@ internal class StratumConfig
 
 	public StratumBackupConfig Backup { get; set; } = new StratumBackupConfig();
 
+	public StratumAnnouncementsConfig Announcements { get; set; } = new StratumAnnouncementsConfig();
+
 	public StratumServerStatsConfig ServerStats { get; set; } = new StratumServerStatsConfig();
 
 	public void EnsurePopulated()
@@ -68,6 +70,7 @@ internal class StratumConfig
 		PlayerPrivacy ??= new StratumPlayerPrivacyConfig();
 		Nametags ??= new StratumNametagsConfig();
 		Backup ??= new StratumBackupConfig();
+		Announcements ??= new StratumAnnouncementsConfig();
 		ServerStats ??= new StratumServerStatsConfig();
 		PacketLimits.EnsureSane();
 		PacketBackPressure.EnsureSane();
@@ -84,6 +87,7 @@ internal class StratumConfig
 		PlayerPrivacy.EnsurePopulated();
 		Nametags.EnsurePopulated();
 		Backup.EnsureSane();
+		Announcements.EnsureSane();
 		ServerStats.EnsureSane();
 		UpdateChecker.EnsureSane();
 		MigrateLegacyDefaults();
@@ -1944,5 +1948,33 @@ internal class StratumBackupConfig
 	{
 		if (IntervalMinutes < 1) IntervalMinutes = 1;
 		if (RetainCount < 1) RetainCount = 1;
+	}
+}
+
+internal class StratumAnnouncementsConfig
+{
+	public bool Enabled { get; set; }
+
+	// Seconds between broadcasts.
+	public int IntervalSeconds { get; set; } = 300;
+
+	// Messages to rotate through. Supports the same HTML formatting as /announce.
+	public string[] Messages { get; set; } = Array.Empty<string>();
+
+	// Prepended to every message. Default matches /announce orange bold styling.
+	public string Prefix { get; set; } = "<strong><font color=\"orange\">";
+
+	// Appended to every message. Closes the Prefix tags.
+	public string Suffix { get; set; } = "</font></strong>";
+
+	// If true, pick a random message each time instead of sequential rotation.
+	public bool RandomOrder { get; set; }
+
+	public void EnsureSane()
+	{
+		if (IntervalSeconds < 10) IntervalSeconds = 10;
+		Messages ??= Array.Empty<string>();
+		Prefix ??= "";
+		Suffix ??= "";
 	}
 }


### PR DESCRIPTION
## Summary

Adds a scheduled chat announcement broadcaster. Set a list of messages in `stratum.json` under `Announcements` and the server rotates through them (in order by default, at random if configured) and broadcasts to all players at a fixed interval. Skips the broadcast when no players are online. Wires into `OnBeginRunGame` next to the backup and item cleanup schedulers, the same pattern every other optional scheduler in that file uses. Disabled by default.

## Type

- [ ] Bug fix
- [ ] Performance
- [x] New feature
- [ ] Refactor or cleanup
- [ ] Docs or build

## Checklist

- [x] `.\scripts\extract-patches.ps1` ran clean.
- [x] `dotnet build VintageStory.slnx -c Release` is green.
- [x] Every vanilla edit has a `// Stratum` marker.
- [x] No vanilla source committed.
- [x] Tested on a real server start, not just compilation.

## Config reference

All fields live under `Announcements` in `stratum.json`. `/stratum get Announcements` and `/stratum set Announcements.<field> <value>` read and write the scalar fields below at runtime. `Messages` is a list, so it needs a direct edit to `stratum.json` plus `/stratum reload`, the same as every other list-shaped config in this file.

| Field | Type | Default | Notes |
|---|---|---|---|
| `Enabled` | bool | `false` | Turns the scheduler on. |
| `IntervalSeconds` | int | `300` | Minimum 10, clamped in `EnsureSane`. |
| `Messages` | string[] | `[]` | Same HTML formatting `/announce` accepts. An empty list keeps the scheduler off even if `Enabled` is true. |
| `Prefix` | string | `<strong><font color="orange">` | Goes at the start of every message, matches `/announce` styling. |
| `Suffix` | string | `</font></strong>` | Goes at the end of every message, closes the `Prefix` tags. |
| `RandomOrder` | bool | `false` | Picks a random message each time instead of rotating in order. |

## Testing

Built clean and booted a real server through the patched launcher (`dotnet publish -p:EmbedPatchedDlls=true`, so the actual patched `VintagestoryLib.dll` loads, not vanilla) twice: once with `Announcements` at its disabled default (boots quiet, no errors), once with it enabled and two test messages (log shows `announcements armed: 2 messages, interval=10s`, server ticks and shuts down clean).

## Related issues

Closes #103
