### PR TITLE
Close cross-column landmines in TerrainFeatures and Vegetation generators, plus two build/test tooling fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,12 @@ CONFIGURATION ?= Release
 VERSION ?= 1.22.5
 SERVER_ARCHIVE ?=
 CLIENT_LIB_DIR ?=
+# Embeds this working tree's compiled DLLs into StratumServer so
+# PatchedFileOverlay actually overlays them at runtime. Without this, the
+# server silently falls back to vanilla's unpatched VintagestoryLib.dll from
+# the downloaded archive; the failure mode is a working build that boots but
+# runs none of this repo's patches.
+EMBED_PATCHED_FILES ?= true
 
 BOOTSTRAP_ARGS :=
 ifneq ($(SERVER_ARCHIVE),)
@@ -28,7 +34,7 @@ bootstrap: ## Download, decompile, and apply patches
 
 build: ## Build Release (runs bootstrap if working tree is missing)
 	@if [ ! -f VintagestoryApi/VintagestoryAPI.csproj ]; then $(MAKE) bootstrap; fi
-	dotnet build VintageStory.slnx -c $(CONFIGURATION)
+	dotnet build VintageStory.slnx -c $(CONFIGURATION) -p:EmbedPatchedFiles=$(EMBED_PATCHED_FILES)
 
 smoke: build ## Build and boot-test the server
 	bash scripts/smoke-test.sh

