### PR TITLE
Lock two races cross-stage concurrency exposed: schematic unpack, chunk-db reads

### DIFF
--- a/patches/VSEssentials/Systems/WorldGen/Standard/Datastructures/BlockSchematicStructure.cs.patch
+++ b/patches/VSEssentials/Systems/WorldGen/Standard/Datastructures/BlockSchematicStructure.cs.patch
@@ -1,5 +1,5 @@
 diff --git a/VSEssentials/Systems/WorldGen/Standard/Datastructures/BlockSchematicStructure.cs b/VSEssentials/Systems/WorldGen/Standard/Datastructures/BlockSchematicStructure.cs
-index 7573f32..27a7943 100644
+index 7573f32..d75ab17 100644
 --- a/VSEssentials/Systems/WorldGen/Standard/Datastructures/BlockSchematicStructure.cs
 +++ b/VSEssentials/Systems/WorldGen/Standard/Datastructures/BlockSchematicStructure.cs
 @@ -12,11 +12,30 @@ using Vintagestory.ServerMods.NoObf;
@@ -123,3 +123,61 @@ index 7573f32..27a7943 100644
              return placed;
          }
  
+@@ -512,29 +536,52 @@ namespace Vintagestory.ServerMods
+             cloned.OriginalPos = OriginalPos;
+ 
+             return cloned;
+         }
+ 
++        // Stratum: guards the lazy unpack below. schematicDatas entries (see WorldGenStructure)
++        // are cached objects reused by every column that draws this schematic, and worldgen has
++        // always let different columns run in different pipeline stages at the same time,
++        // independent of any one stage's own concurrency cap. The original check-then-act let a
++        // second thread observe blocksByPos already non-null, since Init() sets it early, well
++        // before LoadMetaInformationAndValidate finishes populating fields like PathwayStarts,
++        // and skip straight into reading those fields before the thread doing the unpack had set
++        // them. That is the PathwayStarts crash reported while reviewing #179.
++        //
++        // No lock-free fast path on purpose: blocksByPos becoming non-null does not mean
++        // unpacking has finished, so every caller has to go through the lock, not just the one
++        // that finds blocksByPos still null.
++        private readonly object stratumUnpackLock = new object();
++
+         /// <summary>
+         /// Unpack blocks and indices to an array of positioned blocks, and other initialisation steps needed prior to placement and prior to Pathway checks
+         /// <br/>From 1.19.4 we do this Unpack() lazily, only when required, to save RAM [maybe also speeds up game start time, especially if mods add more schematics]
+         /// </summary>
+         /// <param name="api"></param>
+         public void Unpack(ICoreAPI api)
+         {
+-            if (blocksByPos == null)
++            lock (stratumUnpackLock)
+             {
+-                Init(api.World.BlockAccessor);
+-                LoadMetaInformationAndValidate(api.World.BlockAccessor, api.World, FromFile);
++                if (blocksByPos == null)
++                {
++                    Init(api.World.BlockAccessor);
++                    LoadMetaInformationAndValidate(api.World.BlockAccessor, api.World, FromFile);
++                }
+             }
+         }
+ 
+         public void Unpack(ICoreAPI api, int orientation)
+         {
+-            if (orientation > 0 && blocksByPos == null)
++            if (orientation > 0)
+             {
+-                TransformWhilePacked(api.World, EnumOrigin.BottomCenter, orientation * 90, null);
++                lock (stratumUnpackLock)
++                {
++                    if (blocksByPos == null)
++                    {
++                        TransformWhilePacked(api.World, EnumOrigin.BottomCenter, orientation * 90, null);
++                    }
++                }
+             }
+             Unpack(api);
+         }
+     }
+ }

