### PR TITLE
Load sidecar configs even on a fresh stratum.json

### DIFF
--- a/sources/VintagestoryLib/Vintagestory.Server/StratumRuntime.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumRuntime.cs
@@ -211,28 +211,25 @@ internal static class StratumRuntime
 		{
 			GamePaths.EnsurePathExists(GamePaths.Config);
 
-			if (!File.Exists(ConfigPath))
+			bool mainConfigExisted = File.Exists(ConfigPath);
+			Config = mainConfigExisted
+				? JsonConvert.DeserializeObject<StratumConfig>(File.ReadAllText(ConfigPath)) ?? StratumConfig.CreateDefault()
+				: StratumConfig.CreateDefault();
+
+			// Stratum: load the sidecars whenever they exist, not only when stratum.json also
+			// exists. A first boot on a data dir provisioned with just stratum-performance.json
+			// (or stratum-commands.json) used to skip this check and overwrite it with defaults.
+			if (File.Exists(CommandsConfigPath))
 			{
-				Config = StratumConfig.CreateDefault();
-				SaveConfig();
-				message = "created default config";
+				Config.Commands = JsonConvert.DeserializeObject<StratumCommandsConfig>(File.ReadAllText(CommandsConfigPath)) ?? new StratumCommandsConfig();
 			}
-			else
+			if (File.Exists(PerformanceConfigPath))
 			{
-				string json = File.ReadAllText(ConfigPath);
-				Config = JsonConvert.DeserializeObject<StratumConfig>(json) ?? StratumConfig.CreateDefault();
-				if (File.Exists(CommandsConfigPath))
-				{
-					Config.Commands = JsonConvert.DeserializeObject<StratumCommandsConfig>(File.ReadAllText(CommandsConfigPath)) ?? new StratumCommandsConfig();
-				}
-				if (File.Exists(PerformanceConfigPath))
-				{
-					Config.Performance = JsonConvert.DeserializeObject<StratumPerformanceConfig>(File.ReadAllText(PerformanceConfigPath)) ?? new StratumPerformanceConfig();
-				}
-				Config.EnsurePopulated();
-				SaveConfig();
-				message = "loaded config";
+				Config.Performance = JsonConvert.DeserializeObject<StratumPerformanceConfig>(File.ReadAllText(PerformanceConfigPath)) ?? new StratumPerformanceConfig();
 			}
+			Config.EnsurePopulated();
+			SaveConfig();
+			message = mainConfigExisted ? "loaded config" : "created default config";
 
 			LastLoadedUtc = DateTime.UtcNow;
 			LastLoadStatus = message;


### PR DESCRIPTION
## Summary

`LoadOrCreateConfig` only checked for `stratum-commands.json`/`stratum-performance.json` inside the branch that runs when `stratum.json` already exists. A data dir provisioned with a performance or commands sidecar but no main config yet hit the other branch, never read the sidecar, and `SaveConfig` overwrote it with defaults on the very first boot. Now both sidecars load whenever they exist on disk, independent of whether `stratum.json` itself was present.

## Type

- [x] Bug fix
- [ ] Performance
- [ ] New feature
- [ ] Refactor or cleanup
- [ ] Docs or build

## Checklist

- [x] `.\scripts\extract-patches.ps1` ran clean.
- [x] `dotnet build VintageStory.slnx -c Release` is green.
- [x] Every vanilla edit has a `// Stratum` marker.
- [x] No vanilla source committed.
- [x] Tested on a real server start, not just compilation.

## Testing

Seeded a fresh data dir with only `stratum-performance.json` (`MaxChunksPerServerTick: 4242`), no `stratum.json`, and booted through the patched launcher (`dotnet publish -p:EmbedPatchedDlls=true`). Before the fix that value gets replaced with the default on first boot; after the fix it survives into the resaved `stratum-performance.json`, logged as `created default config` since `stratum.json` itself was still new. A second boot logs `loaded config` and reads the same value back, confirming the normal already-provisioned path still works.

## Related issues

Noted in #147 (StratumParity's second behavioral note).
