### PR TITLE
Log mod-owned Harmony patches at startup

### DIFF
--- a/sources/VintagestoryLib/Vintagestory.Server/ServerSystemStratum.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/ServerSystemStratum.cs
@@ -104,6 +104,7 @@ internal class ServerSystemStratum : ServerSystem
 		StratumMetricsPublisher.Start();
 		StratumUpdateChecker.CheckOnStartup();
 		StratumServerStats.Start(server);
+		StratumHarmonyVisibility.LogPatchedMethods(server);
 		if (StratumRuntime.Config.Backup.Enabled)
 		{
 			new StratumBackupScheduler(server);

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumConfig.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumConfig.cs
@@ -431,6 +431,11 @@ internal class StratumDiagnosticsConfig
 	public bool RunStartupPreflight { get; set; } = true;
 
 	public bool LogPreflightWarnings { get; set; } = true;
+
+	// Logs every mod-owned Harmony patch at startup (grouped by mod, split by prefix/postfix/
+	// transpiler/finalizer). Visibility only, does not cross-reference against Stratum's own
+	// source-patched methods -- see StratumHarmonyVisibility.
+	public bool LogModHarmonyPatches { get; set; } = true;
 }
 
 internal class StratumHardeningConfig

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumHarmonyVisibility.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumHarmonyVisibility.cs
@@ -9,8 +9,8 @@ namespace Vintagestory.Server;
 // time, not applied as runtime Harmony patches, so there's nothing here for Stratum to skip or
 // gate the way Synergy's ConflictDetector does for its own patches. This is visibility only: a
 // third-party mod's Harmony *transpiler* against a method Stratum has source-patched is pattern
-// matching IL it expects to look like vanilla, and can silently fail (or, rarer, match the wrong
-// spot) if Stratum's change reshaped that method. Prefix/postfix/finalizer patches just wrap the
+// matching IL it expects to look like vanilla, and can fail with no error (or, rarer, match the
+// wrong spot) if Stratum's change reshaped that method. Prefix/postfix/finalizer patches just wrap the
 // call and aren't affected the same way. This logs what every loaded mod has patched so that's a
 // fast lookup during triage instead of a guess; it does not attempt to cross-reference against
 // Stratum's own changes (that would need a build-time method manifest -- see
