### PR TITLE
Fix mechanical networks freezing under concurrent chunk load

### DIFF
--- a/patches/VSSurvivalMod/Systems/MechanicalPower/MechanicalPowerMod.cs.patch
+++ b/patches/VSSurvivalMod/Systems/MechanicalPower/MechanicalPowerMod.cs.patch
@@ -1,20 +1,31 @@
 diff --git a/VSSurvivalMod/Systems/MechanicalPower/MechanicalPowerMod.cs b/VSSurvivalMod/Systems/MechanicalPower/MechanicalPowerMod.cs
-index f2e4020..7fbc98c 100644
+index f2e4020..4b1178a 100644
 --- a/VSSurvivalMod/Systems/MechanicalPower/MechanicalPowerMod.cs
 +++ b/VSSurvivalMod/Systems/MechanicalPower/MechanicalPowerMod.cs
-@@ -59,10 +59,11 @@ namespace Vintagestory.GameContent.Mechanics
+@@ -59,10 +59,22 @@ namespace Vintagestory.GameContent.Mechanics
  
          public ICoreAPI Api;
  
          MechPowerData data = new MechPowerData();
          SimpleParticleProperties smokeParticles;
 +        private readonly List<MechanicalNetwork> stratumTickNetworks = new List<MechanicalNetwork>(); // Stratum: reuse per tick
++        // Stratum: guards data.networksById and the fullyLoaded flag of every network in
++        // it. BlockEntity.Initialize() (which reaches GetOrCreateNetwork for power
++        // producers) runs on the chunk-loading thread
++        // (ServerSystemSupplyChunks.loadOrGenerateChunkColumn_OnChunkThread), not the
++        // main server thread that OnServerGameTick runs on. Without this, that thread
++        // writes into the same plain Dictionary the tick loop enumerates, and can flip
++        // fullyLoaded to true without the tick thread ever reliably observing it. The
++        // second symptom explains reports of a network reading correct conditions
++        // (e.g. wind speed) but never actually ticking: fullyLoaded stays visible as
++        // false to the tick thread even after the chunk thread set it true.
++        private readonly object stratumNetworksLock = new object();
  
          public override bool ShouldLoad(EnumAppSide side)
          {
              return true;
          }
