### PR TITLE
Restore BlockPatch.cs.patch dropped in dfe165b

### DIFF
--- a/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/8.GenVegetationAndPatches/BlockPatch.cs.patch
+++ b/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/8.GenVegetationAndPatches/BlockPatch.cs.patch
@@ -1,0 +1,18 @@
+diff --git a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/8.GenVegetationAndPatches/BlockPatch.cs b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/8.GenVegetationAndPatches/BlockPatch.cs
+index 6076f3d..2d1eae2 100644
+--- a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/8.GenVegetationAndPatches/BlockPatch.cs
++++ b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/8.GenVegetationAndPatches/BlockPatch.cs
+@@ -235,12 +235,11 @@ namespace Vintagestory.ServerMods.NoObf
+             const int chunkSize = GlobalConstants.ChunkSize;
+ 
+             Block[] blocks = getBlocks(firstBlockId);
+             if (blocks.Length == 0) return;
+ 
+-            ModStdWorldGen modSys = null;
+-            if (blockAccessor is IWorldGenBlockAccessor wgba) modSys = wgba.WorldgenWorldAccessor.Api.ModLoader.GetModSystem<GenVegetationAndPatches>();
++            // Stratum: The modSys initialization in this part of the code is no longer used, but was eating up performance.
+ 
+             while (quantity-- > 0)
+             {
+                 if (quantity < 1 && rnd.NextFloat() > quantity) break;
+ 


### PR DESCRIPTION
My commit dfe165b ran extract-patches on a working tree without the BlockPatch edit from PR #120 applied. The script regenerated patches/ and dropped the file. This restores it from the original commit b46155c.