--- a/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/5.GenDeposits/GenDeposits.cs.patch
+++ b/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/5.GenDeposits/GenDeposits.cs.patch
@@ -1,0 +1,111 @@
+diff --git a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/5.GenDeposits/GenDeposits.cs b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/5.GenDeposits/GenDeposits.cs
+index b6ab588..e497139 100644
+--- a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/5.GenDeposits/GenDeposits.cs
++++ b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/5.GenDeposits/GenDeposits.cs
+@@ -26,10 +26,26 @@ namespace Vintagestory.ServerMods
+ 
+         IBlockAccessor blockAccessor;
+ 
+         public LCGRandom depositRand;
+ 
++        // Stratum: an instance lock, not [ThreadStatic]/ThreadLocal. GeneratePartial
++        // reseeds depositRand then immediately generates with it, the same shape as the
++        // other landmines this session found, but depositRand's actual value gets
++        // captured by reference into every DepositGeneratorBase this class's variants
++        // create (DepositVariant.Init -> DepositGeneratorBase.DepositRand = depositRand,
++        // done once at load time). Swapping depositRand itself to a per-thread instance
++        // would not isolate anything: every generator would still read whatever
++        // depositRand reference existed on whichever thread ran initAssets, not the one
++        // reseeded on the thread actually generating. A lock preserves the existing
++        // object-identity relationship exactly, at the cost of serializing GeneratePartial
++        // calls once TerrainFeatures' same-stage cap ever rises off 1 (it stays at 1
++        // today, so this is not a live race yet, only a landmine closed early). Also
++        // covers subDepositsToPlace and tmpPos below, cleared/set at the top of every
++        // GeneratePartial call and safe to keep as plain fields under the same lock.
++        private readonly object stratumGenDepositsLock = new object();
++
+         BlockPos tmpPos = new BlockPos(API.Config.Dimensions.NormalWorld);
+ 
+         NormalizedSimplexNoise depositShapeDistortNoise;
+         Dictionary<BlockPos, DepositVariant> subDepositsToPlace = new Dictionary<BlockPos, DepositVariant>();
+         MapLayerBase verticalDistortTop;
+@@ -207,48 +223,51 @@ namespace Vintagestory.ServerMods
+             base.GenChunkColumn(request);
+         }
+ 
+         public override void GeneratePartial(IServerChunk[] chunks, int chunkX, int chunkZ, int chunkdX, int chunkdZ)
+         {
+-            LCGRandom chunkRand = this.chunkRand;
+-            int fromChunkx = chunkX + chunkdX;
+-            int fromChunkz = chunkZ + chunkdZ;
++            lock (stratumGenDepositsLock)
++            {
++                LCGRandom chunkRand = this.chunkRand;
++                int fromChunkx = chunkX + chunkdX;
++                int fromChunkz = chunkZ + chunkdZ;
+ 
+-            int fromBaseX = fromChunkx * chunksize;
+-            int fromBaseZ = fromChunkz * chunksize;
++                int fromBaseX = fromChunkx * chunksize;
++                int fromBaseZ = fromChunkz * chunksize;
+ 
+-            subDepositsToPlace.Clear();
++                subDepositsToPlace.Clear();
+ 
+-            float scaleAdjustMul = (float)api.WorldManager.MapSizeY / 256;
++                float scaleAdjustMul = (float)api.WorldManager.MapSizeY / 256;
+ 
+-            for (int i = 0; i < Deposits.Length; i++)
+-            {
+-                DepositVariant variant = Deposits[i];
+-                
+-                float quantityFactor = variant.WithOreMap ? variant.GetOreMapFactor(fromChunkx, fromChunkz) : 1;
++                for (int i = 0; i < Deposits.Length; i++)
++                {
++                    DepositVariant variant = Deposits[i];
+ 
+-                float qModified = variant.TriesPerChunk * quantityFactor * chanceMultiplier * (variant.ScaleWithWorldheight ? scaleAdjustMul : 1);
+-                int quantity = (int)qModified;
+-                quantity += chunkRand.NextInt(100) < 100 * (qModified - quantity) ? 1 : 0;
++                    float quantityFactor = variant.WithOreMap ? variant.GetOreMapFactor(fromChunkx, fromChunkz) : 1;
+ 
+-                while (quantity-- > 0)
+-                {
+-                    tmpPos.Set(fromBaseX + chunkRand.NextInt(chunksize), -99, fromBaseZ + chunkRand.NextInt(chunksize));
+-                    long crseed = chunkRand.NextInt(10000000);
+-                    depositRand.SetWorldSeed(crseed);
+-                    depositRand.InitPositionSeed(fromChunkx, fromChunkz);
++                    float qModified = variant.TriesPerChunk * quantityFactor * chanceMultiplier * (variant.ScaleWithWorldheight ? scaleAdjustMul : 1);
++                    int quantity = (int)qModified;
++                    quantity += chunkRand.NextInt(100) < 100 * (qModified - quantity) ? 1 : 0;
+ 
+-                    GenDeposit(chunks, chunkX, chunkZ, tmpPos, variant);
++                    while (quantity-- > 0)
++                    {
++                        tmpPos.Set(fromBaseX + chunkRand.NextInt(chunksize), -99, fromBaseZ + chunkRand.NextInt(chunksize));
++                        long crseed = chunkRand.NextInt(10000000);
++                        depositRand.SetWorldSeed(crseed);
++                        depositRand.InitPositionSeed(fromChunkx, fromChunkz);
++
++                        GenDeposit(chunks, chunkX, chunkZ, tmpPos, variant);
++                    }
+                 }
+-            }
+ 
+-            foreach (var val in subDepositsToPlace)
+-            {
+-                depositRand.SetWorldSeed(chunkRand.NextInt(10000000));
+-                depositRand.InitPositionSeed(fromChunkx, fromChunkz);
++                foreach (var val in subDepositsToPlace)
++                {
++                    depositRand.SetWorldSeed(chunkRand.NextInt(10000000));
++                    depositRand.InitPositionSeed(fromChunkx, fromChunkz);
+ 
+-                val.Value.GeneratorInst.GenDeposit(blockAccessor, chunks, chunkX, chunkZ, val.Key, ref subDepositsToPlace);
++                    val.Value.GeneratorInst.GenDeposit(blockAccessor, chunks, chunkX, chunkZ, val.Key, ref subDepositsToPlace);
++                }
+             }
+         }
+ 
+ 
+ 

--- a/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/6.GenStructures/GenStructures.cs.patch
+++ b/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/6.GenStructures/GenStructures.cs.patch
@@ -1,0 +1,321 @@
+diff --git a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/6.GenStructures/GenStructures.cs b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/6.GenStructures/GenStructures.cs
+index 95025db..8320886 100644
+--- a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/6.GenStructures/GenStructures.cs
++++ b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/6.GenStructures/GenStructures.cs
+@@ -35,33 +35,38 @@ namespace Vintagestory.ServerMods
+         ICoreServerAPI api;
+ 
+         int worldheight;
+         int regionChunkSize;
+ 
+-        ushort[] heightmap;
+-        int climateUpLeft;
+-        int climateUpRight;
+-        int climateBotLeft;
+-        int climateBotRight;
+-
+-        int forestUpLeft;
+-        int forestUpRight;
+-        int forestBotLeft;
+-        int forestBotRight;
++        // Stratum: every field below used to be a plain instance field, written by
++        // OnChunkColumnGen/DoGenStructures and read a few calls later in the same
++        // column's processing (TryGenerate, TryGenVillages), the same shape of bug as
++        // GenVegetationAndPatches' equivalent fields and GenCreatures' original one for
++        // PreDone. TerrainFeatures (this class's stage) stays at same-stage cap 1 today,
++        // so this was not a live race yet, but a landmine for whoever raises that cap,
++        // same framing as treeAndShrubSupressingStructures below. [ThreadStatic] keeps
++        // every field private to whichever thread is currently inside OnChunkColumnGen
++        // for a given column, at zero cost while only one thread at a time is in here.
++        // strucRand needed the same reasoning as GenVegetationAndPatches' rnd: it is
++        // reseeded per column via InitPositionSeed alone (no SetWorldSeed), which does
++        // not depend on strucRand's own prior state, so lazy-constructing a fresh
++        // instance per thread with the same world-seed argument reproduces today's
++        // single-shared-instance behavior exactly, just isolated per thread.
++        [ThreadStatic] private static ushort[] stratumHeightmap;
++        [ThreadStatic] private static int stratumClimateUpLeft, stratumClimateUpRight, stratumClimateBotLeft, stratumClimateBotRight;
++        [ThreadStatic] private static int stratumForestUpLeft, stratumForestUpRight, stratumForestBotLeft, stratumForestBotRight;
++        [ThreadStatic] private static LCGRandom stratumStrucRand;
++        [ThreadStatic] private static WorldGenStructure[] stratumShuffledStructures;
+ 
+         public event PeventSchematicAtDelegate OnPreventSchematicPlaceAt;
+ 
+         internal WorldGenStructuresConfig scfg;
+ 
+         public WorldGenVillageConfig vcfg;
+ 
+-        LCGRandom strucRand; // Deterministic random
+-
+-
+         IWorldGenBlockAccessor worldgenBlockAccessor;
+ 
+-        WorldGenStructure[] shuffledStructures;
+         private Dictionary<string, WorldGenStructure[]> StoryStructures;
+ 
+         public override double ExecuteOrder() { return 0.3; }
+ 
+         public override void StartServerSide(ICoreServerAPI api)
+@@ -111,12 +116,10 @@ namespace Vintagestory.ServerMods
+ 
+             worldheight = api.WorldManager.MapSizeY;
+             regionChunkSize = api.WorldManager.RegionSize / chunksize;
+             chunkMapSizeY = api.WorldManager.MapSizeY / chunksize;
+ 
+-            strucRand = new LCGRandom(api.WorldManager.Seed + 1090);
+-
+             LoadStructures();
+             LoadVillages();
+ 
+             var genStoryStructures = api.World.Config.GetAsString("loreContent", "true").ToBool(true);
+             if (!genStoryStructures) return;
+@@ -202,11 +205,11 @@ namespace Vintagestory.ServerMods
+                 structures.AddRange(conf.Structures);
+             }
+ 
+             scfg.Structures = structures.ToArray();
+ 
+-            shuffledStructures = new WorldGenStructure[scfg.Structures.Length];
++            stratumShuffledStructures = new WorldGenStructure[scfg.Structures.Length];
+ 
+             scfg.Init(api);
+         }
+ 
+         private void LoadVillages()
+@@ -268,24 +271,24 @@ namespace Vintagestory.ServerMods
+             // rlX, rlZ goes from 0..16 pixel
+             // facF = 16/16 = 1
+             // Get 4 pixels for chunkx, chunkz, chunkx+1 and chunkz+1 inside the map
+ 
+             float facC = (float)climateMap.InnerSize / regionChunkSize;
+-            climateUpLeft = climateMap.GetUnpaddedInt((int)(rlX * facC), (int)(rlZ * facC));
+-            climateUpRight = climateMap.GetUnpaddedInt((int)(rlX * facC + facC), (int)(rlZ * facC));
+-            climateBotLeft = climateMap.GetUnpaddedInt((int)(rlX * facC), (int)(rlZ * facC + facC));
+-            climateBotRight = climateMap.GetUnpaddedInt((int)(rlX * facC + facC), (int)(rlZ * facC + facC));
++            stratumClimateUpLeft = climateMap.GetUnpaddedInt((int)(rlX * facC), (int)(rlZ * facC));
++            stratumClimateUpRight = climateMap.GetUnpaddedInt((int)(rlX * facC + facC), (int)(rlZ * facC));
++            stratumClimateBotLeft = climateMap.GetUnpaddedInt((int)(rlX * facC), (int)(rlZ * facC + facC));
++            stratumClimateBotRight = climateMap.GetUnpaddedInt((int)(rlX * facC + facC), (int)(rlZ * facC + facC));
+ 
+ 
+             float facf = (float)forestMap.InnerSize / regionChunkSize;
+-            forestUpLeft = forestMap.GetUnpaddedInt((int)(rlX * facC), (int)(rlZ * facC));
+-            forestUpRight = forestMap.GetUnpaddedInt((int)(rlX * facC + facC), (int)(rlZ * facC));
+-            forestBotLeft = forestMap.GetUnpaddedInt((int)(rlX * facC), (int)(rlZ * facC + facC));
+-            forestBotRight = forestMap.GetUnpaddedInt((int)(rlX * facC + facC), (int)(rlZ * facC + facC));
++            stratumForestUpLeft = forestMap.GetUnpaddedInt((int)(rlX * facC), (int)(rlZ * facC));
++            stratumForestUpRight = forestMap.GetUnpaddedInt((int)(rlX * facC + facC), (int)(rlZ * facC));
++            stratumForestBotLeft = forestMap.GetUnpaddedInt((int)(rlX * facC), (int)(rlZ * facC + facC));
++            stratumForestBotRight = forestMap.GetUnpaddedInt((int)(rlX * facC + facC), (int)(rlZ * facC + facC));
+ 
+ 
+-            heightmap = chunks[0].MapChunk.WorldGenTerrainHeightMap;
++            stratumHeightmap = chunks[0].MapChunk.WorldGenTerrainHeightMap;
+ 
+             DoGenStructures(region, chunkX, chunkZ, false, structure?.Code, request.ChunkGenParams);
+             if (structure == null)
+             {
+                 TryGenVillages(region, chunkX, chunkZ, false, request.ChunkGenParams);
+@@ -298,22 +301,22 @@ namespace Vintagestory.ServerMods
+             // which is crucial for the translocator to find an exit point
+             if (locationCode != null)
+             {
+                 if (StoryStructures.TryGetValue(locationCode, out var storyStructures))
+                 {
+-                    shuffledStructures = new WorldGenStructure[storyStructures.Length];
+-                    for (int i = 0; i < storyStructures.Length; i++) shuffledStructures[i] = storyStructures[i];
++                    stratumShuffledStructures = new WorldGenStructure[storyStructures.Length];
++                    for (int i = 0; i < storyStructures.Length; i++) stratumShuffledStructures[i] = storyStructures[i];
+                 }
+                 else
+                 {
+                     return;
+                 }
+             }
+             else
+             {
+-                shuffledStructures = new WorldGenStructure[scfg.Structures.Length];
+-                for (int i = 0; i < shuffledStructures.Length; i++) shuffledStructures[i] = scfg.Structures[i];
++                stratumShuffledStructures = new WorldGenStructure[scfg.Structures.Length];
++                for (int i = 0; i < stratumShuffledStructures.Length; i++) stratumShuffledStructures[i] = scfg.Structures[i];
+             }
+             BlockPos startPos = new BlockPos(Dimensions.NormalWorld);
+ 
+             ITreeAttribute chanceModTree = null;
+             ITreeAttribute maxQuantityModTree = null;
+@@ -326,17 +329,17 @@ namespace Vintagestory.ServerMods
+             {
+                 maxQuantityModTree = chunkGenParams["structureMaxCount"] as TreeAttribute;
+             }
+ 
+ 
+-            strucRand.InitPositionSeed(chunkX, chunkZ);
++            (stratumStrucRand ??= new LCGRandom(api.WorldManager.Seed + 1090)).InitPositionSeed(chunkX, chunkZ);
+ 
+-            shuffledStructures.Shuffle(strucRand);
++            stratumShuffledStructures.Shuffle(stratumStrucRand);
+ 
+-            for (int i = 0; i < shuffledStructures.Length; i++)
++            for (int i = 0; i < stratumShuffledStructures.Length; i++)
+             {
+-                WorldGenStructure struc = shuffledStructures[i];
++                WorldGenStructure struc = stratumShuffledStructures[i];
+                 if (struc.PostPass != postPass) continue;
+ 
+                 float chance = struc.Chance * scfg.ChanceMultiplier;
+                 int toGenerate = 9999;
+                 if (chanceModTree != null)
+@@ -348,26 +351,26 @@ namespace Vintagestory.ServerMods
+                 {
+                     toGenerate = maxQuantityModTree.GetInt(struc.Code, 9999);
+                 }
+ 
+ 
+-                while (chance-- > strucRand.NextFloat() && toGenerate > 0)
++                while (chance-- > stratumStrucRand.NextFloat() && toGenerate > 0)
+                 {
+-                    int dx = strucRand.NextInt(chunksize);
+-                    int dz = strucRand.NextInt(chunksize);
+-                    int ySurface = heightmap[dz * chunksize + dx];
++                    int dx = stratumStrucRand.NextInt(chunksize);
++                    int dz = stratumStrucRand.NextInt(chunksize);
++                    int ySurface = stratumHeightmap[dz * chunksize + dx];
+                     if (ySurface <= 0 || ySurface >= worldheight - 15) continue;
+ 
+                     if (struc.Placement == EnumStructurePlacement.Underground)
+                     {
+                         if (struc.Depth != null)
+                         {
+-                            startPos.Set(chunkX * chunksize + dx, ySurface - (int)struc.Depth.nextFloat(1, strucRand), chunkZ * chunksize + dz);
++                            startPos.Set(chunkX * chunksize + dx, ySurface - (int)struc.Depth.nextFloat(1, stratumStrucRand), chunkZ * chunksize + dz);
+                         }
+                         else
+                         {
+-                            startPos.Set(chunkX * chunksize + dx, 8 + strucRand.NextInt(Math.Max(1, ySurface - 8 - 5)), chunkZ * chunksize + dz);
++                            startPos.Set(chunkX * chunksize + dx, 8 + stratumStrucRand.NextInt(Math.Max(1, ySurface - 8 - 5)), chunkZ * chunksize + dz);
+                         }
+                     }
+                     else
+                     {
+                         startPos.Set(chunkX * chunksize + dx, ySurface, chunkZ * chunksize + dz);
+@@ -393,12 +396,12 @@ namespace Vintagestory.ServerMods
+                         {
+                             continue;
+                         }
+                     }
+ 
+-                    int forest = GameMath.BiLerpRgbColor((float)(startPos.X % chunksize) / chunksize, (float)(startPos.Z % chunksize) / chunksize, forestUpLeft, forestUpRight, forestBotLeft, forestBotRight);
+-                    if (struc.TryGenerate(worldgenBlockAccessor, api.World, startPos, climateUpLeft, climateUpRight, climateBotLeft, climateBotRight, forest, locationCode))
++                    int forest = GameMath.BiLerpRgbColor((float)(startPos.X % chunksize) / chunksize, (float)(startPos.Z % chunksize) / chunksize, stratumForestUpLeft, stratumForestUpRight, stratumForestBotLeft, stratumForestBotRight);
++                    if (struc.TryGenerate(worldgenBlockAccessor, api.World, startPos, stratumClimateUpLeft, stratumClimateUpRight, stratumClimateBotLeft, stratumClimateBotRight, forest, locationCode))
+                     {
+                         if(locationCode != null && location != null)
+                         {
+                             if (location.SchematicsSpawned?.TryGetValue(struc.Group, out var spawnedSchematics) == true)
+                             {
+@@ -446,18 +449,18 @@ namespace Vintagestory.ServerMods
+ 
+ 
+ 
+         public void TryGenVillages(IMapRegion region, int chunkX, int chunkZ, bool postPass, ITreeAttribute chunkGenParams = null)
+         {
+-            strucRand.InitPositionSeed(chunkX, chunkZ);
++            (stratumStrucRand ??= new LCGRandom(api.WorldManager.Seed + 1090)).InitPositionSeed(chunkX, chunkZ);
+ 
+             for (int i = 0; i < vcfg.VillageTypes.Length; i++)
+             {
+                 WorldGenVillage struc = vcfg.VillageTypes[i];
+                 if (struc.PostPass != postPass) continue;
+                 float chance = struc.Chance * vcfg.ChanceMultiplier;
+-                while (chance-- > strucRand.NextFloat())
++                while (chance-- > stratumStrucRand.NextFloat())
+                 {
+                     GenVillage(worldgenBlockAccessor, region, struc, chunkX, chunkZ);
+                 }
+             }
+         }
+@@ -466,16 +469,16 @@ namespace Vintagestory.ServerMods
+         {
+             BlockPos pos = new BlockPos(Dimensions.NormalWorld);
+ 
+             int dx = chunksize / 2;
+             int dz = chunksize / 2;
+-            int ySurface = heightmap[dz * chunksize + dx];
++            int ySurface = stratumHeightmap[dz * chunksize + dx];
+             if (ySurface <= 0 || ySurface >= worldheight - 15) return false;
+ 
+             pos.Set(chunkX * chunksize + dx, ySurface, chunkZ * chunksize + dz);
+ 
+-            return struc.TryGenerate(blockAccessor, api.World, pos, climateUpLeft, climateUpRight, climateBotLeft, climateBotRight, (loc, schematic) =>
++            return struc.TryGenerate(blockAccessor, api.World, pos, stratumClimateUpLeft, stratumClimateUpRight, stratumClimateBotLeft, stratumClimateBotRight, (loc, schematic) =>
+             {
+                 string code = (schematic == null ? "" : schematic.FromFile.GetNameWithDomain()) + "/" + struc.Code;
+ 
+                 region.AddGeneratedStructure(new GeneratedStructure() { Code = code, Group = struc.Group, Location = loc.Clone() });
+ 
+@@ -493,40 +496,56 @@ namespace Vintagestory.ServerMods
+                 }
+             }, spawnPos);
+         }
+ 
+ 
++        // Stratum: treeAndShrubSupressingStructures is a single instance field, one
++        // GenStructures per world, that PreventPlacementBroadlyAt clears and rebuilds
++        // per column and PreventPlacementAt reads a bit later for the same column's
++        // Vegetation-stage processing. Both currently only run from within Vegetation,
++        // which stays at same-stage cap 1, so today's callers never overlap. The moment
++        // anyone raises Vegetation's cap the way PreDone/TerrainLate/Terrain already
++        // got raised, two columns' clear-then-read sequences would interleave on the
++        // same shared list. Locked now, while the cost is zero (Vegetation is already
++        // serialized), instead of leaving it as a landmine for whoever raises that cap.
++        readonly object stratumTreeShrubSuppressLock = new object();
+         List<Cuboidi> treeAndShrubSupressingStructures = new List<Cuboidi>();
+         int chunkMapSizeY;
+ 
+         public bool PreventPlacementAt(int x, int z, int category)
+         {
+             if (category != ShrubsHashCode && category != TreesHashCode) return false;
+ 
+-            for (int i = 0; i < treeAndShrubSupressingStructures.Count; i++)
++            lock (stratumTreeShrubSuppressLock)
+             {
+-                if (treeAndShrubSupressingStructures[i].Contains(x, z)) return true;
++                for (int i = 0; i < treeAndShrubSupressingStructures.Count; i++)
++                {
++                    if (treeAndShrubSupressingStructures[i].Contains(x, z)) return true;
++                }
+             }
+ 
+             return false;
+         }
+ 
+         public bool PreventPlacementBroadlyAt(int chunkX, int chunkZ)
+         {
+             BlockPos chunkStart = new BlockPos(Dimensions.NormalWorld);
+             BlockPos chunkEnd = new BlockPos(Dimensions.NormalWorld);
+ 
+-            treeAndShrubSupressingStructures.Clear();
+-            api.World.BlockAccessor.WalkStructures(
+-                chunkStart.Set(chunkX * chunksize, 0, chunkZ * chunksize),
+-                chunkEnd.Set(chunkX * chunksize + chunksize, chunkMapSizeY * chunksize, chunkZ * chunksize + chunksize), (struc) =>
++            lock (stratumTreeShrubSuppressLock)
+             {
+-                if (struc.SuppressTreesAndShrubs)
++                treeAndShrubSupressingStructures.Clear();
++                api.World.BlockAccessor.WalkStructures(
++                    chunkStart.Set(chunkX * chunksize, 0, chunkZ * chunksize),
++                    chunkEnd.Set(chunkX * chunksize + chunksize, chunkMapSizeY * chunksize, chunkZ * chunksize + chunksize), (struc) =>
+                 {
+-                    treeAndShrubSupressingStructures.Add(struc.Location.Clone().GrowBy(1, 1, 1));
+-                }
+-            });
++                    if (struc.SuppressTreesAndShrubs)
++                    {
++                        treeAndShrubSupressingStructures.Add(struc.Location.Clone().GrowBy(1, 1, 1));
++                    }
++                });
++            }
+ 
+             return false;
+         }
+ 
+         public BlockPatchConfig GetPatchProviderAt(int chunkX, int chunkZ, ref EnumHandling handling)

--- a/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/8.GenVegetationAndPatches/GenVegetationAndPatches.cs.patch
+++ b/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/8.GenVegetationAndPatches/GenVegetationAndPatches.cs.patch
@@ -1,0 +1,425 @@
+diff --git a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/8.GenVegetationAndPatches/GenVegetationAndPatches.cs b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/8.GenVegetationAndPatches/GenVegetationAndPatches.cs
+index aadf540..ffa4195 100644
+--- a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/8.GenVegetationAndPatches/GenVegetationAndPatches.cs
++++ b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/8.GenVegetationAndPatches/GenVegetationAndPatches.cs
+@@ -29,11 +29,10 @@ namespace Vintagestory.ServerMods
+     }
+ 
+     public class GenVegetationAndPatches : ModStdWorldGen
+     {
+         protected ICoreServerAPI sapi;
+-        protected LCGRandom rnd;
+         protected IWorldGenBlockAccessor blockAccessor;
+         protected WgenTreeSupplier treeSupplier;
+         protected int worldheight;
+         protected int regionChunkSize;
+         protected IBlockPatchModifier[] patchMod = new IBlockPatchModifier[0];
+@@ -47,10 +46,25 @@ namespace Vintagestory.ServerMods
+ 
+         /// <summary>
+         /// Vegetation and BlockPatch sub seed
+         /// </summary>
+         protected const int subSeed = 87698;
++
++        // Stratum: genPatches/genShrubs/genTrees each allocated a fresh LCGRandom every
++        // column, six per column between them (genPatches runs twice, pre-pass and
++        // post-pass). LCGRandom.SetWorldSeed() overwrites every field the class has
++        // (worldSeed, mapGenSeed, currentSeed) before InitPositionSeed() runs, so a
++        // reused instance behaves identically to a fresh one, nothing carries over
++        // between calls. [ThreadStatic] instead of a shared field: this class also has
++        // an actual shared LCGRandom (rnd, above), reseeded the same way per column,
++        // which stays a real cross-column race risk the moment Vegetation's same-stage
++        // cap moves off 1, flagged separately, not touched by this change.
++        [ThreadStatic] private static LCGRandom stratumPatchIterRandom;
++        [ThreadStatic] private static LCGRandom stratumBlockPatchRandom;
++        [ThreadStatic] private static LCGRandom stratumShrubTryRandom;
++        [ThreadStatic] private static LCGRandom stratumTreeTryRandom;
++
+         public override bool ShouldLoad(EnumAppSide side)
+         {
+             return side == EnumAppSide.Server;
+         }
+ 
+@@ -112,12 +126,10 @@ namespace Vintagestory.ServerMods
+             regionSize = sapi.WorldManager.RegionSize;
+             noiseSizeDensityMap = regionSize / TerraGenConfig.blockPatchesMapScale;
+ 
+             LoadGlobalConfig(sapi);
+ 
+-            rnd = new LCGRandom(sapi.WorldManager.Seed - subSeed);
+-
+             treeSupplier.LoadTrees();
+ 
+             worldheight = sapi.WorldManager.MapSizeY;
+             regionChunkSize = sapi.WorldManager.RegionSize / chunksize;
+ 
+@@ -139,11 +151,11 @@ namespace Vintagestory.ServerMods
+             {
+                 allPatches.AddRange(patches.Value);
+             }
+             bpc.Patches = allPatches.ToArray();
+ 
+-            bpc.ResolveBlockIds(sapi, rockstrata, rnd);
++            bpc.ResolveBlockIds(sapi, rockstrata, stratumRnd ??= new LCGRandom(sapi.WorldManager.Seed - subSeed));
+             treeSupplier.treeGenerators.forestFloorSystem.SetBlockPatches(bpc);
+ 
+ 
+             ITreeAttribute worldConfig = sapi.WorldManager.SaveGame.WorldConfiguration;
+             forestMod = worldConfig.GetString("globalForestation").ToFloat(0);
+@@ -157,80 +169,88 @@ namespace Vintagestory.ServerMods
+                 int seed = sapi.World.Seed + 112897 + hs;
+                 blockPatchMapGens[patch.MapCode] = new MapLayerWobbled(seed, 2, 0.9f, TerraGenConfig.forestMapScale, 4000, -2500);
+             }
+         }
+ 
+-        ushort[] heightmap;
+-        int forestUpLeft;
+-        int forestUpRight;
+-        int forestBotLeft;
+-        int forestBotRight;
+-
+-        int shrubUpLeft;
+-        int shrubUpRight;
+-        int shrubBotLeft;
+-        int shrubBotRight;
+-
+-        int climateUpLeft;
+-        int climateUpRight;
+-        int climateBotLeft;
+-        int climateBotRight;
+-
+-        BlockPos tmpPos = new BlockPos(API.Config.Dimensions.NormalWorld);
++        // Stratum: every field below used to be a plain instance field, written by
++        // OnChunkColumnGen and read a few calls later by genPatches/genShrubs/genTrees/
++        // canGenerateAt, all within the processing of ONE column, the same shape of bug
++        // GenCreatures had for PreDone (see the comment on that class's own [ThreadStatic]
++        // block). Vegetation's own same-stage cap stays at 1 today, so this was not a live
++        // race yet, but two columns' write-then-read sequences would clobber each other
++        // the moment anyone raises that cap, the same way rnd (below) and
++        // treeAndShrubSupressingStructures in GenStructures already did. [ThreadStatic]
++        // keeps every field private to whichever thread is currently inside
++        // OnChunkColumnGen for a given column, at zero cost while only one thread at a
++        // time is ever in here.
++        [ThreadStatic] private static ushort[] stratumHeightmap;
++        [ThreadStatic] private static int stratumForestUpLeft, stratumForestUpRight, stratumForestBotLeft, stratumForestBotRight;
++        [ThreadStatic] private static int stratumShrubUpLeft, stratumShrubUpRight, stratumShrubBotLeft, stratumShrubBotRight;
++        [ThreadStatic] private static int stratumClimateUpLeft, stratumClimateUpRight, stratumClimateBotLeft, stratumClimateBotRight;
++        [ThreadStatic] private static BlockPos stratumTmpPos;
+ 
+         /// <summary>
+         /// Structures generally are sparsely placed in the world, so 99% of the time we can generate block patches unimpeded.
+         /// So for performance reasons, lets do a single broad test first, which allows us to skip detail testing later
+         /// </summary>
+-        bool preventBroadly;
++        [ThreadStatic] private static bool stratumPreventBroadly;
++
++        // Stratum: rnd used to be seeded once for the whole world in initWorldGen and
++        // reseeded per column via InitPositionSeed alone, no SetWorldSeed. That reseed
++        // does not depend on rnd's own prior state (InitPositionSeed derives currentSeed
++        // from mapGenSeed, xPos, and zPos only, and mapGenSeed itself never changes after
++        // the one-time SetWorldSeed call in the constructor), so this needed isolation,
++        // not GenCreatures' extra fix of removing a dispatch-order dependency: two
++        // different columns already got two different, order-independent seeds here.
++        [ThreadStatic] private static LCGRandom stratumRnd;
+ 
+         private void OnChunkColumnGen(IChunkColumnGenerateRequest request)
+         {
+             var chunks = request.Chunks;
+             int chunkX = request.ChunkX;
+             int chunkZ = request.ChunkZ;
+ 
+             blockAccessor.BeginColumn();
+-            rnd.InitPositionSeed(chunkX, chunkZ);
++            (stratumRnd ??= new LCGRandom(sapi.WorldManager.Seed - subSeed)).InitPositionSeed(chunkX, chunkZ);
+ 
+             IMapChunk mapChunk = chunks[0].MapChunk;
+ 
+             IntDataMap2D forestMap = mapChunk.MapRegion.ForestMap;
+             IntDataMap2D shrubMap = mapChunk.MapRegion.ShrubMap;
+             IntDataMap2D climateMap = mapChunk.MapRegion.ClimateMap;
+             int rlX = chunkX % regionChunkSize;
+             int rlZ = chunkZ % regionChunkSize;
+ 
+             float facS = (float)shrubMap.InnerSize / regionChunkSize;
+-            shrubUpLeft = shrubMap.GetUnpaddedInt((int)(rlX * facS), (int)(rlZ * facS));
+-            shrubUpRight = shrubMap.GetUnpaddedInt((int)(rlX * facS + facS), (int)(rlZ * facS));
+-            shrubBotLeft = shrubMap.GetUnpaddedInt((int)(rlX * facS), (int)(rlZ * facS + facS));
+-            shrubBotRight = shrubMap.GetUnpaddedInt((int)(rlX * facS + facS), (int)(rlZ * facS + facS));
++            stratumShrubUpLeft = shrubMap.GetUnpaddedInt((int)(rlX * facS), (int)(rlZ * facS));
++            stratumShrubUpRight = shrubMap.GetUnpaddedInt((int)(rlX * facS + facS), (int)(rlZ * facS));
++            stratumShrubBotLeft = shrubMap.GetUnpaddedInt((int)(rlX * facS), (int)(rlZ * facS + facS));
++            stratumShrubBotRight = shrubMap.GetUnpaddedInt((int)(rlX * facS + facS), (int)(rlZ * facS + facS));
+ 
+             // A region has 16 chunks
+             // Size of the forest map is RegionSize / TerraGenConfig.forestMapScale  => 32*16 / 32  = 16 pixel
+             // rlX, rlZ goes from 0..16 pixel
+             // facF = 16/16 = 1
+             // Get 4 pixels for chunkx, chunkz, chunkx+1 and chunkz+1 inside the map
+             float facF = (float)forestMap.InnerSize / regionChunkSize;
+-            forestUpLeft = forestMap.GetUnpaddedInt((int)(rlX * facF), (int)(rlZ * facF));
+-            forestUpRight = forestMap.GetUnpaddedInt((int)(rlX * facF + facF), (int)(rlZ * facF));
+-            forestBotLeft = forestMap.GetUnpaddedInt((int)(rlX * facF), (int)(rlZ * facF + facF));
+-            forestBotRight = forestMap.GetUnpaddedInt((int)(rlX * facF + facF), (int)(rlZ * facF + facF));
++            stratumForestUpLeft = forestMap.GetUnpaddedInt((int)(rlX * facF), (int)(rlZ * facF));
++            stratumForestUpRight = forestMap.GetUnpaddedInt((int)(rlX * facF + facF), (int)(rlZ * facF));
++            stratumForestBotLeft = forestMap.GetUnpaddedInt((int)(rlX * facF), (int)(rlZ * facF + facF));
++            stratumForestBotRight = forestMap.GetUnpaddedInt((int)(rlX * facF + facF), (int)(rlZ * facF + facF));
+ 
+             float facC = (float)climateMap.InnerSize / regionChunkSize;
+-            climateUpLeft = climateMap.GetUnpaddedInt((int)(rlX * facC), (int)(rlZ * facC));
+-            climateUpRight = climateMap.GetUnpaddedInt((int)(rlX * facC + facC), (int)(rlZ * facC));
+-            climateBotLeft = climateMap.GetUnpaddedInt((int)(rlX * facC), (int)(rlZ * facC + facC));
+-            climateBotRight = climateMap.GetUnpaddedInt((int)(rlX * facC + facC), (int)(rlZ * facC + facC));
++            stratumClimateUpLeft = climateMap.GetUnpaddedInt((int)(rlX * facC), (int)(rlZ * facC));
++            stratumClimateUpRight = climateMap.GetUnpaddedInt((int)(rlX * facC + facC), (int)(rlZ * facC));
++            stratumClimateBotLeft = climateMap.GetUnpaddedInt((int)(rlX * facC), (int)(rlZ * facC + facC));
++            stratumClimateBotRight = climateMap.GetUnpaddedInt((int)(rlX * facC + facC), (int)(rlZ * facC + facC));
+ 
+-            heightmap = chunks[0].MapChunk.RainHeightMap;
+-            preventBroadly = false;
++            stratumHeightmap = chunks[0].MapChunk.RainHeightMap;
++            stratumPreventBroadly = false;
+ 
+             foreach (var provider in patchMod)
+             {
+-                preventBroadly |= provider.PreventPlacementBroadlyAt(chunkX, chunkZ);
++                stratumPreventBroadly |= provider.PreventPlacementBroadlyAt(chunkX, chunkZ);
+             }
+ 
+ 
+             if (TerraGenConfig.GenerateVegetation)
+             {
+@@ -245,12 +265,12 @@ namespace Vintagestory.ServerMods
+         {
+             int dx, dz, x, z;
+             Block liquidBlock;
+             int mapsizeY = blockAccessor.MapSizeY;
+ 
+-            var patchIterRandom = new LCGRandom();
+-            var blockPatchRandom = new LCGRandom();
++            var patchIterRandom = stratumPatchIterRandom ??= new LCGRandom();
++            var blockPatchRandom = stratumBlockPatchRandom ??= new LCGRandom();
+ 
+             // get temp pos to check if we need a story location patch or a regular one
+             patchIterRandom.SetWorldSeed(sapi.WorldManager.Seed - subSeed);
+             patchIterRandom.InitPositionSeed(chunkX, chunkZ);
+ 
+@@ -272,29 +292,29 @@ namespace Vintagestory.ServerMods
+                     dx = patchIterRandom.NextInt(chunksize);
+                     dz = patchIterRandom.NextInt(chunksize);
+                     x = dx + chunkX * chunksize;
+                     z = dz + chunkZ * chunksize;
+ 
+-                    int y = heightmap[dz * chunksize + dx];
++                    int y = stratumHeightmap[dz * chunksize + dx];
+                     if (y <= 0 || y >= worldheight - 15) continue;
+ 
+-                    tmpPos.Set(x, y, z);
++                    (stratumTmpPos ??= new BlockPos(API.Config.Dimensions.NormalWorld)).Set(x, y, z);
+ 
+-                    liquidBlock = blockAccessor.GetBlock(tmpPos, BlockLayersAccess.Fluid);
++                    liquidBlock = blockAccessor.GetBlock(stratumTmpPos, BlockLayersAccess.Fluid);
+ 
+                     // Place according to forest value
+-                    float forestRel = GameMath.BiLerp(forestUpLeft, forestUpRight, forestBotLeft, forestBotRight, (float)dx / chunksize, (float)dz / chunksize) / 255f;
++                    float forestRel = GameMath.BiLerp(stratumForestUpLeft, stratumForestUpRight, stratumForestBotLeft, stratumForestBotRight, (float)dx / chunksize, (float)dz / chunksize) / 255f;
+                     forestRel = GameMath.Clamp(forestRel + forestMod, 0, 1);
+ 
+-                    float shrubRel = GameMath.BiLerp(shrubUpLeft, shrubUpRight, shrubBotLeft, shrubBotRight, (float)dx / chunksize, (float)dz / chunksize) / 255f;
++                    float shrubRel = GameMath.BiLerp(stratumShrubUpLeft, stratumShrubUpRight, stratumShrubBotLeft, stratumShrubBotRight, (float)dx / chunksize, (float)dz / chunksize) / 255f;
+                     shrubRel = GameMath.Clamp(shrubRel + shrubMod, 0, 1);
+ 
+-                    int climate = GameMath.BiLerpRgbColor((float)dx / chunksize, (float)dz / chunksize, climateUpLeft, climateUpRight, climateBotLeft, climateBotRight);
++                    int climate = GameMath.BiLerpRgbColor((float)dx / chunksize, (float)dz / chunksize, stratumClimateUpLeft, stratumClimateUpRight, stratumClimateBotLeft, stratumClimateBotRight);
+ 
+                     if (bpc.IsPatchSuitableAt(blockPatch, liquidBlock, mapsizeY, climate, y, forestRel, shrubRel))
+                     {
+-                        if (!preventBroadly && !canGenerateAt(tmpPos.X, tmpPos.Z, blockPatch.CategoryHashCode)) continue;
++                        if (!stratumPreventBroadly && !canGenerateAt(stratumTmpPos.X, stratumTmpPos.Z, blockPatch.CategoryHashCode)) continue;
+ 
+                         if (blockPatch.MapCode != null && patchIterRandom.NextInt(255) > GetPatchDensity(blockPatch.MapCode, x, z, mapregion))
+                         {
+                             continue;
+                         }
+@@ -306,11 +326,11 @@ namespace Vintagestory.ServerMods
+                         {
+                             found = false;
+                             int dy = 1;
+                             while (dy < 5 && y - dy > 0)
+                             {
+-                                string lastCodePart = blockAccessor.GetBlockBelow(tmpPos, dy, BlockLayersAccess.Solid).LastCodePart();
++                                string lastCodePart = blockAccessor.GetBlockBelow(stratumTmpPos, dy, BlockLayersAccess.Solid).LastCodePart();
+                                 if (RockBlockIdsByType.TryGetValue(lastCodePart, out firstBlockId)) { found = true; break; }
+                                 dy++;
+                             }
+                         }
+ 
+@@ -318,11 +338,11 @@ namespace Vintagestory.ServerMods
+                         {
+                             blockPatchRandom.SetWorldSeed(sapi.WorldManager.Seed - subSeed + i);
+                             blockPatchRandom.InitPositionSeed(x, z);
+                             blockPatch.Generate(
+                                 blockAccessor, patchIterRandom, x, y, z, firstBlockId,
+-                                !preventBroadly ? null : (tx, tz) => canGenerateAt(tx, tz, PatchesHashCode)
++                                !stratumPreventBroadly ? null : (tx, tz) => canGenerateAt(tx, tz, PatchesHashCode)
+                             );
+                         }
+                     }
+                 }
+             }
+@@ -362,15 +382,15 @@ namespace Vintagestory.ServerMods
+             return bpcPatchesNonTree;
+         }
+ 
+         void genShrubs(int chunkX, int chunkZ)
+         {
+-            rnd.InitPositionSeed(chunkX, chunkZ);
+-            int triesShrubs = (int)treeSupplier.treeGenProps.shrubsPerChunk.nextFloat(1f, rnd);
++            (stratumRnd ??= new LCGRandom(sapi.WorldManager.Seed - subSeed)).InitPositionSeed(chunkX, chunkZ);
++            int triesShrubs = (int)treeSupplier.treeGenProps.shrubsPerChunk.nextFloat(1f, stratumRnd);
+             int dx, dz, x, z;
+             Block block;
+-            var shrubTryRandom = new LCGRandom();
++            var shrubTryRandom = stratumShrubTryRandom ??= new LCGRandom();
+ 
+             while (triesShrubs > 0)
+             {
+                 shrubTryRandom.SetWorldSeed(sapi.World.Seed - subSeed + triesShrubs);
+                 shrubTryRandom.InitPositionSeed(chunkX, chunkZ);
+@@ -379,61 +399,61 @@ namespace Vintagestory.ServerMods
+                 dx = shrubTryRandom.NextInt(chunksize);
+                 dz = shrubTryRandom.NextInt(chunksize);
+                 x = dx + chunkX * chunksize;
+                 z = dz + chunkZ * chunksize;
+ 
+-                int y = heightmap[dz * chunksize + dx];
++                int y = stratumHeightmap[dz * chunksize + dx];
+                 if (y <= 0 || y >= worldheight - 15) continue;
+ 
+-                tmpPos.Set(x, y, z);
++                (stratumTmpPos ??= new BlockPos(API.Config.Dimensions.NormalWorld)).Set(x, y, z);
+ 
+-                block = blockAccessor.GetBlock(tmpPos);
++                block = blockAccessor.GetBlock(stratumTmpPos);
+                 if (block.Fertility == 0) continue;
+ 
+                 // Place according to forest value
+-                int climate = GameMath.BiLerpRgbColor((float)dx / chunksize, (float)dz / chunksize, climateUpLeft, climateUpRight, climateBotLeft, climateBotRight);
+-                float shrubChance = GameMath.BiLerp(shrubUpLeft, shrubUpRight, shrubBotLeft, shrubBotRight, (float)dx / chunksize, (float)dz / chunksize);
++                int climate = GameMath.BiLerpRgbColor((float)dx / chunksize, (float)dz / chunksize, stratumClimateUpLeft, stratumClimateUpRight, stratumClimateBotLeft, stratumClimateBotRight);
++                float shrubChance = GameMath.BiLerp(stratumShrubUpLeft, stratumShrubUpRight, stratumShrubBotLeft, stratumShrubBotRight, (float)dx / chunksize, (float)dz / chunksize);
+                 shrubChance = GameMath.Clamp(shrubChance + 255*forestMod, 0, 255);
+ 
+                 if (shrubTryRandom.NextFloat() > (shrubChance / 255f) * (shrubChance / 255f)) continue;
+                 TreeGenInstance treegenParams = treeSupplier.GetRandomShrubGenForClimate(shrubTryRandom, climate, (int)shrubChance, y);
+ 
+                 if (treegenParams != null)
+                 {
+-                    if (preventBroadly && !canGenerateAt(tmpPos.X, tmpPos.Z, ShrubsHashCode)) continue;
++                    if (stratumPreventBroadly && !canGenerateAt(stratumTmpPos.X, stratumTmpPos.Z, ShrubsHashCode)) continue;
+ 
+-                    if (blockAccessor.GetBlock(tmpPos).Replaceable >= 6000)
++                    if (blockAccessor.GetBlock(stratumTmpPos).Replaceable >= 6000)
+                     {
+-                        tmpPos.Y--;
++                        stratumTmpPos.Y--;
+                     }
+ 
+                     treegenParams.skipForestFloor = true;
+ 
+-                    treegenParams.GrowTree(blockAccessor, tmpPos, shrubTryRandom);
++                    treegenParams.GrowTree(blockAccessor, stratumTmpPos, shrubTryRandom);
+                 }
+             }
+         }
+ 
+         void genTrees(int chunkX, int chunkZ)
+         {
+-            rnd.InitPositionSeed(chunkX, chunkZ);
+-            int climate = GameMath.BiLerpRgbColor((float)0.5f, (float)0.5f, climateUpLeft, climateUpRight, climateBotLeft, climateBotRight);
+-            float wetrel = Climate.GetRainFall((climate >> 8) & 0xff, heightmap[(chunksize / 2) * chunksize + chunksize/2]) / 255f;
++            (stratumRnd ??= new LCGRandom(sapi.WorldManager.Seed - subSeed)).InitPositionSeed(chunkX, chunkZ);
++            int climate = GameMath.BiLerpRgbColor((float)0.5f, (float)0.5f, stratumClimateUpLeft, stratumClimateUpRight, stratumClimateBotLeft, stratumClimateBotRight);
++            float wetrel = Climate.GetRainFall((climate >> 8) & 0xff, stratumHeightmap[(chunksize / 2) * chunksize + chunksize/2]) / 255f;
+             float temprel = ((climate>>16) & 0xff) / 255f;
+             float dryrel = 1 - wetrel;
+ 
+             float drypenalty = 1 - GameMath.Clamp(2f * (dryrel - 0.5f + 1.5f*Math.Max(temprel - 0.6f, 0)), 0, 0.8f); // Reduce tree generation by up to 70% in low rain places
+             float wetboost = 1 + 3 * Math.Max(0, wetrel - 0.75f);
+ 
+-            int triesTrees = (int)(treeSupplier.treeGenProps.treesPerChunk.nextFloat(1f, rnd) * drypenalty * wetboost);
++            int triesTrees = (int)(treeSupplier.treeGenProps.treesPerChunk.nextFloat(1f, stratumRnd) * drypenalty * wetboost);
+             int dx, dz, x, z;
+             Block block;
+             int treesGenerated = 0;
+ 
+             EnumHemisphere hemisphere = sapi.World.Calendar.GetHemisphere(new BlockPos(chunkX * chunksize + chunksize / 2, 0, chunkZ * chunksize + chunksize / 2));
+ 
+-            var treeTryRandom = new LCGRandom();
++            var treeTryRandom = stratumTreeTryRandom ??= new LCGRandom();
+             while (triesTrees > 0)
+             {
+                 treeTryRandom.SetWorldSeed(sapi.World.Seed - subSeed + triesTrees);
+                 treeTryRandom.InitPositionSeed(chunkX, chunkZ);
+                 triesTrees--;
+@@ -441,26 +461,26 @@ namespace Vintagestory.ServerMods
+                 dx = treeTryRandom.NextInt(chunksize);
+                 dz = treeTryRandom.NextInt(chunksize);
+                 x = dx + chunkX * chunksize;
+                 z = dz + chunkZ * chunksize;
+ 
+-                int y = heightmap[dz * chunksize + dx];
++                int y = stratumHeightmap[dz * chunksize + dx];
+                 if (y <= 0 || y >= worldheight - 15) continue;
+ 
+                 bool underwater = false;
+ 
+-                tmpPos.Set(x, y, z);
+-                block = blockAccessor.GetBlock(tmpPos, BlockLayersAccess.Fluid);
++                (stratumTmpPos ??= new BlockPos(API.Config.Dimensions.NormalWorld)).Set(x, y, z);
++                block = blockAccessor.GetBlock(stratumTmpPos, BlockLayersAccess.Fluid);
+ 
+-                if (block.IsLiquid()) { underwater = true; tmpPos.Y--; block = blockAccessor.GetBlock(tmpPos, BlockLayersAccess.Fluid); if (block.IsLiquid()) tmpPos.Y--; }
++                if (block.IsLiquid()) { underwater = true; stratumTmpPos.Y--; block = blockAccessor.GetBlock(stratumTmpPos, BlockLayersAccess.Fluid); if (block.IsLiquid()) stratumTmpPos.Y--; }
+ 
+-                block = blockAccessor.GetBlock(tmpPos);
++                block = blockAccessor.GetBlock(stratumTmpPos);
+                 if (block.Fertility == 0) continue;
+ 
+                 // Place according to forest value
+-                float treeDensity = GameMath.BiLerp(forestUpLeft, forestUpRight, forestBotLeft, forestBotRight, (float)dx / chunksize, (float)dz / chunksize);
+-                climate = GameMath.BiLerpRgbColor((float)dx / chunksize, (float)dz / chunksize, climateUpLeft, climateUpRight, climateBotLeft, climateBotRight);
++                float treeDensity = GameMath.BiLerp(stratumForestUpLeft, stratumForestUpRight, stratumForestBotLeft, stratumForestBotRight, (float)dx / chunksize, (float)dz / chunksize);
++                climate = GameMath.BiLerpRgbColor((float)dx / chunksize, (float)dz / chunksize, stratumClimateUpLeft, stratumClimateUpRight, stratumClimateBotLeft, stratumClimateBotRight);
+ 
+                 treeDensity = GameMath.Clamp(treeDensity + forestMod*255, 0, 255);
+ 
+                 float treeDensityNormalized = treeDensity / 255f;
+ 
+@@ -471,22 +491,22 @@ namespace Vintagestory.ServerMods
+                 if (treeTryRandom.NextFloat() > Math.Max(0.0025f, treeDensityNormalized * treeDensityNormalized) || forestMod <= -1) continue;
+                 TreeGenInstance treegenParams = treeSupplier.GetRandomTreeGenForClimate(treeTryRandom, climate, (int)treeDensity, y, underwater);
+ 
+                 if (treegenParams != null)
+                 {
+-                    if (preventBroadly && !canGenerateAt(tmpPos.X, tmpPos.Z, TreesHashCode)) continue;
++                    if (stratumPreventBroadly && !canGenerateAt(stratumTmpPos.X, stratumTmpPos.Z, TreesHashCode)) continue;
+ 
+-                    if (blockAccessor.GetBlock(tmpPos).Replaceable >= 6000)
++                    if (blockAccessor.GetBlock(stratumTmpPos).Replaceable >= 6000)
+                     {
+-                        tmpPos.Y--;
++                        stratumTmpPos.Y--;
+                     }
+ 
+                     treegenParams.skipForestFloor = false;
+                     treegenParams.hemisphere = hemisphere;
+                     treegenParams.treesInChunkGenerated = treesGenerated;
+ 
+-                    treegenParams.GrowTree(blockAccessor, tmpPos, treeTryRandom);
++                    treegenParams.GrowTree(blockAccessor, stratumTmpPos, treeTryRandom);
+ 
+                     treesGenerated++;
+                 }
+             }
+         }

--- a/patches/VSEssentials/Systems/WorldGen/Standard/Datastructures/BlockSchematicStructure.cs.patch
+++ b/patches/VSEssentials/Systems/WorldGen/Standard/Datastructures/BlockSchematicStructure.cs.patch
@@ -1,0 +1,81 @@
+diff --git a/VSEssentials/Systems/WorldGen/Standard/Datastructures/BlockSchematicStructure.cs b/VSEssentials/Systems/WorldGen/Standard/Datastructures/BlockSchematicStructure.cs
+index 7573f32..03c54ee 100644
+--- a/VSEssentials/Systems/WorldGen/Standard/Datastructures/BlockSchematicStructure.cs
++++ b/VSEssentials/Systems/WorldGen/Standard/Datastructures/BlockSchematicStructure.cs
+@@ -12,11 +12,19 @@ using Vintagestory.ServerMods.NoObf;
+ 
+ namespace Vintagestory.ServerMods
+ {
+     public class BlockSchematicStructure : BlockSchematic
+     {
+-        public Dictionary<int, AssetLocation> BlockCodesTmpForRemap = new();
++        // Stratum: was a shared instance field, written by resolveReplaceRemapsForBlockEntities
++        // and read a few lines later by PlaceEntitiesAndBlockEntities, both within the same
++        // placement call. Different columns placing the same cached schematic concurrently
++        // could interleave: one placement's remap overwrites another's before the first reads it
++        // back, or reassigns the field to a different dictionary entirely (the replaceBlocks
++        // == null fast path below). Nothing about this needs to outlive a single placement
++        // call, so it moved to thread-local scratch instead of instance state.
++        [ThreadStatic]
++        private static Dictionary<int, AssetLocation> stratumBlockCodesTmpForRemap;
+ 
+         public AssetLocation FromFile;
+ 
+         public Block[,,] blocksByPos;
+         public Dictionary<int, Block> FluidBlocksByPos;
+@@ -306,35 +314,38 @@ namespace Vintagestory.ServerMods
+                     }
+                 }
+             }
+ 
+             PlaceDecors(blockAccessor, startPos);
+-            PlaceEntitiesAndBlockEntities(blockAccessor, worldForCollectibleResolve, startPos, BlockCodesTmpForRemap, ItemCodes, replaceBlockEntities, replaceBlocks, centerrockblockid, layerBlockForBlockEntities, replaceMetaBlocks);
++            PlaceEntitiesAndBlockEntities(blockAccessor, worldForCollectibleResolve, startPos, stratumBlockCodesTmpForRemap, ItemCodes, replaceBlockEntities, replaceBlocks, centerrockblockid, layerBlockForBlockEntities, replaceMetaBlocks);
+ 
+             return placed;
+         }
+ 
+         private void resolveReplaceRemapsForBlockEntities(IBlockAccessor blockAccessor, IWorldAccessor worldForCollectibleResolve, Dictionary<int, Dictionary<int, int>> replaceBlocks, int centerrockblockid)
+         {
+             if (replaceBlocks == null)
+             {
+-                BlockCodesTmpForRemap = BlockCodes;
++                stratumBlockCodesTmpForRemap = BlockCodes;
+                 return;
+             }
+ 
++            if (stratumBlockCodesTmpForRemap == null || stratumBlockCodesTmpForRemap == BlockCodes) stratumBlockCodesTmpForRemap = new Dictionary<int, AssetLocation>();
++            else stratumBlockCodesTmpForRemap.Clear();
++
+             foreach (var val in BlockCodes)
+             {
+                 Block origBlock = worldForCollectibleResolve.GetBlock(val.Value);
+                 if (origBlock == null) continue; // Invalid blocks
+ 
+-                BlockCodesTmpForRemap[val.Key] = val.Value;
++                stratumBlockCodesTmpForRemap[val.Key] = val.Value;
+ 
+                 if (replaceBlocks.TryGetValue(origBlock.Id, out var replaceByBlock))
+                 {
+                     if (replaceByBlock.TryGetValue(centerrockblockid, out int newBlockId))
+                     {
+-                        BlockCodesTmpForRemap[val.Key] = blockAccessor.GetBlock(newBlockId).Code;
++                        stratumBlockCodesTmpForRemap[val.Key] = blockAccessor.GetBlock(newBlockId).Code;
+                     }
+                 }
+             }
+         }
+ 
+@@ -426,11 +437,11 @@ namespace Vintagestory.ServerMods
+             }
+ 
+             if (!(blockAccessor is IBlockAccessorRevertable))
+             {
+                 PlaceDecors(blockAccessor, startPos);
+-                PlaceEntitiesAndBlockEntities(blockAccessor, worldForCollectibleResolve, startPos, BlockCodesTmpForRemap, ItemCodes, false, null, centerrockblockid, null, GlobalConfig.ReplaceMetaBlocks);
++                PlaceEntitiesAndBlockEntities(blockAccessor, worldForCollectibleResolve, startPos, stratumBlockCodesTmpForRemap, ItemCodes, false, null, centerrockblockid, null, GlobalConfig.ReplaceMetaBlocks);
+             }
+ 
+             return placed;
+         }
+ 

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -13,13 +13,18 @@ set -euo pipefail
 
 script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd -- "$script_dir/.." && pwd)"