--- a/patches/VintagestoryLib/Vintagestory.Common.Database/SQLiteDbConnectionv2.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Common.Database/SQLiteDbConnectionv2.cs.patch
@@ -1,0 +1,68 @@
+diff --git a/VintagestoryLib/Vintagestory.Common.Database/SQLiteDbConnectionv2.cs b/VintagestoryLib/Vintagestory.Common.Database/SQLiteDbConnectionv2.cs
+index 0c59a67..a7ed24d 100644
+--- a/VintagestoryLib/Vintagestory.Common.Database/SQLiteDbConnectionv2.cs
++++ b/VintagestoryLib/Vintagestory.Common.Database/SQLiteDbConnectionv2.cs
+@@ -326,14 +326,23 @@ public class SQLiteDbConnectionv2 : SQLiteDBConnection, IGameDbConnection, IDisp
+ 		return ChunkExists(position, (DbCommand)(object)val);
+ 	}
+ 
+ 	public bool ChunkExists(ulong position, DbCommand preparedCmd)
+ 	{
+-		using DbCommand dbCommand = preparedCmd;
+-		dbCommand.Parameters["position"].Value = position;
+-		using DbDataReader dbDataReader = dbCommand.ExecuteReader();
+-		return dbDataReader.HasRows;
++		// Stratum: every write path here (DeleteChunks, SetChunks, StoreGameData) holds
++		// transactionLock around its own BeginTransaction/Commit; this read path did not
++		// hold it at all, so a concurrent write's open transaction on the shared
++		// sqliteConn could leave this command's Transaction property unset while a
++		// transaction was still pending, throwing at ExecuteReader(). Locking here
++		// matches the discipline the write paths already use.
++		lock (transactionLock)
++		{
++			using DbCommand dbCommand = preparedCmd;
++			dbCommand.Parameters["position"].Value = position;
++			using DbDataReader dbDataReader = dbCommand.ExecuteReader();
++			return dbDataReader.HasRows;
++		}
+ 	}
+ 
+ 	public byte[] GetChunk(ulong position, string tablename)
+ 	{
+ 		SqliteCommand val = sqliteConn.CreateCommand();
+@@ -349,19 +358,28 @@ public class SQLiteDbConnectionv2 : SQLiteDBConnection, IGameDbConnection, IDisp
+ 		}
+ 	}
+ 
+ 	public byte[] GetChunk(ulong position, DbCommand preparedCmd)
+ 	{
+-		using DbCommand dbCommand = preparedCmd;
+-		dbCommand.Parameters["position"].Value = position;
+-		using DbDataReader dbDataReader = dbCommand.ExecuteReader();
+-		byte[] result = null;
+-		if (dbDataReader.Read())
++		// Stratum: see the matching comment on ChunkExists(ulong, DbCommand). This is
++		// the exact call site behind the reported crash: "Execute requires the command
++		// to have a transaction object when the connection assigned to the command is
++		// in a pending local transaction", thrown from GetChunk while a concurrent
++		// write held an open transaction on the same connection with no lock stopping
++		// this read from running in the middle of it.
++		lock (transactionLock)
+ 		{
+-			result = dbDataReader["data"] as byte[];
++			using DbCommand dbCommand = preparedCmd;
++			dbCommand.Parameters["position"].Value = position;
++			using DbDataReader dbDataReader = dbCommand.ExecuteReader();
++			byte[] result = null;
++			if (dbDataReader.Read())
++			{
++				result = dbDataReader["data"] as byte[];
++			}
++			return result;
+ 		}
+-		return result;
+ 	}
+ 
+ 	public void DeleteChunks(IEnumerable<ChunkPos> chunkpositions)
+ 	{
+ 		DeleteChunks(chunkpositions, "chunk");


### PR DESCRIPTION
Fixes the `PathwayStarts` crash @tehtelev hit while reviewing #179, plus a **critical data-corruption bug his review of this PR surfaced**, which turns out to be live on `indev` right now.

> [!WARNING]
> **The third fix below is a live bug on current `indev`, not a regression from this PR.** Until this merges, servers on `indev` are permanently corrupting schematic block-code maps. See "The `BlockCodes` destruction" below. Happy to split it into its own PR if that helps it merge faster.

## The `BlockCodes` destruction (new, critical)

@tehtelev reported a warning on this PR he had never seen before (`block ID 5983 not found in the block registry`), a `KeyNotFoundException` on #188 (`The given key '3683' was not present in the dictionary` in `BlockSchematic.PlaceDecors`), and a warning on #191 (`There is already game:block crate/11562, expected microblock`). **All three are one bug.**

Commit `a9719d0`, shipped as #183 and now on `indev`, converted `BlockSchematicStructure.BlockCodesTmpForRemap` from a **per-instance** field to `[ThreadStatic] private static`. `[ThreadStatic]` on a `static` gives one slot per thread shared by **every schematic instance on that thread**; the original was one per schematic. That difference is the whole bug:

```csharp
if (replaceBlocks == null)
{
    stratumBlockCodesTmpForRemap = BlockCodes;   // aliases THIS schematic's permanent map
    return;
}
if (stratumBlockCodesTmpForRemap == null || stratumBlockCodesTmpForRemap == BlockCodes) stratumBlockCodesTmpForRemap = new Dictionary<int, AssetLocation>();
else stratumBlockCodesTmpForRemap.Clear();      // clears whatever it points at
```

The identity guard only compares against **this** instance's `BlockCodes`. It cannot see that the slot currently aliases a *different* schematic's map. So:

1. Schematic **A** places with `replaceBlocks == null`, and the slot now aliases `A.BlockCodes`.
2. Schematic **B** places on the same thread with `replaceBlocks != null`, the slot is non-null and `!= B.BlockCodes`, so it falls through and **clears `A.BlockCodes`**.

`BlockCodes` is the schematic's permanent id to `AssetLocation` map, loaded once and reused for the process lifetime, so this corrupts that schematic permanently. `BlockSchematic.PlaceOneDecor` then does a bare `BlockCodes[id]` indexer on the emptied map, which is exactly the `KeyNotFoundException`.

**No concurrency is needed to trigger it.** `WorldGenStructure.resolvedRockTypeRemaps` starts `null` and is only populated when a structure configures a rock-type remap group, so structures without remaps supply step 1 and structures with them supply step 2. A normal world has both.

**Fix:** `resolveReplaceRemapsForBlockEntities` now returns the map instead of writing a shared field, both call sites hold it in a local, and the `replaceBlocks == null` path returns `BlockCodes` straight through without ever aliasing or mutating it, matching what vanilla does at `BlockSchematic.cs:709`. A thread-static scratch dictionary is kept for the `replaceBlocks != null` case only, preserving #183's allocation-reuse intent; since it can now only ever hold its own scratch instance, clearing it is provably safe.

## The two original races

**`BlockSchematicStructure.Unpack()`** had an unsynchronized check-then-act on `blocksByPos`. `Init()` sets that field before `LoadMetaInformationAndValidate` finishes populating `PathwayStarts`, so a second thread could see it non-null and read fields that do not exist yet. A lock around both overloads closes it, with no unlocked fast path on purpose: `blocksByPos != null` does not mean the unpack finished.

**`SQLiteDbConnectionv2`**'s `ChunkExists` and `GetChunk` never took `transactionLock` while every write path already did. A concurrent write's open transaction can leave a read command's `Transaction` unset, throwing at `ExecuteReader()`. Locking the two reads matches the discipline the write paths already use.

Both are reachable from cross-stage concurrency alone, which has existed since #175's dispatcher model, so neither needs a raised cap. That ordering matters for #191, which **cannot** merge without this one: raising TerrainFeatures' cap without the `Unpack` lock crashes in `WorldGenStructure.TryGenerateUnderground`.

## Verification

Bootstrap clean, two-pass Release build 0 errors, `smoke-test.sh` reaches RunGame, exactly 2 log lines matching `error|exception` and both are the known false positives (a class literally named `ErrorReporter`, and a line reading "no errors").

Honest limit: a smoke test cannot reproduce the corruption, which needs a large concurrent pregen with a mix of remapped and non-remapped structures. The fix is verified by construction (no path can now mutate or clear a `BlockCodes`-derived reference, checked by inspection and grep) rather than by observing the warnings stop. **Confirming that needs a rerun of your own radius-100 test**, which is the main thing I would like from a re-review.

Split out of #179 per @tehtelev's request to review same-stage concurrency one stage at a time.

/cc @tehtelev
