### PR TITLE
Optimization of the microblock storage structure in memory

### DIFF
--- a/patches/VSSurvivalMod/Systems/Microblock/BEMicroBlock.cs.patch
+++ b/patches/VSSurvivalMod/Systems/Microblock/BEMicroBlock.cs.patch
@@ -1,0 +1,76 @@
+diff --git a/VSSurvivalMod/Systems/Microblock/BEMicroBlock.cs b/VSSurvivalMod/Systems/Microblock/BEMicroBlock.cs
+index 078e651..dded57d 100644
+--- a/VSSurvivalMod/Systems/Microblock/BEMicroBlock.cs
++++ b/VSSurvivalMod/Systems/Microblock/BEMicroBlock.cs
+@@ -2560,29 +2560,64 @@ namespace Vintagestory.GameContent
+         {
+             return GetEncompassingHitbox(VoxelCuboids);
+         }
+     }
+ 
++    // Stratum start:
++    // Tested with 10,200 chunk columns generated:
++    // - BlockEntityMicroBlock.FromTreeAttributes method execution time: decreased from 2843 ms to 2216 ms
+ 
+     /// <summary>
+-    /// Replaces all uses of bool[,,] arrays in BEMicroblock. Ignoring trivial object overhead, this uses 512 bytes of memory, compared with 4096 or 16384 bytes (depending on native code implementation, see https://stackoverflow.com/questions/28514373/what-is-the-size-of-a-boolean-in-c-does-it-really-take-4-bytes) a bool[,,] of the same length
+-    /// Should help to reduce problematic high RAM use of Microblocks
++    /// Compact storage for 4096 bits (16x16x16), occupying exactly 512 bytes of memory.
+     /// </summary>
+     public class BoolArray16x16x16
+     {
+-        BitArray voxels;   // Compact storage of boolean values in this nice high-performance class provided by System.Collections - note, suitable for large arrays of bools as we have here; in contrast, our own SmallBoolArray is more suitable for small arrays of bools especially length 6
++        // Array of 64 ulong elements (64 * 64 bits = 4096 bits), allocated only once upon instantiation
++        private readonly ulong[] voxels = new ulong[64];
+ 
+-        public BoolArray16x16x16()
++        [MethodImpl(MethodImplOptions.AggressiveInlining)]
++        public void Clear()
+         {
+-            voxels = new BitArray(16 * 16 * 16);
++            // Instantly zeroes out all 64 elements without creating a new object (zero allocations)
++            Array.Clear(voxels, 0, 64);
+         }
+ 
++        [MethodImpl(MethodImplOptions.AggressiveInlining)]
++        public bool Get(int x, int y, int z)
++        {
++            // Calculates flat index and checks the target bit using a fast bitwise AND
++            int index = ((x * 16) + y) * 16 + z;
++            return (voxels[index >> 6] & (1UL << (index & 63))) != 0;
++        }
++
++        [MethodImpl(MethodImplOptions.AggressiveInlining)]
++        public void Set(int x, int y, int z, bool value)
++        {
++            // Calculates index and sets the bit to 1 or 0 via bitwise operations
++            int index = ((x * 16) + y) * 16 + z;
++            if (value)
++                voxels[index >> 6] |= (1UL << (index & 63));
++            else
++                voxels[index >> 6] &= ~(1UL << (index & 63));
++        }
++
++        [MethodImpl(MethodImplOptions.AggressiveInlining)]
++        public void SetTrue(int x, int y, int z)
++        {
++            // Optimized Set version: forcibly sets the bit to 1 without an 'if' condition check
++            int index = ((x * 16) + y) * 16 + z;
++            voxels[index >> 6] |= (1UL << (index & 63));
++        }
++
++        // Indexer for full backward compatibility with the legacy array[x, y, z] syntax
+         public bool this[int x, int y, int z]
+         {
+             [MethodImpl(MethodImplOptions.AggressiveInlining)]
+-            get { return voxels[((x * 16) + y) * 16 + z]; }
++            get => Get(x, y, z);
+ 
+             [MethodImpl(MethodImplOptions.AggressiveInlining)]
+-            set { voxels[((x * 16) + y) * 16 + z] = value; }
++            set => Set(x, y, z, value);
+         }
+     }
++
++    // Startum end
+ }


### PR DESCRIPTION
## Summary

Unlike BitArray, which uses slow division and remainder operations on 32-bit numbers, this implementation packs data into 64-bit ulongs and locates the desired bit using ultra-fast bitwise shifts. This allows the processor to calculate the bit address in a single clock instruction, greatly accelerating direct data access in hot cycles.

## Type

- [ ] Bug fix
- [x] Performance
- [ ] New feature
- [ ] Refactor or cleanup
- [ ] Docs or build

## Checklist

- [x] `.\scripts\extract-patches.ps1` ran clean.
- [x] `dotnet build VintageStory.slnx -c Release` is green.
- [x] Every vanilla edit has a `// Stratum` marker.
- [x] No vanilla source committed.
- [x] Tested on a real server start, not just compilation.

## Performance numbers
Tested with 10,200 chunk columns generated:
- BlockEntityMicroBlock.FromTreeAttributes method execution time: decreased from 2843 ms to 2216 ms

**Before**
<img width="919" height="501" alt="microblock before trace" src="https://github.com/user-attachments/assets/c3194e3e-b75f-4946-944d-5ba542a6d503" />


**After**
<img width="926" height="422" alt="microblock after trace" src="https://github.com/user-attachments/assets/283a90b2-056e-4514-9fb8-1fdf5dd91cb1" />
