### PR TITLE
Increased some default values ​​in the chunk pre-generator

### DIFF
--- a/sources/VintagestoryLib/Vintagestory.Server/StratumConfig.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumConfig.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -994,13 +994,13 @@ internal class StratumPregenConfig
 {
 	public bool Enabled { get; set; } = true;
 
-	public int MaxColumnsPerSecond { get; set; } = 32;
+	public int MaxColumnsPerSecond { get; set; } = 500;
 
 	public int MaxScansPerSecond { get; set; } = 4096;
 
-	public int MaxPendingColumnQueue { get; set; } = 256;
+	public int MaxPendingColumnQueue { get; set; } = 500;
 
-	public int MaxWorkerColumnQueue { get; set; } = 512;
+	public int MaxWorkerColumnQueue { get; set; } = 1000;
 
 	public int MaxLoadedChunkColumns { get; set; } = 4096;
 


### PR DESCRIPTION
## Summary

Increased some default values ​​in the chunk pre-generator
The pre-generator already distributes the load as expected.
The generation speed will increase significantly on processors below low-middle and above.

## Type

- [ ] Bug fix
- [ ] Performance
- [ ] New feature
- [x] Refactor or cleanup
- [ ] Docs or build

## Checklist

- [x] `.\scripts\extract-patches.ps1` ran clean.
- [x] `dotnet build VintageStory.slnx -c Release` is green.
- [x] Every vanilla edit has a `// Stratum` marker.
- [x] No vanilla source committed.
- [x] Tested on a real server start, not just compilation.

## Performance numbers

When pre-generating 10,200 chunk columns with 6 threads:
- with standard settings: 190 seconds
- with these settings: 58 seconds