-# Server binary: prefer the built server when testing the working tree, then fall
-# back to the launcher if only StratumServer was built.
+# Server binary: prefer StratumServer, Stratum's own launcher, which applies
+# VanillaBootstrap and PatchedFileOverlay before handing off to the game. A
+# VintagestoryServer binary in this same directory is not something this repo
+# builds; it is the vanilla archive's own entry point, copied in as a side
+# effect of VanillaBootstrap's first-run overlay once StratumServer has run at
+# least once. Preferring it here would silently boot-test unpatched vanilla
+# code instead of this working tree.
 server_dir="$repo_root/StratumServer/bin/Release/net10.0"
-if [[ -f "$server_dir/VintagestoryServer" ]]; then
-  server_bin="$server_dir/VintagestoryServer"
-elif [[ -f "$server_dir/StratumServer" ]]; then
+if [[ -f "$server_dir/StratumServer" ]]; then
   server_bin="$server_dir/StratumServer"
+elif [[ -f "$server_dir/VintagestoryServer" ]]; then
+  server_bin="$server_dir/VintagestoryServer"
 else
   server_bin=""
 fi
@@ -45,15 +50,18 @@ trap cleanup EXIT
 
 cd "$repo_root"
 
-# Build if binary is missing.
+# Build if binary is missing. -p:EmbedPatchedFiles=true is required so
+# StratumServer actually carries this working tree's patched DLLs; without it
+# PatchedFileOverlay has nothing to overlay and the server silently runs
+# vanilla's unpatched VintagestoryLib.dll from the downloaded archive instead.
 if [[ -z "$server_bin" || ! -f "$server_bin" ]]; then
   echo "Building Release..."