-@@ -151,12 +152,16 @@ namespace Vintagestory.GameContent.Mechanics
+@@ -151,12 +163,19 @@ namespace Vintagestory.GameContent.Mechanics
  
          protected void OnServerGameTick(float dt)
          {
@@ -23,9 +34,12 @@ index f2e4020..7fbc98c 100644
 -            List<MechanicalNetwork> clone = data.networksById.Values.ToList();
 -            foreach (MechanicalNetwork network in clone)
 +            stratumTickNetworks.Clear(); // Stratum: reuse list instead of .ToList() allocation
-+            foreach (MechanicalNetwork network in data.networksById.Values)
++            lock (stratumNetworksLock) // Stratum: see the field's own comment
 +            {
-+                stratumTickNetworks.Add(network);
++                foreach (MechanicalNetwork network in data.networksById.Values)
++                {
++                    stratumTickNetworks.Add(network);
++                }
 +            }
 +            foreach (MechanicalNetwork network in stratumTickNetworks)
              {
@@ -33,3 +47,118 @@ index f2e4020..7fbc98c 100644
                  {
                      network.ServerTick(dt, data.tickNumber);
  
+@@ -207,14 +226,16 @@ namespace Vintagestory.GameContent.Mechanics
+             data.networksById.Remove(networkMessage.networkId);
+         }
+ 
+         protected void OnClientRequestPacket(IServerPlayer player, MechClientRequestPacket networkMessage)
+         {
+-            if (data.networksById.TryGetValue(networkMessage.networkId, out MechanicalNetwork nw))
++            MechanicalNetwork nw;
++            lock (stratumNetworksLock) // Stratum: see the field's own comment
+             {
+-                nw.SendBlocksUpdateToClient(player);
++                data.networksById.TryGetValue(networkMessage.networkId, out nw);
+             }
++            nw?.SendBlocksUpdateToClient(player);
+         }
+ 
+         public void broadcastNetwork(MechNetworkPacket packet)
+         {
+             serverNwChannel.BroadcastPacket(packet);
+@@ -295,19 +316,23 @@ namespace Vintagestory.GameContent.Mechanics
+             Renderer?.Dispose();
+         }
+ 
+         public MechanicalNetwork GetOrCreateNetwork(long networkId)
+         {
+-
+-            if (!data.networksById.TryGetValue(networkId, out MechanicalNetwork mw))
++            // Stratum: this runs on the chunk-loading thread when reached through
++            // BlockEntity.Initialize() for a power producer; see stratumNetworksLock.
++            lock (stratumNetworksLock)
+             {
+-                data.networksById[networkId] = mw = new MechanicalNetwork(this, networkId);
+-            }
++                if (!data.networksById.TryGetValue(networkId, out MechanicalNetwork mw))
++                {
++                    data.networksById[networkId] = mw = new MechanicalNetwork(this, networkId);
++                }
+ 
+-            testFullyLoaded(mw);
++                testFullyLoaded(mw);
+ 
+-            return mw;
++                return mw;
++            }
+         }
+ 
+         public void testFullyLoaded(MechanicalNetwork mw)
+         {
+             if (Api.Side != EnumAppSide.Server || mw.fullyLoaded) return;
+@@ -328,20 +353,25 @@ namespace Vintagestory.GameContent.Mechanics
+             if (allNetworksFullyLoaded || reason == EnumChunkDirtyReason.MarkedDirty) return;
+ 
+             allNetworksFullyLoaded = true;
+             nowFullyLoaded.Clear();
+ 
+-            foreach (var network in data.networksById.Values)
++            // Stratum: fires from TriggerChunkDirty on the chunk-loading thread for a
++            // newly loaded chunk; see stratumNetworksLock.
++            lock (stratumNetworksLock)
+             {
+-                if (network.fullyLoaded) continue;
+-                allNetworksFullyLoaded = false;
++                foreach (var network in data.networksById.Values)
++                {
++                    if (network.fullyLoaded) continue;
++                    allNetworksFullyLoaded = false;
+ 
+-                if (network.inChunks.ContainsKey(chunkCoord)) {
+-                    testFullyLoaded(network);
+-                    if (network.fullyLoaded)
+-                    {
+-                        nowFullyLoaded.Add(network);
++                    if (network.inChunks.ContainsKey(chunkCoord)) {
++                        testFullyLoaded(network);
++                        if (network.fullyLoaded)
++                        {
++                            nowFullyLoaded.Add(network);
++                        }
+                     }
+                 }
+             }
+ 
+             for (int i = 0; i < nowFullyLoaded.Count; i++)
+@@ -354,19 +384,28 @@ namespace Vintagestory.GameContent.Mechanics
+         public MechanicalNetwork CreateNetwork(IMechanicalPowerDevice powerProducerNode)
+         {
+             MechanicalNetwork nw = new MechanicalNetwork(this, data.nextNetworkId);
+             nw.fullyLoaded = true;
+ 
+-            data.networksById[data.nextNetworkId] = nw;
+-            data.nextNetworkId++;
++            // Stratum: see stratumNetworksLock.
++            lock (stratumNetworksLock)
++            {
++                data.networksById[data.nextNetworkId] = nw;
++                data.nextNetworkId++;
++            }
+ 
+             return nw;
+         }
+ 
+         public void DeleteNetwork(MechanicalNetwork network)
+         {
+-            data.networksById.Remove(network.networkId);
++            // Stratum: see stratumNetworksLock. Reentrant-safe: RebuildNetwork can call
++            // this from inside its own Event_ChunkDirty lock, on the same thread.
++            lock (stratumNetworksLock)
++            {
++                data.networksById.Remove(network.networkId);
++            }
+             serverNwChannel.BroadcastPacket<NetworkRemovedPacket>(new NetworkRemovedPacket() { networkId = network.networkId });
+         }
+ 
+         public void SendNetworkBlocksUpdateRequestToServer(long networkId)
+         {

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumConfig.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumConfig.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;


### PR DESCRIPTION
## Summary

Fixes mechanical networks (windmills and other kinetic mechanisms) freezing under normal play, reported on Discord and in the mod database as devices reading correct conditions but never moving, speed stuck at 0.

`MechPowerData.networksById`, a plain `Dictionary`, is read every 20ms by `OnServerGameTick` on the main server thread and written by `GetOrCreateNetwork`, reached from `BlockEntity.Initialize()` for every power producer as chunks load. That runs on `ServerSystemSupplyChunks.loadOrGenerateChunkColumn_OnChunkThread`, a different thread, confirmed by tracing the call site itself. Nothing synchronized the two. `MechanicalNetwork.fullyLoaded` has the same problem in a way that matches the report: the chunk thread can set it true, but without a memory barrier between that write and the tick thread's read, the tick loop can keep observing false and never call `ServerTick` on that network again.

tehtelev traced community reports to a specific commit, `dca2ead` (PR #129), which replaced a per-tick `data.networksById.Values.ToList()` with a reused list filled by a manual `foreach`. Both approaches copy the dictionary's values before iterating, so neither introduces the race; the race already existed. What changed is timing: `ToList()` resolves to a single bulk `CopyTo`, about as fast as this gets, while the manual two-pass replacement takes longer per tick by a real margin, widening the window during which the chunk thread's concurrent write can land. A commit aimed at cutting GC pressure ended up making a pre-existing, unrelated race far more likely to fire in practice, which fits with reports clustering around when it shipped even though the underlying gap is older.

Fixed with one lock, `stratumNetworksLock`, covering every place `networksById` gets read or written and every place a network's `fullyLoaded` flag gets set. The tick loop's second pass, which calls `ServerTick`, stays outside the lock: the earlier snapshot pass in the same tick already establishes a happens-before relationship with the chunk thread's writes, so nothing more is needed there, and holding the lock through the longer per-network work would block the chunk thread for no reason. Client-side paths stay untouched since the client doesn't have this thread split.

Considered `ConcurrentDictionary` instead of a lock. Rejected: `MechPowerData` is part of the save-game format (`[ProtoContract(ImplicitFields = ImplicitFields.AllPublic)]`), and a lock closes this with zero change to what gets serialized.

## Type

- [x] Bug fix
- [ ] Performance
- [ ] New feature
- [ ] Refactor or cleanup
- [ ] Docs or build

## Checklist

- [x] `./scripts/extract-patches.sh` ran clean.
- [x] `dotnet build VintageStory.slnx -c Release` is green.
- [x] Every vanilla edit has a `// Stratum` marker.
- [x] No vanilla source committed.
- [x] Tested on a real server start, not just compilation.

## What I tested

Built clean. Boot-tested a full pregen run (radius 20, four worker threads, the same concurrent chunk-loading conditions that trigger the race): zero exceptions, no deadlock, confirming the added locking doesn't introduce one.

I did not reproduce the original race end to end. That needs a live windmill placed near a chunk boundary with precise timing against a background chunk load, not something a headless console-command script can drive. The fix targets the exact unsynchronized access traced through the source, not a guess at the symptom, but that gap stays a gap, not something I'm claiming is covered.

## Related issues

No tracked GitHub issue; reports came through Discord and the mod database. Linking here in case anyone opens one: this addresses the windmill/kinetic-mechanism freeze tehtelev raised, traced from `dca2ead`.
