### PR TITLE
Audit every TerrainFeatures generator, fix the two that crash plus one more landmine

### DIFF
--- a/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/1.GenTerra/GenTerraPostProcess.cs.patch
+++ b/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/1.GenTerra/GenTerraPostProcess.cs.patch
@@ -1,0 +1,90 @@
+diff --git a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/1.GenTerra/GenTerraPostProcess.cs b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/1.GenTerra/GenTerraPostProcess.cs
+index 79c481d..691b108 100644
+--- a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/1.GenTerra/GenTerraPostProcess.cs
++++ b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/1.GenTerra/GenTerraPostProcess.cs
+@@ -13,12 +13,24 @@ namespace Vintagestory.ServerMods
+     public class GenTerraPostProcess : ModStdWorldGen
+     {
+         ICoreServerAPI api;
+         IWorldGenBlockAccessor blockAccessor;
+ 
+-        HashSet<int> chunkVisitedNodes = new HashSet<int>();
+-        List<int> solidNodes = new List<int>(40);
++        // Stratum: every field below used to be a plain instance field, written
++        // and read within the processing of a single column (OnChunkColumnGen ->
++        // deletePotentialFloatingBlocks -> AddToChunkVisitedNodesIfSameChunk),
++        // unsafe once TerrainFeatures' same-stage cap moves off 1. Matches the
++        // InvalidOperationException: Collection was modified crash reported
++        // against this class: two columns concurrently mutating the same shared
++        // HashSet/List. [ThreadStatic] since GenTerraPostProcess is a singleton
++        // ModSystem with no second live instance anywhere in the codebase
++        // (confirmed by search).
++        [ThreadStatic] private static HashSet<int> stratumChunkVisitedNodes;
++        [ThreadStatic] private static List<int> stratumSolidNodes;
++        [ThreadStatic] private static QueueOfInt stratumBfsQueue;
++        [ThreadStatic] private static int[] stratumCurrentVisited;
++        [ThreadStatic] private static int stratumIteration;
+ 
+         public override bool ShouldLoad(EnumAppSide side)
+         {
+             return side == EnumAppSide.Server;
+         }
+@@ -56,10 +68,11 @@ namespace Vintagestory.ServerMods
+             const int chunksize = GlobalConstants.ChunkSize;
+             const int chunksizeSquared = chunksize * chunksize;
+             int chunkY = seaLevel / chunksize;
+             int yMax = chunks[0].MapChunk.YMax;
+             int cyMax = Math.Min(yMax / chunksize + 1, api.World.BlockAccessor.MapSizeY / chunksize);
++            HashSet<int> chunkVisitedNodes = stratumChunkVisitedNodes ??= new HashSet<int>();
+             chunkVisitedNodes.Clear();
+ 
+             for (int cy = chunkY; cy < cyMax; cy++)
+             {
+                 IChunkBlocks chunkdata = chunks[cy].Data;
+@@ -106,28 +119,29 @@ namespace Vintagestory.ServerMods
+             }
+         }
+ 
+ 
+ 
+-        QueueOfInt bfsQueue = new QueueOfInt();
+         const int ARRAYSIZE = 41;  // Note if this constant is increased beyond 64, the bitshifts for compressedPos in the bfsQueue.Enqueue() and .Dequeue() calls may need updating
+-        readonly int[] currentVisited = new int[ARRAYSIZE * ARRAYSIZE * ARRAYSIZE];
+-        int iteration = 0;
+ 
+         /// <summary>
+         /// Very similar to RoomRegistry room search code: we will search for contiguous islands of blocks, surrounded by air on all sides
+         /// </summary>
+         private void deletePotentialFloatingBlocks(int X, int Y, int Z)
+         {
++            List<int> solidNodes = stratumSolidNodes ??= new List<int>(40);
++            QueueOfInt bfsQueue = stratumBfsQueue ??= new QueueOfInt();
++            int[] currentVisited = stratumCurrentVisited ??= new int[ARRAYSIZE * ARRAYSIZE * ARRAYSIZE];
++
+             int halfSize = (ARRAYSIZE - 1) / 2;
+             solidNodes.Clear();
+             bfsQueue.Clear();
+             int compressedPos = halfSize << 12 | halfSize << 6 | halfSize;
+             bfsQueue.Enqueue(compressedPos);
+             solidNodes.Add(compressedPos);
+ 
+-            int iteration = ++this.iteration;
++            int iteration = ++stratumIteration;
+             int visitedIndex = (halfSize * ARRAYSIZE + halfSize) * ARRAYSIZE + halfSize; // Center node
+             currentVisited[visitedIndex] = iteration;
+ 
+             int baseX = X - halfSize;
+             int baseY = Y - halfSize;
+@@ -225,11 +239,11 @@ namespace Vintagestory.ServerMods
+             if (((nposZ ^ origZ) & chunkMask) != 0) return;
+             if (((nposY ^ origY) & chunkMask) != 0) return;
+ 
+             const int inChunkMask = chunksize - 1;
+             int index3d = ((nposY & inChunkMask) * chunksize + (nposZ & inChunkMask)) * chunksize + (nposX & inChunkMask);
+-            chunkVisitedNodes.Add(index3d);
++            stratumChunkVisitedNodes.Add(index3d);
+         }
+ 
+         //struct VisitNode : IEquatable<VisitNode>
+         //{
+         //    public int X, Y, Z;

--- a/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/7.GenPonds/GenPonds.cs.patch
+++ b/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/7.GenPonds/GenPonds.cs.patch
@@ -1,5 +1,5 @@
 diff --git a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/7.GenPonds/GenPonds.cs b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/7.GenPonds/GenPonds.cs
-index acfac74..1bb1cce 100644
+index acfac74..ecbfb47 100644
 --- a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/7.GenPonds/GenPonds.cs
 +++ b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/7.GenPonds/GenPonds.cs
 @@ -9,27 +9,37 @@ using Vintagestory.API.Server;
