### PR TITLE
Restore preflight fixes accidentally dropped by the Nimbus removal

### DIFF
--- a/sources/VintagestoryLib/Vintagestory.Server/StratumRuntime.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumRuntime.cs
@@ -241,8 +241,8 @@ internal static class StratumRuntime
 			LastLoadedUtc = DateTime.UtcNow;
 			LastLoadStatus = "failed to load config: " + exception.Message;
 			message = LastLoadStatus;
-			LogError("Failed to load config at " + ConfigPath);
-			ServerMain.Logger.Error(exception);
+			LogError("Failed to load config at " + ConfigPath + ": " + exception.Message);
+			ServerMain.Logger?.Error(exception);
 			return false;
 		}
 	}
@@ -265,8 +265,11 @@ internal static class StratumRuntime
 		CheckDirectory(report, baseDirectory, "Mods");
 		CheckFile(report, baseDirectory, "VintagestoryLib.dll");
 		CheckFile(report, baseDirectory, "VintagestoryAPI.dll");
-		CheckFile(report, baseDirectory, Path.Combine("Lib", "libSkiaSharp.dll"));
-		CheckSuspiciousRootNative(report, baseDirectory, "libSkiaSharp.dll", 1024 * 1024);
+		string skiaSharpNative = System.OperatingSystem.IsWindows() ? "libSkiaSharp.dll"
+			: System.OperatingSystem.IsMacOS() ? "libSkiaSharp.dylib"
+			: "libSkiaSharp.so";
+		CheckFile(report, baseDirectory, Path.Combine("Lib", skiaSharpNative));
+		CheckSuspiciousRootNative(report, baseDirectory, skiaSharpNative, 1024 * 1024);
 		CheckServerConfigShape(report);
 		CheckStratumConfigSafety(report);
 
@@ -290,7 +293,10 @@ internal static class StratumRuntime
 		}
 
 		string serverConfig = File.ReadAllText(serverConfigPath);
-		if (serverConfig.Contains("\"RolesByCode\"", StringComparison.Ordinal) || serverConfig.Contains("\"Roles\"", StringComparison.Ordinal) || serverConfig.Contains("\"DefaultRoleCode\"", StringComparison.Ordinal))
+		bool hasRoleData = serverConfig.Contains("\"RolesByCode\"", StringComparison.Ordinal)
+			|| serverConfig.Contains("\"Roles\"", StringComparison.Ordinal)
+			|| serverConfig.Contains("\"DefaultRoleCode\"", StringComparison.Ordinal);
+		if (hasRoleData && !File.Exists(rolesConfigPath))
 		{
 			report.Warnings.Add("serverconfig.json still contains role data; run --setconfig or /serverconfig once to rewrite it into serverroles.json");
 		}


### PR DESCRIPTION
## Summary

Restores three fixes in `StratumRuntime.cs` that were accidentally dropped by the Nimbus removal commit.

832558b ("Chunk priority perf fix... rev 10") fixed two Linux preflight false positives, documented in its own commit message: the libSkiaSharp native extension was hardcoded to `.dll`, and the serverconfig role-data warning fired even when `serverroles.json` already exists. The next day, a3a5b333 ("Remove Nimbus proxy integration") reverted three hunks in `StratumRuntime.cs` that have nothing to do with Nimbus (it looks like the file was partially restored from a pre-832558b state). This PR restores those hunks verbatim:

- **Platform-aware SkiaSharp preflight check**: on Linux the check looks for `Lib/libSkiaSharp.dll`, but the Linux archive ships `libSkiaSharp.so`, so the preflight reports a permanent error on every Linux install. Since `Passed` requires zero errors, the consequences are: the startup log always shows `preflight failed (1 errors, ...)`, `/stratum reload` returns an error even when the reload succeeded (`loaded && report.Passed`), `/stratum preflight` always fails, and the metrics publisher exports `preflight ok=false` forever. The `CheckSuspiciousRootNative` companion check was also a no-op on Linux (it watched for a stray `.dll` that can never exist there).
- **Role-data warning gating**: the `serverconfig.json still contains role data` warning fires again even when `serverroles.json` already exists; restored the `hasRoleData && !File.Exists(rolesConfigPath)` gate.
- **Config error logging**: restored the exception message in the `Failed to load config` line and the null-conditional `ServerMain.Logger?.Error` (the logger can be unset that early in boot).

## Type

- [x] Bug fix
- [ ] Performance
- [ ] New feature
- [ ] Refactor or cleanup
- [ ] Docs or build

## Checklist

- [x] `.\scripts\extract-patches.ps1` ran clean (Linux: `scripts/extract-patches.sh`; no stray diffs).
- [x] `dotnet build VintageStory.slnx -c Release` is green.
- [x] Every vanilla edit has a `// Stratum` marker. (No vanilla file touched; `StratumRuntime.cs` is a Stratum source.)
- [x] No vanilla source committed.
- [x] Tested on a real server start, not just compilation. Built from source on Linux (indev tip), overlaid the rebuilt managed files onto a launcher-provisioned install (the release layout), booted to RunGame. Before (official v1.22.3-stratum.16-indev.4 binaries on Linux):

  ```
  [Notification] [Stratum] preflight failed (1 errors, 1 warnings)
  [Warning] [Stratum] preflight: Missing file: Lib/libSkiaSharp.dll
  ```

  After (this branch, same machine, same data path):

  ```
  [Notification] [Stratum] preflight passed
  ```

## Related issues

None filed; found while running Stratum under the StratumParity differential suite on Linux (#147).
