### PR TITLE
Improved multithreaded performance of the chunk generator 

### DIFF
--- a/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/2.GenRockStrata/GenRockStrata.cs.patch
+++ b/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/2.GenRockStrata/GenRockStrata.cs.patch
@@ -1,7 +1,20 @@
 diff --git a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/2.GenRockStrata/GenRockStrata.cs b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/2.GenRockStrata/GenRockStrata.cs
-index cb9eefa..dd7efe6 100644
+index cb9eefa..2918c45 100644
 --- a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/2.GenRockStrata/GenRockStrata.cs
 +++ b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/2.GenRockStrata/GenRockStrata.cs
+@@ -46,11 +46,11 @@ namespace Vintagestory.ServerMods
+         public override void StartServerSide(ICoreServerAPI api)
+         {
+             this.api = api;
+ 
+             api.Event.InitWorldGenerator(initWorldGen, "standard");
+-            api.Event.ChunkColumnGeneration(GenChunkColumn, EnumWorldGenPass.Terrain, "standard");
++            api.Event.ChunkColumnGeneration(GenChunkColumn, EnumWorldGenPass.Terrain2, "standard");// Stratum: we use our generation sub-stage
+ 
+             api.Event.MapRegionGeneration(OnMapRegionGen, "standard");
+         }
+ 
+ 
 @@ -136,10 +136,11 @@ namespace Vintagestory.ServerMods
  
          // Cheap ugly code for better performance :<

--- a/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves.cs.patch
+++ b/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves.cs.patch
@@ -1,8 +1,8 @@
 diff --git a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves.cs b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves.cs
-index 30f034d..3a09055 100644
+index 30f034d..2a019cc 100644
 --- a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves.cs
 +++ b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves.cs
-@@ -30,11 +30,11 @@ namespace Vintagestory.ServerMods
+@@ -30,18 +30,18 @@ namespace Vintagestory.ServerMods
                  api.Event.GetWorldgenBlockAccessor(OnWorldGenBlockAccessor);
  
                  api.ChatCommands.GetOrCreate("dev")
@@ -15,6 +15,14 @@ index 30f034d..3a09055 100644
                      .EndSubCommand();
  
                  api.Event.MapChunkGeneration(OnMapChunkGen, "standard");
+                 api.Event.MapChunkGeneration(OnMapChunkGen, "superflat");
+-                api.Event.ChunkColumnGeneration(GenChunkColumn, EnumWorldGenPass.Terrain, "standard");
++                api.Event.ChunkColumnGeneration(GenChunkColumn, EnumWorldGenPass.Terrain2, "standard");// Stratum: we use our generation sub-stage
+                 api.Event.InitWorldGenerator(initWorldGen, "superflat");
+             }
+         }
+ 
+ 
 @@ -77,16 +77,23 @@ namespace Vintagestory.ServerMods
          private TextCommandResult CmdCaveGenTest(TextCommandCallingArgs args)
          {

--- a/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/4.GenBlockLayers/GenBlockLayers.cs.patch
+++ b/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/4.GenBlockLayers/GenBlockLayers.cs.patch
@@ -1,0 +1,17 @@
+diff --git a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/4.GenBlockLayers/GenBlockLayers.cs b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/4.GenBlockLayers/GenBlockLayers.cs
+index 55b134c..57340a3 100644
+--- a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/4.GenBlockLayers/GenBlockLayers.cs
++++ b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/4.GenBlockLayers/GenBlockLayers.cs
+@@ -46,11 +46,11 @@ namespace Vintagestory.ServerMods
+             //this.api.Event.MapRegionGeneration(OnMapRegionGen, "standard");   // 8.2.24 commented out because the method has no code
+ 
+ 
+             if (TerraGenConfig.DoDecorationPass)
+             {
+-                this.api.Event.ChunkColumnGeneration(OnChunkColumnGeneration, EnumWorldGenPass.Terrain, "standard");
++                this.api.Event.ChunkColumnGeneration(OnChunkColumnGeneration, EnumWorldGenPass.Terrain2, "standard");// Stratum: we use our generation sub-stage
+             }
+             distort2dx = new SimplexNoise(new double[] { 14, 9, 6, 3 }, new double[] { 1 / 100.0, 1 / 50.0, 1 / 25.0, 1 / 12.5 }, api.World.SeaLevel + 20980);
+             distort2dz = new SimplexNoise(new double[] { 14, 9, 6, 3 }, new double[] { 1 / 100.0, 1 / 50.0, 1 / 25.0, 1 / 12.5 }, api.World.SeaLevel + 20981);
+         }
+ 

--- a/patches/VSSurvivalMod/Systems/WorldGen/Standard/ChunkGen/4.GenBlockLayers/GenDevastationLayer.cs.patch
+++ b/patches/VSSurvivalMod/Systems/WorldGen/Standard/ChunkGen/4.GenBlockLayers/GenDevastationLayer.cs.patch
@@ -1,0 +1,17 @@
+diff --git a/VSSurvivalMod/Systems/WorldGen/Standard/ChunkGen/4.GenBlockLayers/GenDevastationLayer.cs b/VSSurvivalMod/Systems/WorldGen/Standard/ChunkGen/4.GenBlockLayers/GenDevastationLayer.cs
+index eb5ff1a..4163ce5 100644
+--- a/VSSurvivalMod/Systems/WorldGen/Standard/ChunkGen/4.GenBlockLayers/GenDevastationLayer.cs
++++ b/VSSurvivalMod/Systems/WorldGen/Standard/ChunkGen/4.GenBlockLayers/GenDevastationLayer.cs
+@@ -52,11 +52,11 @@ namespace Vintagestory.ServerMods
+             api.Event.PreventTerrainHeightSmoothing(SuppressSmoothing);
+             api.Event.PlayerJoin += Event_PlayerJoin;
+ 
+             if (TerraGenConfig.DoDecorationPass)
+             {
+-                api.Event.ChunkColumnGeneration(OnChunkColumnGeneration, EnumWorldGenPass.Terrain, "standard");
++                api.Event.ChunkColumnGeneration(OnChunkColumnGeneration, EnumWorldGenPass.Terrain2, "standard"); // Stratum: we use our generation sub-stage
+                 api.Event.GetWorldgenBlockAccessor(OnWorldGenBlockAccessor);
+             }
+ 
+             distDistort = new SimplexNoise(new double[] { 14, 9, 6, 3 }, new double[] { 1 / 100.0, 1 / 50.0, 1 / 25.0, 1 / 12.5 }, api.World.SeaLevel + 20980);
+         }

--- a/patches/VintagestoryApi/Server/Worldgen/EnumWorldGenPass.cs.patch
+++ b/patches/VintagestoryApi/Server/Worldgen/EnumWorldGenPass.cs.patch
@@ -1,0 +1,78 @@
+diff --git a/VintagestoryApi/Server/Worldgen/EnumWorldGenPass.cs b/VintagestoryApi/Server/Worldgen/EnumWorldGenPass.cs
+index f3ac51d..7a092c2 100644
+--- a/VintagestoryApi/Server/Worldgen/EnumWorldGenPass.cs
++++ b/VintagestoryApi/Server/Worldgen/EnumWorldGenPass.cs
+@@ -13,19 +13,27 @@ namespace Vintagestory.API.Server
+         /// <summary>
+         /// Nothing generated yet
+         /// </summary>
+         None = 0,
+ 
++        // Stratum start: split the Terrain into two stages
++        // this way we get a uniform load across each stage across threads
++
+         /// <summary>
+         /// Does not require neighbour chunks to exist. Should generates 3d rock terrain mostly. Default generators by execute order:
+         /// 0 = Basic 3D Terrain (granite+rock)
++        /// </summary>
++        Terrain = 1,
++
++        /// <summary>
++        /// Doesn't require adjacent fragments to work. Generates the remaining terrain stages. Generators are run in the following order by default:
+         /// 0.1 = Rock Strata
+         /// 0.2 = Rivers
+         /// 0.3 = Cave generator
+         /// 0.4 = Block layers (soil, gravel, sand, ice, tall grass, etc.)
+         /// </summary>
+-        Terrain = 1,
++        Terrain2 = 2,
+ 
+         // Beyond here
+         // - Chunkloader ensures that all neighbour chunks are same or higher pass
+ 
+ 
+@@ -35,37 +43,39 @@ namespace Vintagestory.API.Server
+         /// 0.2 = Deposits (Ores, Peat, Clay, etc.)
+         /// 0.3 = Worldgen Structures
+         /// 0.4 = Above sealevel Lakes
+         /// 0.5 = Worldgen Structures Post Pass
+         /// </summary>
+-        TerrainFeatures = 2,
++        TerrainFeatures = 3,
+ 
+         /// <summary>
+         /// Requires neighbour chunks. Default generators by execute order:
+         /// 0.2 = Story structures. Creates exclusion zones for the other vegetation passes
+         /// 0.5 = Block Patches, Shrubs and Trees
+         /// 0.9 = Rivulets (single block water sources)
+         /// 0.95 = Sunlight flooding only inside current chunk
+         /// </summary>
+-        Vegetation = 3,
++        Vegetation = 4,
+ 
+         /// <summary>
+         /// Requires neighbour chunks. Does the lighting of the chunk.
+         /// 0 = Snow layer
+         /// 0.95 = Sunlight flooding into neighbouring chunks
+         /// </summary>
+-        NeighbourSunLightFlood = 4,
++        NeighbourSunLightFlood = 5,
+ 
+         /// <summary>
+         /// Requires neighbour chunks. Nothing left to generate, but neighbour chunks might still generate stuff into this chunk
+         /// 0.1 = Generate creatures
+         /// </summary>
+-        PreDone = 5,
++        PreDone = 6,
+ 
+         /// <summary>
+         /// Chunk generation complete. This pass is not triggered as an event. 
+         /// </summary>
+-        Done = 6
++        Done = 7
++
++        // Stratum end
+     }
+ 
+ 
+ }

--- a/patches/VintagestoryLib/Vintagestory.Server/ChunkServerThread.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/ChunkServerThread.cs.patch
@@ -1,5 +1,5 @@
 diff --git a/VintagestoryLib/Vintagestory.Server/ChunkServerThread.cs b/VintagestoryLib/Vintagestory.Server/ChunkServerThread.cs
-index ee7d12d..07e051a 100644
+index ee7d12d..f8b2024 100644
 --- a/VintagestoryLib/Vintagestory.Server/ChunkServerThread.cs
 +++ b/VintagestoryLib/Vintagestory.Server/ChunkServerThread.cs
 @@ -12,10 +12,12 @@ namespace Vintagestory.Server;
@@ -15,6 +15,23 @@ index ee7d12d..07e051a 100644
  	internal IndexedFifoQueue<ChunkColumnLoadRequest> peekingChunkColumns;
  
  	internal Dictionary<long, ServerMapRegion> peekingMapRegions = new Dictionary<long, ServerMapRegion>(8);
