### PR TITLE
Pass the Anego manifest to python via a file, not argv

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -158,15 +158,19 @@ download_server_archive() {
   local cache_dir="$1"
   mkdir -p "$cache_dir"
 
-  local manifest
-  manifest="$(curl -L --fail --silent https://api.vintagestory.at/stable-unstable.json)"
+  # The manifest is passed as a file: it is over 128 KiB and Linux caps a single
+  # exec argument at MAX_ARG_STRLEN (32 pages), so passing it through argv fails
+  # with "Argument list too long".
+  local manifest_file="$cache_dir/.stable-unstable.json"
+  curl -L --fail --silent https://api.vintagestory.at/stable-unstable.json -o "$manifest_file"
   local archive_info
-  archive_info="$(python3 - "$version" "$manifest" <<'PY'
+  archive_info="$(python3 - "$version" "$manifest_file" <<'PY'
 import json
 import sys
 
 version = sys.argv[1]
-data = json.loads(sys.argv[2])
+with open(sys.argv[2], "r", encoding="utf-8") as fh:
+    data = json.load(fh)
 try:
     entry = data[version]["linuxserver"]
 except KeyError as exc:


### PR DESCRIPTION
## Summary

`scripts/bootstrap.sh` currently cannot run on Linux: it dies in `download_server_archive` with `python3: Argument list too long`.

The cause: the Anego manifest is passed to python as a single exec argument (`python3 - "$version" "$manifest"`), and `stable-unstable.json` is now ~167 KB while Linux caps one argument at `MAX_ARG_STRLEN` = 32 pages = 128 KiB. The manifest only grows with each release, so every Linux bootstrap fails at the resolve step (the follow-up curl then runs with an empty URL and the script aborts).

Fix: download the manifest to a file in the archive cache dir and `json.load` it from there, keeping the existing heredoc pattern; only the JSON string argument becomes a path argument.

`bootstrap.ps1` is unaffected: it parses the manifest in-process with `Invoke-RestMethod`, which is presumably why this never showed up on Windows.

## Type

- [x] Bug fix
- [ ] Performance
- [ ] New feature
- [ ] Refactor or cleanup
- [x] Docs or build

## Checklist

- [x] `.\scripts\extract-patches.ps1` ran clean (Linux: `scripts/extract-patches.sh`; no stray diffs).
- [x] `dotnet build VintageStory.slnx -c Release` is green.
- [x] Every vanilla edit has a `// Stratum` marker. (No source file touched.)
- [x] No vanilla source committed.
- [x] Tested on a real server start, not just compilation: full `make smoke` on Linux (bootstrap, decompile, patch, build, boot) passes with this change; without it, bootstrap cannot get past the manifest resolve.

## Related issues

None filed.