-  dotnet build VintageStory.slnx -c Release --verbosity quiet
-  # Re-detect after build.
-  if [[ -f "$server_dir/VintagestoryServer" ]]; then
-    server_bin="$server_dir/VintagestoryServer"
-  elif [[ -f "$server_dir/StratumServer" ]]; then
+  dotnet build VintageStory.slnx -c Release -p:EmbedPatchedFiles=true --verbosity quiet
+  # Re-detect after build, same preference as above.
+  if [[ -f "$server_dir/StratumServer" ]]; then
     server_bin="$server_dir/StratumServer"
+  elif [[ -f "$server_dir/VintagestoryServer" ]]; then
+    server_bin="$server_dir/VintagestoryServer"
   fi
 fi
 


### PR DESCRIPTION
## Summary

Preventive thread-safety hardening for `GenVegetationAndPatches` (Vegetation stage), `GenStructures` and `GenDeposits` (TerrainFeatures stage), and `BlockSchematicStructure` (used by structure placement during TerrainFeatures). None of this fixes a live bug: TerrainFeatures and Vegetation both still run at same-stage cap 1, so no two columns are in these generators at once today. It closes the fields anyway so whoever raises either stage's cap next doesn't have to redo this audit, the same reasoning that already shipped TerrainLate's and Terrain's own zero-cost-at-cap-1 fixes ahead of any throughput work on `perf/terrainlate-stage-concurrency` and `perf/terrain-stage-concurrency`.