@@ -59,7 +59,7 @@ internal static class StratumHarmonyVisibility
 			string detail = $"prefix={counts.Prefixes} postfix={counts.Postfixes} transpiler={counts.Transpilers} finalizer={counts.Finalizers}";
 			if (counts.Transpilers > 0)
 			{
-				StratumRuntime.LogWarning($"harmony visibility: mod '{entry.Key}' uses a transpiler ({detail}) -- if it targets a method Stratum has source-patched, verify the mod's feature actually works rather than assuming it does");
+				StratumRuntime.LogWarning($"harmony visibility: mod '{entry.Key}' uses a transpiler ({detail}) -- if it targets a method Stratum has source-patched, verify the mod's feature works instead of assuming it does");
 			}
 			else
 			{

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumHarmonyVisibility.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumHarmonyVisibility.cs
@@ -1,0 +1,98 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using HarmonyLib;
+
+namespace Vintagestory.Server;
+
+// Stratum's own changes are compiled into VintagestoryLib/VSEssentials/VSSurvivalMod at build
+// time, not applied as runtime Harmony patches, so there's nothing here for Stratum to skip or
+// gate the way Synergy's ConflictDetector does for its own patches. This is visibility only: a
+// third-party mod's Harmony *transpiler* against a method Stratum has source-patched is pattern
+// matching IL it expects to look like vanilla, and can silently fail (or, rarer, match the wrong
+// spot) if Stratum's change reshaped that method. Prefix/postfix/finalizer patches just wrap the
+// call and aren't affected the same way. This logs what every loaded mod has patched so that's a
+// fast lookup during triage instead of a guess; it does not attempt to cross-reference against
+// Stratum's own changes (that would need a build-time method manifest -- see
+// research/gap-mod-patch-conflict-visibility.md in the contributions repo for why that turned out
+// to be a much bigger lift than a startup log).
+internal static class StratumHarmonyVisibility
+{
+	public static void LogPatchedMethods(ServerMain server)
+	{
+		StratumDiagnosticsConfig config = StratumRuntime.Config.Diagnostics;
+		if (config == null || !config.LogModHarmonyPatches)
+		{
+			return;
+		}
+
+		Dictionary<string, OwnerCounts> byOwner = new Dictionary<string, OwnerCounts>();
+		int patchedMethodCount = 0;
+
+		foreach (MethodBase method in Harmony.GetAllPatchedMethods())
+		{
+			Patches info = Harmony.GetPatchInfo(method);
+			if (info == null)
+			{
+				continue;
+			}
+
+			patchedMethodCount++;
+			CountOwners(byOwner, info.Prefixes, counts => counts.Prefixes++);
+			CountOwners(byOwner, info.Postfixes, counts => counts.Postfixes++);
+			CountOwners(byOwner, info.Transpilers, counts => counts.Transpilers++);
+			CountOwners(byOwner, info.Finalizers, counts => counts.Finalizers++);
+		}
+
+		if (byOwner.Count == 0)
+		{
+			StratumRuntime.LogInfo("harmony visibility: no mod-owned Harmony patches detected");
+			return;
+		}
+
+		int transpilerOwners = byOwner.Count(entry => entry.Value.Transpilers > 0);
+		StratumRuntime.LogInfo($"harmony visibility: {byOwner.Count} mod(s) patch {patchedMethodCount} method(s) total ({transpilerOwners} mod(s) use a transpiler)");
+
+		foreach (KeyValuePair<string, OwnerCounts> entry in byOwner.OrderByDescending(e => e.Value.Transpilers).ThenBy(e => e.Key, System.StringComparer.OrdinalIgnoreCase))
+		{
+			OwnerCounts counts = entry.Value;
+			string detail = $"prefix={counts.Prefixes} postfix={counts.Postfixes} transpiler={counts.Transpilers} finalizer={counts.Finalizers}";
+			if (counts.Transpilers > 0)
+			{
+				StratumRuntime.LogWarning($"harmony visibility: mod '{entry.Key}' uses a transpiler ({detail}) -- if it targets a method Stratum has source-patched, verify the mod's feature actually works rather than assuming it does");
+			}
+			else
+			{
+				StratumRuntime.LogInfo($"harmony visibility: mod '{entry.Key}' ({detail})");
+			}
+		}
+	}
+
+	private static void CountOwners(Dictionary<string, OwnerCounts> byOwner, IReadOnlyCollection<Patch> patches, System.Action<OwnerCounts> increment)
+	{
+		if (patches == null)
+		{
+			return;
+		}
+
+		foreach (Patch patch in patches)
+		{
+			string owner = string.IsNullOrWhiteSpace(patch.owner) ? "(unknown)" : patch.owner;
+			if (!byOwner.TryGetValue(owner, out OwnerCounts counts))
+			{
+				counts = new OwnerCounts();
+				byOwner[owner] = counts;
+			}
+
+			increment(counts);
+		}
+	}
+
+	private sealed class OwnerCounts
+	{
+		public int Prefixes;
+		public int Postfixes;
+		public int Transpilers;
+		public int Finalizers;
+	}
+}


### PR DESCRIPTION
## What

Logs every mod-owned Harmony patch at startup, grouped by mod, split by prefix/postfix/transpiler/finalizer counts. Mods that use a transpiler get a warning-level line instead of info.

## Why

Stratum's changes are compiled into the assembly at build time, not applied as runtime Harmony patches, so there's no patch-skipping gate to add on Stratum's side. The risk shows up in a different shape: a third-party mod's Harmony transpiler against a method Stratum has source-patched is pattern matching IL it expects to look like vanilla. If Stratum's change reshaped that method, the transpiler can fail to find its pattern with no error, or rarer, match the wrong spot. Prefix/postfix/finalizer patches just wrap the call and don't have this problem.

This gives a fast answer to "what's patched on this install" during triage instead of a guess. It does not cross-reference against Stratum's own changes. I checked that path first: git's diff funcname heuristic doesn't resolve to C# method signatures for this codebase, 6 of 527 patch hunks land on anything method-shaped and the rest land on the enclosing class line since methods are indented. A real manifest needs Roslyn AST diffing at build time. That's a bigger lift than a startup log, and there's no incident on record yet to justify it, so this stays a visibility check for now.

## Where it hooks in

`OnBeginRunGame`, same place `StratumServerStats`/`StratumMetricsPublisher`/the backup scheduler already start. I checked the mod-loading phase order to confirm this is late enough: mods finish `StartServerSide`, the usual `PatchAll()` call site, at phase 5 (`ModsAndConfigReady`), three phases before `RunGame`(8). A mod that defers `PatchAll()` past its own `StartServerSide` won't show up here, worth knowing but not a blocker for a best-effort diagnostic.

## Config

`Diagnostics.LogModHarmonyPatches`, default `true`. Matches the existing `LogStartupSummary`/`RunStartupPreflight`/`LogPreflightWarnings` defaults, all on by default since they're informational and don't touch gameplay.

## Testing

Built a throwaway single-DLL test mod (`Harmony.Patch` with a prefix on `GameMath.Clamp(int,int,int)` and a transpiler on `GameMath.Clamp(float,float,float)`, both no-op) and loaded it against a patched build.

No mods loaded:
```
[Stratum] harmony visibility: no mod-owned Harmony patches detected
```

Test mod loaded:
```
[Stratum] harmony visibility: 1 mod(s) patch 2 method(s) total (1 mod(s) use a transpiler)
[Server Warning] [Stratum] harmony visibility: mod 'testharmonymod' uses a transpiler (prefix=1 postfix=0 transpiler=1 finalizer=0) -- if it targets a method Stratum has source-patched, verify the mod's feature works instead of assuming it does
```

Counts and the warning escalation on the transpiler-owning mod both came out correct. Both servers reached `RunGame` and shut down clean.