@@ -144,7 +144,22 @@ index acfac74..1bb1cce 100644
              while (pondPositions.Count > 0)
              {
                  int p = pondPositions.Dequeue();
-@@ -300,14 +312,14 @@ namespace Vintagestory.ServerMods
+@@ -281,10 +293,14 @@ namespace Vintagestory.ServerMods
+                 // Get correct chunk and correct climate data if we don't have it already
+                 if (curChunkX != prevChunkX || curChunkZ != prevChunkZ)
+                 {
+                     chunk = (IServerChunk)blockAccessor.GetChunk(curChunkX, pondYPos / chunksize, curChunkZ);
+                     if (chunk == null) chunk = api.WorldManager.GetChunk(curChunkX, pondYPos / chunksize, curChunkZ);
++                    // Stratum: the fallback lookup can still return null (e.g. a neighbour column that's absent or mid-unload
++                    // while multiple columns run TerrainFeatures concurrently); the sibling chunkOneBlockBelow lookup just
++                    // below already guards this way, so bail out here too instead of NRE'ing on Unpack().
++                    if (chunk == null) return;
+                     chunk.Unpack();
+ 
+                     if (ly == 0)
+                     {
+                         chunkOneBlockBelow = ((IServerChunk)blockAccessor.GetChunk(curChunkX, (pondYPos - 1) / chunksize, curChunkZ));
+@@ -300,14 +316,14 @@ namespace Vintagestory.ServerMods
  
                      float fac = (float)climateMap.InnerSize / regionChunkSize;
                      int rlX = curChunkX % regionChunkSize;
@@ -163,7 +178,7 @@ index acfac74..1bb1cce 100644
                      prevChunkZ = curChunkZ;
  
                      chunkOneBlockBelow.MarkModified();
-@@ -317,11 +329,11 @@ namespace Vintagestory.ServerMods
+@@ -317,11 +333,11 @@ namespace Vintagestory.ServerMods
  
                  // Raise heightmap by 1 (only relevant for above-ground ponds)
                  if (mapchunk.RainHeightMap[lz * chunksize + lx] < pondYPos) mapchunk.RainHeightMap[lz * chunksize + lx] = (ushort)pondYPos;
@@ -176,7 +191,7 @@ index acfac74..1bb1cce 100644
  
                  // 1. Place water or ice block
                  int index3d = (ly * chunksize + lz) * chunksize + lx;
-@@ -355,11 +367,11 @@ namespace Vintagestory.ServerMods
+@@ -355,11 +371,11 @@ namespace Vintagestory.ServerMods
  
                  float rainRel = Climate.GetRainFall((climate >> 8) & 0xff, pondYPos) / 255f;
                  int rockBlockId = mapchunk.TopRockIdMap[lz * chunksize + lx];

--- a/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/7.GenPonds/GenPonds.cs.patch
+++ b/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/7.GenPonds/GenPonds.cs.patch
@@ -1,0 +1,191 @@
+diff --git a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/7.GenPonds/GenPonds.cs b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/7.GenPonds/GenPonds.cs
+index acfac74..1bb1cce 100644
+--- a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/7.GenPonds/GenPonds.cs
++++ b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/7.GenPonds/GenPonds.cs
+@@ -9,27 +9,37 @@ using Vintagestory.API.Server;
+ namespace Vintagestory.ServerMods
+ {
+     public class GenPonds : ModStdWorldGen
+     {
+         ICoreServerAPI api;
+-        LCGRandom rand;
++        // Stratum: every field below used to be a plain instance field, written by
++        // OnChunkColumnGen/TryPlacePondAt for one column and read a few calls later
++        // in the same call chain, unsafe once TerrainFeatures' same-stage cap moves
++        // off 1. [ThreadStatic] since GenPonds is a singleton ModSystem with no
++        // second live instance anywhere in the codebase (confirmed by search).
++        // rand needs lazy per-thread construction with the same world-seed offset
++        // the old shared instance used (see stratumWorldSeed below), since it's
++        // reseeded via InitPositionSeed alone per column, never from prior state.
++        // Wrapped in a StratumWorldgenThreadGuard (opt-in, off by default, see that
++        // class) instead of stored bare: this field's whole value is that no other
++        // thread should ever read it, so it is exactly the kind of resource the
++        // guard is meant to catch a violation of, if one exists.
++        [ThreadStatic] private static StratumWorldgenThreadGuard<LCGRandom> stratumRandGuard;
++        [ThreadStatic] private static QueueOfInt stratumSearchPositionsDeltas;
++        [ThreadStatic] private static QueueOfInt stratumPondPositions;
++        [ThreadStatic] private static int[] stratumDidCheckPosition;
++        [ThreadStatic] private static int stratumIteration;
++        [ThreadStatic] private static int stratumClimateUpLeft, stratumClimateUpRight, stratumClimateBotLeft, stratumClimateBotRight;
++
++        long worldSeed;
+         int mapheight;
+         IWorldGenBlockAccessor blockAccessor;
+-        readonly QueueOfInt searchPositionsDeltas = new QueueOfInt();
+-        readonly QueueOfInt pondPositions = new QueueOfInt();
+         int searchSize;
+         int mapOffset;
+         int minBoundary;
+         int maxBoundary;
+ 
+-        int climateUpLeft;
+-        int climateUpRight;
+-        int climateBotLeft;
+-        int climateBotRight;
+-        int[] didCheckPosition;
+-        int iteration;
+-
+         LakeBedLayerProperties lakebedLayerConfig;
+ 
+ 
+         public override double ExecuteOrder()
+         {
+@@ -65,17 +75,16 @@ namespace Vintagestory.ServerMods
+ 
+         public void initWorldGen()
+         {
+             LoadGlobalConfig(api);
+ 
+-            rand = new LCGRandom(api.WorldManager.Seed - 12);
++            worldSeed = api.WorldManager.Seed - 12;
+             searchSize = 3 * chunksize;
+             mapOffset = chunksize;
+             minBoundary = -chunksize + 1;
+             maxBoundary = 2 * chunksize - 1;
+             mapheight = api.WorldManager.MapSizeY;
+-            didCheckPosition = new int[searchSize * searchSize];
+ 
+             var blockLayerConfig = BlockLayerConfig.GetInstance(api);
+ 
+             lakebedLayerConfig = blockLayerConfig.LakeBedLayer;
+         }
+@@ -88,11 +97,11 @@ namespace Vintagestory.ServerMods
+             if (GetIntersectingStructure(chunkX * chunksize + chunksize / 2, chunkZ * chunksize + chunksize / 2, PondsHashCode) != null)
+             {
+                 return;
+             }
+             blockAccessor.BeginColumn();
+-            LCGRandom rand = this.rand;
++            LCGRandom rand = (stratumRandGuard ??= new StratumWorldgenThreadGuard<LCGRandom>("GenPonds.rand", new LCGRandom(worldSeed))).Get();
+             rand.InitPositionSeed(chunkX, chunkZ);
+             int maxHeight = mapheight - 1;
+             int pondYPos;
+ 
+             ushort[] heightmap = chunks[0].MapChunk.RainHeightMap;
+@@ -102,16 +111,16 @@ namespace Vintagestory.ServerMods
+             int regionChunkSize = api.WorldManager.RegionSize / chunksize;
+             float fac = (float)climateMap.InnerSize / regionChunkSize;
+             int rlX = chunkX % regionChunkSize;
+             int rlZ = chunkZ % regionChunkSize;
+ 
+-            climateUpLeft = climateMap.GetUnpaddedInt((int)(rlX * fac), (int)(rlZ * fac));
+-            climateUpRight = climateMap.GetUnpaddedInt((int)(rlX * fac + fac), (int)(rlZ * fac));
+-            climateBotLeft = climateMap.GetUnpaddedInt((int)(rlX * fac), (int)(rlZ * fac + fac));
+-            climateBotRight = climateMap.GetUnpaddedInt((int)(rlX * fac + fac), (int)(rlZ * fac + fac));
++            stratumClimateUpLeft = climateMap.GetUnpaddedInt((int)(rlX * fac), (int)(rlZ * fac));
++            stratumClimateUpRight = climateMap.GetUnpaddedInt((int)(rlX * fac + fac), (int)(rlZ * fac));
++            stratumClimateBotLeft = climateMap.GetUnpaddedInt((int)(rlX * fac), (int)(rlZ * fac + fac));
++            stratumClimateBotRight = climateMap.GetUnpaddedInt((int)(rlX * fac + fac), (int)(rlZ * fac + fac));
+ 
+-            int climateMid = GameMath.BiLerpRgbColor(0.5f, 0.5f, climateUpLeft, climateUpRight, climateBotLeft, climateBotRight);
++            int climateMid = GameMath.BiLerpRgbColor(0.5f, 0.5f, stratumClimateUpLeft, stratumClimateUpRight, stratumClimateBotLeft, stratumClimateBotRight);
+ 
+             // 16-23 bits = Red = temperature
+             // 8-15 bits = Green = rain
+             // 0-7 bits = Blue = humidity
+ 
+@@ -184,10 +193,13 @@ namespace Vintagestory.ServerMods
+             int searchSize = this.searchSize;
+             int minBoundary = this.minBoundary;
+             int maxBoundary = this.maxBoundary;
+             int waterID = gcfg.waterBlockId;
+             int ndx, ndz;
++            QueueOfInt searchPositionsDeltas = stratumSearchPositionsDeltas ??= new QueueOfInt();
++            QueueOfInt pondPositions = stratumPondPositions ??= new QueueOfInt();
++            int[] didCheckPosition = stratumDidCheckPosition ??= new int[searchSize * searchSize];
+             searchPositionsDeltas.Clear();
+             pondPositions.Clear();
+ 
+             int basePosX = chunkX * chunksize;
+             int basePosZ = chunkZ * chunksize;
+@@ -195,11 +207,11 @@ namespace Vintagestory.ServerMods
+ 
+             // The starting block is an air block
+             int arrayIndex = (dz + mapOffset) * searchSize + dx + mapOffset;
+             searchPositionsDeltas.Enqueue(arrayIndex);
+             pondPositions.Enqueue(arrayIndex);
+-            int iteration = ++this.iteration;
++            int iteration = ++stratumIteration;
+             didCheckPosition[arrayIndex] = iteration;
+ 
+             BlockPos tmpPos = new BlockPos(API.Config.Dimensions.NormalWorld);
+ 
+             while (searchPositionsDeltas.Count > 0)
+@@ -262,11 +274,11 @@ namespace Vintagestory.ServerMods
+             IServerChunk chunk = null;
+             IServerChunk chunkOneBlockBelow = null;
+ 
+             int ly = GameMath.Mod(pondYPos, chunksize);
+ 
+-            bool extraPondDepth = rand.NextFloat() > 0.5f;
++            bool extraPondDepth = stratumRandGuard.Get().NextFloat() > 0.5f;
+             bool withSeabed = extraPondDepth || pondPositions.Count > 16;
+ 
+             while (pondPositions.Count > 0)
+             {
+                 int p = pondPositions.Dequeue();
+@@ -300,14 +312,14 @@ namespace Vintagestory.ServerMods
+ 
+                     float fac = (float)climateMap.InnerSize / regionChunkSize;
+                     int rlX = curChunkX % regionChunkSize;
+                     int rlZ = curChunkZ % regionChunkSize;
+ 
+-                    climateUpLeft = climateMap.GetUnpaddedInt((int)(rlX * fac), (int)(rlZ * fac));
+-                    climateUpRight = climateMap.GetUnpaddedInt((int)(rlX * fac + fac), (int)(rlZ * fac));
+-                    climateBotLeft = climateMap.GetUnpaddedInt((int)(rlX * fac), (int)(rlZ * fac + fac));
+-                    climateBotRight = climateMap.GetUnpaddedInt((int)(rlX * fac + fac), (int)(rlZ * fac + fac));
++                    stratumClimateUpLeft = climateMap.GetUnpaddedInt((int)(rlX * fac), (int)(rlZ * fac));
++                    stratumClimateUpRight = climateMap.GetUnpaddedInt((int)(rlX * fac + fac), (int)(rlZ * fac));
++                    stratumClimateBotLeft = climateMap.GetUnpaddedInt((int)(rlX * fac), (int)(rlZ * fac + fac));
++                    stratumClimateBotRight = climateMap.GetUnpaddedInt((int)(rlX * fac + fac), (int)(rlZ * fac + fac));
+ 
+                     prevChunkX = curChunkX;
+                     prevChunkZ = curChunkZ;
+ 
+                     chunkOneBlockBelow.MarkModified();
+@@ -317,11 +329,11 @@ namespace Vintagestory.ServerMods
+ 
+                 // Raise heightmap by 1 (only relevant for above-ground ponds)
+                 if (mapchunk.RainHeightMap[lz * chunksize + lx] < pondYPos) mapchunk.RainHeightMap[lz * chunksize + lx] = (ushort)pondYPos;
+ 
+                 // Identify correct climate at this position - could be optimised if we place water into ponds in columns instead of layers
+-                int climate = GameMath.BiLerpRgbColor((float)lx / chunksize, (float)lz / chunksize, climateUpLeft, climateUpRight, climateBotLeft, climateBotRight);
++                int climate = GameMath.BiLerpRgbColor((float)lx / chunksize, (float)lz / chunksize, stratumClimateUpLeft, stratumClimateUpRight, stratumClimateBotLeft, stratumClimateBotRight);
+                 float temp = Climate.GetScaledAdjustedTemperatureFloat((climate >> 16) & 0xff, pondYPos - TerraGenConfig.seaLevel);
+ 
+ 
+                 // 1. Place water or ice block
+                 int index3d = (ly * chunksize + lz) * chunksize + lx;
+@@ -355,11 +367,11 @@ namespace Vintagestory.ServerMods
+ 
+                 float rainRel = Climate.GetRainFall((climate >> 8) & 0xff, pondYPos) / 255f;
+                 int rockBlockId = mapchunk.TopRockIdMap[lz * chunksize + lx];
+                 if (rockBlockId == 0) continue;
+ 
+-                int lakebedId = lakebedLayerConfig.GetSuitable(temp, rainRel, (float)pondYPos / mapheight, rand, rockBlockId);
++                int lakebedId = lakebedLayerConfig.GetSuitable(temp, rainRel, (float)pondYPos / mapheight, stratumRandGuard.Get(), rockBlockId);
+                 if (lakebedId != 0) chunkOneBlockBelow.Data[index] = lakebedId;
+             }
+ 
+ 
+             if (extraPondDepth)

--- a/patches/VSSurvivalMod/Systems/WorldGen/Standard/ChunkGen/6.GenStructures/GenDungeons.cs.patch
+++ b/patches/VSSurvivalMod/Systems/WorldGen/Standard/ChunkGen/6.GenStructures/GenDungeons.cs.patch
@@ -1,0 +1,293 @@
+diff --git a/VSSurvivalMod/Systems/WorldGen/Standard/ChunkGen/6.GenStructures/GenDungeons.cs b/VSSurvivalMod/Systems/WorldGen/Standard/ChunkGen/6.GenStructures/GenDungeons.cs
+index dfdae53..1f1ef56 100644
+--- a/VSSurvivalMod/Systems/WorldGen/Standard/ChunkGen/6.GenStructures/GenDungeons.cs
++++ b/VSSurvivalMod/Systems/WorldGen/Standard/ChunkGen/6.GenStructures/GenDungeons.cs
+@@ -1,5 +1,7 @@
++using System;
++using System.Collections.Concurrent;
+ using System.Collections.Generic;
+ using System.Diagnostics.CodeAnalysis;
+ using System.Linq;
+ using ProtoBuf;
+ using Vintagestory.API.Common;
+@@ -48,19 +50,40 @@ namespace Vintagestory.ServerMods
+     public class GenDungeons : ModStdWorldGen
+     {
+         private ModSystemTiledDungeons tiledDungeonsSys = null!;
+         private IWorldGenBlockAccessor worldgenBlockAccessor = null!;
+         private ICoreServerAPI sapi = null!;
+-        private LCGRandom rand = null!;
+ 
+-        private Dictionary<long, List<DungeonPlaceTask>> dungeonPlaceTasksByRegion = new Dictionary<long, List<DungeonPlaceTask>>();
++        // Stratum: rand and grassRand used to be plain instance fields, reseeded
++        // via InitPositionSeed per column/connector and read a few calls later in
++        // the same call chain, unsafe once TerrainFeatures' same-stage cap moves
++        // off 1. [ThreadStatic] since GenDungeons is a singleton ModSystem with no
++        // second live instance anywhere in the codebase (confirmed by search), and
++        // both need lazy per-thread construction with the same seed formula the
++        // old shared instances used, since both are reseeded via InitPositionSeed
++        // alone, never from prior state.
++        [ThreadStatic] private static LCGRandom stratumRand;
++        [ThreadStatic] private static LCGRandom stratumGrassRand;
++
++        // Stratum: dungeonPlaceTasksByRegion and Dungeons are not per-column
++        // scratch, they are persistent, cross-column, cross-region shared state
++        // by design (region generation removes/adds entries a chunk-column call
++        // three regions over can be reading or mutating at the same time), so
++        // [ThreadStatic] would be wrong here, this needs to stay one shared,
++        // consistent structure. ConcurrentDictionary covers the dictionary's own
++        // structure; stratumDungeonStateLock covers the compound read-modify-write
++        // sequences (region generation's clear-then-repopulate of Dungeons, and a
++        // chunk column's read-then-mutate of a shared DungeonPlaceTask's fields)
++        // that neither a concurrent collection nor per-field atomicity would make
++        // safe on their own.
++        private readonly object stratumDungeonStateLock = new object();
++        private ConcurrentDictionary<long, List<DungeonPlaceTask>> dungeonPlaceTasksByRegion = new ConcurrentDictionary<long, List<DungeonPlaceTask>>();
+ 
+         private int regionSize;
+         private BlockPos spawnPos = null!;
+         private GenStoryStructures storyStructSys = null!;
+         private GenBlockLayers genBlockLayers = null!;
+-        private LCGRandom grassRand = null!;
+         public List<DungeonLocation> Dungeons = new List<DungeonLocation>();
+         public bool DungeonsDirty = false;
+ 
+         public override double ExecuteOrder() { return 0.12; }
+ 
+@@ -101,17 +124,15 @@ namespace Vintagestory.ServerMods
+             {
+                 spawnPos = sapi.World.BlockAccessor.MapSize.AsBlockPos / 2;
+             }
+ 
+             storyStructSys = sapi.ModLoader.GetModSystem<GenStoryStructures>();
+-            grassRand = new LCGRandom(sapi.WorldManager.Seed);
+         }
+ 
+         private void OnWorldGenBlockAccessor(IChunkProviderThread chunkProvider)
+         {
+             worldgenBlockAccessor = chunkProvider.GetBlockAccessor(false);
+-            rand = new LCGRandom(sapi.WorldManager.Seed ^ 8991827198);
+             regionSize = sapi.World.BlockAccessor.RegionSize;
+         }
+ 
+         private void Event_MapRegionLoaded(Vec2i mapCoord, IMapRegion region)
+         {
+@@ -131,21 +152,27 @@ namespace Vintagestory.ServerMods
+ 
+         private void Event_GameWorldSave()
+         {
+             if (DungeonsDirty)
+             {
+-                sapi.WorldManager.SaveGame.StoreData("dungeonLocations", SerializerUtil.Serialize(Dungeons));
+-                DungeonsDirty = false;
++                lock (stratumDungeonStateLock)
++                {
++                    sapi.WorldManager.SaveGame.StoreData("dungeonLocations", SerializerUtil.Serialize(Dungeons));
++                    DungeonsDirty = false;
++                }
+             }
+         }
+ 
+         private void Event_SaveGameLoaded()
+         {
+             var strucs = sapi.WorldManager.SaveGame.GetData<List<DungeonLocation>>("dungeonLocations");
+             if (strucs != null)
+             {
+-                Dungeons.AddRange(strucs);
++                lock (stratumDungeonStateLock)
++                {
++                    Dungeons.AddRange(strucs);
++                }
+             }
+         }
+ 
+         private void Event_MapRegionUnloaded(Vec2i mapCoord, IMapRegion region)
+         {
+@@ -161,63 +188,69 @@ namespace Vintagestory.ServerMods
+             var mapRand = new LCGRandom(sapi.WorldManager.Seed ^ 8991827198);
+             mapRand.InitPositionSeed(regionX * size, regionZ * size);
+ 
+             long mapRegionIndex = MapRegionIndex2D(regionX, regionZ);
+ 
+-            if (dungeonPlaceTasksByRegion.ContainsKey(mapRegionIndex))
++            // Stratum: locked for the whole method, see stratumDungeonStateLock's
++            // own comment. This is per-region, not per-column, so contention stays
++            // low even once same-stage concurrency reaches this far.
++            lock (stratumDungeonStateLock)
+             {
+-                Dungeons.RemoveAll(d => d.Position.X / regionSize == regionX && d.Position.Z / regionSize == regionZ);
+-            }
++                if (dungeonPlaceTasksByRegion.ContainsKey(mapRegionIndex))
++                {
++                    Dungeons.RemoveAll(d => d.Position.X / regionSize == regionX && d.Position.Z / regionSize == regionZ);
++                }
+ 
+-            dungeonPlaceTasksByRegion[mapRegionIndex] = new List<DungeonPlaceTask>();
++                dungeonPlaceTasksByRegion[mapRegionIndex] = new List<DungeonPlaceTask>();
+ 
+-            var dungeons = tiledDungeonsSys.Tcfg.Dungeons.Where(d => d.Worldgen).ToList();
++                var dungeons = tiledDungeonsSys.Tcfg.Dungeons.Where(d => d.Worldgen).ToList();
+ 
+-            var dungeIndices = new int[dungeons.Count];
+-            for (int l = 0; l < dungeIndices.Length; l++) dungeIndices[l] = l;
++                var dungeIndices = new int[dungeons.Count];
++                for (int l = 0; l < dungeIndices.Length; l++) dungeIndices[l] = l;
+ 
+-            var seaLevel = sapi.World.SeaLevel;
+-            for (int i = 0; i < 12; i++)
+-            {
+-                int posx = regionX * size + mapRand.NextInt(size);
+-                int posz = regionZ * size + mapRand.NextInt(size);
+-
+-                if(!SatisfiesMinDistance(posx, seaLevel, posz)) continue;
++                var seaLevel = sapi.World.SeaLevel;
++                for (int i = 0; i < 12; i++)
++                {
++                    int posx = regionX * size + mapRand.NextInt(size);
++                    int posz = regionZ * size + mapRand.NextInt(size);
+ 
+-                if(storyStructSys.Structures.values.Values.Any(storyLoc =>
+-                       storyLoc.CenterPos.HorDistanceSqTo(posx, posz) < tiledDungeonsSys.Tcfg.StoryStructMinDistanceSq)) continue;
++                    if(!SatisfiesMinDistance(posx, seaLevel, posz)) continue;
+ 
+-                var dungeon = pickDungeon(dungeIndices, mapRand, dungeons);
++                    if(storyStructSys.Structures.values.Values.Any(storyLoc =>
++                           storyLoc.CenterPos.HorDistanceSqTo(posx, posz) < tiledDungeonsSys.Tcfg.StoryStructMinDistanceSq)) continue;
+ 
+-                if (spawnPos.HorDistanceSqTo(posx, posz) < dungeon.MinSpawnDistance * dungeon.MinSpawnDistance) continue;
++                    var dungeon = pickDungeon(dungeIndices, mapRand, dungeons);
+ 
+-                if (IsInOcean(mapRegion, posx, posz)) continue;
++                    if (spawnPos.HorDistanceSqTo(posx, posz) < dungeon.MinSpawnDistance * dungeon.MinSpawnDistance) continue;
+ 
+-                if (!HasSuitableLandforms(dungeon, mapRegion, posx, posz)) continue;
++                    if (IsInOcean(mapRegion, posx, posz)) continue;
+ 
++                    if (!HasSuitableLandforms(dungeon, mapRegion, posx, posz)) continue;
+ 
+-                int posy = seaLevel-dungeon.MaxDepth + mapRand.NextInt(dungeon.MaxDepth-dungeon.MinDepth);
+-                var dungeonStartPos = new BlockPos(posx, posy, posz);
+-                var didGen = false;
+-                for (int j = 0; j < 5; j++)
+-                {
+-                    var placeTask = tiledDungeonsSys.TryPregenerateTiledDungeon(mapRand, dungeon, mapRegion.GeneratedStructures, dungeonStartPos, dungeon.MinTiles, dungeon.MaxTiles);
+ 
+-                    if (placeTask != null)
++                    int posy = seaLevel-dungeon.MaxDepth + mapRand.NextInt(dungeon.MaxDepth-dungeon.MinDepth);
++                    var dungeonStartPos = new BlockPos(posx, posy, posz);
++                    var didGen = false;
++                    for (int j = 0; j < 5; j++)
+                     {
+-                        sapi.Logger.Debug($"Dungeon {dungeon.Code} @: /tp ={posx} {posy} ={posz}");
+-                        placeTask.IsDirty = true;
+-                        dungeonPlaceTasksByRegion[mapRegionIndex].Add(placeTask);
+-                        Dungeons.Add(new DungeonLocation(dungeonStartPos, placeTask.Code, placeTask.DungeonBoundaries));
+-                        DungeonsDirty = true;
+-                        mapRegion.AddGeneratedStructures(placeTask.GeneratedStructures);
+-                        didGen = true;
+-                        break;
++                        var placeTask = tiledDungeonsSys.TryPregenerateTiledDungeon(mapRand, dungeon, mapRegion.GeneratedStructures, dungeonStartPos, dungeon.MinTiles, dungeon.MaxTiles);
++
++                        if (placeTask != null)
++                        {
++                            sapi.Logger.Debug($"Dungeon {dungeon.Code} @: /tp ={posx} {posy} ={posz}");
++                            placeTask.IsDirty = true;
++                            dungeonPlaceTasksByRegion[mapRegionIndex].Add(placeTask);
++                            Dungeons.Add(new DungeonLocation(dungeonStartPos, placeTask.Code, placeTask.DungeonBoundaries));
++                            DungeonsDirty = true;
++                            mapRegion.AddGeneratedStructures(placeTask.GeneratedStructures);
++                            didGen = true;
++                            break;
++                        }
+                     }
+-                }
+ 
+-                if (didGen) break;
++                    if (didGen) break;
++                }
+             }
+         }
+ 
+         private static TiledDungeon pickDungeon(int[] dungeIndices, LCGRandom mapRand, List<TiledDungeon> dungeons)
+         {
+@@ -363,10 +396,19 @@ namespace Vintagestory.ServerMods
+                     if (!dungeonPlaceTasksByRegion.TryGetValue(mapRegionIndex2D, out var dungePlaceTasks)) continue;
+ 
+                     foreach (var placeTask in dungePlaceTasks)
+                     {
+                         if (!placeTask.DungeonBoundaries.Intersects(cuboid)) continue;
++                        // Stratum: locked from here to the end of this placeTask's
++                        // processing, see stratumDungeonStateLock's own comment.
++                        // placeTask.RockBlockCode and .SurfacePlaceTasks are both
++                        // check-then-compute-then-assign sequences on an object
++                        // shared with every other column touching this dungeon;
++                        // two columns racing here could both compute and one
++                        // assignment would silently overwrite the other's.
++                        lock (stratumDungeonStateLock)
++                        {
+                         if (!tiledDungeonsSys.Tcfg.DungeonsByCode.TryGetValue(placeTask.Code, out var dungeon)) return; // Ignore dungeons that no longer exist in assets
+ 
+                         Block? rockBlock = null;
+                         // get the rockblock for the first generating chunk and reuse that for each room
+                         if (placeTask.RockBlockCode == null)
+@@ -408,10 +450,11 @@ namespace Vintagestory.ServerMods
+                             var height = sapi.World.BlockAccessor.GetTerrainMapheightAt(pos);
+                             if (height == 0) continue;
+                             // skip if we get our of range where we can generate, should not happen if the stairs and surface rooms are not larger than 2 chunks
+                             height += dungeon.surfaceYOffset;
+ 
++                            LCGRandom rand = stratumRand ??= new LCGRandom(sapi.WorldManager.Seed ^ 8991827198);
+                             rand.InitPositionSeed(connector.Position.X, connector.Position.Y, connector.Position.Z);
+                             var tileIndices = new int[dungeon.StairCase.Tiles.Count];
+                             for (int i = 0; i < tileIndices.Length; i++) tileIndices[i] = i;
+ 
+                             DungeonGenWorkspace dgd = new DungeonGenWorkspace(dungeon.StairCase, 0, 0, [], [], [], [], null);
+@@ -500,31 +543,32 @@ namespace Vintagestory.ServerMods
+ 
+                         if (placeTask.SurfacePlaceTasks != null)
+                         {
+                             generateDungeonSurfacePartial(request ,region, dungeon, placeTask.SurfacePlaceTasks, request.Chunks, request.ChunkX, request.ChunkZ, rockBlock);
+                         }
++                        }
+                     }
+                 }
+             }
+         }
+ 
+ 
+         private bool pickStairTile(DungeonGenWorkspace dgd, ConnectorMetaData connector, int[] tileIndices, [NotNullWhen(true)] ref BlockSchematicPartial? schematic, [NotNullWhen(true)] ref DungeonTile? tile, [NotNullWhen(true)] ref FastVec3i? offsetPos)
+         {
+-            tile = tiledDungeonsSys.dungeonGen.pickTile(dgd, tileIndices, rand, connector);
++            tile = tiledDungeonsSys.dungeonGen.pickTile(dgd, tileIndices, stratumRand, connector);
+             if (tile != null)
+             {
+-                tile.FreshShuffleIndices(rand);
++                tile.FreshShuffleIndices(stratumRand);
+                 int len = tile.ResolvedSchematics.Length;
+                 for (var k = 0; k < len; k++)
+                 {
+                     var schematicByRot = tile.ResolvedSchematics[tile.ShuffledIndices[k]];
+ 
+                     int startRot = connector.Rotation;
+                     if (connector.Facing.IsHorizontal)
+                     {
+-                        startRot = rand.NextInt(4);
++                        startRot = stratumRand.NextInt(4);
+                     }
+ 
+                     // Try any of the 4 sides and see which one can connect
+                     for (var i = 0; i < 4; i++)
+                     {
+@@ -579,11 +623,11 @@ namespace Vintagestory.ServerMods
+                 if (schematic == null) continue;
+                 var placed = schematic.PlacePartial(chunks, worldgenBlockAccessor, sapi.World, chunkX, chunkZ, placeTask.Pos, EnumReplaceMode.ReplaceAll, null, GlobalConfig.ReplaceMetaBlocks, true, dungeon.resolvedRockTypeRemaps, dungeon.replacewithblocklayersBlockids, rockBlock);
+                 if (placed > 0)
+                 {
+                     UpdateHeightmap(request, worldgenBlockAccessor);
+-                    GenerateGrass(sapi, request, grassRand, genBlockLayers);
++                    GenerateGrass(sapi, request, stratumGrassRand ??= new LCGRandom(sapi.WorldManager.Seed), genBlockLayers);
+                 }
+ 
+                 if (request.ChunkX == placeTask.Pos.X / chunksize && request.ChunkZ == placeTask.Pos.Z / chunksize)
+                 {
+                     var location = new Cuboidi(placeTask.Pos, placeTask.Pos.AddCopy(schematic.SizeX, schematic.SizeY, schematic.SizeZ));

--- a/sources/VSEssentials/Systems/WorldGen/Standard/StratumWorldgenThreadGuard.cs
+++ b/sources/VSEssentials/Systems/WorldGen/Standard/StratumWorldgenThreadGuard.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Threading;
+
+namespace Vintagestory.ServerMods
+{
+    // Stratum: shared, non-generic toggle for StratumWorldgenThreadGuard<T> below.
+    // Kept separate from the generic wrapper because static fields on a generic
+    // type are per-closed-type in .NET (StratumWorldgenThreadGuard<LCGRandom> and
+    // StratumWorldgenThreadGuard<QueueOfInt> would each get their own copy), which
+    // would silently defeat a single on/off switch meant to cover every guarded
+    // resource at once.
+    public static class StratumWorldgenThreadGuard
+    {
+        // Off by default. Not wired into stratum.json's config system: StratumConfig
+        // and StratumRuntime are internal to VintagestoryLib with no
+        // InternalsVisibleTo toward this assembly, so there is no compile-time path
+        // from here to that config today. Flip these in code, or set the
+        // environment variables below, while actively chasing a worldgen threading
+        // bug; wiring a real stratum.json toggle through is a small, separate
+        // follow-up (would need either a public bridge property on the
+        // VintagestoryLib side, or moving this guard there instead).
+        public static bool Enabled = string.Equals(
+            Environment.GetEnvironmentVariable("STRATUM_ENFORCE_SAFE_WORLDGEN_THREAD_ACCESS"),
+            "true", StringComparison.OrdinalIgnoreCase);
+
+        // When Enabled is also true: throw instead of just logging a warning and
+        // continuing. Matches C2ME-fabric's own enforceSafeWorldRandomAccess split
+        // between "warn and fall back" and "hard crash" (see CheckedThreadLocalRandom
+        // in github.com/RelativityMC/C2ME-fabric), so a violation can be caught live
+        // in a debugger instead of only leaving a log line to find later.
+        public static bool Strict = string.Equals(
+            Environment.GetEnvironmentVariable("STRATUM_ENFORCE_SAFE_WORLDGEN_THREAD_ACCESS_STRICT"),
+            "true", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Canary for worldgen state meant to be [ThreadStatic]-confined (per-column
+    /// Random instances, scratch buffers), modeled on C2ME-fabric's
+    /// CheckedThreadLocalRandom. A [ThreadStatic] field cannot be read from the
+    /// wrong thread by construction, so a correctly-behaving caller should never
+    /// trip this; if it does, a reference to the guarded value escaped across a
+    /// thread hop (a captured delegate, an async continuation resuming on a
+    /// different thread) instead of being re-fetched fresh from the [ThreadStatic]
+    /// field on every use, or something bypassed the field via reflection.
+    /// </summary>
+    /// <example>
+    /// Store the guard itself, not the raw resource, in the [ThreadStatic] field:
+    /// <code>
+    /// [ThreadStatic] private static StratumWorldgenThreadGuard&lt;LCGRandom&gt; stratumRandGuard;
+    /// ...
+    /// LCGRandom rand = (stratumRandGuard ??= new StratumWorldgenThreadGuard&lt;LCGRandom&gt;(
+    ///     "GenPonds.rand", new LCGRandom(worldSeed))).Get();
+    /// </code>
+    /// </example>
+    public sealed class StratumWorldgenThreadGuard<T> where T : class
+    {
+        private readonly string resourceName;
+        private readonly Thread owner;
+        private readonly T value;
+
+        public StratumWorldgenThreadGuard(string resourceName, T value)
+        {
+            this.resourceName = resourceName;
+            this.value = value;
+            this.owner = Thread.CurrentThread;
+        }
+
+        public T Get()
+        {
+            if (StratumWorldgenThreadGuard.Enabled && !ReferenceEquals(Thread.CurrentThread, owner))
+            {
+                HandleViolation();
+            }
+            return value;
+        }
+
+        private void HandleViolation()
+        {
+            string message = $"Stratum: {resourceName} accessed from thread '{Thread.CurrentThread.Name}' " +
+                $"but constructed on thread '{owner.Name}'. This resource lives in a [ThreadStatic] field, " +
+                "so this almost certainly means a reference to it escaped across a thread hop (a captured " +
+                "delegate, an async continuation resuming elsewhere) rather than the field declaration itself " +
+                "being unsafe. The stack trace below is the offending access, not the original construction.";
+
+            if (StratumWorldgenThreadGuard.Strict)
+            {
+                throw new InvalidOperationException(message);
+            }
+
+            Console.Error.WriteLine(message);
+            Console.Error.WriteLine(Environment.StackTrace);
+        }
+    }
+}


### PR DESCRIPTION
The TerrainFeatures generator audit @tehtelev asked for in the second review pass on #179. #183 already closed the landmines in `GenDeposits`, `GenStructures`, `GenVegetationAndPatches`, and `BlockSchematicStructure`; this finishes the stage by going through every remaining generator registered at `EnumWorldGenPass.TerrainFeatures`.

## What each generator needed

| Generator | Verdict | Fix |
| --- | --- | --- |
| `GenTerraPostProcess` | crashed | per-column scratch to `[ThreadStatic]` |
| `GenPonds` | crashed | per-column scratch to `[ThreadStatic]` |
| `GenDungeons` | two distinct hazards | `[ThreadStatic]` for the Randoms, `ConcurrentDictionary` plus a dedicated lock for genuinely shared region state |
| `GenHotSprings` | already clean | none |

`GenHotSprings` is worth recording explicitly so the next audit does not redo the check: every per-column value there is already a local, and the only shared state it touches is `api.World.Rand`, which `ServerMain` already backs with a `ThreadLocal<Random>`.

`GenDungeons` needed two different fixes because it has two different shapes of state. `rand` and `grassRand` are the familiar per-column-reseeded `LCGRandom` pattern, fixed with `[ThreadStatic]` like everywhere else. `dungeonPlaceTasksByRegion` and `Dungeons` are not per-column scratch at all: they are persistent cross-column, cross-region shared state by design, so `[ThreadStatic]` would have been the wrong tool. The dictionary itself moved to `ConcurrentDictionary`, and a dedicated lock covers the compound read-modify-write sequences that neither a concurrent collection nor per-field atomicity makes safe: region generation's clear-then-repopulate of `Dungeons`, and a column's check-then-compute-then-assign of a shared `DungeonPlaceTask`'s `RockBlockCode` and `SurfacePlaceTasks`. Two columns touching the same dungeon would otherwise silently generate a structure's stairs twice or lose one column's rock-block choice, rather than crash.

## `StratumWorldgenThreadGuard<T>`

Also adds a canary for `[ThreadStatic]`-confined worldgen state, modeled on C2ME-fabric's `CheckedThreadLocalRandom` ([RelativityMC/C2ME-fabric](https://github.com/RelativityMC/C2ME-fabric)).

A `[ThreadStatic]` field cannot be read from the wrong thread by construction, so this should never fire. If it ever does, it means a reference to the guarded value escaped across a thread hop instead of being re-fetched from the field, which is a different and more interesting bug than an unsafe field declaration.

Off by default behind `STRATUM_ENFORCE_SAFE_WORLDGEN_THREAD_ACCESS`. Not wired into `stratum.json` because `StratumConfig`/`StratumRuntime` are internal to `VintagestoryLib` with no `InternalsVisibleTo` toward that assembly. Wired into `GenPonds.rand` as the concrete demonstration rather than retrofitted everywhere in one go.

## Verification

- Release build clean, 0 errors, after fixing one real compile error along the way (`GenDungeons.cs` was missing `using System`, needed for `[ThreadStatic]`).
- `extract-patches.sh` round-trips clean: exactly the four expected new files, nothing unexpected.
- `bash scripts/smoke-test.sh` reaches RunGame with zero fatal errors.
- Pregen comparison, radius 20, `MaxWorldgenThreads=4`: **27s with zero exceptions and zero watchdog fires**, against `indev`'s own clean **24s** baseline. This branch raises no cap, so the useful check was confirming the fixes do not regress anything, and they do not.

One thing worth stating plainly rather than leaving implied: this run also confirmed the "worldgen has become stuck" watchdog seen on `perf/predone-stage-concurrency` at the time (3m52s, one watchdog fire, 178 stuck-column lines, same thread setting) was **not** explained by anything fixed here. Fixing these generators changed nothing about that watchdog. It was root-caused separately, to a same-request double-claim in the dispatcher, and is fixed on the cap-raise branches.

## Relationship to the other branches

This raises no concurrency cap. It is a prerequisite for `perf/terrainfeatures-stage-concurrency`, which does, and which also needs #186 for reasons that branch's description covers.

Split out of #179 per @tehtelev's request to review same-stage concurrency one stage at a time.

/cc @tehtelev

---

## Added after @tehtelev's review: `GenPonds` null-chunk guard

His testing of #186+#187 caught one error, a `NullReferenceException` in `GenPonds.TryPlacePondAt` at the TerrainFeatures pass with 3 worldgen threads. Fixed here.

Pond search walks outward from a candidate position and pulls in whatever chunk covers each visited coordinate:

```csharp
chunk = (IServerChunk)blockAccessor.GetChunk(curChunkX, pondYPos / chunksize, curChunkZ);
if (chunk == null) chunk = api.WorldManager.GetChunk(curChunkX, pondYPos / chunksize, curChunkZ);
chunk.Unpack();                       // NRE when the fallback also returns null
```

The first lookup is null checked, the fallback is not. Four lines below, the sibling lookup for `chunkOneBlockBelow` **already** guards with `if (chunkOneBlockBelow == null) return;`, so the omission is an inconsistency rather than a deliberate invariant, and matching it needs no new policy: bailing out abandons one pond placement, which is exactly what the existing guard does.

**Vanilla-inherited, not introduced by this audit.** `.baseline/.../GenPonds.cs` is byte-identical at that spot and this branch's `GenPonds.cs.patch` does not touch the line. What changes is reachability: pond search crosses into neighbouring columns, and once several columns run TerrainFeatures at once a neighbour can legitimately be absent or mid-unload, which is effectively unreachable while the stage stays at one column at a time.

Verified only what a smoke test can show: build clean, server reaches RunGame, exactly the 2 known false-positive log lines. A smoke test cannot reproduce the original crash, so the guard is reasoned from your stack trace rather than observed to stop it. A rerun of your radius-100 test is what would confirm it.