Split out of #179 into its own branch per the request to review same-stage concurrency one stage at a time. This one doesn't touch any stage's cap, so it's independent of the three cap-raise branches (`perf/predone-stage-concurrency`, `perf/terrainlate-stage-concurrency`, `perf/terrain-stage-concurrency`) and the cross-stage race fix (`fix/cross-stage-schematic-chunkdb-races`). Safe to review in any order relative to those.

It's also a real prerequisite for the TerrainFeatures generator audit the second review on #179 asked for (`GenPonds`, `GenTerraPostProcess`, and whatever else `EnumWorldGenPass.TerrainFeatures` registers): `GenDeposits` and `GenStructures` are two of that stage's own generators, so this closes their landmine fields ahead of that audit instead of leaving them for it to rediscover.

Second commit is unrelated to the worldgen changes above: two local build/test tooling fixes found while getting a real boot test working for this PR, see "Two build/tooling fixes made along the way" under Testing below.

### What's fixed, by file

| File | Stage | Fields moved to `[ThreadStatic]` | Other fix |
|---|---|---|---|
| `GenVegetationAndPatches.cs` | Vegetation | 16: `heightmap`, 4× forest context, 4× shrub context, 4× climate context, `tmpPos`, `preventBroadly`, `rnd` | none |
| `GenStructures.cs` | TerrainFeatures | 11: `heightmap`, 4× climate context, 4× forest context, `strucRand`, `shuffledStructures` | `treeAndShrubSupressingStructures` locked (List a column clears and rebuilds, then reads later in the same call) |
| `GenDeposits.cs` | TerrainFeatures | none | `depositRand`, `subDepositsToPlace`, `tmpPos` closed with a lock around `GeneratePartial`'s body instead (see "Why GenDeposits gets a lock" below) |
| `BlockSchematicStructure.cs` | called during TerrainFeatures structure placement | `BlockCodesTmpForRemap` (write in `resolveReplaceRemapsForBlockEntities`, read a few lines later in `PlaceEntitiesAndBlockEntities`, same placement call) | none |

