### PR TITLE
Bump actions/setup-dotnet to v6 on indev

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
           sudo apt-get install -y powershell
 
       - name: Install .NET 10 SDK
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: '10.0.x'
 


### PR DESCRIPTION
Port of #171 to indev: prerelease tags are cut from indev commits and the release workflow runs from the tagged commit, so the bump must live here too.

Same review as #171: the only breaking change in the v4 to v6 line is v5.0.0 requiring a Node 24 capable runner (2.327.1+), which GitHub-hosted ubuntu-latest satisfies; v6.0.0 is an internal ESM migration. Our `dotnet-version: '10.0.x'` usage is unaffected.

Game-level validation on top of the changelog review: the StratumParity suite ran its full pipeline with a v6-installed SDK (Pixnop/StratumParity#19): built the scenarios against the real VintagestoryAPI, booted both vanilla 1.22.3 and stratum.15, 17/17 scenarios green on each with no divergence. Workflow-only change.