+@@ -39,13 +41,13 @@ public class ChunkServerThread : ServerThread, IChunkProvider
+ 	public ILogger Logger => ServerMain.Logger;
+ 
+ 	public ChunkServerThread(ServerMain server, string threadname, CancellationToken cancellationToken)
+ 		: base(server, threadname, cancellationToken)
+ 	{
+-		int val = 5;
+-		additionalWorldGenThreadsCount = Math.Min(val, MagicNum.MaxWorldgenThreads - 1);
+-		if (server.ReducedServerThreads)
++		int val = (int)EnumWorldGenPass.Done - 1; // Stratum:  Getting rid of the magic number
++        additionalWorldGenThreadsCount = Math.Min(val, MagicNum.MaxWorldgenThreads); // Stratum: We take as many streams as are actually needed for each generation stage.
++        if (server.ReducedServerThreads)
+ 		{
+ 			additionalWorldGenThreadsCount = 0;
+ 		}
+ 		if (additionalWorldGenThreadsCount < 0)
+ 		{
 @@ -101,15 +103,21 @@ public class ChunkServerThread : ServerThread, IChunkProvider
  		return peekingChunkColumns.GetByIndex(index);
  	}

--- a/patches/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs.patch
@@ -1,277 +1,930 @@
 diff --git a/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs b/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs
-index d6e727a..018b171 100644
+index d6e727a..3396d28 100644
 --- a/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs
 +++ b/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs
-@@ -37,10 +37,26 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -14,1595 +14,1835 @@ using Vintagestory.Common.Database;
  
- 	private string[] storyChunkSpawnEvents;
+ namespace Vintagestory.Server;
  
- 	private int blockingRequestsRemaining;
- 
-+	// Stratum: priority list built once per OnSeparateThreadTick, shared across all inner
-+	// tryLoadOrGenerateChunkColumnsInQueue calls within that tick. The profiler showed that
-+	// a time-based 100ms cache was hitting the rebuild branch on virtually every call
-+	// (7.4M rebuilds/session at 100 players). Building once per tick drops that to ~14K.
-+	private List<ChunkColumnLoadRequest>? stratumPriorityListCache;
-+	private int stratumPriorityListCacheIdx;
-+	// Reused player-position arrays so TryBuildStratumPriorityList doesn't allocate on each rebuild.
-+	private float[] stratumPlayerCx = [];
-+	private float[] stratumPlayerCz = [];
-+	private int stratumPlayerCount;
-+	private Comparison<ChunkColumnLoadRequest>? stratumSortComparison;
-+	private readonly List<long> stratumMoveBuffer = new List<long>();
-+	private readonly List<ChunkColumnLoadRequest> stratumCandidatesBuffer = new List<ChunkColumnLoadRequest>();
-+	private readonly List<ChunkPos> stratumDeleteChunksList = new List<ChunkPos>(64);
-+	private readonly List<ChunkPos> stratumDeleteMapChunksList = new List<ChunkPos>(16);
-+	private readonly HashSet<ChunkPos> stratumDeleteRegionsSet = new HashSet<ChunkPos>();
- 	public ServerSystemSupplyChunks(ServerMain server, ChunkServerThread chunkthread)
- 		: base(server)
- 	{
- 		this.chunkthread = chunkthread;
- 		chunkthread.loadsavechunks = this;
-@@ -124,16 +140,18 @@ internal class ServerSystemSupplyChunks : ServerSystem
- 				break;
- 			case EnumChunkType.MapRegion:
- 				exists = chunkthread.gameDatabase.MapRegionExists(val.chunkX, val.chunkZ);
- 				break;
- 			}
+ internal class ServerSystemSupplyChunks : ServerSystem
+ {
+-	private WorldGenHandler worldgenHandler;
+-
+-	private ChunkServerThread chunkthread;
+-
+-	private bool is8Core = Environment.ProcessorCount >= 8;
+-
+-	private bool requiresChunkBorderSmoothing;
+-
+-	private bool requiresSetEmptyFlag;
+-
+-	private volatile int pauseAllWorldgenThreads;
+-
+-	[ThreadStatic]
+-	private static FastMemoryStream saveChunksStream;
+-
+-	private List<long> entitiesToRemove = new List<long>();
+-
+-	private int storyEventPrints;
+-
+-	private string[] storyChunkSpawnEvents;
+-
+-	private int blockingRequestsRemaining;
+-
+-	public ServerSystemSupplyChunks(ServerMain server, ChunkServerThread chunkthread)
+-		: base(server)
+-	{
+-		this.chunkthread = chunkthread;
+-		chunkthread.loadsavechunks = this;
+-		server.RegisterGameTickListener(delegate
+-		{
+-			server.serverChunkDataPool.SlowDispose();
+-		}, 1000);
+-	}
+-
+-	public override int GetUpdateInterval()
+-	{
+-		if (chunkthread.requestedChunkColumns.Count == 0 || !is8Core)
+-		{
+-			return MagicNum.ChunkThreadTickTime;
+-		}
+-		return chunkthread.additionalWorldGenThreadsCount - 1;
+-	}
+-
+-	public override void OnBeginGameReady(SaveGame savegame)
+-	{
+-		requiresChunkBorderSmoothing = savegame.CreatedWorldGenVersion != 3;
+-		requiresSetEmptyFlag = GameVersion.IsLowerVersionThan(server.SaveGameData.LastSavedGameVersion, "1.12-dev.1");
+-		if (chunkthread.additionalWorldGenThreadsCount > 0)
+-		{
+-			int num = 1;
+-			for (int i = 0; i < chunkthread.additionalWorldGenThreadsCount; i++)
+-			{
+-				CreateAdditionalWorldGenThread(num, num + 1, i + 1);
+-				num++;
+-			}
+-		}
+-	}
+-
+-	public override void OnSeparateThreadTick()
+-	{
+-		if (server.RunPhase != EnumServerRunPhase.RunGame)
+-		{
+-			return;
+-		}
+-		deleteChunkColumns();
+-		moveRequestsToGeneratingQueue();
+-		KeyValuePair<HorRectanglei, ChunkLoadOptions> result;
+-		while (!server.fastChunkQueue.IsEmpty && server.fastChunkQueue.TryDequeue(out result))
+-		{
+-			loadChunkAreaBlocking(result.Key.X1, result.Key.Z1, result.Key.X2, result.Key.Z2, isStartupLoad: false, result.Value.ChunkGenParams);
+-			if (result.Value.OnLoaded != null)
+-			{
+-				server.EnqueueMainThreadTask(result.Value.OnLoaded);
+-			}
+-		}
+-		if (!server.simpleLoadRequests.IsEmpty && server.mapMiddleSpawnPos != null)
+-		{
+-			ChunkColumnLoadRequest result2;
+-			while (server.simpleLoadRequests.TryDequeue(out result2))
+-			{
+-				simplyLoadChunkColumn(result2);
+-			}
+-		}
+-		if (!server.peekChunkColumnQueue.IsEmpty && server.peekChunkColumnQueue.TryDequeue(out var result3))
+-		{
+-			if (PauseAllWorldgenThreads(3600))
+-			{
+-				PeekChunkAreaLocking(result3.Key, result3.Value.UntilPass, result3.Value.OnGenerated, result3.Value.ChunkGenParams);
+-			}
+-			ResumeAllWorldgenThreads();
+-		}
+-		while (!server.testChunkExistsQueue.IsEmpty)
+-		{
+-			if (!server.testChunkExistsQueue.TryDequeue(out var val))
+-			{
+-				break;
+-			}
+-			bool exists = false;
+-			switch (val.Type)
+-			{
+-			case EnumChunkType.Chunk:
+-				exists = chunkthread.gameDatabase.ChunkExists(val.chunkX, val.chunkY, val.chunkZ);
+-				break;
+-			case EnumChunkType.MapChunk:
+-				exists = chunkthread.gameDatabase.MapChunkExists(val.chunkX, val.chunkZ);
+-				break;
+-			case EnumChunkType.MapRegion:
+-				exists = chunkthread.gameDatabase.MapRegionExists(val.chunkX, val.chunkZ);
+-				break;
+-			}
 -			server.EnqueueMainThreadTask(delegate
 -			{
 -				val.onTested(exists);
 -				ServerMain.FrameProfiler.Mark("MTT-TestExists");
 -			});
-+			val.Exists = exists;
-+			server.EnqueueMainThreadTask(val.Complete);
- 		}
-+		// Stratum: build priority list once per tick. tryLoadOrGenerateChunkColumnsInQueue is
-+		// called up to MagicNum.ChunkColumnsToGeneratePerThreadTick times per tick; the previous
-+		// time-based cache was rebuilt on nearly every call due to clock resolution differences.
-+		stratumPriorityListCache = TryBuildStratumPriorityList();
-+		stratumPriorityListCacheIdx = 0;
- 		for (int num = 0; num < MagicNum.ChunkColumnsToGeneratePerThreadTick; num++)
- 		{
- 			if (!tryLoadOrGenerateChunkColumnsInQueue())
- 			{
- 				break;
-@@ -145,12 +163,16 @@ internal class ServerSystemSupplyChunks : ServerSystem
- 		}
- 	}
- 
- 	private void deleteChunkColumns()
- 	{
+-		}
+-		for (int num = 0; num < MagicNum.ChunkColumnsToGeneratePerThreadTick; num++)
+-		{
+-			if (!tryLoadOrGenerateChunkColumnsInQueue())
+-			{
+-				break;
+-			}
+-			if (server.Suspended)
+-			{
+-				break;
+-			}
+-		}
+-	}
+-
+-	private void deleteChunkColumns()
+-	{
 -		List<ChunkPos> list = null;
 -		List<ChunkPos> list2 = null;
-+		List<ChunkPos> list = stratumDeleteChunksList;
-+		List<ChunkPos> list2 = stratumDeleteMapChunksList;
-+		HashSet<ChunkPos> hashSet = stratumDeleteRegionsSet;
-+		list.Clear();
-+		list2.Clear();
-+		hashSet.Clear();
- 		int chunkMapSizeY = server.WorldMap.ChunkMapSizeY;
- 		long result;
- 		while (!server.deleteChunkColumns.IsEmpty && server.deleteChunkColumns.TryDequeue(out result))
- 		{
- 			if (list == null)
-@@ -219,11 +241,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
- 		}
- 		if (list2 != null && list2.Count > 0)
- 		{
- 			chunkthread.gameDatabase.DeleteMapChunks(list2);
- 		}
+-		int chunkMapSizeY = server.WorldMap.ChunkMapSizeY;
+-		long result;
+-		while (!server.deleteChunkColumns.IsEmpty && server.deleteChunkColumns.TryDequeue(out result))
+-		{
+-			if (list == null)
+-			{
+-				list = new List<ChunkPos>();
+-			}
+-			if (list2 == null)
+-			{
+-				list2 = new List<ChunkPos>();
+-			}
+-			if (chunkthread.requestedChunkColumns.Remove(result))
+-			{
+-				server.ChunkColumnRequested.Remove(result);
+-			}
+-			ChunkPos item = server.WorldMap.ChunkPosFromChunkIndex2D(result);
+-			int x = item.X;
+-			int z = item.Z;
+-			if (x < 0 || z < 0)
+-			{
+-				ServerMain.Logger.Error("Delete chunks: mapchunkindex outside the map: " + x + "," + z);
+-				continue;
+-			}
+-			UpdateLoadedNeighboursFlags(server.WorldMap, x, z);
+-			for (int i = 0; i < chunkMapSizeY; i++)
+-			{
+-				ServerChunk serverChunk = (ServerChunk)server.WorldMap.GetChunk(x, i, z);
+-				if (serverChunk != null)
+-				{
+-					Entity[] entities = serverChunk.Entities;
+-					for (int j = 0; j < entities.Length; j++)
+-					{
+-						Entity entity = entities[j];
+-						if (entity is EntityPlayer)
+-						{
+-							continue;
+-						}
+-						if (entity == null)
+-						{
+-							if (j >= serverChunk.EntitiesCount)
+-							{
+-								break;
+-							}
+-						}
+-						else
+-						{
+-							server.DespawnEntity(entity, new EntityDespawnData
+-							{
+-								Reason = EnumDespawnReason.Death
+-							});
+-						}
+-					}
+-				}
+-				list.Add(new ChunkPos
+-				{
+-					X = x,
+-					Y = i,
+-					Z = z
+-				});
+-			}
+-			list2.Add(item);
+-			server.loadedMapChunks.Remove(result);
+-		}
+-		if (list != null && list.Count > 0)
+-		{
+-			chunkthread.gameDatabase.DeleteChunks(list);
+-		}
+-		if (list2 != null && list2.Count > 0)
+-		{
+-			chunkthread.gameDatabase.DeleteMapChunks(list2);
+-		}
 -		HashSet<ChunkPos> hashSet = null;
-+		hashSet = null;
- 		long result2;
- 		while (!server.deleteMapRegions.IsEmpty && server.deleteMapRegions.TryDequeue(out result2))
- 		{
- 			ChunkPos item2 = server.WorldMap.MapRegionPosFromIndex2D(result2);
- 			if (hashSet == null)
-@@ -239,21 +261,21 @@ internal class ServerSystemSupplyChunks : ServerSystem
- 		}
- 	}
- 
- 	private void moveRequestsToGeneratingQueue()
- 	{
+-		long result2;
+-		while (!server.deleteMapRegions.IsEmpty && server.deleteMapRegions.TryDequeue(out result2))
+-		{
+-			ChunkPos item2 = server.WorldMap.MapRegionPosFromIndex2D(result2);
+-			if (hashSet == null)
+-			{
+-				hashSet = new HashSet<ChunkPos>();
+-			}
+-			hashSet.Add(item2);
+-			server.loadedMapRegions.Remove(result2);
+-		}
+-		if (hashSet != null && hashSet.Count > 0)
+-		{
+-			chunkthread.gameDatabase.DeleteMapRegions(hashSet);
+-		}
+-	}
+-
+-	private void moveRequestsToGeneratingQueue()
+-	{
 -		List<long> list = new List<long>();
-+		stratumMoveBuffer.Clear();
- 		lock (server.requestedChunkColumnsLock)
- 		{
+-		lock (server.requestedChunkColumnsLock)
+-		{
 -			while (server.requestedChunkColumns.Count > 0 && chunkthread.requestedChunkColumns.Capacity - chunkthread.requestedChunkColumns.Count >= list.Count + 200)
-+			while (server.requestedChunkColumns.Count > 0 && chunkthread.requestedChunkColumns.Capacity - chunkthread.requestedChunkColumns.Count >= stratumMoveBuffer.Count + 200)
- 			{
+-			{
 -				list.Add(server.requestedChunkColumns.Dequeue());
-+				stratumMoveBuffer.Add(server.requestedChunkColumns.Dequeue());
- 			}
- 		}
+-			}
+-		}
 -		for (int i = 0; i < list.Count; i++)
-+		for (int i = 0; i < stratumMoveBuffer.Count; i++)
- 		{
+-		{
 -			long num = list[i];
-+			long num = stratumMoveBuffer[i];
- 			Vec2i vec2i = server.WorldMap.MapChunkPosFromChunkIndex2D(num);
- 			chunkthread.addChunkColumnRequest(num, vec2i.X, vec2i.Y, -1);
- 		}
- 	}
- 
-@@ -293,10 +315,43 @@ internal class ServerSystemSupplyChunks : ServerSystem
- 		{
- 			return false;
- 		}
- 		CleanupRequestsQueue();
- 		int additionalWorldGenThreadsCount = chunkthread.additionalWorldGenThreadsCount;
-+
-+		// Stratum: use the per-tick priority list built in OnSeparateThreadTick. Falls through
-+		// to vanilla FIFO when the list is null (priority disabled) or exhausted for this tick.
-+		List<ChunkColumnLoadRequest>? stratumPrioritized = (stratumPriorityListCache != null && stratumPriorityListCacheIdx < stratumPriorityListCache.Count)
-+			? stratumPriorityListCache
-+			: null;
-+
-+		if (stratumPrioritized != null)
-+		{
-+			for (; stratumPriorityListCacheIdx < stratumPrioritized.Count; stratumPriorityListCacheIdx++)
-+			{
-+				ChunkColumnLoadRequest requestedChunkColumn = stratumPrioritized[stratumPriorityListCacheIdx];
-+				if (requestedChunkColumn == null || requestedChunkColumn.Disposed)
-+				{
-+					continue;
-+				}
-+				int currentIncompletePass_AsInt = requestedChunkColumn.CurrentIncompletePass_AsInt;
-+				if (currentIncompletePass_AsInt == 0 || currentIncompletePass_AsInt > additionalWorldGenThreadsCount)
-+				{
-+					if (server.Suspended)
-+					{
-+						return false;
-+					}
-+					if (loadOrGenerateChunkColumn_OnChunkThread(requestedChunkColumn, currentIncompletePass_AsInt) && chunkthread.additionalWorldGenThreadsCount == 0)
-+					{
-+						stratumPriorityListCacheIdx++;
-+						return true;
-+					}
-+				}
-+			}
-+			// Priority list exhausted for this tick. Fall through to vanilla FIFO.
-+		}
-+
- 		foreach (ChunkColumnLoadRequest requestedChunkColumn in chunkthread.requestedChunkColumns)
- 		{
- 			if (requestedChunkColumn == null || requestedChunkColumn.Disposed)
- 			{
- 				continue;
-@@ -315,10 +370,92 @@ internal class ServerSystemSupplyChunks : ServerSystem
- 			}
- 		}
- 		return false;
- 	}
- 
-+	// Builds a sorted (by min distance to nearest online player, optionally motion-predicted)
-+	// snapshot of the next StratumChunkPriorityConfig.MaxSortedPerTick pending chunk-column
-+	// requests.
-+	// Returns null only when priority is disabled — caller falls through to vanilla.
-+	// Returns empty stratumCandidatesBuffer when priority is on but nothing to process — caller
-+	// skips vanilla (which would also find nothing). Returns a non-empty sorted list normally.
-+	private List<ChunkColumnLoadRequest> TryBuildStratumPriorityList()
-+	{
-+		StratumChunkPriorityConfig prioCfg = StratumRuntime.Config?.Performance?.ChunkPriority;
-+		if (prioCfg == null || !prioCfg.Enabled) return null;
-+
-+		// Clear here so every non-null early return below yields an empty (non-null) buffer,
-+		// signalling "priority on, nothing to do" rather than "priority off".
-+		stratumCandidatesBuffer.Clear();
-+
-+		int qcount = chunkthread.requestedChunkColumns.Count;
-+		if (qcount == 0) return stratumCandidatesBuffer;
-+
-+		IPlayer[] players = server.AllOnlinePlayers;
-+		if (players == null || players.Length == 0) return stratumCandidatesBuffer;
-+
-+		// Snapshot player chunk-center positions, with optional motion forward-prediction.
-+		// Server tick rate is ~30Hz; Motion is per-tick velocity in blocks.
-+		float pred = prioCfg.PredictionSeconds * 30f;
-+		if (stratumPlayerCx.Length < players.Length)
-+		{
-+			stratumPlayerCx = new float[players.Length];
-+			stratumPlayerCz = new float[players.Length];
-+		}
-+		int pi = 0;
-+		for (int p = 0; p < players.Length; p++)
-+		{
-+			Entity ent = players[p]?.Entity;
-+			if (ent == null) continue;
-+			EntityPos pos = ent.SidedPos;
-+			if (pos == null) continue;
-+			double px = pos.X + (pred > 0f ? pos.Motion.X * pred : 0.0);
-+			double pz = pos.Z + (pred > 0f ? pos.Motion.Z * pred : 0.0);
-+			stratumPlayerCx[pi] = (float)(px / 32.0);
-+			stratumPlayerCz[pi] = (float)(pz / 32.0);
-+			pi++;
-+		}
-+		if (pi == 0) return stratumCandidatesBuffer;
-+		stratumPlayerCount = pi;
-+
-+		int cap = Math.Min(qcount, prioCfg.MaxSortedPerTick);
-+		int picked = 0;
-+		foreach (ChunkColumnLoadRequest r in chunkthread.requestedChunkColumns)
-+		{
-+			if (picked >= cap) break;
-+			if (r == null || r.Disposed) continue;
-+			stratumCandidatesBuffer.Add(r);
-+			picked++;
-+		}
-+		if (stratumCandidatesBuffer.Count == 0) return stratumCandidatesBuffer;
-+
-+		stratumCandidatesBuffer.Sort(stratumSortComparison ??= StratumSortByPlayerDist);
-+		return stratumCandidatesBuffer;
-+	}
-+
-+	private int StratumSortByPlayerDist(ChunkColumnLoadRequest a, ChunkColumnLoadRequest b)
-+	{
-+		float da = StratumMinSqDistToPlayers(a, stratumPlayerCx, stratumPlayerCz, stratumPlayerCount);
-+		float db = StratumMinSqDistToPlayers(b, stratumPlayerCx, stratumPlayerCz, stratumPlayerCount);
-+		return da.CompareTo(db);
-+	}
-+
-+	private static float StratumMinSqDistToPlayers(ChunkColumnLoadRequest req, float[] px, float[] pz, int count)
-+	{
-+		float min = float.MaxValue;
-+		float cx = req.chunkX + 0.5f;
-+		float cz = req.chunkZ + 0.5f;
-+		for (int i = 0; i < count; i++)
-+		{
-+			float dx = cx - px[i];
-+			float dz = cz - pz[i];
-+			float d = dx * dx + dz * dz;
-+			if (d < min) min = d;
-+		}
-+		return min;
-+	}
-+
- 	private int CleanupRequestsQueue()
- 	{
- 		int num = 0;
- 		ConcurrentIndexedFifoQueue<ChunkColumnLoadRequest> requestedChunkColumns = chunkthread.requestedChunkColumns;
- 		while (requestedChunkColumns.Count > 0)
-@@ -836,11 +973,15 @@ internal class ServerSystemSupplyChunks : ServerSystem
- 		long key = server.api.WorldManager.MapRegionIndex2D(regionX, regionZ);
- 		if (!dictionary.TryGetValue(key, out var value) || value == null)
- 		{
- 			return;
- 		}
+-			Vec2i vec2i = server.WorldMap.MapChunkPosFromChunkIndex2D(num);
+-			chunkthread.addChunkColumnRequest(num, vec2i.X, vec2i.Y, -1);
+-		}
+-	}
+-
+-	private bool simplyLoadChunkColumn(ChunkColumnLoadRequest request)
+-	{
+-		ServerMapChunk orCreateMapChunk = chunkthread.loadsavechunks.GetOrCreateMapChunk(request);
+-		if (orCreateMapChunk == null)
+-		{
+-			return false;
+-		}
+-		ServerChunk[] array = chunkthread.loadsavechunks.TryLoadChunkColumn(request);
+-		if (array == null)
+-		{
+-			return false;
+-		}
+-		foreach (ServerChunk obj in array)
+-		{
+-			obj.serverMapChunk = orCreateMapChunk;
+-			obj.MarkFresh();
+-		}
+-		request.MapChunk = orCreateMapChunk;
+-		request.Chunks = array;
+-		server.EnqueueMainThreadTask(delegate
+-		{
+-			chunkthread.loadsavechunks.mainThreadLoadChunkColumn(request);
+-		});
+-		return true;
+-	}
+-
+-	private bool tryLoadOrGenerateChunkColumnsInQueue()
+-	{
+-		if (chunkthread.requestedChunkColumns.Count == 0)
+-		{
+-			return false;
+-		}
+-		if (pauseAllWorldgenThreads > 0)
+-		{
+-			return false;
+-		}
+-		CleanupRequestsQueue();
+-		int additionalWorldGenThreadsCount = chunkthread.additionalWorldGenThreadsCount;
+-		foreach (ChunkColumnLoadRequest requestedChunkColumn in chunkthread.requestedChunkColumns)
+-		{
+-			if (requestedChunkColumn == null || requestedChunkColumn.Disposed)
+-			{
+-				continue;
+-			}
+-			int currentIncompletePass_AsInt = requestedChunkColumn.CurrentIncompletePass_AsInt;
+-			if (currentIncompletePass_AsInt == 0 || currentIncompletePass_AsInt > additionalWorldGenThreadsCount)
+-			{
+-				if (server.Suspended)
+-				{
+-					return false;
+-				}
+-				if (loadOrGenerateChunkColumn_OnChunkThread(requestedChunkColumn, currentIncompletePass_AsInt) && chunkthread.additionalWorldGenThreadsCount == 0)
+-				{
+-					return true;
+-				}
+-			}
+-		}
+-		return false;
+-	}
+-
+-	private int CleanupRequestsQueue()
+-	{
+-		int num = 0;
+-		ConcurrentIndexedFifoQueue<ChunkColumnLoadRequest> requestedChunkColumns = chunkthread.requestedChunkColumns;
+-		while (requestedChunkColumns.Count > 0)
+-		{
+-			ChunkColumnLoadRequest chunkColumnLoadRequest = requestedChunkColumns.Peek();
+-			if (chunkColumnLoadRequest == null || chunkColumnLoadRequest.disposeOrRequeueFlags == 0)
+-			{
+-				break;
+-			}
+-			if (chunkColumnLoadRequest.Disposed)
+-			{
+-				requestedChunkColumns.DequeueWithoutRemovingFromIndex();
+-				num++;
+-			}
+-			else
+-			{
+-				chunkColumnLoadRequest.disposeOrRequeueFlags = 0;
+-				requestedChunkColumns.Requeue();
+-			}
+-		}
+-		return num;
+-	}
+-
+-	public bool loadOrGenerateChunkColumn_OnChunkThread(ChunkColumnLoadRequest chunkRequest, int stage)
+-	{
+-		ServerMapChunk orCreateMapChunk = GetOrCreateMapChunk(chunkRequest);
+-		bool flag = orCreateMapChunk.CurrentIncompletePass >= EnumWorldGenPass.Done || orCreateMapChunk.WorldGenVersion >= 3;
+-		if (!flag && orCreateMapChunk.WorldGenVersion != 0)
+-		{
+-			orCreateMapChunk = GetOrCreateMapChunk(chunkRequest, forceCreate: true);
+-			chunkRequest.Chunks = null;
+-		}
+-		if (chunkRequest.Chunks == null)
+-		{
+-			if (flag)
+-			{
+-				chunkRequest.Chunks = TryLoadChunkColumn(chunkRequest);
+-				if (chunkRequest.Chunks != null)
+-				{
+-					for (int i = 0; i < chunkRequest.Chunks.Length; i++)
+-					{
+-						ServerChunk obj = chunkRequest.Chunks[i];
+-						obj.serverMapChunk = orCreateMapChunk;
+-						obj.MarkFresh();
+-					}
+-				}
+-			}
+-			int regionX = chunkRequest.chunkX / (server.api.WorldManager.RegionSize / server.api.WorldManager.ChunkSize);
+-			int regionZ = chunkRequest.chunkZ / (server.api.WorldManager.RegionSize / server.api.WorldManager.ChunkSize);
+-			long index2d = server.api.WorldManager.MapRegionIndex2D(regionX, regionZ);
+-			IMapRegion mapRegion = server.api.WorldManager.GetMapRegion(index2d);
+-			if (mapRegion != null)
+-			{
+-				TryRestoreGeneratedStructures(regionX, regionZ, chunkRequest.chunkGenParams, mapRegion);
+-			}
+-			if (chunkRequest.Chunks == null)
+-			{
+-				GenerateNewChunkColumn(orCreateMapChunk, chunkRequest);
+-			}
+-		}
+-		chunkRequest.MapChunk = orCreateMapChunk;
+-		if (chunkRequest.CurrentIncompletePass == EnumWorldGenPass.Done)
+-		{
+-			if (chunkRequest.blockingRequest && --blockingRequestsRemaining == 0)
+-			{
+-				ServerMain.Logger.VerboseDebug("Completed area loading/generation");
+-			}
+-			runScheduledBlockUpdatesWithNeighbours(chunkRequest);
+-			try
+-			{
+-				ServerEventAPI eventapi = server.api.eventapi;
+-				ServerMapChunk mapChunk = orCreateMapChunk;
+-				int chunkX = chunkRequest.chunkX;
+-				int chunkZ = chunkRequest.chunkZ;
+-				IWorldChunk[] chunks = chunkRequest.Chunks;
+-				eventapi.TriggerBeginChunkColumnLoadChunkThread(mapChunk, chunkX, chunkZ, chunks);
+-			}
+-			catch (Exception ex)
+-			{
+-				ServerMain.Logger.Error("Exception throwing during chunk Unpack() at chunkpos xz {0}/{1}. Likely corrupted. Exception: {2}", chunkRequest.chunkX, chunkRequest.chunkZ, ex);
+-				if (server.Config.RepairMode)
+-				{
+-					ServerMain.Logger.Error("Repair mode is enabled so will delete the entire chunk column.");
+-					GenerateNewChunkColumn(orCreateMapChunk, chunkRequest);
+-					return false;
+-				}
+-			}
+-			server.EnqueueMainThreadTask(delegate
+-			{
+-				mainThreadLoadChunkColumn(chunkRequest);
+-				chunkthread.requestedChunkColumns.elementsByIndex.Remove(chunkRequest.Index);
+-			});
+-			chunkRequest.FlagToDispose();
+-			return true;
+-		}
+-		if (orCreateMapChunk.currentpass != stage && orCreateMapChunk.currentpass <= chunkthread.additionalWorldGenThreadsCount)
+-		{
+-			return stage == 0;
+-		}
+-		bool num = CanGenerateChunkColumn(chunkRequest);
+-		if (num)
+-		{
+-			PopulateChunk(chunkRequest);
+-		}
+-		if (!num || chunkthread.additionalWorldGenThreadsCount == 0)
+-		{
+-			chunkRequest.FlagToRequeue();
+-		}
+-		return num;
+-	}
+-
+-	public int GenerateChunkColumns_OnSeparateThread(int stageStart, int stageEnd)
+-	{
+-		ChunkColumnLoadRequest chunkColumnLoadRequest = null;
+-		long num = long.MinValue;
+-		foreach (ChunkColumnLoadRequest requestedChunkColumn in chunkthread.requestedChunkColumns)
+-		{
+-			if (requestedChunkColumn == null || requestedChunkColumn.Disposed)
+-			{
+-				continue;
+-			}
+-			int currentIncompletePass_AsInt = requestedChunkColumn.CurrentIncompletePass_AsInt;
+-			if (currentIncompletePass_AsInt < stageStart || currentIncompletePass_AsInt >= stageEnd)
+-			{
+-				continue;
+-			}
+-			if (currentIncompletePass_AsInt >= requestedChunkColumn.untilPass)
+-			{
+-				requestedChunkColumn.FlagToRequeue();
+-			}
+-			else if (requestedChunkColumn.creationTime > num)
+-			{
+-				if (ensurePrettyNeighbourhood(requestedChunkColumn))
+-				{
+-					num = requestedChunkColumn.creationTime;
+-					chunkColumnLoadRequest = requestedChunkColumn;
+-				}
+-				else
+-				{
+-					requestedChunkColumn.FlagToRequeue();
+-				}
+-			}
+-		}
+-		if (chunkColumnLoadRequest != null)
+-		{
+-			PopulateChunk(chunkColumnLoadRequest);
+-			return 1;
+-		}
+-		return 0;
+-	}
+-
+-	public bool CanGenerateChunkColumn(ChunkColumnLoadRequest chunkRequest)
+-	{
+-		if (chunkRequest.CurrentIncompletePass_AsInt >= chunkRequest.untilPass || !ensurePrettyNeighbourhood(chunkRequest))
+-		{
+-			return false;
+-		}
+-		return true;
+-	}
+-
+-	internal void mainThreadLoadChunkColumn(ChunkColumnLoadRequest chunkRequest)
+-	{
+-		if (server.RunPhase == EnumServerRunPhase.Shutdown)
+-		{
+-			return;
+-		}
+-		ServerMain.FrameProfiler.Enter("MTT-ChunkLoaded-Begin");
+-		ServerEventAPI eventapi = server.api.eventapi;
+-		Vec2i chunkCoord = new Vec2i(chunkRequest.chunkX, chunkRequest.chunkZ);
+-		IWorldChunk[] chunks = chunkRequest.Chunks;
+-		eventapi.TriggerChunkColumnLoaded(chunkCoord, chunks);
+-		ServerMain.FrameProfiler.Mark("MTT-ChunkLoaded-LoadedEvent");
+-		for (int i = 0; i < chunkRequest.Chunks.Length; i++)
+-		{
+-			ServerMain.FrameProfiler.Mark("MTT-ChunkLoaded-LoadedEvent");
+-			ServerChunk serverChunk = chunkRequest.Chunks[i];
+-			int num = i + chunkRequest.dimension * 1024;
+-			long num2 = server.WorldMap.ChunkIndex3D(chunkRequest.chunkX, num, chunkRequest.chunkZ);
+-			server.loadedChunksLock.AcquireWriteLock();
+-			try
+-			{
+-				if (server.loadedChunks.ContainsKey(num2))
+-				{
+-					continue;
+-				}
+-				server.loadedChunks[num2] = serverChunk;
+-				serverChunk.MarkToPack();
+-				goto IL_00ff;
+-			}
+-			finally
+-			{
+-				server.loadedChunksLock.ReleaseWriteLock();
+-			}
+-			IL_00ff:
+-			if (server.Config.AnalyzeMode)
+-			{
+-				try
+-				{
+-					serverChunk.Unpack();
+-				}
+-				catch (Exception ex)
+-				{
+-					ServerMain.Logger.Error("Exception throwing during chunk Unpack() at chunkpos {0}/{1}/{2}, dimension {4}. Likely corrupted. Exception: {3}", chunkRequest.chunkX, i, chunkRequest.chunkZ, ex, chunkRequest.dimension);
+-					if (server.Config.RepairMode && chunkRequest.dimension == 0)
+-					{
+-						ServerMain.Logger.Error("Repair mode is enabled so will delete the entire chunk column.");
+-						server.api.worldapi.DeleteChunkColumn(chunkRequest.chunkX, chunkRequest.chunkZ);
+-						ServerMain.FrameProfiler.Leave();
+-						return;
+-					}
+-				}
+-			}
+-			entitiesToRemove.Clear();
+-			if (serverChunk.Entities != null)
+-			{
+-				for (int j = 0; j < serverChunk.Entities.Length; j++)
+-				{
+-					Entity entity = serverChunk.Entities[j];
+-					if (entity == null)
+-					{
+-						if (j >= serverChunk.EntitiesCount)
+-						{
+-							break;
+-						}
+-					}
+-					else
+-					{
+-						if (server.LoadEntity(entity, num2))
+-						{
+-							continue;
+-						}
+-						entitiesToRemove.Add(entity.EntityId);
+-						if (entity.Code.Path.StartsWith("villager"))
+-						{
+-							string text = "-";
+-							try
+-							{
+-								text = entity.WatchedAttributes.GetTreeAttribute("nametag")?.GetString("name") ?? "-";
+-							}
+-							catch (Exception)
+-							{
+-							}
+-							ServerMain.Logger.Log(EnumLogType.Worldgen, "In " + server.WorldName + ", villager " + text + " removed at " + entity.Pos.AsBlockPos?.ToString() + " due to an exception on loading");
+-						}
+-					}
+-				}
+-			}
+-			foreach (long item in entitiesToRemove)
+-			{
+-				serverChunk.RemoveEntity(item);
+-			}
+-			ServerMain.FrameProfiler.Enter("MTT-ChunkLoaded-LoadBlockEntities");
+-			foreach (KeyValuePair<BlockPos, BlockEntity> blockEntity in serverChunk.BlockEntities)
+-			{
+-				BlockEntity value = blockEntity.Value;
+-				if (value == null)
+-				{
+-					continue;
+-				}
+-				try
+-				{
+-					ServerMain.FrameProfiler.Enter(value.Block.Code.Path);
+-					value.Initialize(server.api);
+-					if (serverChunk.serverMapChunk.NewBlockEntities.Contains(value.Pos))
+-					{
+-						serverChunk.serverMapChunk.NewBlockEntities.Remove(value.Pos);
+-						value.OnBlockPlaced();
+-					}
+-					ServerMain.FrameProfiler.Leave();
+-				}
+-				catch (Exception ex3)
+-				{
+-					ServerMain.Logger.Notification("Exception thrown when trying to initialize a block entity @{0}: {1}", value.Pos, ex3);
+-					value.UnregisterAllTickListeners();
+-				}
+-			}
+-			ServerMain.FrameProfiler.Leave();
+-			server.api.eventapi.TriggerChunkDirty(new Vec3i(chunkRequest.chunkX, num, chunkRequest.chunkZ), serverChunk, EnumChunkDirtyReason.NewlyLoaded);
+-		}
+-		ServerMain.FrameProfiler.Mark("MTT-ChunkLoaded-MarkDirtyEvent");
+-		updateNeighboursLoadedFlags(chunkRequest.MapChunk, chunkRequest.chunkX, chunkRequest.chunkZ);
+-		ServerMain.FrameProfiler.Mark("MTT-ChunkLoaded-UpdateNeighboursFlags");
+-		for (int k = 0; k < chunkRequest.Chunks.Length; k++)
+-		{
+-			chunkRequest.Chunks[k].TryPackAndCommit();
+-		}
+-		ServerMain.FrameProfiler.Mark("MTT-ChunkLoaded-Pack");
+-		ServerMain.FrameProfiler.Leave();
+-	}
+-
+-	private void updateNeighboursLoadedFlags(ServerMapChunk mapChunk, int chunkX, int chunkZ)
+-	{
+-		mapChunk.NeighboursLoaded = default(SmallBoolArray);
+-		mapChunk.SelfLoaded = true;
+-		for (int i = 0; i < Cardinal.ALL.Length; i++)
+-		{
+-			Cardinal cardinal = Cardinal.ALL[i];
+-			ServerMapChunk serverMapChunk = (ServerMapChunk)server.WorldMap.GetMapChunk(chunkX + cardinal.Normali.X, chunkZ + cardinal.Normali.Z);
+-			if (serverMapChunk != null)
+-			{
+-				mapChunk.NeighboursLoaded[i] = serverMapChunk.SelfLoaded;
+-				serverMapChunk.NeighboursLoaded[cardinal.Opposite.Index] = true;
+-			}
+-		}
+-	}
+-
+-	public static void UpdateLoadedNeighboursFlags(ServerWorldMap WorldMap, int chunkX, int chunkZ)
+-	{
+-		ServerMapChunk serverMapChunk = (ServerMapChunk)WorldMap.GetMapChunk(chunkX, chunkZ - 1);
+-		ServerMapChunk serverMapChunk2 = (ServerMapChunk)WorldMap.GetMapChunk(chunkX + 1, chunkZ - 1);
+-		ServerMapChunk serverMapChunk3 = (ServerMapChunk)WorldMap.GetMapChunk(chunkX + 1, chunkZ);
+-		ServerMapChunk serverMapChunk4 = (ServerMapChunk)WorldMap.GetMapChunk(chunkX + 1, chunkZ + 1);
+-		ServerMapChunk serverMapChunk5 = (ServerMapChunk)WorldMap.GetMapChunk(chunkX, chunkZ + 1);
+-		ServerMapChunk serverMapChunk6 = (ServerMapChunk)WorldMap.GetMapChunk(chunkX - 1, chunkZ + 1);
+-		ServerMapChunk serverMapChunk7 = (ServerMapChunk)WorldMap.GetMapChunk(chunkX - 1, chunkZ);
+-		ServerMapChunk serverMapChunk8 = (ServerMapChunk)WorldMap.GetMapChunk(chunkX - 1, chunkZ - 1);
+-		if (serverMapChunk != null)
+-		{
+-			serverMapChunk.NeighboursLoaded[4] = false;
+-		}
+-		if (serverMapChunk2 != null)
+-		{
+-			serverMapChunk2.NeighboursLoaded[5] = false;
+-		}
+-		if (serverMapChunk3 != null)
+-		{
+-			serverMapChunk3.NeighboursLoaded[6] = false;
+-		}
+-		if (serverMapChunk4 != null)
+-		{
+-			serverMapChunk4.NeighboursLoaded[7] = false;
+-		}
+-		if (serverMapChunk5 != null)
+-		{
+-			serverMapChunk5.NeighboursLoaded[0] = false;
+-		}
+-		if (serverMapChunk6 != null)
+-		{
+-			serverMapChunk6.NeighboursLoaded[1] = false;
+-		}
+-		if (serverMapChunk7 != null)
+-		{
+-			serverMapChunk7.NeighboursLoaded[2] = false;
+-		}
+-		if (serverMapChunk8 != null)
+-		{
+-			serverMapChunk8.NeighboursLoaded[3] = false;
+-		}
+-	}
+-
+-	private void runScheduledBlockUpdatesWithNeighbours(ChunkColumnLoadRequest chunkRequest)
+-	{
+-		for (int i = -1; i <= 1; i++)
+-		{
+-			for (int j = -1; j <= 1; j++)
+-			{
+-				bool flag = false;
+-				if (server.loadedMapChunks.TryGetValue(server.WorldMap.MapChunkIndex2D(chunkRequest.chunkX + j, chunkRequest.chunkZ + i), out var value) && value.CurrentIncompletePass == EnumWorldGenPass.Done && value.ScheduledBlockUpdates.Count > 0 && areAllChunkNeighboursLoaded(value, chunkRequest.chunkX + j, chunkRequest.chunkZ + i))
+-				{
+-					flag = true;
+-				}
+-				if (!flag)
+-				{
+-					continue;
+-				}
+-				foreach (BlockPos scheduledBlockUpdate in value.ScheduledBlockUpdates)
+-				{
+-					server.WorldMap.MarkBlockModified(scheduledBlockUpdate);
+-				}
+-				value.ScheduledBlockUpdates.Clear();
+-			}
+-		}
+-	}
+-
+-	private bool areAllChunkNeighboursLoaded(ServerMapChunk mpc, int chunkX, int chunkZ)
+-	{
+-		int num = 0;
+-		for (int i = -1; i <= 1; i++)
+-		{
+-			for (int j = -1; j <= 1; j++)
+-			{
+-				if ((j != 0 || i != 0) && server.loadedMapChunks.TryGetValue(server.WorldMap.MapChunkIndex2D(chunkX + j, chunkZ + i), out var value) && value.CurrentIncompletePass == EnumWorldGenPass.Done)
+-				{
+-					num++;
+-				}
+-			}
+-		}
+-		return num == 8;
+-	}
+-
+-	private ServerMapRegion GetOrCreateMapRegionEnsureNeighbours(int chunkX, int chunkZ, ITreeAttribute chunkGenParams, bool updateEarlierVersion)
+-	{
+-		ServerMapRegion orCreateMapRegion = GetOrCreateMapRegion(chunkX, chunkZ, chunkGenParams, updateEarlierVersion);
+-		if (!orCreateMapRegion.NeighbourRegionsChecked)
+-		{
+-			int num = chunkX / MagicNum.ChunkRegionSizeInChunks;
+-			int num2 = chunkZ / MagicNum.ChunkRegionSizeInChunks;
+-			for (int i = -1; i <= 1; i++)
+-			{
+-				for (int j = -1; j <= 1; j++)
+-				{
+-					if (num + i >= 0 && num2 + j >= 0 && (i != 0 || j != 0))
+-					{
+-						GetOrCreateMapRegion((num + i) * MagicNum.ChunkRegionSizeInChunks, (num2 + j) * MagicNum.ChunkRegionSizeInChunks, chunkGenParams, updateEarlierVersion: false);
+-					}
+-				}
+-			}
+-			orCreateMapRegion.NeighbourRegionsChecked = true;
+-			for (int k = 0; k < worldgenHandler.OnMapRegionNeighborsLoaded.Count; k++)
+-			{
+-				worldgenHandler.OnMapRegionNeighborsLoaded[k](orCreateMapRegion, num, num2, chunkGenParams);
+-			}
+-		}
+-		return orCreateMapRegion;
+-	}
+-
+-	public ServerMapRegion GetOrCreateMapRegionNoStore(int regionX, int regionZ, long mapRegionIndex2d, ITreeAttribute chunkGenParams, bool updateEarlierVersion)
+-	{
+-		server.loadedMapRegions.TryGetValue(mapRegionIndex2d, out var value);
+-		if (value != null)
+-		{
+-			if (!updateEarlierVersion || value.worldgenVersion == 3)
+-			{
+-				return value;
+-			}
+-		}
+-		else
+-		{
+-			value = TryLoadMapRegion(regionX, regionZ);
+-		}
+-		List<GeneratedStructure> list = null;
+-		Dictionary<string, byte[]> dictionary = null;
+-		Dictionary<string, IntDataMap2D> dictionary2 = null;
+-		IntDataMap2D intDataMap2D = null;
+-		IntDataMap2D[] array = null;
+-		bool flag = true;
+-		if (value != null)
+-		{
+-			if (value.worldgenVersion != 3 && updateEarlierVersion)
+-			{
+-				ServerMain.Logger.Worldgen("Updating existing mapregion with worldgenVersion " + value.worldgenVersion + " at " + regionX * MagicNum.ChunkRegionSizeInChunks + "," + regionZ * MagicNum.ChunkRegionSizeInChunks + " in world: " + server.WorldName);
+-				list = value.GeneratedStructures;
+-				dictionary = value.ModData;
+-				dictionary2 = value.OreMaps;
+-				intDataMap2D = value.GeologicProvinceMap;
+-				array = value.RockStrata;
+-			}
+-			else
+-			{
+-				flag = false;
+-				value.loadedTotalMs = server.ElapsedMilliseconds;
+-			}
+-		}
+-		if (flag)
+-		{
+-			value = CreateMapRegion(regionX, regionZ, chunkGenParams);
+-			value.loadedTotalMs = server.ElapsedMilliseconds;
+-			if (list != null)
+-			{
+-				value.GeneratedStructures = list;
+-			}
+-			if (dictionary != null)
+-			{
+-				value.ModData = dictionary;
+-			}
+-			if (dictionary2 != null)
+-			{
+-				value.OreMaps = dictionary2;
+-			}
+-			if (intDataMap2D != null)
+-			{
+-				value.GeologicProvinceMap = intDataMap2D;
+-			}
+-			if (array != null)
+-			{
+-				value.RockStrata = array;
+-			}
+-		}
+-		return value;
+-	}
+-
+-	private ServerMapRegion GetOrCreateMapRegion(int chunkX, int chunkZ, ITreeAttribute chunkGenParams, bool updateEarlierVersion)
+-	{
+-		int regionX = chunkX / MagicNum.ChunkRegionSizeInChunks;
+-		int regionZ = chunkZ / MagicNum.ChunkRegionSizeInChunks;
+-		long num = server.WorldMap.MapRegionIndex2D(regionX, regionZ);
+-		ServerMapRegion mapRegion = GetOrCreateMapRegionNoStore(regionX, regionZ, num, chunkGenParams, updateEarlierVersion);
+-		server.loadedMapRegions[num] = mapRegion;
+-		server.EnqueueMainThreadTask(delegate
+-		{
+-			server.api.eventapi.TriggerMapRegionLoaded(new Vec2i(regionX, regionZ), mapRegion);
+-			ServerMain.FrameProfiler.Mark("trigger-mapregionloaded");
+-		});
+-		return mapRegion;
+-	}
+-
+-	private ServerMapRegion CreateMapRegion(int regionX, int regionZ, ITreeAttribute chunkGenParams)
+-	{
+-		ServerMapRegion serverMapRegion = ServerMapRegion.CreateNew();
+-		for (int i = 0; i < worldgenHandler.OnMapRegionGen.Count; i++)
+-		{
+-			worldgenHandler.OnMapRegionGen[i](serverMapRegion, regionX, regionZ, chunkGenParams);
+-		}
+-		return serverMapRegion;
+-	}
+-
+-	private void TryRestoreGeneratedStructures(int regionX, int regionZ, ITreeAttribute chunkGenParams, IMapRegion mapRegion)
+-	{
+-		byte[] array = chunkGenParams?.GetBytes("GeneratedStructures");
+-		if (array == null)
+-		{
+-			return;
+-		}
+-		Dictionary<long, List<GeneratedStructure>> dictionary = SerializerUtil.Deserialize<Dictionary<long, List<GeneratedStructure>>>(array);
+-		long key = server.api.WorldManager.MapRegionIndex2D(regionX, regionZ);
+-		if (!dictionary.TryGetValue(key, out var value) || value == null)
+-		{
+-			return;
+-		}
 -		List<GeneratedStructure> generatedStructure = value.Where((GeneratedStructure structure) => !mapRegion.GeneratedStructures.Any((GeneratedStructure s) => s.Location.Start.Equals(structure.Location.Start))).ToList();
-+		// Stratum: original code used Where+Any = O(N*M) nested scan. As a region accumulates
-+		// structures from many loaded chunks, mapRegion.GeneratedStructures grows and the inner
-+		// Any() iterates the whole list for every candidate. HashSet reduces this to O(N+M).
-+		HashSet<Vec3i> existingStarts = mapRegion.GeneratedStructures.Select(s => s.Location.Start).ToHashSet();
-+		List<GeneratedStructure> generatedStructure = [..value.Where(structure => !existingStarts.Contains(structure.Location.Start))];
- 		mapRegion.AddGeneratedStructures(generatedStructure);
- 	}
- 
- 	internal ServerMapChunk GetOrCreateMapChunk(ChunkColumnLoadRequest chunkRequest, bool forceCreate = false)
- 	{
-@@ -931,32 +1072,79 @@ internal class ServerSystemSupplyChunks : ServerSystem
- 	internal ServerChunk[] TryLoadChunkColumn(ChunkColumnLoadRequest chunkRequest)
- 	{
- 		int chunkMapSizeY = server.WorldMap.ChunkMapSizeY;
- 		ServerChunk[] array = new ServerChunk[chunkMapSizeY];
- 		int num = 0;
+-		mapRegion.AddGeneratedStructures(generatedStructure);
+-	}
+-
+-	internal ServerMapChunk GetOrCreateMapChunk(ChunkColumnLoadRequest chunkRequest, bool forceCreate = false)
+-	{
+-		int chunkX = chunkRequest.chunkX;
+-		int chunkZ = chunkRequest.chunkZ;
+-		long key = server.WorldMap.MapChunkIndex2D(chunkX, chunkZ);
+-		ServerMapRegion orCreateMapRegionEnsureNeighbours;
+-		ServerMapChunk value;
+-		if (!forceCreate)
+-		{
+-			server.loadedMapChunks.TryGetValue(key, out value);
+-			if (value != null)
+-			{
+-				return value;
+-			}
+-			value = TryLoadMapChunk(chunkX, chunkZ);
+-			if (value != null)
+-			{
+-				orCreateMapRegionEnsureNeighbours = GetOrCreateMapRegionEnsureNeighbours(chunkX, chunkZ, chunkRequest.chunkGenParams, updateEarlierVersion: false);
+-				value.MapRegion = orCreateMapRegionEnsureNeighbours;
+-				server.loadedMapChunks[key] = value;
+-				return value;
+-			}
+-		}
+-		bool updateEarlierVersion = GameVersion.IsLowerVersionThan(server.SaveGameData.CreatedGameVersion, "1.22.3");
+-		orCreateMapRegionEnsureNeighbours = GetOrCreateMapRegionEnsureNeighbours(chunkX, chunkZ, chunkRequest.chunkGenParams, updateEarlierVersion);
+-		value = CreateMapChunk(chunkX, chunkZ, orCreateMapRegionEnsureNeighbours);
+-		server.loadedMapChunks[key] = value;
+-		return value;
+-	}
+-
+-	private ServerMapChunk PeekMapChunk(int chunkX, int chunkZ)
+-	{
+-		long key = server.WorldMap.MapChunkIndex2D(chunkX, chunkZ);
+-		server.loadedMapChunks.TryGetValue(key, out var value);
+-		if (value != null)
+-		{
+-			return value;
+-		}
+-		return TryLoadMapChunk(chunkX, chunkZ);
+-	}
+-
+-	private ServerMapChunk CreateMapChunk(int chunkX, int chunkZ, ServerMapRegion mapRegion)
+-	{
+-		ServerMapChunk serverMapChunk = ServerMapChunk.CreateNew(mapRegion);
+-		for (int i = 0; i < worldgenHandler.OnMapChunkGen.Count; i++)
+-		{
+-			worldgenHandler.OnMapChunkGen[i](serverMapChunk, chunkX, chunkZ);
+-		}
+-		return serverMapChunk;
+-	}
+-
+-	private void GenerateNewChunkColumn(ServerMapChunk mapChunk, ChunkColumnLoadRequest chunkRequest)
+-	{
+-		int chunkMapSizeY = server.WorldMap.ChunkMapSizeY;
+-		chunkRequest.Chunks = new ServerChunk[chunkMapSizeY];
+-		for (int i = 0; i < chunkMapSizeY; i++)
+-		{
+-			ServerChunk serverChunk = ServerChunk.CreateNew(server.serverChunkDataPool);
+-			serverChunk.serverMapChunk = mapChunk;
+-			chunkRequest.Chunks[i] = serverChunk;
+-		}
+-		chunkRequest.MapChunk = mapChunk;
+-		if (requiresChunkBorderSmoothing)
+-		{
+-			for (int j = 0; j < Cardinal.ALL.Length; j++)
+-			{
+-				Cardinal cardinal = Cardinal.ALL[j];
+-				ServerMapChunk serverMapChunk = PeekMapChunk(chunkRequest.chunkX + cardinal.Normali.X, chunkRequest.chunkZ + cardinal.Normali.Z);
+-				if (serverMapChunk != null && serverMapChunk.CurrentIncompletePass >= EnumWorldGenPass.Done && serverMapChunk.WorldGenVersion != 3)
+-				{
+-					if (chunkRequest.NeighbourTerrainHeight == null)
+-					{
+-						chunkRequest.NeighbourTerrainHeight = new ushort[8][];
+-					}
+-					chunkRequest.NeighbourTerrainHeight[j] = serverMapChunk.WorldGenTerrainHeightMap;
+-				}
+-			}
+-			chunkRequest.RequiresChunkBorderSmoothing = chunkRequest.NeighbourTerrainHeight != null;
+-			if (mapChunk.CurrentIncompletePass < EnumWorldGenPass.NeighbourSunLightFlood && mapChunk.WorldGenVersion != 3)
+-			{
+-				mapChunk.WorldGenVersion = 3;
+-			}
+-		}
+-		chunkRequest.CurrentIncompletePass = EnumWorldGenPass.Terrain;
+-	}
+-
+-	internal ServerChunk[] TryLoadChunkColumn(ChunkColumnLoadRequest chunkRequest)
+-	{
+-		int chunkMapSizeY = server.WorldMap.ChunkMapSizeY;
+-		ServerChunk[] array = new ServerChunk[chunkMapSizeY];
+-		int num = 0;
 -		for (int i = 0; i < chunkMapSizeY; i++)
 -		{
 -			byte[] chunk = chunkthread.gameDatabase.GetChunk(chunkRequest.chunkX, i, chunkRequest.chunkZ, chunkRequest.dimension);
@@ -280,85 +933,2497 @@ index d6e727a..018b171 100644
 -				continue;
 -			}
 -			try
-+
-+		StratumChunkReadPool pool = chunkthread.stratumReadPool;
-+		StratumChunkIoConfig ioCfg = StratumRuntime.Config?.Performance?.ChunkIo;
-+		bool useParallel = pool != null
-+			&& pool.IsOpen
-+			&& ioCfg != null
-+			&& ioCfg.Enabled
-+			&& chunkMapSizeY >= ioCfg.MinChunkYLevelsForParallel
-+			&& pool.WorkerCount >= 2;
-+
-+		if (useParallel)
-+		{
-+			byte[][] rawChunks = new byte[chunkMapSizeY][];
-+			int maxDop = Math.Min(pool.WorkerCount, chunkMapSizeY);
-+			int cx = chunkRequest.chunkX;
-+			int cz = chunkRequest.chunkZ;
-+			int dim = chunkRequest.dimension;
-+			System.Threading.Tasks.Parallel.For(0, chunkMapSizeY,
-+				new System.Threading.Tasks.ParallelOptions { MaxDegreeOfParallelism = maxDop },
-+				i => {
-+					rawChunks[i] = pool.GetChunkBytes(Vintagestory.Common.Database.ChunkPos.ToChunkIndex(cx, i, cz, dim));
-+				});
-+			for (int i = 0; i < chunkMapSizeY; i++)
- 			{
+-			{
 -				num++;
 -				array[i] = ServerChunk.FromBytes(chunk, server.serverChunkDataPool, server);
-+				byte[] chunk = rawChunks[i];
-+				if (chunk == null) continue;
-+				try
-+				{
-+					num++;
-+					array[i] = ServerChunk.FromBytes(chunk, server.serverChunkDataPool, server);
-+				}
-+				catch (Exception ex)
-+				{
-+					if (server.Config.RegenerateCorruptChunks || server.Config.RepairMode)
-+					{
-+						array[i] = ServerChunk.CreateNew(server.serverChunkDataPool);
-+						ServerMain.Logger.Error("Failed deserializing a chunk (parallel path), we are in repair mode, so will initilize empty one. Exception: {0}", ex);
-+						continue;
-+					}
-+					ServerMain.Logger.Error("Failed deserializing a chunk (parallel path). Not in repair mode, will exit.");
-+					throw;
-+				}
- 			}
+-			}
 -			catch (Exception ex)
-+		}
-+		else
-+		{
-+			for (int i = 0; i < chunkMapSizeY; i++)
- 			{
+-			{
 -				if (server.Config.RegenerateCorruptChunks || server.Config.RepairMode)
-+				byte[] chunk = chunkthread.gameDatabase.GetChunk(chunkRequest.chunkX, i, chunkRequest.chunkZ, chunkRequest.dimension);
-+				if (chunk == null)
- 				{
+-				{
 -					array[i] = ServerChunk.CreateNew(server.serverChunkDataPool);
 -					ServerMain.Logger.Error("Failed deserializing a chunk, we are in repair mode, so will initilize empty one. Exception: {0}", ex);
- 					continue;
- 				}
+-					continue;
+-				}
 -				ServerMain.Logger.Error("Failed deserializing a chunk. Not in repair mode, will exit.");
 -				throw;
-+				try
-+				{
-+					num++;
-+					array[i] = ServerChunk.FromBytes(chunk, server.serverChunkDataPool, server);
-+				}
-+				catch (Exception ex)
-+				{
-+					if (server.Config.RegenerateCorruptChunks || server.Config.RepairMode)
-+					{
-+						array[i] = ServerChunk.CreateNew(server.serverChunkDataPool);
-+						ServerMain.Logger.Error("Failed deserializing a chunk, we are in repair mode, so will initilize empty one. Exception: {0}", ex);
-+						continue;
-+					}
-+					ServerMain.Logger.Error("Failed deserializing a chunk. Not in repair mode, will exit.");
-+					throw;
-+				}
- 			}
- 		}
- 		if (requiresSetEmptyFlag)
- 		{
- 			foreach (ServerChunk serverChunk in array)
+-			}
+-		}
+-		if (requiresSetEmptyFlag)
+-		{
+-			foreach (ServerChunk serverChunk in array)
+-			{
+-				if (serverChunk != null)
+-				{
+-					serverChunk.Unpack();
+-					serverChunk.MarkModified();
+-					serverChunk.TryPackAndCommit();
+-				}
+-			}
+-		}
+-		if (num != 0 && num != chunkMapSizeY)
+-		{
+-			ServerMain.Logger.Error("Loaded some but not all chunks of a column? Discarding whole column.");
+-			return null;
+-		}
+-		if (num != chunkMapSizeY)
+-		{
+-			return null;
+-		}
+-		return array;
+-	}
+-
+-	private ServerMapChunk TryLoadMapChunk(int chunkX, int chunkZ)
+-	{
+-		byte[] mapChunk = chunkthread.gameDatabase.GetMapChunk(chunkX, chunkZ);
+-		if (mapChunk != null)
+-		{
+-			try
+-			{
+-				ServerMapChunk serverMapChunk = ServerMapChunk.FromBytes(mapChunk);
+-				if (GameVersion.IsLowerVersionThan(server.SaveGameData.CreatedGameVersion, "1.7"))
+-				{
+-					serverMapChunk.YMax = (ushort)(server.SaveGameData.MapSizeY - 1);
+-				}
+-				return serverMapChunk;
+-			}
+-			catch (Exception ex)
+-			{
+-				if (chunkX == 0 && chunkZ == 0)
+-				{
+-					return null;
+-				}
+-				if (!server.Config.RegenerateCorruptChunks && !server.Config.RepairMode)
+-				{
+-					ServerMain.Logger.Error("Failed deserializing a map chunk. Not in repair mode, will exit.");
+-					throw;
+-				}
+-				ServerMain.Logger.Error("Failed deserializing a map chunk, we are in repair mode, so will initialize empty one. Exception: {0}", ex);
+-				return null;
+-			}
+-		}
+-		return null;
+-	}
+-
+-	private ServerMapRegion TryLoadMapRegion(int regionX, int regionZ)
+-	{
+-		byte[] mapRegion = chunkthread.gameDatabase.GetMapRegion(regionX, regionZ);
+-		try
+-		{
+-			if (mapRegion != null)
+-			{
+-				return ServerMapRegion.FromBytes(mapRegion);
+-			}
+-		}
+-		catch (Exception e)
+-		{
+-			if (server.Config.RepairMode)
+-			{
+-				ServerMain.Logger.Error("Failed deserializing a map region, we are in repair mode, so will initialize empty one.");
+-				ServerMain.Logger.Error(e);
+-				return null;
+-			}
+-			ServerMain.Logger.Error("Failed deserializing a map region. Not in repair mode, will exit.");
+-			throw;
+-		}
+-		return null;
+-	}
+-
+-	public void InitWorldgenAndSpawnChunks()
+-	{
+-		worldgenHandler = (WorldGenHandler)server.api.Event.TriggerInitWorldGen();
+-		ServerMain.Logger.Event("Loading {0}x{1}x{2} spawn chunks...", MagicNum.SpawnChunksWidth, MagicNum.SpawnChunksWidth, server.WorldMap.ChunkMapSizeY);
+-		if (storyChunkSpawnEvents == null)
+-		{
+-			storyChunkSpawnEvents = new string[15]
+-			{
+-				Lang.Get("...the carved mountains"),
+-				Lang.Get("...the rolling hills"),
+-				Lang.Get("...the vertical cliffs"),
+-				Lang.Get("...the endless plains"),
+-				Lang.Get("...the winter lands"),
+-				Lang.Get("...and scorching deserts"),
+-				Lang.Get("...spring waters"),
+-				Lang.Get("...tunnels deep below"),
+-				Lang.Get("...the luscious trees"),
+-				Lang.Get("...the fragrant flowers"),
+-				Lang.Get("...the roaming creatures"),
+-				Lang.Get("with their offspring..."),
+-				Lang.Get("...a misty sunrise"),
+-				Lang.Get("...dew drops on a blade of grass"),
+-				Lang.Get("...a soft breeze")
+-			};
+-		}
+-		BlockPos blockPos = new BlockPos(server.WorldMap.MapSizeX / 2, 0, server.WorldMap.MapSizeZ / 2, 0);
+-		if (GameVersion.IsLowerVersionThan(server.SaveGameData.CreatedGameVersion, "1.20.0-pre.14"))
+-		{
+-			int num = 0;
+-			int num2 = 0;
+-			bool flag = false;
+-			Random random = new Random(server.Seed);
+-			int num3 = 5;
+-			int num4 = 20;
+-			for (int i = 0; i < num3; i++)
+-			{
+-				if (i > 0)
+-				{
+-					double num5 = (double)GameMath.Sqrt((double)i * (1.0 / (double)num3)) * (double)num4;
+-					double num6 = (1.0 - Math.Abs(random.NextDouble() - random.NextDouble())) * num5;
+-					double value = random.NextDouble() * 6.2831854820251465;
+-					double num7 = num6 * GameMath.Sin(value);
+-					double num8 = num6 * GameMath.Cos(value);
+-					num = (int)num7;
+-					num2 = (int)num8;
+-					blockPos = new BlockPos(num * 32 + server.WorldMap.MapSizeX / 2, 0, num2 * 32 + server.WorldMap.MapSizeZ / 2, 0);
+-				}
+-				loadChunkAreaBlocking(num + server.WorldMap.ChunkMapSizeX / 2 - MagicNum.SpawnChunksWidth / 2, num2 + server.WorldMap.ChunkMapSizeZ / 2 - MagicNum.SpawnChunksWidth / 2, num + server.WorldMap.ChunkMapSizeX / 2 + MagicNum.SpawnChunksWidth / 2, num2 + server.WorldMap.ChunkMapSizeZ / 2 + MagicNum.SpawnChunksWidth / 2, isStartupLoad: true);
+-				server.ProcessMainThreadTasks();
+-				if (AdjustForSaveSpawnSpot(server, blockPos, null, random))
+-				{
+-					flag = true;
+-					break;
+-				}
+-				if (i + 1 < num3)
+-				{
+-					server.api.Logger.Notification("Trying another spawn location ({0}/{1})...", i + 2, num3);
+-				}
+-			}
+-			if (!flag)
+-			{
+-				blockPos = new BlockPos(server.WorldMap.MapSizeX / 2, 0, server.WorldMap.MapSizeZ / 2, 0);
+-				blockPos.Y = server.blockAccessor.GetRainMapHeightAt(blockPos);
+-				if (!server.blockAccessor.GetBlock(blockPos).SideSolid[BlockFacing.UP.Index])
+-				{
+-					server.blockAccessor.SetBlock(server.blockAccessor.GetBlock(new AssetLocation("planks-oak-we")).Id, blockPos);
+-				}
+-				blockPos.Y++;
+-			}
+-		}
+-		else
+-		{
+-			loadChunkAreaBlocking(server.WorldMap.ChunkMapSizeX / 2 - MagicNum.SpawnChunksWidth / 2, server.WorldMap.ChunkMapSizeZ / 2 - MagicNum.SpawnChunksWidth / 2, server.WorldMap.ChunkMapSizeX / 2 + MagicNum.SpawnChunksWidth / 2, server.WorldMap.ChunkMapSizeZ / 2 + MagicNum.SpawnChunksWidth / 2, isStartupLoad: true);
+-			server.ProcessMainThreadTasks();
+-		}
+-		server.mapMiddleSpawnPos = new PlayerSpawnPos
+-		{
+-			x = blockPos.X,
+-			y = blockPos.Y,
+-			z = blockPos.Z
+-		};
+-		if (blockPos.Y < 0)
+-		{
+-			server.mapMiddleSpawnPos.y = null;
+-		}
+-		server.api.Logger.VerboseDebug("Done spawn chunk");
+-	}
+-
+-	public static bool AdjustForSaveSpawnSpot(ServerMain server, BlockPos pos, IServerPlayer forPlayer, Random rand)
+-	{
+-		int num = 60;
+-		int num2 = 0;
+-		int num3 = 0;
+-		int num4 = 0;
+-		int num5 = 0;
+-		int num6 = 0;
+-		while (num-- > 0)
+-		{
+-			num4 = GameMath.Clamp(num2 + pos.X, 0, server.WorldMap.MapSizeX - 1);
+-			num6 = GameMath.Clamp(num3 + pos.Z, 0, server.WorldMap.MapSizeZ - 1);
+-			num5 = server.WorldMap.GetTerrainGenSurfacePosY(num4, num6);
+-			pos.Set(num4, num5, num6);
+-			num2 = rand.Next(64) - 32;
+-			num3 = rand.Next(64) - 32;
+-			if (num5 != 0 && !((double)num5 > 0.75 * (double)server.WorldMap.MapSizeY))
+-			{
+-				if (server.WorldMap.GetBlockingLandClaimant(forPlayer, pos, EnumBlockAccessFlags.Use) != null)
+-				{
+-					server.api.Logger.Notification("Spawn pos blocked at " + pos);
+-				}
+-				else if (!server.BlockAccessor.GetBlockRaw(num4, num5 + 1, num6, 2).IsLiquid() && !server.BlockAccessor.GetBlockRaw(num4, num5, num6, 2).IsLiquid() && !server.BlockAccessor.IsSideSolid(num4, num5 + 1, num6, BlockFacing.UP))
+-				{
+-					return true;
+-				}
+-			}
+-		}
+-		return false;
+-	}
+-
+-	private void PeekChunkAreaLocking(Vec2i coords, EnumWorldGenPass untilPass, OnChunkPeekedDelegate onGenerated, ITreeAttribute chunkGenParams)
+-	{
+-		chunkthread.peekMode = true;
+-		int x = coords.X;
+-		int y = coords.Y;
+-		Dictionary<long, ServerMapRegion> dictionary = new Dictionary<long, ServerMapRegion>();
+-		int i = 1;
+-		int num = Math.Min((int)untilPass, 5);
+-		int num2 = num - i;
+-		ChunkColumnLoadRequest[,] array = new ChunkColumnLoadRequest[num2 * 2 + 1, num2 * 2 + 1];
+-		for (int j = -num2; j <= num2; j++)
+-		{
+-			for (int k = -num2; k <= num2; k++)
+-			{
+-				if (server.WorldMap.IsValidChunkPos(x + j, 0, y + k))
+-				{
+-					long index2d = server.WorldMap.MapChunkIndex2D(x + j, y + k);
+-					int regionX = (x + j) / MagicNum.ChunkRegionSizeInChunks;
+-					int regionZ = (y + k) / MagicNum.ChunkRegionSizeInChunks;
+-					long num3 = server.WorldMap.MapRegionIndex2D(regionX, regionZ);
+-					if (!dictionary.TryGetValue(num3, out var value))
+-					{
+-						bool updateEarlierVersion = GameVersion.IsLowerVersionThan(server.SaveGameData.CreatedGameVersion, "1.22.3");
+-						value = (dictionary[num3] = GetOrCreateMapRegionNoStore(regionX, regionZ, num3, chunkGenParams, updateEarlierVersion));
+-						chunkthread.peekingMapRegions.TryAdd(num3, value);
+-					}
+-					ServerMapChunk mapChunk = CreateMapChunk(x, y, value);
+-					ChunkColumnLoadRequest chunkColumnLoadRequest = new ChunkColumnLoadRequest(index2d, x + j, y + k, 0, (int)untilPass, server)
+-					{
+-						chunkGenParams = ((j == 0 && k == 0) ? chunkGenParams : null)
+-					};
+-					chunkColumnLoadRequest.MapChunk = mapChunk;
+-					GenerateNewChunkColumn(mapChunk, chunkColumnLoadRequest);
+-					chunkColumnLoadRequest.Unpack();
+-					array[j + num2, k + num2] = chunkColumnLoadRequest;
+-					lock (chunkthread.peekingChunkColumns)
+-					{
+-						chunkthread.peekingChunkColumns.Enqueue(chunkColumnLoadRequest);
+-					}
+-				}
+-			}
+-		}
+-		int num4 = num - i;
+-		for (; i <= num; i++)
+-		{
+-			num4 = num - i;
+-			for (int l = -num4; l <= num4; l++)
+-			{
+-				for (int m = -num4; m <= num4; m++)
+-				{
+-					if (server.WorldMap.IsValidChunkPos(l + x, 0, m + y))
+-					{
+-						ChunkColumnLoadRequest chunkRequest = array[l + num2, m + num2];
+-						runGenerators(chunkRequest, i);
+-					}
+-				}
+-			}
+-		}
+-		Dictionary<Vec2i, IServerChunk[]> columnsByChunkCoordinate = new Dictionary<Vec2i, IServerChunk[]>();
+-		lock (chunkthread.peekingChunkColumns)
+-		{
+-			for (int n = -num2; n <= num2; n++)
+-			{
+-				for (int num5 = -num2; num5 <= num2; num5++)
+-				{
+-					long index = server.WorldMap.MapChunkIndex2D(x + n, y + num5);
+-					chunkthread.peekingChunkColumns.Remove(index);
+-					if (server.WorldMap.IsValidChunkPos(n + x, 0, num5 + y))
+-					{
+-						ChunkColumnLoadRequest chunkColumnLoadRequest2 = array[n + num2, num5 + num2];
+-						Dictionary<Vec2i, IServerChunk[]> dictionary2 = columnsByChunkCoordinate;
+-						Vec2i key = new Vec2i(x + n, y + num5);
+-						IServerChunk[] chunks = chunkColumnLoadRequest2.Chunks;
+-						dictionary2[key] = chunks;
+-					}
+-				}
+-			}
+-		}
+-		foreach (var (key2, _) in dictionary)
+-		{
+-			chunkthread.peekingMapRegions.Remove(key2);
+-		}
+-		chunkthread.peekMode = false;
+-		server.EnqueueMainThreadTask(delegate
+-		{
+-			onGenerated(columnsByChunkCoordinate);
+-			ServerMain.FrameProfiler.Mark("MTT-PeekChunk");
+-		});
+-	}
+-
+-	private void loadChunkAreaBlocking(int chunkX1, int chunkZ1, int chunkX2, int chunkZ2, bool isStartupLoad = false, ITreeAttribute chunkGenParams = null)
+-	{
+-		ResumeAllWorldgenThreads();
+-		int num = server.loadedChunks.Count / server.WorldMap.ChunkMapSizeY;
+-		int num2 = (chunkX2 - chunkX1 + 1) * (chunkZ2 - chunkZ1 + 1);
+-		CleanupRequestsQueue();
+-		moveRequestsToGeneratingQueue();
+-		blockingRequestsRemaining = 0;
+-		foreach (ChunkColumnLoadRequest requestedChunkColumn in chunkthread.requestedChunkColumns)
+-		{
+-			requestedChunkColumn.blockingRequest = false;
+-		}
+-		for (int i = chunkX1; i <= chunkX2; i++)
+-		{
+-			for (int j = chunkZ1; j <= chunkZ2; j++)
+-			{
+-				if (server.WorldMap.IsValidChunkPos(i, 0, j) && !server.IsChunkColumnFullyLoaded(i, j))
+-				{
+-					ChunkColumnLoadRequest chunkColumnLoadRequest = new ChunkColumnLoadRequest(server.WorldMap.MapChunkIndex2D(i, j), i, j, server.serverConsoleId, 6, server)
+-					{
+-						chunkGenParams = chunkGenParams
+-					};
+-					chunkColumnLoadRequest.blockingRequest = true;
+-					if (chunkthread.addChunkColumnRequest(chunkColumnLoadRequest))
+-					{
+-						blockingRequestsRemaining++;
+-					}
+-				}
+-			}
+-		}
+-		long num3 = Environment.TickCount + 12000;
+-		ServerMain.Logger.VerboseDebug("Starting area loading/generation: columns " + blockingRequestsRemaining + ", total queue length " + chunkthread.requestedChunkColumns.Count);
+-		while (!server.stopped && server.exitState.Mode == EnumExitMode.None)
+-		{
+-			CleanupRequestsQueue();
+-			if (blockingRequestsRemaining <= 0 || chunkthread.requestedChunkColumns.Count == 0)
+-			{
+-				break;
+-			}
+-			if (isStartupLoad && server.totalUnpausedTime.ElapsedMilliseconds - millisecondsSinceStart > 1500)
+-			{
+-				millisecondsSinceStart = server.totalUnpausedTime.ElapsedMilliseconds;
+-				float num4 = 100f * ((float)server.loadedChunks.Count / (float)server.WorldMap.ChunkMapSizeY - (float)num) / (float)num2;
+-				ServerMain.Logger.Event(num4.ToString("0.#") + "% ({0} in queue)", chunkthread.requestedChunkColumns.Count);
+-				if (storyEventPrints < storyChunkSpawnEvents.Length)
+-				{
+-					ServerMain.Logger.StoryEvent(storyChunkSpawnEvents[storyEventPrints]);
+-				}
+-				else
+-				{
+-					ServerMain.Logger.StoryEvent("...");
+-				}
+-				storyEventPrints++;
+-			}
+-			bool flag = false;
+-			foreach (ChunkColumnLoadRequest requestedChunkColumn2 in chunkthread.requestedChunkColumns)
+-			{
+-				if (requestedChunkColumn2 == null || requestedChunkColumn2.Disposed)
+-				{
+-					continue;
+-				}
+-				int currentIncompletePass_AsInt = requestedChunkColumn2.CurrentIncompletePass_AsInt;
+-				if (currentIncompletePass_AsInt == 0 || currentIncompletePass_AsInt > chunkthread.additionalWorldGenThreadsCount)
+-				{
+-					if (server.exitState.Mode == EnumExitMode.HardExit || server.stopped)
+-					{
+-						return;
+-					}
+-					flag |= loadOrGenerateChunkColumn_OnChunkThread(requestedChunkColumn2, currentIncompletePass_AsInt);
+-				}
+-			}
+-			if (flag)
+-			{
+-				num3 = Environment.TickCount + 12000;
+-			}
+-			else
+-			{
+-				if (Environment.TickCount <= num3)
+-				{
+-					continue;
+-				}
+-				ServerMain.Logger.Error("Attempting to force generate chunk columns from " + chunkX1 + "," + chunkZ1 + " to " + chunkX2 + "," + chunkZ2);
+-				ServerMain.Logger.Error(chunkthread.additionalWorldGenThreadsCount + " additional worldgen threads active, number of 'undone' chunks is " + blockingRequestsRemaining);
+-				foreach (ChunkColumnLoadRequest requestedChunkColumn3 in chunkthread.requestedChunkColumns)
+-				{
+-					if (requestedChunkColumn3 != null)
+-					{
+-						string text = ((requestedChunkColumn3.chunkX >= chunkX1 && requestedChunkColumn3.chunkX <= chunkX2 && requestedChunkColumn3.chunkZ >= chunkZ1 && requestedChunkColumn3.chunkZ <= chunkZ2) ? " (in original req)" : "");
+-						ServerMain.Logger.Error("Column " + requestedChunkColumn3.ChunkX + "," + requestedChunkColumn3.ChunkZ + " has reached pass " + requestedChunkColumn3.CurrentIncompletePass_AsInt + text);
+-					}
+-				}
+-				throw new Exception("Somehow worldgen has become stuck in an endless loop, please report this as a bug!  Additional data in the server-main log");
+-			}
+-		}
+-	}
+-
+-	private void PopulateChunk(ChunkColumnLoadRequest chunkRequest)
+-	{
+-		chunkRequest.Unpack();
+-		chunkRequest.generatingLock.AcquireWriteLock();
+-		try
+-		{
+-			if (server.Config.SkipEveryChunkRow > 0 && chunkRequest.chunkX % (server.Config.SkipEveryChunkRow + server.Config.SkipEveryChunkRowWidth) < server.Config.SkipEveryChunkRowWidth)
+-			{
+-				if (chunkRequest.CurrentIncompletePass == EnumWorldGenPass.Terrain)
+-				{
+-					ushort sunLight = (ushort)server.sunBrightness;
+-					for (int i = 0; i < chunkRequest.Chunks.Length; i++)
+-					{
+-						chunkRequest.Chunks[i].Lighting.ClearWithSunlight(sunLight);
+-					}
+-				}
+-			}
+-			else
+-			{
+-				runGenerators(chunkRequest, chunkRequest.MapChunk.currentpass);
+-			}
+-			if (chunkRequest.CurrentIncompletePass == EnumWorldGenPass.Terrain)
+-			{
+-				chunkRequest.MapChunk.WorldGenVersion = 3;
+-			}
+-			for (int j = 0; j < chunkRequest.Chunks.Length; j++)
+-			{
+-				chunkRequest.Chunks[j].MarkModified();
+-			}
+-			chunkRequest.MapChunk.currentpass++;
+-			chunkRequest.MapChunk.DirtyForSaving = true;
+-		}
+-		finally
+-		{
+-			chunkRequest.generatingLock.ReleaseWriteLock();
+-		}
+-	}
+-
+-	private void runGenerators(ChunkColumnLoadRequest chunkRequest, int forPass)
+-	{
+-		List<ChunkColumnGenerationDelegate> list = worldgenHandler.OnChunkColumnGen[forPass];
+-		if (list == null)
+-		{
+-			return;
+-		}
+-		for (int i = 0; i < list.Count; i++)
+-		{
+-			try
+-			{
+-				list[i](chunkRequest);
+-			}
+-			catch (Exception ex)
+-			{
+-				ServerMain.Logger.Worldgen("An error was thrown in pass {5} when generating chunk column X={0},Z={1} in world '{3}' with seed {4}\nException {2}\n\n", chunkRequest.chunkX, chunkRequest.chunkZ, ex, server.SaveGameData.WorldName, server.SaveGameData.Seed, chunkRequest.CurrentIncompletePass.ToString());
+-				if (chunkRequest.CurrentIncompletePass <= EnumWorldGenPass.Terrain)
+-				{
+-					break;
+-				}
+-			}
+-		}
+-	}
+-
+-	private bool ensurePrettyNeighbourhood(ChunkColumnLoadRequest chunkRequest)
+-	{
+-		if (chunkRequest.CurrentIncompletePass <= EnumWorldGenPass.Terrain)
+-		{
+-			return true;
+-		}
+-		bool result = true;
+-		int currentIncompletePass_AsInt = chunkRequest.CurrentIncompletePass_AsInt;
+-		int num = Math.Max(chunkRequest.chunkX - 1, 0);
+-		int num2 = Math.Min(chunkRequest.chunkX + 1, server.WorldMap.ChunkMapSizeX - 1);
+-		int num3 = Math.Max(chunkRequest.chunkZ - 1, 0);
+-		int num4 = Math.Min(chunkRequest.chunkZ + 1, server.WorldMap.ChunkMapSizeZ - 1);
+-		if (!chunkRequest.prettified && !EnsureQueueSpace(chunkRequest))
+-		{
+-			return false;
+-		}
+-		for (int i = num; i <= num2; i++)
+-		{
+-			for (int j = num3; j <= num4; j++)
+-			{
+-				if (i == chunkRequest.chunkX && j == chunkRequest.chunkZ)
+-				{
+-					continue;
+-				}
+-				long index2d = server.WorldMap.MapChunkIndex2D(i, j);
+-				if (!chunkthread.EnsureMinimumWorldgenPassAt(index2d, i, j, currentIncompletePass_AsInt, chunkRequest.creationTime))
+-				{
+-					if (chunkRequest.prettified)
+-					{
+-						return false;
+-					}
+-					result = false;
+-				}
+-			}
+-		}
+-		chunkRequest.prettified = true;
+-		return result;
+-	}
+-
+-	private EnumWorldGenPass getLoadedOrQueuedChunkPass(long index2d)
+-	{
+-		server.loadedMapChunks.TryGetValue(index2d, out var value);
+-		if (value == null || value.CurrentIncompletePass != EnumWorldGenPass.Done)
+-		{
+-			return chunkthread.requestedChunkColumns.GetByIndex(index2d)?.CurrentIncompletePass ?? EnumWorldGenPass.None;
+-		}
+-		return EnumWorldGenPass.Done;
+-	}
+-
+-	private bool EnsureQueueSpace(ChunkColumnLoadRequest curRequest)
+-	{
+-		int num = chunkthread.requestedChunkColumns.Count + 30 - chunkthread.requestedChunkColumns.Capacity;
+-		if (num <= 0)
+-		{
+-			return true;
+-		}
+-		if (!PauseAllWorldgenThreads(5000))
+-		{
+-			return false;
+-		}
+-		try
+-		{
+-			ServerMain.Logger.Warning("Requested chunks buffer is too small! Taking measures to attempt to free enough space. Try increasing servermagicnumbers RequestChunkColumnsQueueSize?");
+-			((ServerSystemUnloadChunks)chunkthread.serversystems[2]).UnloadGeneratingChunkColumns(MagicNum.UncompressedChunkTTL / 10);
+-			foreach (ChunkColumnLoadRequest item in chunkthread.requestedChunkColumns.Snapshot())
+-			{
+-				item.FlagToRequeue();
+-			}
+-			num -= CleanupRequestsQueue();
+-			if (num <= 0)
+-			{
+-				return true;
+-			}
+-			ServerMain.Logger.Error("Requested chunks buffer is too small! Can't free enough space to completely generate chunks, clearing whole buffer. This may cause issues. Try increasing servermagicnumbers RequestChunkColumnsQueueSize and/or reducing UncompressedChunkTTL.");
+-			FullyClearGeneratingQueue();
+-			chunkthread.requestedChunkColumns.Enqueue(curRequest);
+-			return true;
+-		}
+-		finally
+-		{
+-			ResumeAllWorldgenThreads();
+-			if (chunkthread.additionalWorldGenThreadsCount > 0)
+-			{
+-				ServerMain.Logger.VerboseDebug("Un-pausing all worldgen threads.");
+-			}
+-		}
+-	}
+-
+-	internal void FullyClearGeneratingQueue()
+-	{
+-		chunkthread.loadsavegame.SaveAllDirtyGeneratingChunks(saveChunksStream ?? (saveChunksStream = new FastMemoryStream()));
+-		foreach (ChunkColumnLoadRequest requestedChunkColumn in chunkthread.requestedChunkColumns)
+-		{
+-			if (requestedChunkColumn != null && !requestedChunkColumn.Disposed)
+-			{
+-				server.loadedMapChunks.Remove(requestedChunkColumn.mapIndex2d);
+-				server.ChunkColumnRequested.Remove(requestedChunkColumn.mapIndex2d);
+-			}
+-		}
+-		chunkthread.requestedChunkColumns.Clear();
+-		ServerMain.Logger.VerboseDebug("Incomplete chunks stored and wiped.");
+-	}
+-
+-	private Thread CreateAdditionalWorldGenThread(int stageStart, int stageEnd, int threadnum)
+-	{
+-		Thread thread = TyronThreadPool.CreateDedicatedThread(delegate
+-		{
+-			GeneratorThreadLoop(stageStart, stageEnd);
+-		}, "worldgen" + threadnum);
+-		thread.Start();
+-		return thread;
+-	}
+-
+-	public void GeneratorThreadLoop(int stageStart, int stageEnd)
+-	{
+-		Thread.Sleep(5);
+-		int num = Math.Min(3, MagicNum.ChunkColumnsToGeneratePerThreadTick / chunkthread.additionalWorldGenThreadsCount);
+-		int num2 = 0;
+-		while (!server.stopped)
+-		{
+-			if (chunkthread.requestedChunkColumns.Count > 0 && (!server.Suspended || server.RunPhase == EnumServerRunPhase.WorldReady))
+-			{
+-				try
+-				{
+-					for (int i = 0; i < num; i++)
+-					{
+-						int num3 = GenerateChunkColumns_OnSeparateThread(stageStart, stageEnd);
+-						num2 += num3;
+-						if (num3 == 0)
+-						{
+-							break;
+-						}
+-					}
+-				}
+-				catch (Exception e)
+-				{
+-					ServerMain.Logger.Error(e);
+-				}
+-			}
+-			PauseWorldgenThreadIfRequired(onChunkthread: false);
+-			Thread.Sleep(1);
+-		}
+-		BlockAccessorWorldGen.ThreadDispose();
+-	}
+-
+-	public override void OnSeperateThreadShutDown()
+-	{
+-		BlockAccessorWorldGen.ThreadDispose();
+-	}
+-
+-	public override void Dispose()
+-	{
+-		BlockAccessorWorldGen.ThreadDispose();
+-	}
+-
+-	public bool PauseAllWorldgenThreads(int timeoutms)
+-	{
+-		if (Interlocked.CompareExchange(ref pauseAllWorldgenThreads, 1, 0) != 0)
+-		{
+-			return false;
+-		}
+-		if (chunkthread.additionalWorldGenThreadsCount > 0)
+-		{
+-			ServerMain.Logger.VerboseDebug("Pausing all worldgen threads.");
+-		}
+-		long num = Environment.TickCount + timeoutms;
+-		while (pauseAllWorldgenThreads < chunkthread.additionalWorldGenThreadsCount + 1 && !server.stopped)
+-		{
+-			if (Environment.TickCount > num)
+-			{
+-				ServerMain.Logger.VerboseDebug("Pausing all worldgen threads - exceeded timeout!");
+-				return false;
+-			}
+-			Thread.Sleep(1);
+-		}
+-		return true;
+-	}
+-
+-	public void ResumeAllWorldgenThreads()
+-	{
+-		pauseAllWorldgenThreads = 0;
+-	}
+-
+-	public void PauseWorldgenThreadIfRequired(bool onChunkthread)
+-	{
+-		if (pauseAllWorldgenThreads <= 0)
+-		{
+-			return;
+-		}
+-		Interlocked.Increment(ref pauseAllWorldgenThreads);
+-		long num = Environment.TickCount + 5000;
+-		while (pauseAllWorldgenThreads != 0 && !server.stopped)
+-		{
+-			if (Environment.TickCount > num)
+-			{
+-				ServerMain.Logger.VerboseDebug("Pausing all worldgen threads - exceeded 5s timeout!");
+-				break;
+-			}
+-			Thread.Sleep(15);
+-		}
+-	}
++    private WorldGenHandler worldgenHandler;
++
++    private ChunkServerThread chunkthread;
++
++    private bool is8Core = Environment.ProcessorCount >= 8;
++
++    private bool requiresChunkBorderSmoothing;
++
++    private bool requiresSetEmptyFlag;
++
++    private volatile int pauseAllWorldgenThreads;
++
++    [ThreadStatic]
++    private static FastMemoryStream saveChunksStream;
++
++    private List<long> entitiesToRemove = new List<long>();
++
++    private int storyEventPrints;
++
++    private string[] storyChunkSpawnEvents;
++
++    private int blockingRequestsRemaining;
++
++    // Stratum: priority list built once per OnSeparateThreadTick, shared across all inner
++    // tryLoadOrGenerateChunkColumnsInQueue calls within that tick. The profiler showed that
++    // a time-based 100ms cache was hitting the rebuild branch on virtually every call
++    // (7.4M rebuilds/session at 100 players). Building once per tick drops that to ~14K.
++    private List<ChunkColumnLoadRequest>? stratumPriorityListCache;
++    private int stratumPriorityListCacheIdx;
++    // Reused player-position arrays so TryBuildStratumPriorityList doesn't allocate on each rebuild.
++    private float[] stratumPlayerCx = [];
++    private float[] stratumPlayerCz = [];
++    private int stratumPlayerCount;
++    private Comparison<ChunkColumnLoadRequest>? stratumSortComparison;
++    private readonly List<long> stratumMoveBuffer = new List<long>();
++    private readonly List<ChunkColumnLoadRequest> stratumCandidatesBuffer = new List<ChunkColumnLoadRequest>();
++    private readonly List<ChunkPos> stratumDeleteChunksList = new List<ChunkPos>(64);
++    private readonly List<ChunkPos> stratumDeleteMapChunksList = new List<ChunkPos>(16);
++    private readonly HashSet<ChunkPos> stratumDeleteRegionsSet = new HashSet<ChunkPos>();
++
++    // Stratum: Array for tracking the occupancy of generation stages
++    // Indexes correspond to EnumWorldGenPass (Terrain..PreDone)
++    // false = stage is free, true = stage is occupied by a thread
++    private volatile bool[] stratumStageBusy = new bool[(int)EnumWorldGenPass.Done];
++
++
++    public ServerSystemSupplyChunks(ServerMain server, ChunkServerThread chunkthread)
++        : base(server)
++    {
++        this.chunkthread = chunkthread;
++        chunkthread.loadsavechunks = this;
++        server.RegisterGameTickListener(delegate
++        {
++            server.serverChunkDataPool.SlowDispose();
++        }, 1000);
++    }
++
++    public override int GetUpdateInterval()
++    {
++        if (chunkthread.requestedChunkColumns.Count == 0 || !is8Core)
++        {
++            return MagicNum.ChunkThreadTickTime;
++        }
++        return chunkthread.additionalWorldGenThreadsCount - 1;
++    }
++
++    public override void OnBeginGameReady(SaveGame savegame)
++    {
++        requiresChunkBorderSmoothing = savegame.CreatedWorldGenVersion != 3;
++        requiresSetEmptyFlag = GameVersion.IsLowerVersionThan(server.SaveGameData.LastSavedGameVersion, "1.12-dev.1");
++        if (chunkthread.additionalWorldGenThreadsCount > 0)
++        {
++            // Stratum: All threads are created identically, without being bound to ranges
++            // Each thread can take any task from the Terrain..PreDone stages
++            for (int i = 0; i < chunkthread.additionalWorldGenThreadsCount; i++)
++            {
++                CreateAdditionalWorldGenThread(i + 1);
++            }
++        }
++    }
++
++    public override void OnSeparateThreadTick()
++    {
++        if (server.RunPhase != EnumServerRunPhase.RunGame)
++        {
++            return;
++        }
++        deleteChunkColumns();
++        moveRequestsToGeneratingQueue();
++        KeyValuePair<HorRectanglei, ChunkLoadOptions> result;
++        while (!server.fastChunkQueue.IsEmpty && server.fastChunkQueue.TryDequeue(out result))
++        {
++            loadChunkAreaBlocking(result.Key.X1, result.Key.Z1, result.Key.X2, result.Key.Z2, isStartupLoad: false, result.Value.ChunkGenParams);
++            if (result.Value.OnLoaded != null)
++            {
++                server.EnqueueMainThreadTask(result.Value.OnLoaded);
++            }
++        }
++        if (!server.simpleLoadRequests.IsEmpty && server.mapMiddleSpawnPos != null)
++        {
++            ChunkColumnLoadRequest result2;
++            while (server.simpleLoadRequests.TryDequeue(out result2))
++            {
++                simplyLoadChunkColumn(result2);
++            }
++        }
++        if (!server.peekChunkColumnQueue.IsEmpty && server.peekChunkColumnQueue.TryDequeue(out var result3))
++        {
++            if (PauseAllWorldgenThreads(3600))
++            {
++                PeekChunkAreaLocking(result3.Key, result3.Value.UntilPass, result3.Value.OnGenerated, result3.Value.ChunkGenParams);
++            }
++            ResumeAllWorldgenThreads();
++        }
++        while (!server.testChunkExistsQueue.IsEmpty)
++        {
++            if (!server.testChunkExistsQueue.TryDequeue(out var val))
++            {
++                break;
++            }
++            bool exists = false;
++            switch (val.Type)
++            {
++                case EnumChunkType.Chunk:
++                    exists = chunkthread.gameDatabase.ChunkExists(val.chunkX, val.chunkY, val.chunkZ);
++                    break;
++                case EnumChunkType.MapChunk:
++                    exists = chunkthread.gameDatabase.MapChunkExists(val.chunkX, val.chunkZ);
++                    break;
++                case EnumChunkType.MapRegion:
++                    exists = chunkthread.gameDatabase.MapRegionExists(val.chunkX, val.chunkZ);
++                    break;
++            }
++            val.Exists = exists;
++            server.EnqueueMainThreadTask(val.Complete);
++        }
++        // Stratum: build priority list once per tick. tryLoadOrGenerateChunkColumnsInQueue is
++        // called up to MagicNum.ChunkColumnsToGeneratePerThreadTick times per tick; the previous
++        // time-based cache was rebuilt on nearly every call due to clock resolution differences.
++        stratumPriorityListCache = TryBuildStratumPriorityList();
++        stratumPriorityListCacheIdx = 0;
++        for (int num = 0; num < MagicNum.ChunkColumnsToGeneratePerThreadTick; num++)
++        {
++            if (!tryLoadOrGenerateChunkColumnsInQueue())
++            {
++                break;
++            }
++            if (server.Suspended)
++            {
++                break;
++            }
++        }
++    }
++
++    private void deleteChunkColumns()
++    {
++        List<ChunkPos> list = stratumDeleteChunksList;
++        List<ChunkPos> list2 = stratumDeleteMapChunksList;
++        HashSet<ChunkPos> hashSet = stratumDeleteRegionsSet;
++        list.Clear();
++        list2.Clear();
++        hashSet.Clear();
++        int chunkMapSizeY = server.WorldMap.ChunkMapSizeY;
++        long result;
++        while (!server.deleteChunkColumns.IsEmpty && server.deleteChunkColumns.TryDequeue(out result))
++        {
++            if (list == null)
++            {
++                list = new List<ChunkPos>();
++            }
++            if (list2 == null)
++            {
++                list2 = new List<ChunkPos>();
++            }
++            if (chunkthread.requestedChunkColumns.Remove(result))
++            {
++                server.ChunkColumnRequested.Remove(result);
++            }
++            ChunkPos item = server.WorldMap.ChunkPosFromChunkIndex2D(result);
++            int x = item.X;
++            int z = item.Z;
++            if (x < 0 || z < 0)
++            {
++                ServerMain.Logger.Error("Delete chunks: mapchunkindex outside the map: " + x + "," + z);
++                continue;
++            }
++            UpdateLoadedNeighboursFlags(server.WorldMap, x, z);
++            for (int i = 0; i < chunkMapSizeY; i++)
++            {
++                ServerChunk serverChunk = (ServerChunk)server.WorldMap.GetChunk(x, i, z);
++                if (serverChunk != null)
++                {
++                    Entity[] entities = serverChunk.Entities;
++                    for (int j = 0; j < entities.Length; j++)
++                    {
++                        Entity entity = entities[j];
++                        if (entity is EntityPlayer)
++                        {
++                            continue;
++                        }
++                        if (entity == null)
++                        {
++                            if (j >= serverChunk.EntitiesCount)
++                            {
++                                break;
++                            }
++                        }
++                        else
++                        {
++                            server.DespawnEntity(entity, new EntityDespawnData
++                            {
++                                Reason = EnumDespawnReason.Death
++                            });
++                        }
++                    }
++                }
++                list.Add(new ChunkPos
++                {
++                    X = x,
++                    Y = i,
++                    Z = z
++                });
++            }
++            list2.Add(item);
++            server.loadedMapChunks.Remove(result);
++        }
++        if (list != null && list.Count > 0)
++        {
++            chunkthread.gameDatabase.DeleteChunks(list);
++        }
++        if (list2 != null && list2.Count > 0)
++        {
++            chunkthread.gameDatabase.DeleteMapChunks(list2);
++        }
++        hashSet = null;
++        long result2;
++        while (!server.deleteMapRegions.IsEmpty && server.deleteMapRegions.TryDequeue(out result2))
++        {
++            ChunkPos item2 = server.WorldMap.MapRegionPosFromIndex2D(result2);
++            if (hashSet == null)
++            {
++                hashSet = new HashSet<ChunkPos>();
++            }
++            hashSet.Add(item2);
++            server.loadedMapRegions.Remove(result2);
++        }
++        if (hashSet != null && hashSet.Count > 0)
++        {
++            chunkthread.gameDatabase.DeleteMapRegions(hashSet);
++        }
++    }
++
++    private void moveRequestsToGeneratingQueue()
++    {
++        stratumMoveBuffer.Clear();
++        lock (server.requestedChunkColumnsLock)
++        {
++            while (server.requestedChunkColumns.Count > 0 && chunkthread.requestedChunkColumns.Capacity - chunkthread.requestedChunkColumns.Count >= stratumMoveBuffer.Count + 200)
++            {
++                stratumMoveBuffer.Add(server.requestedChunkColumns.Dequeue());
++            }
++        }
++        for (int i = 0; i < stratumMoveBuffer.Count; i++)
++        {
++            long num = stratumMoveBuffer[i];
++            Vec2i vec2i = server.WorldMap.MapChunkPosFromChunkIndex2D(num);
++            chunkthread.addChunkColumnRequest(num, vec2i.X, vec2i.Y, -1);
++        }
++    }
++
++    private bool simplyLoadChunkColumn(ChunkColumnLoadRequest request)
++    {
++        ServerMapChunk orCreateMapChunk = chunkthread.loadsavechunks.GetOrCreateMapChunk(request);
++        if (orCreateMapChunk == null)
++        {
++            return false;
++        }
++        ServerChunk[] array = chunkthread.loadsavechunks.TryLoadChunkColumn(request);
++        if (array == null)
++        {
++            return false;
++        }
++        foreach (ServerChunk obj in array)
++        {
++            obj.serverMapChunk = orCreateMapChunk;
++            obj.MarkFresh();
++        }
++        request.MapChunk = orCreateMapChunk;
++        request.Chunks = array;
++        server.EnqueueMainThreadTask(delegate
++        {
++            chunkthread.loadsavechunks.mainThreadLoadChunkColumn(request);
++        });
++        return true;
++    }
++
++    private bool tryLoadOrGenerateChunkColumnsInQueue()
++    {
++        if (chunkthread.requestedChunkColumns.Count == 0)
++        {
++            return false;
++        }
++        if (pauseAllWorldgenThreads > 0)
++        {
++            return false;
++        }
++        CleanupRequestsQueue();
++        int additionalWorldGenThreadsCount = chunkthread.additionalWorldGenThreadsCount;
++
++        // Stratum: use the per-tick priority list built in OnSeparateThreadTick. Falls through
++        // to vanilla FIFO when the list is null (priority disabled) or exhausted for this tick.
++        List<ChunkColumnLoadRequest>? stratumPrioritized = (stratumPriorityListCache != null && stratumPriorityListCacheIdx < stratumPriorityListCache.Count)
++            ? stratumPriorityListCache
++            : null;
++
++        if (stratumPrioritized != null)
++        {
++            for (; stratumPriorityListCacheIdx < stratumPrioritized.Count; stratumPriorityListCacheIdx++)
++            {
++                ChunkColumnLoadRequest requestedChunkColumn = stratumPrioritized[stratumPriorityListCacheIdx];
++                if (requestedChunkColumn == null || requestedChunkColumn.Disposed)
++                {
++                    continue;
++                }
++                int currentIncompletePass_AsInt = requestedChunkColumn.CurrentIncompletePass_AsInt;
++                // Stratum: The main thread only processes stage 0 (loading) and the Done stage
++                if (currentIncompletePass_AsInt == (int)EnumWorldGenPass.None || currentIncompletePass_AsInt >= (int)EnumWorldGenPass.Done)
++                {
++                    if (server.Suspended)
++                    {
++                        return false;
++                    }
++                    if (loadOrGenerateChunkColumn_OnChunkThread(requestedChunkColumn, currentIncompletePass_AsInt) && chunkthread.additionalWorldGenThreadsCount == 0)
++                    {
++                        stratumPriorityListCacheIdx++;
++                        return true;
++                    }
++                }
++            }
++            // Priority list exhausted for this tick. Fall through to vanilla FIFO.
++        }
++
++        foreach (ChunkColumnLoadRequest requestedChunkColumn in chunkthread.requestedChunkColumns)
++        {
++            if (requestedChunkColumn == null || requestedChunkColumn.Disposed)
++            {
++                continue;
++            }
++            int currentIncompletePass_AsInt = requestedChunkColumn.CurrentIncompletePass_AsInt;
++            // Stratum: The main thread only processes stage 0 (loading) and the Done stage
++            if (currentIncompletePass_AsInt == (int)EnumWorldGenPass.None || currentIncompletePass_AsInt >= (int)EnumWorldGenPass.Done)
++            {
++                if (server.Suspended)
++                {
++                    return false;
++                }
++                if (loadOrGenerateChunkColumn_OnChunkThread(requestedChunkColumn, currentIncompletePass_AsInt) && chunkthread.additionalWorldGenThreadsCount == 0)
++                {
++                    return true;
++                }
++            }
++        }
++        return false;
++    }
++
++    // Builds a sorted (by min distance to nearest online player, optionally motion-predicted)
++    // snapshot of the next StratumChunkPriorityConfig.MaxSortedPerTick pending chunk-column
++    // requests.
++    // Returns null only when priority is disabled — caller falls through to vanilla.
++    // Returns empty stratumCandidatesBuffer when priority is on but nothing to process — caller
++    // skips vanilla (which would also find nothing). Returns a non-empty sorted list normally.
++    private List<ChunkColumnLoadRequest> TryBuildStratumPriorityList()
++    {
++        StratumChunkPriorityConfig prioCfg = StratumRuntime.Config?.Performance?.ChunkPriority;
++        if (prioCfg == null || !prioCfg.Enabled) return null;
++
++        // Clear here so every non-null early return below yields an empty (non-null) buffer,
++        // signalling "priority on, nothing to do" rather than "priority off".
++        stratumCandidatesBuffer.Clear();
++
++        int qcount = chunkthread.requestedChunkColumns.Count;
++        if (qcount == 0) return stratumCandidatesBuffer;
++
++        IPlayer[] players = server.AllOnlinePlayers;
++        if (players == null || players.Length == 0) return stratumCandidatesBuffer;
++
++        // Snapshot player chunk-center positions, with optional motion forward-prediction.
++        // Server tick rate is ~30Hz; Motion is per-tick velocity in blocks.
++        float pred = prioCfg.PredictionSeconds * 30f;
++        if (stratumPlayerCx.Length < players.Length)
++        {
++            stratumPlayerCx = new float[players.Length];
++            stratumPlayerCz = new float[players.Length];
++        }
++        int pi = 0;
++        for (int p = 0; p < players.Length; p++)
++        {
++            Entity ent = players[p]?.Entity;
++            if (ent == null) continue;
++            EntityPos pos = ent.SidedPos;
++            if (pos == null) continue;
++            double px = pos.X + (pred > 0f ? pos.Motion.X * pred : 0.0);
++            double pz = pos.Z + (pred > 0f ? pos.Motion.Z * pred : 0.0);
++            stratumPlayerCx[pi] = (float)(px / 32.0);
++            stratumPlayerCz[pi] = (float)(pz / 32.0);
++            pi++;
++        }
++        if (pi == 0) return stratumCandidatesBuffer;
++        stratumPlayerCount = pi;
++
++        int cap = Math.Min(qcount, prioCfg.MaxSortedPerTick);
++        int picked = 0;
++        foreach (ChunkColumnLoadRequest r in chunkthread.requestedChunkColumns)
++        {
++            if (picked >= cap) break;
++            if (r == null || r.Disposed) continue;
++            stratumCandidatesBuffer.Add(r);
++            picked++;
++        }
++        if (stratumCandidatesBuffer.Count == 0) return stratumCandidatesBuffer;
++
++        stratumCandidatesBuffer.Sort(stratumSortComparison ??= StratumSortByPlayerDist);
++        return stratumCandidatesBuffer;
++    }
++
++    private int StratumSortByPlayerDist(ChunkColumnLoadRequest a, ChunkColumnLoadRequest b)
++    {
++        float da = StratumMinSqDistToPlayers(a, stratumPlayerCx, stratumPlayerCz, stratumPlayerCount);
++        float db = StratumMinSqDistToPlayers(b, stratumPlayerCx, stratumPlayerCz, stratumPlayerCount);
++        return da.CompareTo(db);
++    }
++
++    private static float StratumMinSqDistToPlayers(ChunkColumnLoadRequest req, float[] px, float[] pz, int count)
++    {
++        float min = float.MaxValue;
++        float cx = req.chunkX + 0.5f;
++        float cz = req.chunkZ + 0.5f;
++        for (int i = 0; i < count; i++)
++        {
++            float dx = cx - px[i];
++            float dz = cz - pz[i];
++            float d = dx * dx + dz * dz;
++            if (d < min) min = d;
++        }
++        return min;
++    }
++
++    private int CleanupRequestsQueue()
++    {
++        int num = 0;
++        ConcurrentIndexedFifoQueue<ChunkColumnLoadRequest> requestedChunkColumns = chunkthread.requestedChunkColumns;
++        while (requestedChunkColumns.Count > 0)
++        {
++            ChunkColumnLoadRequest chunkColumnLoadRequest = requestedChunkColumns.Peek();
++            if (chunkColumnLoadRequest == null || chunkColumnLoadRequest.disposeOrRequeueFlags == 0)
++            {
++                break;
++            }
++            if (chunkColumnLoadRequest.Disposed)
++            {
++                requestedChunkColumns.DequeueWithoutRemovingFromIndex();
++                num++;
++            }
++            else
++            {
++                chunkColumnLoadRequest.disposeOrRequeueFlags = 0;
++                requestedChunkColumns.Requeue();
++            }
++        }
++        return num;
++    }
++
++    public bool loadOrGenerateChunkColumn_OnChunkThread(ChunkColumnLoadRequest chunkRequest, int stage)
++    {
++        ServerMapChunk orCreateMapChunk = GetOrCreateMapChunk(chunkRequest);
++        bool flag = orCreateMapChunk.CurrentIncompletePass >= EnumWorldGenPass.Done || orCreateMapChunk.WorldGenVersion >= 3;
++        if (!flag && orCreateMapChunk.WorldGenVersion != 0)
++        {
++            orCreateMapChunk = GetOrCreateMapChunk(chunkRequest, forceCreate: true);
++            chunkRequest.Chunks = null;
++        }
++        if (chunkRequest.Chunks == null)
++        {
++            if (flag)
++            {
++                chunkRequest.Chunks = TryLoadChunkColumn(chunkRequest);
++                if (chunkRequest.Chunks != null)
++                {
++                    for (int i = 0; i < chunkRequest.Chunks.Length; i++)
++                    {
++                        ServerChunk obj = chunkRequest.Chunks[i];
++                        obj.serverMapChunk = orCreateMapChunk;
++                        obj.MarkFresh();
++                    }
++                }
++            }
++            int regionX = chunkRequest.chunkX / (server.api.WorldManager.RegionSize / server.api.WorldManager.ChunkSize);
++            int regionZ = chunkRequest.chunkZ / (server.api.WorldManager.RegionSize / server.api.WorldManager.ChunkSize);
++            long index2d = server.api.WorldManager.MapRegionIndex2D(regionX, regionZ);
++            IMapRegion mapRegion = server.api.WorldManager.GetMapRegion(index2d);
++            if (mapRegion != null)
++            {
++                TryRestoreGeneratedStructures(regionX, regionZ, chunkRequest.chunkGenParams, mapRegion);
++            }
++            if (chunkRequest.Chunks == null)
++            {
++                GenerateNewChunkColumn(orCreateMapChunk, chunkRequest);
++            }
++        }
++        chunkRequest.MapChunk = orCreateMapChunk;
++        if (chunkRequest.CurrentIncompletePass == EnumWorldGenPass.Done)
++        {
++            if (chunkRequest.blockingRequest && --blockingRequestsRemaining == 0)
++            {
++                ServerMain.Logger.VerboseDebug("Completed area loading/generation");
++            }
++            runScheduledBlockUpdatesWithNeighbours(chunkRequest);
++            try
++            {
++                ServerEventAPI eventapi = server.api.eventapi;
++                ServerMapChunk mapChunk = orCreateMapChunk;
++                int chunkX = chunkRequest.chunkX;
++                int chunkZ = chunkRequest.chunkZ;
++                IWorldChunk[] chunks = chunkRequest.Chunks;
++                eventapi.TriggerBeginChunkColumnLoadChunkThread(mapChunk, chunkX, chunkZ, chunks);
++            }
++            catch (Exception ex)
++            {
++                ServerMain.Logger.Error("Exception throwing during chunk Unpack() at chunkpos xz {0}/{1}. Likely corrupted. Exception: {2}", chunkRequest.chunkX, chunkRequest.chunkZ, ex);
++                if (server.Config.RepairMode)
++                {
++                    ServerMain.Logger.Error("Repair mode is enabled so will delete the entire chunk column.");
++                    GenerateNewChunkColumn(orCreateMapChunk, chunkRequest);
++                    return false;
++                }
++            }
++            server.EnqueueMainThreadTask(delegate
++            {
++                mainThreadLoadChunkColumn(chunkRequest);
++                chunkthread.requestedChunkColumns.elementsByIndex.Remove(chunkRequest.Index);
++            });
++            chunkRequest.FlagToDispose();
++            return true;
++        }
++        // Stratum: If the stage does not match and it is a working stage (not Done), skip
++        if (orCreateMapChunk.currentpass != stage && orCreateMapChunk.currentpass < (int)EnumWorldGenPass.Done)
++        {
++            return stage == 0;
++        }
++        bool num = CanGenerateChunkColumn(chunkRequest);
++        if (num)
++        {
++            PopulateChunk(chunkRequest);
++        }
++        if (!num || chunkthread.additionalWorldGenThreadsCount == 0)
++        {
++            chunkRequest.FlagToRequeue();
++        }
++        return num;
++    }
++
++
++    public int GenerateChunkColumns_OnSeparateThread()
++    {
++        ChunkColumnLoadRequest chunkColumnLoadRequest = null;
++        long num = long.MinValue;
++        int targetPass = -1;
++
++        // Stratum: Scan the entire queue, looking for a task from the Terrain..PreDone stages
++        foreach (ChunkColumnLoadRequest requestedChunkColumn in chunkthread.requestedChunkColumns)
++        {
++            if (requestedChunkColumn == null || requestedChunkColumn.Disposed)
++            {
++                continue;
++            }
++            int currentIncompletePass_AsInt = requestedChunkColumn.CurrentIncompletePass_AsInt;
++
++            // Stratum: We work only with Terrain..PreDone (not Done) stages
++            if (currentIncompletePass_AsInt < (int)EnumWorldGenPass.None + 1 ||
++                currentIncompletePass_AsInt >= (int)EnumWorldGenPass.Done)
++            {
++                continue;
++            }
++
++            // Stratum: Проверяем, не занят ли этот этап другим потоком
++            if (stratumStageBusy[currentIncompletePass_AsInt])
++            {
++                continue; // The stage is busy, skipping
++            }
++
++            if (currentIncompletePass_AsInt >= requestedChunkColumn.untilPass)
++            {
++                requestedChunkColumn.FlagToRequeue();
++            }
++            else if (requestedChunkColumn.creationTime > num)
++            {
++                if (ensurePrettyNeighbourhood(requestedChunkColumn))
++                {
++                    num = requestedChunkColumn.creationTime;
++                    chunkColumnLoadRequest = requestedChunkColumn;
++                    targetPass = currentIncompletePass_AsInt;
++                }
++                else
++                {
++                    requestedChunkColumn.FlagToRequeue();
++                }
++            }
++        }
++
++        if (chunkColumnLoadRequest != null)
++        {
++            // Stratum: Trying to atomically capture a stage
++            if (Interlocked.CompareExchange(ref stratumStageBusy[targetPass], true, false) == false)
++            {
++                try
++                {
++                    PopulateChunk(chunkColumnLoadRequest);
++                    return 1;
++                }
++                finally
++                {
++                    // Stratum: Release the stage after generation is complete
++                    stratumStageBusy[targetPass] = false;
++                }
++            }
++        }
++        return 0;
++    }
++
++    public bool CanGenerateChunkColumn(ChunkColumnLoadRequest chunkRequest)
++    {
++        if (chunkRequest.CurrentIncompletePass_AsInt >= chunkRequest.untilPass || !ensurePrettyNeighbourhood(chunkRequest))
++        {
++            return false;
++        }
++        return true;
++    }
++
++    internal void mainThreadLoadChunkColumn(ChunkColumnLoadRequest chunkRequest)
++    {
++        if (server.RunPhase == EnumServerRunPhase.Shutdown)
++        {
++            return;
++        }
++        ServerMain.FrameProfiler.Enter("MTT-ChunkLoaded-Begin");
++        ServerEventAPI eventapi = server.api.eventapi;
++        Vec2i chunkCoord = new Vec2i(chunkRequest.chunkX, chunkRequest.chunkZ);
++        IWorldChunk[] chunks = chunkRequest.Chunks;
++        eventapi.TriggerChunkColumnLoaded(chunkCoord, chunks);
++        ServerMain.FrameProfiler.Mark("MTT-ChunkLoaded-LoadedEvent");
++        for (int i = 0; i < chunkRequest.Chunks.Length; i++)
++        {
++            ServerMain.FrameProfiler.Mark("MTT-ChunkLoaded-LoadedEvent");
++            ServerChunk serverChunk = chunkRequest.Chunks[i];
++            int num = i + chunkRequest.dimension * 1024;
++            long num2 = server.WorldMap.ChunkIndex3D(chunkRequest.chunkX, num, chunkRequest.chunkZ);
++            server.loadedChunksLock.AcquireWriteLock();
++            try
++            {
++                if (server.loadedChunks.ContainsKey(num2))
++                {
++                    continue;
++                }
++                server.loadedChunks[num2] = serverChunk;
++                serverChunk.MarkToPack();
++                goto IL_00ff;
++            }
++            finally
++            {
++                server.loadedChunksLock.ReleaseWriteLock();
++            }
++        IL_00ff:
++            if (server.Config.AnalyzeMode)
++            {
++                try
++                {
++                    serverChunk.Unpack();
++                }
++                catch (Exception ex)
++                {
++                    ServerMain.Logger.Error("Exception throwing during chunk Unpack() at chunkpos {0}/{1}/{2}, dimension {4}. Likely corrupted. Exception: {3}", chunkRequest.chunkX, i, chunkRequest.chunkZ, ex, chunkRequest.dimension);
++                    if (server.Config.RepairMode && chunkRequest.dimension == 0)
++                    {
++                        ServerMain.Logger.Error("Repair mode is enabled so will delete the entire chunk column.");
++                        server.api.worldapi.DeleteChunkColumn(chunkRequest.chunkX, chunkRequest.chunkZ);
++                        ServerMain.FrameProfiler.Leave();
++                        return;
++                    }
++                }
++            }
++            entitiesToRemove.Clear();
++            if (serverChunk.Entities != null)
++            {
++                for (int j = 0; j < serverChunk.Entities.Length; j++)
++                {
++                    Entity entity = serverChunk.Entities[j];
++                    if (entity == null)
++                    {
++                        if (j >= serverChunk.EntitiesCount)
++                        {
++                            break;
++                        }
++                    }
++                    else
++                    {
++                        if (server.LoadEntity(entity, num2))
++                        {
++                            continue;
++                        }
++                        entitiesToRemove.Add(entity.EntityId);
++                        if (entity.Code.Path.StartsWith("villager"))
++                        {
++                            string text = "-";
++                            try
++                            {
++                                text = entity.WatchedAttributes.GetTreeAttribute("nametag")?.GetString("name") ?? "-";
++                            }
++                            catch (Exception)
++                            {
++                            }
++                            ServerMain.Logger.Log(EnumLogType.Worldgen, "In " + server.WorldName + ", villager " + text + " removed at " + entity.Pos.AsBlockPos?.ToString() + " due to an exception on loading");
++                        }
++                    }
++                }
++            }
++            foreach (long item in entitiesToRemove)
++            {
++                serverChunk.RemoveEntity(item);
++            }
++            ServerMain.FrameProfiler.Enter("MTT-ChunkLoaded-LoadBlockEntities");
++            foreach (KeyValuePair<BlockPos, BlockEntity> blockEntity in serverChunk.BlockEntities)
++            {
++                BlockEntity value = blockEntity.Value;
++                if (value == null)
++                {
++                    continue;
++                }
++                try
++                {
++                    ServerMain.FrameProfiler.Enter(value.Block.Code.Path);
++                    value.Initialize(server.api);
++                    if (serverChunk.serverMapChunk.NewBlockEntities.Contains(value.Pos))
++                    {
++                        serverChunk.serverMapChunk.NewBlockEntities.Remove(value.Pos);
++                        value.OnBlockPlaced();
++                    }
++                    ServerMain.FrameProfiler.Leave();
++                }
++                catch (Exception ex3)
++                {
++                    ServerMain.Logger.Notification("Exception thrown when trying to initialize a block entity @{0}: {1}", value.Pos, ex3);
++                    value.UnregisterAllTickListeners();
++                }
++            }
++            ServerMain.FrameProfiler.Leave();
++            server.api.eventapi.TriggerChunkDirty(new Vec3i(chunkRequest.chunkX, num, chunkRequest.chunkZ), serverChunk, EnumChunkDirtyReason.NewlyLoaded);
++        }
++        ServerMain.FrameProfiler.Mark("MTT-ChunkLoaded-MarkDirtyEvent");
++        updateNeighboursLoadedFlags(chunkRequest.MapChunk, chunkRequest.chunkX, chunkRequest.chunkZ);
++        ServerMain.FrameProfiler.Mark("MTT-ChunkLoaded-UpdateNeighboursFlags");
++        for (int k = 0; k < chunkRequest.Chunks.Length; k++)
++        {
++            chunkRequest.Chunks[k].TryPackAndCommit();
++        }
++        ServerMain.FrameProfiler.Mark("MTT-ChunkLoaded-Pack");
++        ServerMain.FrameProfiler.Leave();
++    }
++
++    private void updateNeighboursLoadedFlags(ServerMapChunk mapChunk, int chunkX, int chunkZ)
++    {
++        mapChunk.NeighboursLoaded = default(SmallBoolArray);
++        mapChunk.SelfLoaded = true;
++        for (int i = 0; i < Cardinal.ALL.Length; i++)
++        {
++            Cardinal cardinal = Cardinal.ALL[i];
++            ServerMapChunk serverMapChunk = (ServerMapChunk)server.WorldMap.GetMapChunk(chunkX + cardinal.Normali.X, chunkZ + cardinal.Normali.Z);
++            if (serverMapChunk != null)
++            {
++                mapChunk.NeighboursLoaded[i] = serverMapChunk.SelfLoaded;
++                serverMapChunk.NeighboursLoaded[cardinal.Opposite.Index] = true;
++            }
++        }
++    }
++
++    public static void UpdateLoadedNeighboursFlags(ServerWorldMap WorldMap, int chunkX, int chunkZ)
++    {
++        ServerMapChunk serverMapChunk = (ServerMapChunk)WorldMap.GetMapChunk(chunkX, chunkZ - 1);
++        ServerMapChunk serverMapChunk2 = (ServerMapChunk)WorldMap.GetMapChunk(chunkX + 1, chunkZ - 1);
++        ServerMapChunk serverMapChunk3 = (ServerMapChunk)WorldMap.GetMapChunk(chunkX + 1, chunkZ);
++        ServerMapChunk serverMapChunk4 = (ServerMapChunk)WorldMap.GetMapChunk(chunkX + 1, chunkZ + 1);
++        ServerMapChunk serverMapChunk5 = (ServerMapChunk)WorldMap.GetMapChunk(chunkX, chunkZ + 1);
++        ServerMapChunk serverMapChunk6 = (ServerMapChunk)WorldMap.GetMapChunk(chunkX - 1, chunkZ + 1);
++        ServerMapChunk serverMapChunk7 = (ServerMapChunk)WorldMap.GetMapChunk(chunkX - 1, chunkZ);
++        ServerMapChunk serverMapChunk8 = (ServerMapChunk)WorldMap.GetMapChunk(chunkX - 1, chunkZ - 1);
++        if (serverMapChunk != null)
++        {
++            serverMapChunk.NeighboursLoaded[4] = false;
++        }
++        if (serverMapChunk2 != null)
++        {
++            serverMapChunk2.NeighboursLoaded[5] = false;
++        }
++        if (serverMapChunk3 != null)
++        {
++            serverMapChunk3.NeighboursLoaded[6] = false;
++        }
++        if (serverMapChunk4 != null)
++        {
++            serverMapChunk4.NeighboursLoaded[7] = false;
++        }
++        if (serverMapChunk5 != null)
++        {
++            serverMapChunk5.NeighboursLoaded[0] = false;
++        }
++        if (serverMapChunk6 != null)
++        {
++            serverMapChunk6.NeighboursLoaded[1] = false;
++        }
++        if (serverMapChunk7 != null)
++        {
++            serverMapChunk7.NeighboursLoaded[2] = false;
++        }
++        if (serverMapChunk8 != null)
++        {
++            serverMapChunk8.NeighboursLoaded[3] = false;
++        }
++    }
++
++    private void runScheduledBlockUpdatesWithNeighbours(ChunkColumnLoadRequest chunkRequest)
++    {
++        for (int i = -1; i <= 1; i++)
++        {
++            for (int j = -1; j <= 1; j++)
++            {
++                bool flag = false;
++                if (server.loadedMapChunks.TryGetValue(server.WorldMap.MapChunkIndex2D(chunkRequest.chunkX + j, chunkRequest.chunkZ + i), out var value) && value.CurrentIncompletePass == EnumWorldGenPass.Done && value.ScheduledBlockUpdates.Count > 0 && areAllChunkNeighboursLoaded(value, chunkRequest.chunkX + j, chunkRequest.chunkZ + i))
++                {
++                    flag = true;
++                }
++                if (!flag)
++                {
++                    continue;
++                }
++                foreach (BlockPos scheduledBlockUpdate in value.ScheduledBlockUpdates)
++                {
++                    server.WorldMap.MarkBlockModified(scheduledBlockUpdate);
++                }
++                value.ScheduledBlockUpdates.Clear();
++            }
++        }
++    }
++
++    private bool areAllChunkNeighboursLoaded(ServerMapChunk mpc, int chunkX, int chunkZ)
++    {
++        int num = 0;
++        for (int i = -1; i <= 1; i++)
++        {
++            for (int j = -1; j <= 1; j++)
++            {
++                if ((j != 0 || i != 0) && server.loadedMapChunks.TryGetValue(server.WorldMap.MapChunkIndex2D(chunkX + j, chunkZ + i), out var value) && value.CurrentIncompletePass == EnumWorldGenPass.Done)
++                {
++                    num++;
++                }
++            }
++        }
++        return num == 8;
++    }
++
++    private ServerMapRegion GetOrCreateMapRegionEnsureNeighbours(int chunkX, int chunkZ, ITreeAttribute chunkGenParams, bool updateEarlierVersion)
++    {
++        ServerMapRegion orCreateMapRegion = GetOrCreateMapRegion(chunkX, chunkZ, chunkGenParams, updateEarlierVersion);
++        if (!orCreateMapRegion.NeighbourRegionsChecked)
++        {
++            int num = chunkX / MagicNum.ChunkRegionSizeInChunks;
++            int num2 = chunkZ / MagicNum.ChunkRegionSizeInChunks;
++            for (int i = -1; i <= 1; i++)
++            {
++                for (int j = -1; j <= 1; j++)
++                {
++                    if (num + i >= 0 && num2 + j >= 0 && (i != 0 || j != 0))
++                    {
++                        GetOrCreateMapRegion((num + i) * MagicNum.ChunkRegionSizeInChunks, (num2 + j) * MagicNum.ChunkRegionSizeInChunks, chunkGenParams, updateEarlierVersion: false);
++                    }
++                }
++            }
++            orCreateMapRegion.NeighbourRegionsChecked = true;
++            for (int k = 0; k < worldgenHandler.OnMapRegionNeighborsLoaded.Count; k++)
++            {
++                worldgenHandler.OnMapRegionNeighborsLoaded[k](orCreateMapRegion, num, num2, chunkGenParams);
++            }
++        }
++        return orCreateMapRegion;
++    }
++
++    public ServerMapRegion GetOrCreateMapRegionNoStore(int regionX, int regionZ, long mapRegionIndex2d, ITreeAttribute chunkGenParams, bool updateEarlierVersion)
++    {
++        server.loadedMapRegions.TryGetValue(mapRegionIndex2d, out var value);
++        if (value != null)
++        {
++            if (!updateEarlierVersion || value.worldgenVersion == 3)
++            {
++                return value;
++            }
++        }
++        else
++        {
++            value = TryLoadMapRegion(regionX, regionZ);
++        }
++        List<GeneratedStructure> list = null;
++        Dictionary<string, byte[]> dictionary = null;
++        Dictionary<string, IntDataMap2D> dictionary2 = null;
++        IntDataMap2D intDataMap2D = null;
++        IntDataMap2D[] array = null;
++        bool flag = true;
++        if (value != null)
++        {
++            if (value.worldgenVersion != 3 && updateEarlierVersion)
++            {
++                ServerMain.Logger.Worldgen("Updating existing mapregion with worldgenVersion " + value.worldgenVersion + " at " + regionX * MagicNum.ChunkRegionSizeInChunks + "," + regionZ * MagicNum.ChunkRegionSizeInChunks + " in world: " + server.WorldName);
++                list = value.GeneratedStructures;
++                dictionary = value.ModData;
++                dictionary2 = value.OreMaps;
++                intDataMap2D = value.GeologicProvinceMap;
++                array = value.RockStrata;
++            }
++            else
++            {
++                flag = false;
++                value.loadedTotalMs = server.ElapsedMilliseconds;
++            }
++        }
++        if (flag)
++        {
++            value = CreateMapRegion(regionX, regionZ, chunkGenParams);
++            value.loadedTotalMs = server.ElapsedMilliseconds;
++            if (list != null)
++            {
++                value.GeneratedStructures = list;
++            }
++            if (dictionary != null)
++            {
++                value.ModData = dictionary;
++            }
++            if (dictionary2 != null)
++            {
++                value.OreMaps = dictionary2;
++            }
++            if (intDataMap2D != null)
++            {
++                value.GeologicProvinceMap = intDataMap2D;
++            }
++            if (array != null)
++            {
++                value.RockStrata = array;
++            }
++        }
++        return value;
++    }
++
++    private ServerMapRegion GetOrCreateMapRegion(int chunkX, int chunkZ, ITreeAttribute chunkGenParams, bool updateEarlierVersion)
++    {
++        int regionX = chunkX / MagicNum.ChunkRegionSizeInChunks;
++        int regionZ = chunkZ / MagicNum.ChunkRegionSizeInChunks;
++        long num = server.WorldMap.MapRegionIndex2D(regionX, regionZ);
++        ServerMapRegion mapRegion = GetOrCreateMapRegionNoStore(regionX, regionZ, num, chunkGenParams, updateEarlierVersion);
++        server.loadedMapRegions[num] = mapRegion;
++        server.EnqueueMainThreadTask(delegate
++        {
++            server.api.eventapi.TriggerMapRegionLoaded(new Vec2i(regionX, regionZ), mapRegion);
++            ServerMain.FrameProfiler.Mark("trigger-mapregionloaded");
++        });
++        return mapRegion;
++    }
++
++    private ServerMapRegion CreateMapRegion(int regionX, int regionZ, ITreeAttribute chunkGenParams)
++    {
++        ServerMapRegion serverMapRegion = ServerMapRegion.CreateNew();
++        for (int i = 0; i < worldgenHandler.OnMapRegionGen.Count; i++)
++        {
++            worldgenHandler.OnMapRegionGen[i](serverMapRegion, regionX, regionZ, chunkGenParams);
++        }
++        return serverMapRegion;
++    }
++
++    private void TryRestoreGeneratedStructures(int regionX, int regionZ, ITreeAttribute chunkGenParams, IMapRegion mapRegion)
++    {
++        byte[] array = chunkGenParams?.GetBytes("GeneratedStructures");
++        if (array == null)
++        {
++            return;
++        }
++        Dictionary<long, List<GeneratedStructure>> dictionary = SerializerUtil.Deserialize<Dictionary<long, List<GeneratedStructure>>>(array);
++        long key = server.api.WorldManager.MapRegionIndex2D(regionX, regionZ);
++        if (!dictionary.TryGetValue(key, out var value) || value == null)
++        {
++            return;
++        }
++        // Stratum: original code used Where+Any = O(N*M) nested scan. As a region accumulates
++        // structures from many loaded chunks, mapRegion.GeneratedStructures grows and the inner
++        // Any() iterates the whole list for every candidate. HashSet reduces this to O(N+M).
++        HashSet<Vec3i> existingStarts = mapRegion.GeneratedStructures.Select(s => s.Location.Start).ToHashSet();
++        List<GeneratedStructure> generatedStructure = [.. value.Where(structure => !existingStarts.Contains(structure.Location.Start))];
++        mapRegion.AddGeneratedStructures(generatedStructure);
++    }
++
++    internal ServerMapChunk GetOrCreateMapChunk(ChunkColumnLoadRequest chunkRequest, bool forceCreate = false)
++    {
++        int chunkX = chunkRequest.chunkX;
++        int chunkZ = chunkRequest.chunkZ;
++        long key = server.WorldMap.MapChunkIndex2D(chunkX, chunkZ);
++        ServerMapRegion orCreateMapRegionEnsureNeighbours;
++        ServerMapChunk value;
++        if (!forceCreate)
++        {
++            server.loadedMapChunks.TryGetValue(key, out value);
++            if (value != null)
++            {
++                return value;
++            }
++            value = TryLoadMapChunk(chunkX, chunkZ);
++            if (value != null)
++            {
++                orCreateMapRegionEnsureNeighbours = GetOrCreateMapRegionEnsureNeighbours(chunkX, chunkZ, chunkRequest.chunkGenParams, updateEarlierVersion: false);
++                value.MapRegion = orCreateMapRegionEnsureNeighbours;
++                server.loadedMapChunks[key] = value;
++                return value;
++            }
++        }
++        bool updateEarlierVersion = GameVersion.IsLowerVersionThan(server.SaveGameData.CreatedGameVersion, "1.22.3");
++        orCreateMapRegionEnsureNeighbours = GetOrCreateMapRegionEnsureNeighbours(chunkX, chunkZ, chunkRequest.chunkGenParams, updateEarlierVersion);
++        value = CreateMapChunk(chunkX, chunkZ, orCreateMapRegionEnsureNeighbours);
++        server.loadedMapChunks[key] = value;
++        return value;
++    }
++
++    private ServerMapChunk PeekMapChunk(int chunkX, int chunkZ)
++    {
++        long key = server.WorldMap.MapChunkIndex2D(chunkX, chunkZ);
++        server.loadedMapChunks.TryGetValue(key, out var value);
++        if (value != null)
++        {
++            return value;
++        }
++        return TryLoadMapChunk(chunkX, chunkZ);
++    }
++
++    private ServerMapChunk CreateMapChunk(int chunkX, int chunkZ, ServerMapRegion mapRegion)
++    {
++        ServerMapChunk serverMapChunk = ServerMapChunk.CreateNew(mapRegion);
++        for (int i = 0; i < worldgenHandler.OnMapChunkGen.Count; i++)
++        {
++            worldgenHandler.OnMapChunkGen[i](serverMapChunk, chunkX, chunkZ);
++        }
++        return serverMapChunk;
++    }
++
++    private void GenerateNewChunkColumn(ServerMapChunk mapChunk, ChunkColumnLoadRequest chunkRequest)
++    {
++        int chunkMapSizeY = server.WorldMap.ChunkMapSizeY;
++        chunkRequest.Chunks = new ServerChunk[chunkMapSizeY];
++        for (int i = 0; i < chunkMapSizeY; i++)
++        {
++            ServerChunk serverChunk = ServerChunk.CreateNew(server.serverChunkDataPool);
++            serverChunk.serverMapChunk = mapChunk;
++            chunkRequest.Chunks[i] = serverChunk;
++        }
++        chunkRequest.MapChunk = mapChunk;
++        if (requiresChunkBorderSmoothing)
++        {
++            for (int j = 0; j < Cardinal.ALL.Length; j++)
++            {
++                Cardinal cardinal = Cardinal.ALL[j];
++                ServerMapChunk serverMapChunk = PeekMapChunk(chunkRequest.chunkX + cardinal.Normali.X, chunkRequest.chunkZ + cardinal.Normali.Z);
++                if (serverMapChunk != null && serverMapChunk.CurrentIncompletePass >= EnumWorldGenPass.Done && serverMapChunk.WorldGenVersion != 3)
++                {
++                    if (chunkRequest.NeighbourTerrainHeight == null)
++                    {
++                        chunkRequest.NeighbourTerrainHeight = new ushort[8][];
++                    }
++                    chunkRequest.NeighbourTerrainHeight[j] = serverMapChunk.WorldGenTerrainHeightMap;
++                }
++            }
++            chunkRequest.RequiresChunkBorderSmoothing = chunkRequest.NeighbourTerrainHeight != null;
++            if (mapChunk.CurrentIncompletePass < EnumWorldGenPass.NeighbourSunLightFlood && mapChunk.WorldGenVersion != 3)
++            {
++                mapChunk.WorldGenVersion = 3;
++            }
++        }
++        chunkRequest.CurrentIncompletePass = EnumWorldGenPass.Terrain;
++    }
++
++    internal ServerChunk[] TryLoadChunkColumn(ChunkColumnLoadRequest chunkRequest)
++    {
++        int chunkMapSizeY = server.WorldMap.ChunkMapSizeY;
++        ServerChunk[] array = new ServerChunk[chunkMapSizeY];
++        int num = 0;
++
++        StratumChunkReadPool pool = chunkthread.stratumReadPool;
++        StratumChunkIoConfig ioCfg = StratumRuntime.Config?.Performance?.ChunkIo;
++        bool useParallel = pool != null
++            && pool.IsOpen
++            && ioCfg != null
++            && ioCfg.Enabled
++            && chunkMapSizeY >= ioCfg.MinChunkYLevelsForParallel
++            && pool.WorkerCount >= 2;
++
++        if (useParallel)
++        {
++            byte[][] rawChunks = new byte[chunkMapSizeY][];
++            int maxDop = Math.Min(pool.WorkerCount, chunkMapSizeY);
++            int cx = chunkRequest.chunkX;
++            int cz = chunkRequest.chunkZ;
++            int dim = chunkRequest.dimension;
++            System.Threading.Tasks.Parallel.For(0, chunkMapSizeY,
++                new System.Threading.Tasks.ParallelOptions { MaxDegreeOfParallelism = maxDop },
++                i => {
++                    rawChunks[i] = pool.GetChunkBytes(Vintagestory.Common.Database.ChunkPos.ToChunkIndex(cx, i, cz, dim));
++                });
++            for (int i = 0; i < chunkMapSizeY; i++)
++            {
++                byte[] chunk = rawChunks[i];
++                if (chunk == null) continue;
++                try
++                {
++                    num++;
++                    array[i] = ServerChunk.FromBytes(chunk, server.serverChunkDataPool, server);
++                }
++                catch (Exception ex)
++                {
++                    if (server.Config.RegenerateCorruptChunks || server.Config.RepairMode)
++                    {
++                        array[i] = ServerChunk.CreateNew(server.serverChunkDataPool);
++                        ServerMain.Logger.Error("Failed deserializing a chunk (parallel path), we are in repair mode, so will initilize empty one. Exception: {0}", ex);
++                        continue;
++                    }
++                    ServerMain.Logger.Error("Failed deserializing a chunk (parallel path). Not in repair mode, will exit.");
++                    throw;
++                }
++            }
++        }
++        else
++        {
++            for (int i = 0; i < chunkMapSizeY; i++)
++            {
++                byte[] chunk = chunkthread.gameDatabase.GetChunk(chunkRequest.chunkX, i, chunkRequest.chunkZ, chunkRequest.dimension);
++                if (chunk == null)
++                {
++                    continue;
++                }
++                try
++                {
++                    num++;
++                    array[i] = ServerChunk.FromBytes(chunk, server.serverChunkDataPool, server);
++                }
++                catch (Exception ex)
++                {
++                    if (server.Config.RegenerateCorruptChunks || server.Config.RepairMode)
++                    {
++                        array[i] = ServerChunk.CreateNew(server.serverChunkDataPool);
++                        ServerMain.Logger.Error("Failed deserializing a chunk, we are in repair mode, so will initilize empty one. Exception: {0}", ex);
++                        continue;
++                    }
++                    ServerMain.Logger.Error("Failed deserializing a chunk. Not in repair mode, will exit.");
++                    throw;
++                }
++            }
++        }
++        if (requiresSetEmptyFlag)
++        {
++            foreach (ServerChunk serverChunk in array)
++            {
++                if (serverChunk != null)
++                {
++                    serverChunk.Unpack();
++                    serverChunk.MarkModified();
++                    serverChunk.TryPackAndCommit();
++                }
++            }
++        }
++        if (num != 0 && num != chunkMapSizeY)
++        {
++            ServerMain.Logger.Error("Loaded some but not all chunks of a column? Discarding whole column.");
++            return null;
++        }
++        if (num != chunkMapSizeY)
++        {
++            return null;
++        }
++        return array;
++    }
++
++    private ServerMapChunk TryLoadMapChunk(int chunkX, int chunkZ)
++    {
++        byte[] mapChunk = chunkthread.gameDatabase.GetMapChunk(chunkX, chunkZ);
++        if (mapChunk != null)
++        {
++            try
++            {
++                ServerMapChunk serverMapChunk = ServerMapChunk.FromBytes(mapChunk);
++                if (GameVersion.IsLowerVersionThan(server.SaveGameData.CreatedGameVersion, "1.7"))
++                {
++                    serverMapChunk.YMax = (ushort)(server.SaveGameData.MapSizeY - 1);
++                }
++                return serverMapChunk;
++            }
++            catch (Exception ex)
++            {
++                if (chunkX == 0 && chunkZ == 0)
++                {
++                    return null;
++                }
++                if (!server.Config.RegenerateCorruptChunks && !server.Config.RepairMode)
++                {
++                    ServerMain.Logger.Error("Failed deserializing a map chunk. Not in repair mode, will exit.");
++                    throw;
++                }
++                ServerMain.Logger.Error("Failed deserializing a map chunk, we are in repair mode, so will initialize empty one. Exception: {0}", ex);
++                return null;
++            }
++        }
++        return null;
++    }
++
++    private ServerMapRegion TryLoadMapRegion(int regionX, int regionZ)
++    {
++        byte[] mapRegion = chunkthread.gameDatabase.GetMapRegion(regionX, regionZ);
++        try
++        {
++            if (mapRegion != null)
++            {
++                return ServerMapRegion.FromBytes(mapRegion);
++            }
++        }
++        catch (Exception e)
++        {
++            if (server.Config.RepairMode)
++            {
++                ServerMain.Logger.Error("Failed deserializing a map region, we are in repair mode, so will initialize empty one.");
++                ServerMain.Logger.Error(e);
++                return null;
++            }
++            ServerMain.Logger.Error("Failed deserializing a map region. Not in repair mode, will exit.");
++            throw;
++        }
++        return null;
++    }
++
++    public void InitWorldgenAndSpawnChunks()
++    {
++        worldgenHandler = (WorldGenHandler)server.api.Event.TriggerInitWorldGen();
++        ServerMain.Logger.Event("Loading {0}x{1}x{2} spawn chunks...", MagicNum.SpawnChunksWidth, MagicNum.SpawnChunksWidth, server.WorldMap.ChunkMapSizeY);
++        if (storyChunkSpawnEvents == null)
++        {
++            storyChunkSpawnEvents = new string[15]
++            {
++                Lang.Get("...the carved mountains"),
++                Lang.Get("...the rolling hills"),
++                Lang.Get("...the vertical cliffs"),
++                Lang.Get("...the endless plains"),
++                Lang.Get("...the winter lands"),
++                Lang.Get("...and scorching deserts"),
++                Lang.Get("...spring waters"),
++                Lang.Get("...tunnels deep below"),
++                Lang.Get("...the luscious trees"),
++                Lang.Get("...the fragrant flowers"),
++                Lang.Get("...the roaming creatures"),
++                Lang.Get("with their offspring..."),
++                Lang.Get("...a misty sunrise"),
++                Lang.Get("...dew drops on a blade of grass"),
++                Lang.Get("...a soft breeze")
++            };
++        }
++        BlockPos blockPos = new BlockPos(server.WorldMap.MapSizeX / 2, 0, server.WorldMap.MapSizeZ / 2, 0);
++        if (GameVersion.IsLowerVersionThan(server.SaveGameData.CreatedGameVersion, "1.20.0-pre.14"))
++        {
++            int num = 0;
++            int num2 = 0;
++            bool flag = false;
++            Random random = new Random(server.Seed);
++            int num3 = 5;
++            int num4 = 20;
++            for (int i = 0; i < num3; i++)
++            {
++                if (i > 0)
++                {
++                    double num5 = (double)GameMath.Sqrt((double)i * (1.0 / (double)num3)) * (double)num4;
++                    double num6 = (1.0 - Math.Abs(random.NextDouble() - random.NextDouble())) * num5;
++                    double value = random.NextDouble() * 6.2831854820251465;
++                    double num7 = num6 * GameMath.Sin(value);
++                    double num8 = num6 * GameMath.Cos(value);
++                    num = (int)num7;
++                    num2 = (int)num8;
++                    blockPos = new BlockPos(num * 32 + server.WorldMap.MapSizeX / 2, 0, num2 * 32 + server.WorldMap.MapSizeZ / 2, 0);
++                }
++                loadChunkAreaBlocking(num + server.WorldMap.ChunkMapSizeX / 2 - MagicNum.SpawnChunksWidth / 2, num2 + server.WorldMap.ChunkMapSizeZ / 2 - MagicNum.SpawnChunksWidth / 2, num + server.WorldMap.ChunkMapSizeX / 2 + MagicNum.SpawnChunksWidth / 2, num2 + server.WorldMap.ChunkMapSizeZ / 2 + MagicNum.SpawnChunksWidth / 2, isStartupLoad: true);
++                server.ProcessMainThreadTasks();
++                if (AdjustForSaveSpawnSpot(server, blockPos, null, random))
++                {
++                    flag = true;
++                    break;
++                }
++                if (i + 1 < num3)
++                {
++                    server.api.Logger.Notification("Trying another spawn location ({0}/{1})...", i + 2, num3);
++                }
++            }
++            if (!flag)
++            {
++                blockPos = new BlockPos(server.WorldMap.MapSizeX / 2, 0, server.WorldMap.MapSizeZ / 2, 0);
++                blockPos.Y = server.blockAccessor.GetRainMapHeightAt(blockPos);
++                if (!server.blockAccessor.GetBlock(blockPos).SideSolid[BlockFacing.UP.Index])
++                {
++                    server.blockAccessor.SetBlock(server.blockAccessor.GetBlock(new AssetLocation("planks-oak-we")).Id, blockPos);
++                }
++                blockPos.Y++;
++            }
++        }
++        else
++        {
++            loadChunkAreaBlocking(server.WorldMap.ChunkMapSizeX / 2 - MagicNum.SpawnChunksWidth / 2, server.WorldMap.ChunkMapSizeZ / 2 - MagicNum.SpawnChunksWidth / 2, server.WorldMap.ChunkMapSizeX / 2 + MagicNum.SpawnChunksWidth / 2, server.WorldMap.ChunkMapSizeZ / 2 + MagicNum.SpawnChunksWidth / 2, isStartupLoad: true);
++            server.ProcessMainThreadTasks();
++        }
++        server.mapMiddleSpawnPos = new PlayerSpawnPos
++        {
++            x = blockPos.X,
++            y = blockPos.Y,
++            z = blockPos.Z
++        };
++        if (blockPos.Y < 0)
++        {
++            server.mapMiddleSpawnPos.y = null;
++        }
++        server.api.Logger.VerboseDebug("Done spawn chunk");
++    }
++
++    public static bool AdjustForSaveSpawnSpot(ServerMain server, BlockPos pos, IServerPlayer forPlayer, Random rand)
++    {
++        int num = 60;
++        int num2 = 0;
++        int num3 = 0;
++        int num4 = 0;
++        int num5 = 0;
++        int num6 = 0;
++        while (num-- > 0)
++        {
++            num4 = GameMath.Clamp(num2 + pos.X, 0, server.WorldMap.MapSizeX - 1);
++            num6 = GameMath.Clamp(num3 + pos.Z, 0, server.WorldMap.MapSizeZ - 1);
++            num5 = server.WorldMap.GetTerrainGenSurfacePosY(num4, num6);
++            pos.Set(num4, num5, num6);
++            num2 = rand.Next(64) - 32;
++            num3 = rand.Next(64) - 32;
++            if (num5 != 0 && !((double)num5 > 0.75 * (double)server.WorldMap.MapSizeY))
++            {
++                if (server.WorldMap.GetBlockingLandClaimant(forPlayer, pos, EnumBlockAccessFlags.Use) != null)
++                {
++                    server.api.Logger.Notification("Spawn pos blocked at " + pos);
++                }
++                else if (!server.BlockAccessor.GetBlockRaw(num4, num5 + 1, num6, 2).IsLiquid() && !server.BlockAccessor.GetBlockRaw(num4, num5, num6, 2).IsLiquid() && !server.BlockAccessor.IsSideSolid(num4, num5 + 1, num6, BlockFacing.UP))
++                {
++                    return true;
++                }
++            }
++        }
++        return false;
++    }
++
++    private void PeekChunkAreaLocking(Vec2i coords, EnumWorldGenPass untilPass, OnChunkPeekedDelegate onGenerated, ITreeAttribute chunkGenParams)
++    {
++        chunkthread.peekMode = true;
++        int x = coords.X;
++        int y = coords.Y;
++        Dictionary<long, ServerMapRegion> dictionary = new Dictionary<long, ServerMapRegion>();
++        int i = 1;
++        int num = Math.Min((int)untilPass, (int)EnumWorldGenPass.PreDone); // Stratum:  Getting rid of the magic number
++        int num2 = num - i;
++        ChunkColumnLoadRequest[,] array = new ChunkColumnLoadRequest[num2 * 2 + 1, num2 * 2 + 1];
++        for (int j = -num2; j <= num2; j++)
++        {
++            for (int k = -num2; k <= num2; k++)
++            {
++                if (server.WorldMap.IsValidChunkPos(x + j, 0, y + k))
++                {
++                    long index2d = server.WorldMap.MapChunkIndex2D(x + j, y + k);
++                    int regionX = (x + j) / MagicNum.ChunkRegionSizeInChunks;
++                    int regionZ = (y + k) / MagicNum.ChunkRegionSizeInChunks;
++                    long num3 = server.WorldMap.MapRegionIndex2D(regionX, regionZ);
++                    if (!dictionary.TryGetValue(num3, out var value))
++                    {
++                        bool updateEarlierVersion = GameVersion.IsLowerVersionThan(server.SaveGameData.CreatedGameVersion, "1.22.3");
++                        value = (dictionary[num3] = GetOrCreateMapRegionNoStore(regionX, regionZ, num3, chunkGenParams, updateEarlierVersion));
++                        chunkthread.peekingMapRegions.TryAdd(num3, value);
++                    }
++                    ServerMapChunk mapChunk = CreateMapChunk(x, y, value);
++                    ChunkColumnLoadRequest chunkColumnLoadRequest = new ChunkColumnLoadRequest(index2d, x + j, y + k, 0, (int)untilPass, server)
++                    {
++                        chunkGenParams = ((j == 0 && k == 0) ? chunkGenParams : null)
++                    };
++                    chunkColumnLoadRequest.MapChunk = mapChunk;
++                    GenerateNewChunkColumn(mapChunk, chunkColumnLoadRequest);
++                    chunkColumnLoadRequest.Unpack();
++                    array[j + num2, k + num2] = chunkColumnLoadRequest;
++                    lock (chunkthread.peekingChunkColumns)
++                    {
++                        chunkthread.peekingChunkColumns.Enqueue(chunkColumnLoadRequest);
++                    }
++                }
++            }
++        }
++        int num4 = num - i;
++        for (; i <= num; i++)
++        {
++            num4 = num - i;
++            for (int l = -num4; l <= num4; l++)
++            {
++                for (int m = -num4; m <= num4; m++)
++                {
++                    if (server.WorldMap.IsValidChunkPos(l + x, 0, m + y))
++                    {
++                        ChunkColumnLoadRequest chunkRequest = array[l + num2, m + num2];
++                        runGenerators(chunkRequest, i);
++                    }
++                }
++            }
++        }
++        Dictionary<Vec2i, IServerChunk[]> columnsByChunkCoordinate = new Dictionary<Vec2i, IServerChunk[]>();
++        lock (chunkthread.peekingChunkColumns)
++        {
++            for (int n = -num2; n <= num2; n++)
++            {
++                for (int num5 = -num2; num5 <= num2; num5++)
++                {
++                    long index = server.WorldMap.MapChunkIndex2D(x + n, y + num5);
++                    chunkthread.peekingChunkColumns.Remove(index);
++                    if (server.WorldMap.IsValidChunkPos(n + x, 0, num5 + y))
++                    {
++                        ChunkColumnLoadRequest chunkColumnLoadRequest2 = array[n + num2, num5 + num2];
++                        Dictionary<Vec2i, IServerChunk[]> dictionary2 = columnsByChunkCoordinate;
++                        Vec2i key = new Vec2i(x + n, y + num5);
++                        IServerChunk[] chunks = chunkColumnLoadRequest2.Chunks;
++                        dictionary2[key] = chunks;
++                    }
++                }
++            }
++        }
++        foreach (var (key2, _) in dictionary)
++        {
++            chunkthread.peekingMapRegions.Remove(key2);
++        }
++        chunkthread.peekMode = false;
++        server.EnqueueMainThreadTask(delegate
++        {
++            onGenerated(columnsByChunkCoordinate);
++            ServerMain.FrameProfiler.Mark("MTT-PeekChunk");
++        });
++    }
++
++    private void loadChunkAreaBlocking(int chunkX1, int chunkZ1, int chunkX2, int chunkZ2, bool isStartupLoad = false, ITreeAttribute chunkGenParams = null)
++    {
++        ResumeAllWorldgenThreads();
++        int num = server.loadedChunks.Count / server.WorldMap.ChunkMapSizeY;
++        int num2 = (chunkX2 - chunkX1 + 1) * (chunkZ2 - chunkZ1 + 1);
++        CleanupRequestsQueue();
++        moveRequestsToGeneratingQueue();
++        blockingRequestsRemaining = 0;
++        foreach (ChunkColumnLoadRequest requestedChunkColumn in chunkthread.requestedChunkColumns)
++        {
++            requestedChunkColumn.blockingRequest = false;
++        }
++        for (int i = chunkX1; i <= chunkX2; i++)
++        {
++            for (int j = chunkZ1; j <= chunkZ2; j++)
++            {
++                if (server.WorldMap.IsValidChunkPos(i, 0, j) && !server.IsChunkColumnFullyLoaded(i, j))
++                {
++                    ChunkColumnLoadRequest chunkColumnLoadRequest = new ChunkColumnLoadRequest(server.WorldMap.MapChunkIndex2D(i, j), i, j, server.serverConsoleId, (int)EnumWorldGenPass.Done, server) // Stratum:  Getting rid of the magic number
++                    {
++                        chunkGenParams = chunkGenParams
++                    };
++                    chunkColumnLoadRequest.blockingRequest = true;
++                    if (chunkthread.addChunkColumnRequest(chunkColumnLoadRequest))
++                    {
++                        blockingRequestsRemaining++;
++                    }
++                }
++            }
++        }
++        long num3 = Environment.TickCount + 12000;
++        ServerMain.Logger.VerboseDebug("Starting area loading/generation: columns " + blockingRequestsRemaining + ", total queue length " + chunkthread.requestedChunkColumns.Count);
++        while (!server.stopped && server.exitState.Mode == EnumExitMode.None)
++        {
++            CleanupRequestsQueue();
++            if (blockingRequestsRemaining <= 0 || chunkthread.requestedChunkColumns.Count == 0)
++            {
++                break;
++            }
++            if (isStartupLoad && server.totalUnpausedTime.ElapsedMilliseconds - millisecondsSinceStart > 1500)
++            {
++                millisecondsSinceStart = server.totalUnpausedTime.ElapsedMilliseconds;
++                float num4 = 100f * ((float)server.loadedChunks.Count / (float)server.WorldMap.ChunkMapSizeY - (float)num) / (float)num2;
++                ServerMain.Logger.Event(num4.ToString("0.#") + "% ({0} in queue)", chunkthread.requestedChunkColumns.Count);
++                if (storyEventPrints < storyChunkSpawnEvents.Length)
++                {
++                    ServerMain.Logger.StoryEvent(storyChunkSpawnEvents[storyEventPrints]);
++                }
++                else
++                {
++                    ServerMain.Logger.StoryEvent("...");
++                }
++                storyEventPrints++;
++            }
++            bool flag = false;
++            foreach (ChunkColumnLoadRequest requestedChunkColumn2 in chunkthread.requestedChunkColumns)
++            {
++                if (requestedChunkColumn2 == null || requestedChunkColumn2.Disposed)
++                {
++                    continue;
++                }
++                int currentIncompletePass_AsInt = requestedChunkColumn2.CurrentIncompletePass_AsInt;
++                // Stratum: Force generation handles stage 0 (loading) and the Done stage
++                if (currentIncompletePass_AsInt == (int)EnumWorldGenPass.None || currentIncompletePass_AsInt >= (int)EnumWorldGenPass.Done)
++                {
++                    if (server.exitState.Mode == EnumExitMode.HardExit || server.stopped)
++                    {
++                        return;
++                    }
++                    flag |= loadOrGenerateChunkColumn_OnChunkThread(requestedChunkColumn2, currentIncompletePass_AsInt);
++                }
++            }
++            if (flag)
++            {
++                num3 = Environment.TickCount + 12000;
++            }
++            else
++            {
++                if (Environment.TickCount <= num3)
++                {
++                    continue;
++                }
++                ServerMain.Logger.Error("Attempting to force generate chunk columns from " + chunkX1 + "," + chunkZ1 + " to " + chunkX2 + "," + chunkZ2);
++                ServerMain.Logger.Error(chunkthread.additionalWorldGenThreadsCount + " additional worldgen threads active, number of 'undone' chunks is " + blockingRequestsRemaining);
++                foreach (ChunkColumnLoadRequest requestedChunkColumn3 in chunkthread.requestedChunkColumns)
++                {
++                    if (requestedChunkColumn3 != null)
++                    {
++                        string text = ((requestedChunkColumn3.chunkX >= chunkX1 && requestedChunkColumn3.chunkX <= chunkX2 && requestedChunkColumn3.chunkZ >= chunkZ1 && requestedChunkColumn3.chunkZ <= chunkZ2) ? " (in original req)" : "");
++                        ServerMain.Logger.Error("Column " + requestedChunkColumn3.ChunkX + "," + requestedChunkColumn3.ChunkZ + " has reached pass " + requestedChunkColumn3.CurrentIncompletePass_AsInt + text);
++                    }
++                }
++                throw new Exception("Somehow worldgen has become stuck in an endless loop, please report this as a bug!  Additional data in the server-main log");
++            }
++        }
++    }
++
++    private void PopulateChunk(ChunkColumnLoadRequest chunkRequest)
++    {
++        chunkRequest.Unpack();
++        chunkRequest.generatingLock.AcquireWriteLock();
++        try
++        {
++            if (server.Config.SkipEveryChunkRow > 0 && chunkRequest.chunkX % (server.Config.SkipEveryChunkRow + server.Config.SkipEveryChunkRowWidth) < server.Config.SkipEveryChunkRowWidth)
++            {
++                if (chunkRequest.CurrentIncompletePass == EnumWorldGenPass.Terrain)
++                {
++                    ushort sunLight = (ushort)server.sunBrightness;
++                    for (int i = 0; i < chunkRequest.Chunks.Length; i++)
++                    {
++                        chunkRequest.Chunks[i].Lighting.ClearWithSunlight(sunLight);
++                    }
++                }
++            }
++            else
++            {
++                // Stratum: Protection against generating a stage Done or higher
++                if (chunkRequest.MapChunk.currentpass < (int)EnumWorldGenPass.Done)
++                {
++                    runGenerators(chunkRequest, chunkRequest.MapChunk.currentpass);
++                }
++            }
++            if (chunkRequest.CurrentIncompletePass == EnumWorldGenPass.Terrain)
++            {
++                chunkRequest.MapChunk.WorldGenVersion = 3;
++            }
++            for (int j = 0; j < chunkRequest.Chunks.Length; j++)
++            {
++                chunkRequest.Chunks[j].MarkModified();
++            }
++            chunkRequest.MapChunk.currentpass++;
++            chunkRequest.MapChunk.DirtyForSaving = true;
++        }
++        finally
++        {
++            chunkRequest.generatingLock.ReleaseWriteLock();
++        }
++    }
++
++    private void runGenerators(ChunkColumnLoadRequest chunkRequest, int forPass)
++    {
++        List<ChunkColumnGenerationDelegate> list = worldgenHandler.OnChunkColumnGen[forPass];
++        if (list == null)
++        {
++            return;
++        }
++        for (int i = 0; i < list.Count; i++)
++        {
++            try
++            {
++                list[i](chunkRequest);
++            }
++            catch (Exception ex)
++            {
++                ServerMain.Logger.Worldgen("An error was thrown in pass {5} when generating chunk column X={0},Z={1} in world '{3}' with seed {4}\nException {2}\n\n", chunkRequest.chunkX, chunkRequest.chunkZ, ex, server.SaveGameData.WorldName, server.SaveGameData.Seed, chunkRequest.CurrentIncompletePass.ToString());
++                if (chunkRequest.CurrentIncompletePass <= EnumWorldGenPass.Terrain)
++                {
++                    break;
++                }
++            }
++        }
++    }
++
++    private bool ensurePrettyNeighbourhood(ChunkColumnLoadRequest chunkRequest)
++    {
++        if (chunkRequest.CurrentIncompletePass <= EnumWorldGenPass.Terrain2) // Stratum:  Getting rid of the magic number
++        {
++            return true;
++        }
++        bool result = true;
++        int currentIncompletePass_AsInt = chunkRequest.CurrentIncompletePass_AsInt;
++        int num = Math.Max(chunkRequest.chunkX - 1, 0);
++        int num2 = Math.Min(chunkRequest.chunkX + 1, server.WorldMap.ChunkMapSizeX - 1);
++        int num3 = Math.Max(chunkRequest.chunkZ - 1, 0);
++        int num4 = Math.Min(chunkRequest.chunkZ + 1, server.WorldMap.ChunkMapSizeZ - 1);
++        if (!chunkRequest.prettified && !EnsureQueueSpace(chunkRequest))
++        {
++            return false;
++        }
++        for (int i = num; i <= num2; i++)
++        {
++            for (int j = num3; j <= num4; j++)
++            {
++                if (i == chunkRequest.chunkX && j == chunkRequest.chunkZ)
++                {
++                    continue;
++                }
++                long index2d = server.WorldMap.MapChunkIndex2D(i, j);
++                if (!chunkthread.EnsureMinimumWorldgenPassAt(index2d, i, j, currentIncompletePass_AsInt, chunkRequest.creationTime))
++                {
++                    if (chunkRequest.prettified)
++                    {
++                        return false;
++                    }
++                    result = false;
++                }
++            }
++        }
++        chunkRequest.prettified = true;
++        return result;
++    }
++
++    private EnumWorldGenPass getLoadedOrQueuedChunkPass(long index2d)
++    {
++        server.loadedMapChunks.TryGetValue(index2d, out var value);
++        if (value == null || value.CurrentIncompletePass != EnumWorldGenPass.Done)
++        {
++            return chunkthread.requestedChunkColumns.GetByIndex(index2d)?.CurrentIncompletePass ?? EnumWorldGenPass.None;
++        }
++        return EnumWorldGenPass.Done;
++    }
++
++    private bool EnsureQueueSpace(ChunkColumnLoadRequest curRequest)
++    {
++        int num = chunkthread.requestedChunkColumns.Count + 30 - chunkthread.requestedChunkColumns.Capacity;
++        if (num <= 0)
++        {
++            return true;
++        }
++        if (!PauseAllWorldgenThreads(5000))
++        {
++            return false;
++        }
++        try
++        {
++            ServerMain.Logger.Warning("Requested chunks buffer is too small! Taking measures to attempt to free enough space. Try increasing servermagicnumbers RequestChunkColumnsQueueSize?");
++            ((ServerSystemUnloadChunks)chunkthread.serversystems[2]).UnloadGeneratingChunkColumns(MagicNum.UncompressedChunkTTL / 10);
++            foreach (ChunkColumnLoadRequest item in chunkthread.requestedChunkColumns.Snapshot())
++            {
++                item.FlagToRequeue();
++            }
++            num -= CleanupRequestsQueue();
++            if (num <= 0)
++            {
++                return true;
++            }
++            ServerMain.Logger.Error("Requested chunks buffer is too small! Can't free enough space to completely generate chunks, clearing whole buffer. This may cause issues. Try increasing servermagicnumbers RequestChunkColumnsQueueSize and/or reducing UncompressedChunkTTL.");
++            FullyClearGeneratingQueue();
++            chunkthread.requestedChunkColumns.Enqueue(curRequest);
++            return true;
++        }
++        finally
++        {
++            ResumeAllWorldgenThreads();
++            if (chunkthread.additionalWorldGenThreadsCount > 0)
++            {
++                ServerMain.Logger.VerboseDebug("Un-pausing all worldgen threads.");
++            }
++        }
++    }
++
++    internal void FullyClearGeneratingQueue()
++    {
++        chunkthread.loadsavegame.SaveAllDirtyGeneratingChunks(saveChunksStream ?? (saveChunksStream = new FastMemoryStream()));
++        foreach (ChunkColumnLoadRequest requestedChunkColumn in chunkthread.requestedChunkColumns)
++        {
++            if (requestedChunkColumn != null && !requestedChunkColumn.Disposed)
++            {
++                server.loadedMapChunks.Remove(requestedChunkColumn.mapIndex2d);
++                server.ChunkColumnRequested.Remove(requestedChunkColumn.mapIndex2d);
++            }
++        }
++        chunkthread.requestedChunkColumns.Clear();
++        ServerMain.Logger.VerboseDebug("Incomplete chunks stored and wiped.");
++    }
++
++    // Stratum start: 
++    // Instead of threads executing only their own stage, threads can now execute any free task
++    private Thread CreateAdditionalWorldGenThread(int threadnum)
++    {
++        
++        Thread thread = TyronThreadPool.CreateDedicatedThread(GeneratorThreadLoop, "worldgen" + threadnum);
++        thread.Start();
++        return thread;
++    }
++
++    public void GeneratorThreadLoop()
++    {
++        Thread.Sleep(5);
++        while (!server.stopped)
++        {
++            bool didWork = false;
++            if (chunkthread.requestedChunkColumns.Count > 0 && (!server.Suspended || server.RunPhase == EnumServerRunPhase.WorldReady))
++            {
++                try
++                {
++                    // Scan the entire queue and take any available task
++                    // taking into account stage capture via stratumStageBusy
++                    int generated = GenerateChunkColumns_OnSeparateThread();
++
++                    if (generated > 0)
++                    {
++                        // We continue working while there are tasks
++                        while (GenerateChunkColumns_OnSeparateThread() != 0)
++                        {
++                            didWork = true;
++                            if (server.stopped)
++                                break;
++                            if (pauseAllWorldgenThreads > 0)
++                            {
++                                PauseWorldgenThreadIfRequired(onChunkthread: false);
++                            }
++                        }
++                    }
++                }
++                catch (Exception e)
++                {
++                    ServerMain.Logger.Error(e);
++                }
++            }
++            PauseWorldgenThreadIfRequired(onChunkthread: false);
++            if (!didWork) Thread.Sleep(1);
++        }
++        BlockAccessorWorldGen.ThreadDispose();
++    }
++    // Stratum end
++
++    public override void OnSeperateThreadShutDown()
++    {
++        BlockAccessorWorldGen.ThreadDispose();
++    }
++
++    public override void Dispose()
++    {
++        BlockAccessorWorldGen.ThreadDispose();
++    }
++
++    public bool PauseAllWorldgenThreads(int timeoutms)
++    {
++        if (Interlocked.CompareExchange(ref pauseAllWorldgenThreads, 1, 0) != 0)
++        {
++            return false;
++        }
++        if (chunkthread.additionalWorldGenThreadsCount > 0)
++        {
++            ServerMain.Logger.VerboseDebug("Pausing all worldgen threads.");
++        }
++        long num = Environment.TickCount + timeoutms;
++        while (pauseAllWorldgenThreads < chunkthread.additionalWorldGenThreadsCount + 1 && !server.stopped)
++        {
++            if (Environment.TickCount > num)
++            {
++                ServerMain.Logger.VerboseDebug("Pausing all worldgen threads - exceeded timeout!");
++                return false;
++            }
++            Thread.Sleep(1);
++        }
++        return true;
++    }
++
++    public void ResumeAllWorldgenThreads()
++    {
++        pauseAllWorldgenThreads = 0;
++    }
++
++    public void PauseWorldgenThreadIfRequired(bool onChunkthread)
++    {
++        if (pauseAllWorldgenThreads <= 0)
++        {
++            return;
++        }
++        Interlocked.Increment(ref pauseAllWorldgenThreads);
++        long num = Environment.TickCount + 5000;
++        while (pauseAllWorldgenThreads != 0 && !server.stopped)
++        {
++            if (Environment.TickCount > num)
++            {
++                ServerMain.Logger.VerboseDebug("Pausing all worldgen threads - exceeded 5s timeout!");
++                break;
++            }
++            Thread.Sleep(15);
++        }
++    }
+ }

--- a/patches/VintagestoryLib/Vintagestory.Server/WorldGenHandler.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/WorldGenHandler.cs.patch
@@ -1,0 +1,48 @@
+diff --git a/VintagestoryLib/Vintagestory.Server/WorldGenHandler.cs b/VintagestoryLib/Vintagestory.Server/WorldGenHandler.cs
+index 20f5814..f0ad9e1 100644
+--- a/VintagestoryLib/Vintagestory.Server/WorldGenHandler.cs
++++ b/VintagestoryLib/Vintagestory.Server/WorldGenHandler.cs
+@@ -13,30 +13,33 @@ public class WorldGenHandler : IWorldGenHandler
+ 
+ 	public List<MapRegionGeneratorDelegate> OnMapRegionNeighborsLoaded = new List<MapRegionGeneratorDelegate>();
+ 
+ 	public List<MapChunkGeneratorDelegate> OnMapChunkGen = new List<MapChunkGeneratorDelegate>();
+ 
+-	public List<ChunkColumnGenerationDelegate>[] OnChunkColumnGen = new List<ChunkColumnGenerationDelegate>[6];
++	public List<ChunkColumnGenerationDelegate>[] OnChunkColumnGen = new List<ChunkColumnGenerationDelegate>[(int)EnumWorldGenPass.Done]; // Stratum:  Getting rid of the magic number
+ 
+-	public Dictionary<string, WorldGenHookDelegate> SpecialHooks = new Dictionary<string, WorldGenHookDelegate>();
++    public Dictionary<string, WorldGenHookDelegate> SpecialHooks = new Dictionary<string, WorldGenHookDelegate>();
+ 
+ 	List<MapRegionGeneratorDelegate> IWorldGenHandler.OnMapRegionGen => OnMapRegionGen;
+ 
+ 	List<MapChunkGeneratorDelegate> IWorldGenHandler.OnMapChunkGen => OnMapChunkGen;
+ 
+ 	List<ChunkColumnGenerationDelegate>[] IWorldGenHandler.OnChunkColumnGen => OnChunkColumnGen;
+ 
+ 	public WorldGenHandler()
+ 	{
+-		OnChunkColumnGen[1] = new List<ChunkColumnGenerationDelegate>();
+-		OnChunkColumnGen[2] = new List<ChunkColumnGenerationDelegate>();
+-		OnChunkColumnGen[3] = new List<ChunkColumnGenerationDelegate>();
+-		OnChunkColumnGen[4] = new List<ChunkColumnGenerationDelegate>();
+-		OnChunkColumnGen[5] = new List<ChunkColumnGenerationDelegate>();
+-	}
+-
+-	public void WipeAllHandlers()
++        // Stratum start: Initialize the generator lists for all work stages
++        // regardless of how many there may be
++        // (Terrain..PreDone), excluding None (0) and Done
++        for (int pass = (int)EnumWorldGenPass.None+1; pass < (int)EnumWorldGenPass.Done; pass++)
++        {
++            OnChunkColumnGen[pass] = new List<ChunkColumnGenerationDelegate>();
++        }
++        // Stratum end
++    }
++
++    public void WipeAllHandlers()
+ 	{
+ 		OnMapRegionGen.Clear();
+ 		OnMapChunkGen.Clear();
+ 		for (int i = 0; i < OnChunkColumnGen.Length; i++)
+ 		{


### PR DESCRIPTION
## Summary

The following changes have been made to chunk generation:
- The Terrain stage has been split into two stages of equal load. This will allow for a more even distribution of the load across the threads.
- All generation stages are processed exclusively on separate threads, regardless of their number.
- Generation threads can now work on any available tasks. However, the restriction that the same stage cannot be executed simultaneously by different threads is strictly enforced. The stratumStageBusy array is responsible for this.

What do these changes mean? All specified generation threads are fully utilized in generation as much as possible, regardless of the generation modes installed or the time each stage takes.

## Type

- [ ] Bug fix
- [x] Performance
- [ ] New feature
- [ ] Refactor or cleanup
- [ ] Docs or build

## Checklist

- [x] `.\scripts\extract-patches.ps1` ran clean.
- [x] `dotnet build VintageStory.slnx -c Release` is green.
- [x] Every vanilla edit has a `// Stratum` marker.
- [x] No vanilla source committed.
- [x] Tested on a real server start, not just compilation.

## Performance numbers

Tested on 10200 chunk columns:
/stratum pregen start radius 50 16000 16000

The same empty world was used each time.

My pregeneration settings:
MaxColumnsPerSecond: 1024
 "UncompressedChunkTTL": 1500,
 "CompressedChunkTTL": 4500,
    "MaxPendingColumnQueue": 1024,
    "MaxWorkerColumnQueue": 2048,
"RequestChunkColumnsQueueSize": 9000,

**Vanilla**
"MaxWorldgenThreads": 2,
Time: 137 s.
<img width="1615" height="532" alt="image" src="https://github.com/user-attachments/assets/2877d7b5-13f4-4475-8b9f-a6f606a47a22" />

"MaxWorldgenThreads": 6,
Time: 96.7 s.
<img width="1611" height="678" alt="image" src="https://github.com/user-attachments/assets/ef68b60a-2134-4f0f-9891-7e42d655ef28" />


**After**
"MaxWorldgenThreads": 2,
Time: 81.5 s.
<img width="974" height="302" alt="image" src="https://github.com/user-attachments/assets/9965f130-c68b-4bfd-8f01-cc7f39ba3741" />

"MaxWorldgenThreads": 6,
Time: 62.7 s.
<img width="974" height="436" alt="image" src="https://github.com/user-attachments/assets/38812cb6-aae6-4c60-83ac-522146a7be61" />