`GenVegetationAndPatches` and `GenStructures` are both singleton `ModSystem`s with no second live instance anywhere in the codebase (checked), so `[ThreadStatic]` is safe there, same precedent as `GenCreatures`' existing PreDone fix. `rnd` and `strucRand` need lazy per-thread construction with the same world-seed argument the old shared instance used, since both reseed via `InitPositionSeed` alone (no `SetWorldSeed`), and `InitPositionSeed` derives its seed from `mapGenSeed` (fixed at construction) plus the column position only, never from prior state, so a freshly-constructed instance behaves identically to the old shared one.

### Why GenDeposits gets a lock instead of [ThreadStatic]

`GenDeposits` extends `GenPartial`, which already has a second live instance: `ProPickWorkSpace` constructs one for prospecting-pick probing (the same reason `GenPartial.chunkRand` and `GenCaves.caveRand` use `ThreadLocal` instance fields rather than `[ThreadStatic]` static ones on `perf/terrainlate-stage-concurrency`). A static field would leak state across those two instances.

`depositRand` specifically has a second problem beyond that: `DepositVariant.Init` passes it into `DepositGeneratorBase`, which stores the reference in its own field and reads *that* stored reference during generation, not `GenDeposits.depositRand` directly. Making it per-thread wouldn't isolate anything: every generator would keep reading whichever reference existed on whatever thread happened to run the one-time `Init` call, which breaks the per-column reseed rather than fixing a race. A lock around `GeneratePartial`'s full body preserves the existing object-identity relationship exactly and closes `subDepositsToPlace`/`tmpPos` the same way, at the cost of serializing `GeneratePartial` only once TerrainFeatures' cap ever rises off 1.

