### PR TITLE
Skip HashSet rebuild in prospecting pick ore-bearing check

### DIFF
--- a/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/5.GenDeposits/Generators/DiscGenerator.cs.patch
+++ b/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/5.GenDeposits/Generators/DiscGenerator.cs.patch
@@ -1,5 +1,5 @@
 diff --git a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/5.GenDeposits/Generators/DiscGenerator.cs b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/5.GenDeposits/Generators/DiscGenerator.cs
-index 2b6633c..328948f 100644
+index 2b6633c..1cbe062 100644
 --- a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/5.GenDeposits/Generators/DiscGenerator.cs
 +++ b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/5.GenDeposits/Generators/DiscGenerator.cs
 @@ -206,24 +206,62 @@ namespace Vintagestory.ServerMods
@@ -117,12 +117,12 @@ index 2b6633c..328948f 100644
 +                            posy--;
 +                            continue;
 +                        }
++
++                        int posyChunksizeMod = posy % chunksize;
++                        int posyChunksizeDiv = posy / chunksize;
  
 -                        int index3d = ((posy % chunksize) * chunksize + lz) * chunksize + lx;
 -                        int blockId = chunks[posy / chunksize].Data.GetBlockIdUnsafe(index3d);
-+                        int posyChunksizeMod = posy % chunksize;
-+                        int posyChunksizeDiv = posy / chunksize;
-+
 +                        int index3d = ((posyChunksizeMod) * chunksize + lz) * chunksize + lx;
 +                        int blockId = chunks[posyChunksizeDiv].Data.GetBlockIdUnsafe(index3d);
  
@@ -222,3 +222,43 @@ index 2b6633c..328948f 100644
              return yOffBot * (1 - yRel) + yOffTop * yRel;
  
          }
+@@ -442,33 +493,28 @@ namespace Vintagestory.ServerMods
+ 
+ 
+ 
+         private double oreBearingBlockQuantityRelative(BlockPos pos, string oreCode, int[] blockColumn)
+         {
+-            HashSet<int> oreBearingBlocks = new HashSet<int>();
+-
+             if (variant == null) return 0;
+ 
+-            int[] blocks = GetBearingBlocks();
+-            if (blocks == null) return 1;
+-
+-            foreach (var val in blocks)
+-            {
+-                oreBearingBlocks.Add(val);
+-            }
+-
++            // Stratum start: query placeBlockByInBlockId directly instead of copying its keys into
++            // a fresh int[] via GetBearingBlocks() and rebuilding a HashSet<int> from that array on
++            // every call. placeBlockByInBlockId is populated once during generator setup and
++            // read-only afterward, so ContainsKey here is equivalent and allocation-free.
+             GetYMinMax(pos, out double minYAvg, out double maxYAvg);
+ 
+             int q = 0;
+             for (int ypos = 0; ypos < blockColumn.Length; ypos++)
+             {
+                 if (ypos < minYAvg || ypos > maxYAvg) continue;
+ 
+-                if (oreBearingBlocks.Contains(blockColumn[ypos])) q++;
++                if (placeBlockByInBlockId.ContainsKey(blockColumn[ypos])) q++;
+             }
+ 
+             return (double)q / blockColumn.Length;
++            // Stratum end
+         }
+ 
+         /// <summary>
+         /// This will always return the same result for the same ore generator if Radius or Thickness have not been changed.
+         /// <see cref="GetAbsAvgQuantity(LCGRandom)"/>


### PR DESCRIPTION
## Summary

`oreBearingBlockQuantityRelative` built a fresh `int[]` via `GetBearingBlocks()` (`placeBlockByInBlockId.Keys.ToArray()`) then copied it into a fresh `HashSet<int>` on every call, just to run `Contains` checks in the loop below. `placeBlockByInBlockId` is populated once during generator setup and stays read-only during generation, so a direct `ContainsKey` against it produces the same result and skips both allocations. `GetBearingBlocks()` itself is untouched, this only removes its internal use inside `oreBearingBlockQuantityRelative`.

## Type

- [ ] Bug fix
- [x] Performance
- [ ] Refactor or cleanup
- [ ] New feature
- [ ] Docs or build

## Checklist

- [x] `.\scripts\extract-patches.ps1` ran clean.
- [x] `dotnet build VintageStory.slnx -c Release` is green.
- [x] Every vanilla edit has a `// Stratum` marker.
- [x] No vanilla source committed.
- [x] Tested on a real server start, not just compilation.

## Performance numbers

Benchmarked the actual before/after method bodies (`research/benchmarks/propick-reading-reuse`), against a 6-entry bearing-block dictionary and a full 256-block-tall column:

| Method | Mean | Allocated |
|---|---|---|
| Before | 2.167 μs | 320 B |
| After | 1.308 μs | 0 B |

Every allocation gone, mean time down about 40%. Runs once per Y-column per prospecting pick read, so the win scales with how many players are prospecting at once.

## Testing

Behavioral equivalence checked with a standalone harness running both the old and new algorithm side by side against 2000+ randomized `(dict, column, Y-range)` combinations plus three explicit edge cases, all produced identical output. That includes the one case a naive port gets wrong: an empty bearing-block dictionary returns `0.0` today because the loop falls through with zero matches, not `1.0` from the `blocks == null` check a few lines up (that check is dead in the current source, `Keys.ToArray()` on an empty dictionary returns an empty array, never `null`). The rewrite drops that dead check and just lets `ContainsKey` return false on an empty dictionary, same `0.0` result.