### Also folded in: GenVegetationAndPatches allocation pooling

`genPatches`, `genShrubs`, and `genTrees` each allocated a fresh `LCGRandom` per column, six allocations per column between them since `genPatches` runs twice (pre-pass and post-pass). Every one gets `SetWorldSeed()` then `InitPositionSeed()` before any read, and `SetWorldSeed()` overwrites every field `LCGRandom` has, so a reused instance behaves identically to a fresh one. Moved to `[ThreadStatic]`, reused instead of reallocated.

Flagging directly since it's a different kind of change than everything else in this PR: **this one is not measured**. No byte count or GC-time delta was taken, just reasoned from the code (six fewer allocations of a small object per column). Filed here because it's the same file, same audit pass, and touches nothing the rest of this PR doesn't already touch, not because it's been shown to matter.

## Type

- [x] Refactor or cleanup
- [x] Bug fix
- [ ] Performance
- [ ] New feature
- [ ] Docs or build

## Checklist

- [x] `./scripts/extract-patches.sh` round-trips clean against the bootstrapped tree: re-extracted all 162 patches in the repo, `git status` showed zero diff, byte-identical to what's committed.
- [x] `dotnet build VintageStory.slnx -c Release` is green: 0 errors, 1528 warnings, all pre-existing (`CS8632` nullable-annotation-context notices and one `CS0618` obsolete-API notice in `VSSurvivalMod`, none in the four files this PR touches).
- [x] Every vanilla edit has a `// Stratum` marker.
- [x] No vanilla source committed.
- [x] Tested on a real server start, not just compilation.

## Testing

Built clean, then verified three ways: pregen runs, a `dotnet-trace` capture, and a real server boot.

| Check | Result |
|---|---|
| Pregen run 1 (radius 40, seed `1027995113`) | 0 worldgen exceptions |
| Pregen run 2 (radius 30, seed `stratumitem4terrain`) | 0 worldgen exceptions |
| `dotnet-trace` capture (`gc-verbose` profile, ~3.5 min, radius 40 seed `1027995113`) | no method from any of the four changed files in the top 20 by callstack time, consistent with the `[ThreadStatic]` accesses being cheap and the `GenDeposits` lock being uncontended at today's cap of 1 |
| Server boot test (`bash scripts/smoke-test.sh`, no manual binary selection) | `PASS: server reached RunGame, no fatal errors.` World generation ran during startup (dungeons/structures placed, chunk queue drained), Stratum runtime came up (`[Stratum] runtime ready`) |

Both structure-heavy seeds were chosen deliberately since `GenStructures`/`GenDeposits` are the two generators changed here that place actual world content, not just scratch state.

No throughput or allocation numbers are claimed anywhere in this PR. Every field closed here is zero-cost today (TerrainFeatures and Vegetation both stay at same-stage cap 1), and the one piece that touches allocations (the `LCGRandom` pooling above) was reasoned from code, not profiled.

### Two build/tooling fixes made along the way

The first three boot attempts in this sandbox failed before reaching any worldgen code, for reasons that turned out to be real gaps in local build/test tooling rather than anything in the worldgen changes above. Fixed both in the second commit on this branch, since a broken local boot test would keep hitting whoever tries to verify this PR (or the four sibling branches split from #179) the same way:

1. A plain `dotnet build VintageStory.slnx -c Release` never embedded Stratum's own compiled `VintagestoryLib.dll`/mod DLLs into `StratumServer`. That only happens with `-p:EmbedPatchedFiles=true`; without it, `PatchedFileOverlay.Apply` (`StratumServer/PatchedFileOverlay.cs`) has nothing to overlay, so the server silently boots on whatever `VintagestoryLib.dll` the vanilla archive download provides, completely unpatched, no error or warning. This produced a Mono.Cecil assembly-resolution crash during mod loading that looked code-related but wasn't. Fixed by making the Makefile's `build` target (and `smoke`, which depends on it) pass `-p:EmbedPatchedFiles=true` by default, overridable with `EMBED_PATCHED_FILES=false`; `smoke-test.sh`'s own auto-build fallback gets the same flag.
2. `scripts/smoke-test.sh` preferred a binary literally named `VintagestoryServer` over `StratumServer` when both exist in the output directory. In this deployment model `VintagestoryServer` is not something this repo builds; it's the vanilla archive's own launcher, copied in as a side effect of `VanillaBootstrap`'s first-run overlay. When both were present the script picked the vanilla one and bypassed Stratum's bootstrap entirely, which is how a working `StratumServer` build produced a `Could not load file or assembly 'VintagestoryLib'` crash. Fixed by swapping the preference so `StratumServer` wins whenever it exists, in both the initial detection and the post-auto-build redetection.

Verified the fix, not just the workaround: `make build` then `bash scripts/smoke-test.sh`, no manual flags or binary selection, `PASS` on the first try.
