### PR TITLE
Let TerrainLate run several columns at once, with a two-axis mod-safety fallback

### DIFF
--- a/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/2.GenRockStrata/GenRockStrata.cs.patch
+++ b/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/2.GenRockStrata/GenRockStrata.cs.patch
@@ -1,8 +1,34 @@
 diff --git a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/2.GenRockStrata/GenRockStrata.cs b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/2.GenRockStrata/GenRockStrata.cs
-index cb9eefa..c3f1057 100644
+index cb9eefa..dcb6063 100644
 --- a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/2.GenRockStrata/GenRockStrata.cs
 +++ b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/2.GenRockStrata/GenRockStrata.cs
-@@ -46,11 +46,11 @@ namespace Vintagestory.ServerMods
+@@ -1,7 +1,9 @@
+ using System;
++using System.Collections.Concurrent;
+ using System.Collections.Generic;
++using System.Threading;
+ using Vintagestory.API.Common;
+ using Vintagestory.API.Datastructures;
+ using Vintagestory.API.MathTools;
+ using Vintagestory.API.Server;
+ using Vintagestory.ServerMods.NoObf;
+@@ -24,11 +26,14 @@ namespace Vintagestory.ServerMods
+         internal SimplexNoise distort2dx;
+         internal SimplexNoise distort2dz;
+         internal MapLayerCustomPerlin[] strataNoises;
+ 
+         int regionMapSize;
+-        Dictionary<int, LerpedWeightedIndex2DMap> ProvinceMapByRegion = new Dictionary<int, LerpedWeightedIndex2DMap>(10);
++        // Stratum: ConcurrentDictionary since TerrainLate can now run concurrently for
++        // distant columns (see StratumWorldGenStages), and two columns from different,
++        // not-yet-cached regions could otherwise race on the same bucket at once.
++        ConcurrentDictionary<int, LerpedWeightedIndex2DMap> ProvinceMapByRegion = new ConcurrentDictionary<int, LerpedWeightedIndex2DMap>();
+ 
+         public override bool ShouldLoad(EnumAppSide side)
+         {
+             return side == EnumAppSide.Server;
+         }
+@@ -46,11 +51,11 @@ namespace Vintagestory.ServerMods
          public override void StartServerSide(ICoreServerAPI api)
          {
              this.api = api;
@@ -15,25 +41,106 @@ index cb9eefa..c3f1057 100644
          }
  
  
-@@ -136,10 +136,11 @@ namespace Vintagestory.ServerMods
+@@ -134,24 +139,38 @@ namespace Vintagestory.ServerMods
+         }
+ 
  
          // Cheap ugly code for better performance :<
          #region
-         float[] rockGroupMaxThickness = new float[4];
-         int[] rockGroupCurrentThickness = new int[4];
-+        float[] indicesBuf; // Stratum: reused buffer
+-        float[] rockGroupMaxThickness = new float[4];
+-        int[] rockGroupCurrentThickness = new int[4];
++        // Stratum start: TerrainLate can now run concurrently for distant columns
++        // (see StratumWorldGenStages). preLoad/genBlockColumn always run back-to-back
++        // on the same worker thread for a given column (no internal Parallel.For
++        // here, unlike GenTerra), so per-thread scratch is sufficient. ThreadLocal
++        // instead of [ThreadStatic] because this class has a second instance used by
++        // ProPickWorkSpace for prospecting-pick probing (see that file), and a
++        // [ThreadStatic] static field would be shared between both instances on
++        // whatever thread happens to run them, not scoped to this instance.
++        class ThreadLocalScratch
++        {
++            public float[] rockGroupMaxThickness = new float[4];
++            public int[] rockGroupCurrentThickness = new int[4];
++            public float[] indicesBuf; // resized lazily once province count is known
  
-         IMapChunk mapChunk;
-         ushort[] heightMap;
-         int rdx;
-         int rdz;
-@@ -192,19 +193,31 @@ namespace Vintagestory.ServerMods
+-        IMapChunk mapChunk;
+-        ushort[] heightMap;
+-        int rdx;
+-        int rdz;
++            public IMapChunk mapChunk;
++            public ushort[] heightMap;
++            public int rdx;
++            public int rdz;
+ 
+-        LerpedWeightedIndex2DMap map;
+-        float lerpMapInv;
+-        float chunkInRegionX;
+-        float chunkInRegionZ;
++            public LerpedWeightedIndex2DMap map;
++            public float lerpMapInv;
++            public float chunkInRegionX;
++            public float chunkInRegionZ;
+ 
+-        GeologicProvinces provinces = NoiseGeoProvince.provinces;
++            public GeologicProvinces provinces;
++        }
++        readonly ThreadLocal<ThreadLocalScratch> scratchThreadLocal = new ThreadLocal<ThreadLocalScratch>(() => new ThreadLocalScratch());
++        // Stratum end
+         #endregion
+ 
+         internal void GenChunkColumn(IChunkColumnGenerateRequest request)
+         {
+             var chunks = request.Chunks;
+@@ -169,42 +188,60 @@ namespace Vintagestory.ServerMods
+             }
+         }
+ 
+         public void preLoad(IServerChunk[] chunks, int chunkX, int chunkZ)
+         {
+-            mapChunk = chunks[0].MapChunk;
+-            heightMap = mapChunk.WorldGenTerrainHeightMap;
+-            rdx = chunkX % regionChunkSize;
+-            rdz = chunkZ % regionChunkSize;
+-
+-            map = GetOrLoadLerpedProvinceMap(chunks[0].MapChunk, chunkX, chunkZ);
+-            lerpMapInv = 1f / TerraGenConfig.geoProvMapScale;
+-            chunkInRegionX = (chunkX % regionChunkSize) * lerpMapInv * chunksize;
+-            chunkInRegionZ = (chunkZ % regionChunkSize) * lerpMapInv * chunksize;
+-
+-            provinces = NoiseGeoProvince.provinces;
++            var s = scratchThreadLocal.Value; // Stratum: per-thread scratch, see the field declaration
++            s.mapChunk = chunks[0].MapChunk;
++            s.heightMap = s.mapChunk.WorldGenTerrainHeightMap;
++            s.rdx = chunkX % regionChunkSize;
++            s.rdz = chunkZ % regionChunkSize;
++
++            s.map = GetOrLoadLerpedProvinceMap(chunks[0].MapChunk, chunkX, chunkZ);
++            s.lerpMapInv = 1f / TerraGenConfig.geoProvMapScale;
++            s.chunkInRegionX = (chunkX % regionChunkSize) * s.lerpMapInv * chunksize;
++            s.chunkInRegionZ = (chunkZ % regionChunkSize) * s.lerpMapInv * chunksize;
++
++            s.provinces = NoiseGeoProvince.provinces;
+         }
+ 
+         public void genBlockColumn(IServerChunk[] chunks, int chunkX, int chunkZ, int lx, int lz)
+         {
+-            int surfaceY = heightMap[lz * chunksize + lx];
++            var s = scratchThreadLocal.Value; // Stratum: per-thread scratch, see the field declaration
++            int surfaceY = s.heightMap[lz * chunksize + lx];
+             int ylower = 1;
+             int yupper = surfaceY;
              int rockBlockId = this.rockBlockId;
  
++            float[] rockGroupMaxThickness = s.rockGroupMaxThickness;
++            int[] rockGroupCurrentThickness = s.rockGroupCurrentThickness;
              rockGroupMaxThickness[0] = rockGroupMaxThickness[1] = rockGroupMaxThickness[2] = rockGroupMaxThickness[3] = 0;
              rockGroupCurrentThickness[0] = rockGroupCurrentThickness[1] = rockGroupCurrentThickness[2] = rockGroupCurrentThickness[3] = 0;
  
 -            float[] indices = new float[provinces.Variants.Length];
+-            map.WeightsAt(
+-                chunkInRegionX + lx * lerpMapInv,
+-                chunkInRegionZ + lz * lerpMapInv,
+-                indices
 +            // Stratum start:
 +            // use a buffer to reduce allocations
 +            // Just in case, check the dimensions
@@ -41,14 +148,15 @@ index cb9eefa..c3f1057 100644
 +            // Tested on the generation of 10200 chunk columns:
 +            // - method execution time: reduced from 16152 ms to 14678 ms;
 +            // - GC memory allocations: reduced from 646 MB to 90 MB.
-+            
-+            if (indicesBuf == null || indicesBuf.Length != provinces.Variants.Length)
-+                indicesBuf = new float[provinces.Variants.Length];
 +
-             map.WeightsAt(
-                 chunkInRegionX + lx * lerpMapInv,
-                 chunkInRegionZ + lz * lerpMapInv,
--                indices
++            GeologicProvinces provinces = s.provinces;
++            if (s.indicesBuf == null || s.indicesBuf.Length != provinces.Variants.Length)
++                s.indicesBuf = new float[provinces.Variants.Length];
++            float[] indicesBuf = s.indicesBuf;
++
++            s.map.WeightsAt(
++                s.chunkInRegionX + lx * s.lerpMapInv,
++                s.chunkInRegionZ + lz * s.lerpMapInv,
 +                indicesBuf
              );
 -            for (int i = 0; i < indices.Length; i++)
@@ -63,3 +171,59 @@ index cb9eefa..c3f1057 100644
                  GeologicProvinceRockStrata[] localstrata = provinces.Variants[i].RockStrataIndexed;
  
                  rockGroupMaxThickness[0] += localstrata[0].ScaledMaxThickness * w;
+@@ -227,24 +264,24 @@ namespace Vintagestory.ServerMods
+             while (ylower <= yupper)
+             {
+                 if (--strataThickness <= 0f)
+                 {
+                     rockStrataId++;
+-                    if (rockStrataId >= strata.Variants.Length || rockStrataId >= mapChunk.MapRegion.RockStrata.Length)
++                    if (rockStrataId >= strata.Variants.Length || rockStrataId >= s.mapChunk.MapRegion.RockStrata.Length)
+                     {
+                         break;
+                     }
+                     stratum = strata.Variants[rockStrataId];
+-                    rockMap = mapChunk.MapRegion.RockStrata[rockStrataId];
++                    rockMap = s.mapChunk.MapRegion.RockStrata[rockStrataId];
+                     step = (float)rockMap.InnerSize / regionChunkSize;
+ 
+                     grp = (int)stratum.RockGroup;
+ 
+                     float allowedThickness = rockGroupMaxThickness[grp] * thicknessDistort - rockGroupCurrentThickness[grp];
+ 
+-                    var nx = rdx * step + step * (float)(lx + distx) / chunksize;
+-                    var nz = rdz * step + step * (float)(lz + distz) / chunksize;
++                    var nx = s.rdx * step + step * (float)(lx + distx) / chunksize;
++                    var nz = s.rdz * step + step * (float)(lz + distz) / chunksize;
+ 
+                     // 1.20 fix, only clamp the values, to prevent chunk borders
+                     // In 1.21 we ought to simply use normalized noise * rockmapsize
+                     nx = Math.Max(nx, -1.499f);
+                     nz = Math.Max(nz, -1.499f);
+@@ -312,21 +349,23 @@ namespace Vintagestory.ServerMods
+ 
+         LerpedWeightedIndex2DMap GetOrLoadLerpedProvinceMap(IMapChunk mapchunk, int chunkX, int chunkZ)
+         {
+             int index2d = chunkZ / regionChunkSize * regionMapSize + chunkX / regionChunkSize;
+ 
+-            ProvinceMapByRegion.TryGetValue(index2d, out LerpedWeightedIndex2DMap map);
+-            if (map != null) return map;
++            if (ProvinceMapByRegion.TryGetValue(index2d, out LerpedWeightedIndex2DMap map)) return map;
+ 
+             return CreateLerpedProvinceMap(mapchunk.MapRegion.GeologicProvinceMap, chunkX / regionChunkSize, chunkZ / regionChunkSize);
+         }
+ 
+         LerpedWeightedIndex2DMap CreateLerpedProvinceMap(IntDataMap2D geoMap, int regionX, int regionZ)
+         {
+             int index2d = regionZ * regionMapSize + regionX;
+ 
+-            return ProvinceMapByRegion[index2d] = new LerpedWeightedIndex2DMap(geoMap.Data, geoMap.Size, TerraGenConfig.geoProvSmoothingRadius, geoMap.TopLeftPadding, geoMap.BottomRightPadding);
++            // Stratum: GetOrAdd instead of a plain indexer write, so two threads racing
++            // on the same not-yet-cached region under TerrainLate concurrency settle on
++            // one shared instance instead of one silently overwriting the other's.
++            return ProvinceMapByRegion.GetOrAdd(index2d, _ => new LerpedWeightedIndex2DMap(geoMap.Data, geoMap.Size, TerraGenConfig.geoProvSmoothingRadius, geoMap.TopLeftPadding, geoMap.BottomRightPadding));
+         }
+ 
+ 
+     }
+ }

--- a/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves.cs.patch
+++ b/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves.cs.patch
@@ -1,8 +1,36 @@
 diff --git a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves.cs b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves.cs
-index 30f034d..def7acd 100644
+index 30f034d..6c87d18 100644
 --- a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves.cs
 +++ b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves.cs
-@@ -30,18 +30,18 @@ namespace Vintagestory.ServerMods
+@@ -1,7 +1,8 @@
+ using System;
+ using System.Collections.Generic;
++using System.Threading;
+ using Vintagestory.API.Common;
+ using Vintagestory.API.MathTools;
+ using Vintagestory.API.Server;
+ 
+ #nullable disable
+@@ -12,11 +13,17 @@ namespace Vintagestory.ServerMods
+     {
+         protected override int chunkRange { get { return 5; } }
+ 
+         public override double ExecuteOrder() { return 0.3; }
+ 
+-        internal LCGRandom caveRand;
++        // Stratum: ThreadLocal, not a plain field. GeneratePartial reseeds caveRand per
++        // (chunkX+cdx, chunkZ+cdz) then hands it into CarveTunnel/CarveShaft's recursive
++        // NextInt() sequence; if TerrainLate ever runs two columns at once, a shared
++        // field lets one thread's reseed land mid-sequence of another thread's carve,
++        // splicing two columns' cave shapes together.
++        ThreadLocal<LCGRandom> caveRandThreadLocal;
++        internal LCGRandom caveRand => caveRandThreadLocal.Value;
+         IWorldGenBlockAccessor worldgenBlockAccessor;
+ 
+         NormalizedSimplexNoise basaltNoise;
+         NormalizedSimplexNoise heightvarNoise;
+         int regionsize;
+@@ -30,27 +37,28 @@ namespace Vintagestory.ServerMods
                  api.Event.GetWorldgenBlockAccessor(OnWorldGenBlockAccessor);
  
                  api.ChatCommands.GetOrCreate("dev")
@@ -23,11 +51,26 @@ index 30f034d..def7acd 100644
          }
  
  
-@@ -77,16 +77,23 @@ namespace Vintagestory.ServerMods
+         public override void initWorldGen()
+         {
+             base.initWorldGen();
+-            caveRand = new LCGRandom(api.WorldManager.Seed + 123128);
++            int caveSeed = api.WorldManager.Seed + 123128;
++            caveRandThreadLocal = new ThreadLocal<LCGRandom>(() => new LCGRandom(caveSeed));
+             basaltNoise = NormalizedSimplexNoise.FromDefaultOctaves(2, 1f / 3.5f, 0.9f, api.World.Seed + 12);
+             heightvarNoise = NormalizedSimplexNoise.FromDefaultOctaves(3, 1f / 20f, 0.9f, api.World.Seed + 12);
+ 
+             regionsize = api.World.BlockAccessor.RegionSize;
+         }
+@@ -74,19 +82,25 @@ namespace Vintagestory.ServerMods
+             }
+         }
+ 
          private TextCommandResult CmdCaveGenTest(TextCommandCallingArgs args)
          {
-             caveRand = new LCGRandom(api.WorldManager.Seed + 123128);
-             initWorldGen();
+-            caveRand = new LCGRandom(api.WorldManager.Seed + 123128);
+-            initWorldGen();
++            initWorldGen(); // Stratum: this already reseeds caveRandThreadLocal with the same formula, no need to do it twice
  
 +            // Stratum start:
 +            // Adding light recalculation for caves
@@ -49,7 +92,7 @@ index 30f034d..def7acd 100644
                  for (int dz = -5; dz <= 5; dz++)
                  {
                      int chunkX = baseChunkX + dx;
-@@ -96,19 +103,19 @@ namespace Vintagestory.ServerMods
+@@ -96,19 +110,19 @@ namespace Vintagestory.ServerMods
  
                      for (int i = 0; i < chunks.Length; i++)
                      {
@@ -71,7 +114,7 @@ index 30f034d..def7acd 100644
                  for (int dz = -5; dz <= 5; dz++)
                  {
                      int chunkX = baseChunkX + dx;
-@@ -125,15 +132,24 @@ namespace Vintagestory.ServerMods
+@@ -125,15 +139,24 @@ namespace Vintagestory.ServerMods
                              chunkRand.InitPositionSeed(chunkX + gdx, chunkZ + gdz);
                              GeneratePartial(chunks, chunkX, chunkZ, gdx, gdz);
                          }
@@ -96,7 +139,7 @@ index 30f034d..def7acd 100644
          }
  
          private IServerChunk[] GetChunkColumn(int chunkX, int chunkZ)
-@@ -506,160 +522,225 @@ namespace Vintagestory.ServerMods
+@@ -506,160 +529,225 @@ namespace Vintagestory.ServerMods
  
  
  

--- a/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/4.GenBlockLayers/GenBlockLayers.cs.patch
+++ b/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/4.GenBlockLayers/GenBlockLayers.cs.patch
@@ -1,8 +1,53 @@
 diff --git a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/4.GenBlockLayers/GenBlockLayers.cs b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/4.GenBlockLayers/GenBlockLayers.cs
-index 55b134c..2de9132 100644
+index 55b134c..0a3927d 100644
 --- a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/4.GenBlockLayers/GenBlockLayers.cs
 +++ b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/4.GenBlockLayers/GenBlockLayers.cs
-@@ -46,11 +46,11 @@ namespace Vintagestory.ServerMods
+@@ -1,7 +1,8 @@
+ using System;
+ using System.Collections.Generic;
++using System.Threading;
+ using Vintagestory.API.Common;
+ using Vintagestory.API.Datastructures;
+ using Vintagestory.API.MathTools;
+ using Vintagestory.API.Server;
+ 
+@@ -12,19 +13,31 @@ namespace Vintagestory.ServerMods
+ 
+     public class GenBlockLayers : ModStdWorldGen
+     {
+         private ICoreServerAPI api;
+ 
+-        List<int> BlockLayersIds = new List<int>();
+-        LCGRandom rnd;
++        // Stratum: TerrainLate can now run concurrently for distant columns. rnd gets
++        // reseeded per column at the top of OnChunkColumnGeneration, then LoadBlockLayers
++        // writes BlockLayersIds/layersUnderWater and PutLayers reads them back a few
++        // calls later, all within the processing of one column, the same shared-scratch
++        // shape GenCreatures had. ThreadLocal instead of [ThreadStatic] static since
++        // this class is a plain instance field owner with no other instances today, but
++        // matches the idiom used across the rest of this pass rather than relying on
++        // "only one instance exists right now" staying true.
++        class ThreadLocalScratch
++        {
++            public LCGRandom rnd;
++            public List<int> BlockLayersIds = new List<int>();
++            public int[] layersUnderWaterTmp = new int[1];
++            public int[] layersUnderWater = Array.Empty<int>();
++        }
++        ThreadLocal<ThreadLocalScratch> scratchThreadLocal;
+         int mapheight;
+         ClampedSimplexNoise grassDensity;
+         ClampedSimplexNoise grassHeight;
+         int boilingWaterBlockId;
+ 
+-        public int[] layersUnderWaterTmp = new int[1];
+-        public int[] layersUnderWater = Array.Empty<int>();
+         public BlockLayerConfig blockLayerConfig;
+         public SimplexNoise distort2dx;
+         public SimplexNoise distort2dz;
+ 
+         public override bool ShouldLoad(EnumAppSide side)
+@@ -46,11 +59,11 @@ namespace Vintagestory.ServerMods
              //this.api.Event.MapRegionGeneration(OnMapRegionGen, "standard");   // 8.2.24 commented out because the method has no code
  
  
@@ -15,3 +60,204 @@ index 55b134c..2de9132 100644
              distort2dz = new SimplexNoise(new double[] { 14, 9, 6, 3 }, new double[] { 1 / 100.0, 1 / 50.0, 1 / 25.0, 1 / 12.5 }, api.World.SeaLevel + 20981);
          }
  
+@@ -81,13 +94,15 @@ namespace Vintagestory.ServerMods
+             LoadGlobalConfig(api);
+ 
+             api.ObjectCache.Remove(BlockLayerConfig.cacheKey);
+             blockLayerConfig = BlockLayerConfig.GetInstance(api);
+ 
+-            rnd = new LCGRandom(api.WorldManager.Seed);
+-            grassDensity = new ClampedSimplexNoise(new double[] { 4 }, new double[] { 0.5 }, rnd.NextInt());
+-            grassHeight = new ClampedSimplexNoise(new double[] { 1.5 }, new double[] { 0.5 }, rnd.NextInt());
++            int seed = api.WorldManager.Seed;
++            LCGRandom setupRnd = new LCGRandom(seed); // one-time draw for the two noise fields below, not the per-column scratch
++            grassDensity = new ClampedSimplexNoise(new double[] { 4 }, new double[] { 0.5 }, setupRnd.NextInt());
++            grassHeight = new ClampedSimplexNoise(new double[] { 1.5 }, new double[] { 0.5 }, setupRnd.NextInt());
++            scratchThreadLocal = new ThreadLocal<ThreadLocalScratch>(() => new ThreadLocalScratch { rnd = new LCGRandom(seed) });
+ 
+             mapheight = api.WorldManager.MapSizeY;
+ 
+             boilingWaterBlockId = gcfg.boilingWaterBlockId;
+         }
+@@ -96,11 +111,12 @@ namespace Vintagestory.ServerMods
+         {
+             var chunks = request.Chunks;
+             int chunkX = request.ChunkX;
+             int chunkZ = request.ChunkZ;
+ 
+-            rnd.InitPositionSeed(chunkX, chunkZ);
++            ThreadLocalScratch s = scratchThreadLocal.Value; // Stratum: per-thread scratch, fetched once and threaded through for this column
++            s.rnd.InitPositionSeed(chunkX, chunkZ);
+ 
+             IntDataMap2D forestMap = chunks[0].MapChunk.MapRegion.ForestMap;
+             IntDataMap2D climateMap = chunks[0].MapChunk.MapRegion.ClimateMap;
+             IntDataMap2D beachMap = chunks[0].MapChunk.MapRegion.BeachMap;
+             IntDataMap2D biomeMap = chunks[0].MapChunk.MapRegion.BiomeMap;
+@@ -201,19 +217,19 @@ namespace Vintagestory.ServerMods
+                         }
+                     }
+ 
+                     herePos.Y = posY;
+                     int disty = (int)(distort2dx.Noise(-herePos.X, -herePos.Z) / 4.0);
+-                    posY = PutLayers(transitionRand, x, z, disty, herePos, chunks, rainRel, temp, tempUnscaled, heightMap, biome);
++                    posY = PutLayers(s, transitionRand, x, z, disty, herePos, chunks, rainRel, temp, tempUnscaled, heightMap, biome);
+ 
+                     if (prevY == TerraGenConfig.seaLevel - 1)
+                     {
+                         float beachRel = GameMath.BiLerp(beachUpLeft, beachUpRight, beachBotLeft, beachBotRight, (float)x / chunksize, (float)z / chunksize) / 255f;
+                         GenBeach(x, prevY, z, chunks, rainRel, temp, beachRel, rockblockID);
+                     }
+ 
+-                    PlaceTallGrass(x, prevY, z, chunks, rainRel, tempRel, temp, forestRel, biome);
++                    PlaceTallGrass(s, x, prevY, z, chunks, rainRel, tempRel, temp, forestRel, biome);
+ 
+ 
+                     // Try again to put layers if above sealevel and we found over 10 air blocks
+                     int foundAir = 0;
+                     while (posY >= TerraGenConfig.seaLevel - 1)
+@@ -255,11 +271,11 @@ namespace Vintagestory.ServerMods
+             distx = distort2dx.Noise(herePos.X, herePos.Z);
+             distz = distort2dz.Noise(herePos.X, herePos.Z);
+             return (int)(distx / 5);
+         }
+ 
+-        private int PutLayers(double posRand, int lx, int lz, int posyoffs, BlockPos pos, IServerChunk[] chunks, float rainRel, float temp, int unscaledTemp, ushort[] heightMap, int biome)
++        private int PutLayers(ThreadLocalScratch s, double posRand, int lx, int lz, int posyoffs, BlockPos pos, IServerChunk[] chunks, float rainRel, float temp, int unscaledTemp, ushort[] heightMap, int biome)
+         {
+             int i = 0;
+             int j = 0;
+             bool underWater = false;
+             bool isOcean = false;
+@@ -302,24 +318,24 @@ namespace Vintagestory.ServerMods
+                     if (heightMap != null && first)
+                     {
+                         chunks[0].MapChunk.TopRockIdMap[lz * chunksize + lx] = blockId;
+                         if (underIce) break;   // radfast 30.1.24: Note, under ice we do not set the sea/lake floor layers (gravel etc), for consistency with legacy worldgen prior to 1.19.4
+ 
+-                        LoadBlockLayers(posRand, rainRel, temp, unscaledTemp, startPosY + posyoffs, pos, blockId, isOcean, biome);
++                        LoadBlockLayers(s, posRand, rainRel, temp, unscaledTemp, startPosY + posyoffs, pos, blockId, isOcean, biome);
+                         first = false;
+ 
+                         if (!underWater) heightMap[lz * chunksize + lx] = (ushort)(pos.Y + 1);
+                     }
+ 
+-                    if (i >= BlockLayersIds.Count || (underWater && j >= layersUnderWater.Length))
++                    if (i >= s.BlockLayersIds.Count || (underWater && j >= s.layersUnderWater.Length))
+                     {
+                         return pos.Y;
+                     }
+ 
+ 
+                     IChunkBlocks chunkdata = chunks[chunkY].Data;
+-                    chunkdata.SetBlockUnsafe(index3d, underWater ? layersUnderWater[j++] : BlockLayersIds[i++]);
++                    chunkdata.SetBlockUnsafe(index3d, underWater ? s.layersUnderWater[j++] : s.BlockLayersIds[i++]);
+                     chunkdata.SetFluid(index3d, 0);
+                 }
+                 else
+                 {
+                     if ((i > 0 && temp > -18) || j > 0) return pos.Y;
+@@ -357,27 +373,36 @@ namespace Vintagestory.ServerMods
+                     }
+                 }
+             }
+         }
+ 
++        // Stratum: kept for external callers (ModStdWorldGen.GenerateGrass calls this on
++        // whatever generator invoked it, which may not have a ThreadLocalScratch handle
++        // of its own) that can't see the private ThreadLocalScratch type. Resolves the
++        // per-thread scratch itself, same as the internal call sites do explicitly.
+         public void PlaceTallGrass(int x, int posY, int z, IServerChunk[] chunks, float rainRel, float tempRel, float temp, float forestRel, int biome)
+         {
+-            double rndVal = blockLayerConfig.Tallgrass.RndWeight * rnd.NextDouble() + blockLayerConfig.Tallgrass.PerlinWeight * grassDensity.Noise(x, z, -0.5f);
++            PlaceTallGrass(scratchThreadLocal.Value, x, posY, z, chunks, rainRel, tempRel, temp, forestRel, biome);
++        }
++
++        private void PlaceTallGrass(ThreadLocalScratch s, int x, int posY, int z, IServerChunk[] chunks, float rainRel, float tempRel, float temp, float forestRel, int biome)
++        {
++            double rndVal = blockLayerConfig.Tallgrass.RndWeight * s.rnd.NextDouble() + blockLayerConfig.Tallgrass.PerlinWeight * grassDensity.Noise(x, z, -0.5f);
+ 
+             double extraGrass = Math.Max(0, rainRel * tempRel - 0.25);
+ 
+             if (rndVal <= GameMath.Clamp(forestRel - extraGrass, 0.05, 0.99) || posY >= mapheight - 1 || posY < 1) return;
+ 
+             int blockId = chunks[posY / chunksize].Data[(chunksize * (posY % chunksize) + z) * chunksize + x];
+ 
+-            if (api.World.Blocks[blockId].Fertility <= rnd.NextInt(100)) return;
++            if (api.World.Blocks[blockId].Fertility <= s.rnd.NextInt(100)) return;
+ 
+             if (blockLayerConfig.Tallgrass.BlockCodeByBiome != null)
+             {
+                 var layers = blockLayerConfig.Tallgrass.BlockCodeByBiome;
+                 double gh = Math.Max(0, grassHeight.Noise(x, z) * layers.Length - 1);
+-                int st = (int)gh + (rnd.NextDouble() < gh ? 1 : 0);
++                int st = (int)gh + (s.rnd.NextDouble() < gh ? 1 : 0);
+                 for (int i = st; i < layers.Length; i++)
+                 {
+                     if (layers[i].Biome == -1 || layers[i].Biome == biome)
+                     {
+                         chunks[(posY + 1) / chunksize].Data[(chunksize * ((posY + 1) % chunksize) + z) * chunksize + x] = layers[i].BlockId;
+@@ -387,11 +412,11 @@ namespace Vintagestory.ServerMods
+             }
+ 
+             if (blockLayerConfig.Tallgrass.BlockCodeByMin != null)
+             {
+                 double gheight = Math.Max(0, grassHeight.Noise(x, z) * blockLayerConfig.Tallgrass.BlockCodeByMin.Length - 1);
+-                int start = (int)gheight + (rnd.NextDouble() < gheight ? 1 : 0);
++                int start = (int)gheight + (s.rnd.NextDouble() < gheight ? 1 : 0);
+ 
+                 for (int i = start; i < blockLayerConfig.Tallgrass.BlockCodeByMin.Length; i++)
+                 {
+                     TallGrassBlockCodeByMin bcbymin = blockLayerConfig.Tallgrass.BlockCodeByMin[i];
+ 
+@@ -404,22 +429,23 @@ namespace Vintagestory.ServerMods
+                 }
+             }
+         }
+ 
+ 
+-        private void LoadBlockLayers(double posRand, float rainRel, float temperature, int unscaledTemp, int posY, BlockPos pos, int firstBlockId, bool isOcean, int biome)
++        private void LoadBlockLayers(ThreadLocalScratch s, double posRand, float rainRel, float temperature, int unscaledTemp, int posY, BlockPos pos, int firstBlockId, bool isOcean, int biome)
+         {
+             float heightRel = ((float)posY - TerraGenConfig.seaLevel) / ((float)mapheight - TerraGenConfig.seaLevel);
+             float fertilityRel = Climate.GetFertilityFromUnscaledTemp((int)(rainRel * 255), unscaledTemp, heightRel) / 255f;
+ 
+             float depthf = TerraGenConfig.SoilThickness(rainRel, temperature, posY - TerraGenConfig.seaLevel, 1f);
+             int depth = (int)depthf;
+-            if (depthf - depth > rnd.NextFloat()) depth++;
++            if (depthf - depth > s.rnd.NextFloat()) depth++;
+ 
+             // Hardcoding crime here. Please don't look. Makes deep layers of ice work
+             if (temperature < -16) depth += 10;
+ 
++            List<int> BlockLayersIds = s.BlockLayersIds;
+             BlockLayersIds.Clear();
+             for (int j = 0; j < blockLayerConfig.Blocklayers.Length; j++)
+             {
+                 BlockLayer bl = blockLayerConfig.Blocklayers[j];
+                 float yDist = bl.CalcYDistance(posY, mapheight);
+@@ -460,20 +486,20 @@ namespace Vintagestory.ServerMods
+             }
+ 
+             int lakeBedId;
+             if (isOcean)
+             {
+-                lakeBedId = blockLayerConfig.OceanBedLayer.GetSuitable(temperature, rainRel, (float)pos.Y / api.WorldManager.MapSizeY, rnd, firstBlockId);
++                lakeBedId = blockLayerConfig.OceanBedLayer.GetSuitable(temperature, rainRel, (float)pos.Y / api.WorldManager.MapSizeY, s.rnd, firstBlockId);
+             }
+             else
+             {
+-                lakeBedId = blockLayerConfig.LakeBedLayer.GetSuitable(temperature, rainRel, (float)pos.Y / api.WorldManager.MapSizeY, rnd, firstBlockId);
++                lakeBedId = blockLayerConfig.LakeBedLayer.GetSuitable(temperature, rainRel, (float)pos.Y / api.WorldManager.MapSizeY, s.rnd, firstBlockId);
+             }
+-            if (lakeBedId == 0) layersUnderWater = Array.Empty<int>();
++            if (lakeBedId == 0) s.layersUnderWater = Array.Empty<int>();
+             else
+             {
+-                layersUnderWaterTmp[0] = lakeBedId;
+-                layersUnderWater = layersUnderWaterTmp;
++                s.layersUnderWaterTmp[0] = lakeBedId;
++                s.layersUnderWater = s.layersUnderWaterTmp;
+             }
+         }
+     }
+ }

--- a/patches/VSEssentials/Systems/WorldGen/Standard/GenPartial.cs.patch
+++ b/patches/VSEssentials/Systems/WorldGen/Standard/GenPartial.cs.patch
@@ -1,0 +1,57 @@
+diff --git a/VSEssentials/Systems/WorldGen/Standard/GenPartial.cs b/VSEssentials/Systems/WorldGen/Standard/GenPartial.cs
+index 58aa710..43ec0ad 100644
+--- a/VSEssentials/Systems/WorldGen/Standard/GenPartial.cs
++++ b/VSEssentials/Systems/WorldGen/Standard/GenPartial.cs
+@@ -1,5 +1,6 @@
++using System.Threading;
+ using Vintagestory.API.MathTools;
+ using Vintagestory.API.Server;
+ 
+ #nullable disable
+ 
+@@ -11,11 +12,21 @@ namespace Vintagestory.ServerMods
+         protected int worldheight;
+         public int airBlockId = 0;
+ 
+         protected abstract int chunkRange { get; }
+ 
+-        protected LCGRandom chunkRand;
++        // Stratum: ThreadLocal instance field, not a plain LCGRandom field. GenChunkColumn
++        // reseeds chunkRand per (chunkX+dx, chunkZ+dz) right before each GeneratePartial
++        // call, which only stays correct if one column's reseed-then-use sequence can't
++        // interleave with another's; a plain shared field breaks that the moment a stage
++        // runs more than one column at a time (see GenCaves, the current TerrainLate
++        // occupant that reaches this class). ThreadLocal, not [ThreadStatic] static,
++        // because GenPartial has more than one live subclass instance (GenCaves,
++        // GenDeposits, GenHugePatches), and a static field would be shared by all of
++        // them on whatever thread happens to run them.
++        protected ThreadLocal<LCGRandom> chunkRandThreadLocal;
++        protected LCGRandom chunkRand => chunkRandThreadLocal.Value;
+ 
+         public override void StartServerSide(ICoreServerAPI api)
+         {
+             this.api = api;
+ 
+@@ -25,19 +36,21 @@ namespace Vintagestory.ServerMods
+         public virtual void initWorldGen()
+         {
+             LoadGlobalConfig(api);
+ 
+             worldheight = api.WorldManager.MapSizeY;
+-            chunkRand = new LCGRandom(api.WorldManager.Seed);
++            int seed = api.WorldManager.Seed;
++            chunkRandThreadLocal = new ThreadLocal<LCGRandom>(() => new LCGRandom(seed));
+         }
+ 
+ 
+         protected virtual void GenChunkColumn(IChunkColumnGenerateRequest request)
+         {
+             var chunks = request.Chunks;
+             int chunkX = request.ChunkX;
+             int chunkZ = request.ChunkZ;
++            LCGRandom chunkRand = this.chunkRand;
+ 
+             for (int dx = -chunkRange; dx <= chunkRange; dx++)
+             {
+                 for (int dz = -chunkRange; dz <= chunkRange; dz++)
+                 {

--- a/patches/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs.patch
@@ -1,8 +1,8 @@
 diff --git a/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs b/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs
-index f644852..995d8f0 100644
+index f644852..a04c162 100644
 --- a/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs
 +++ b/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs
-@@ -1,139 +1,1028 @@
+@@ -1,139 +1,1029 @@
  using System;
  using System.Collections.Generic;
  using System.Linq;
@@ -349,6 +349,7 @@ index f644852..995d8f0 100644
 +		stratumStageMaxConcurrent = new int[StratumWorldGenStages.Done];
 +		for (int i = 0; i < stratumStageMaxConcurrent.Length; i++) stratumStageMaxConcurrent[i] = 1;
 +		stratumStageMaxConcurrent[StratumWorldGenStages.PreDone] = Math.Max(1, chunkthread.additionalWorldGenThreadsCount);
++		stratumStageMaxConcurrent[StratumWorldGenStages.TerrainLate] = Math.Max(1, chunkthread.additionalWorldGenThreadsCount);
  	}
  
 +	/// <summary>
@@ -1053,7 +1054,7 @@ index f644852..995d8f0 100644
  			if (!tryLoadOrGenerateChunkColumnsInQueue())
  			{
  				break;
-@@ -143,39 +1032,59 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -143,39 +1033,59 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				break;
  			}
  		}
@@ -1115,7 +1116,7 @@ index f644852..995d8f0 100644
  				ServerChunk serverChunk = (ServerChunk)server.WorldMap.GetChunk(x, i, z);
  				if (serverChunk != null)
  				{
-@@ -183,11 +1092,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -183,11 +1093,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					for (int j = 0; j < entities.Length; j++)
  					{
  						Entity entity = entities[j];
@@ -1128,7 +1129,7 @@ index f644852..995d8f0 100644
  						{
  							if (j >= serverChunk.EntitiesCount)
  							{
-@@ -211,19 +1120,23 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -211,19 +1121,23 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				});
  			}
  			list2.Add(item);
@@ -1153,7 +1154,7 @@ index f644852..995d8f0 100644
  		{
  			ChunkPos item2 = server.WorldMap.MapRegionPosFromIndex2D(result2);
  			if (hashSet == null)
-@@ -237,28 +1150,46 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -237,28 +1151,46 @@ internal class ServerSystemSupplyChunks : ServerSystem
  		{
  			chunkthread.gameDatabase.DeleteMapRegions(hashSet);
  		}
@@ -1205,7 +1206,7 @@ index f644852..995d8f0 100644
  		ServerMapChunk orCreateMapChunk = chunkthread.loadsavechunks.GetOrCreateMapChunk(request);
  		if (orCreateMapChunk == null)
  		{
-@@ -267,94 +1198,203 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -267,94 +1199,203 @@ internal class ServerSystemSupplyChunks : ServerSystem
  		ServerChunk[] array = chunkthread.loadsavechunks.TryLoadChunkColumn(request);
  		if (array == null)
  		{
@@ -1415,7 +1416,7 @@ index f644852..995d8f0 100644
  				chunkRequest.Chunks = TryLoadChunkColumn(chunkRequest);
  				if (chunkRequest.Chunks != null)
  				{
-@@ -364,31 +1404,42 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -364,31 +1405,42 @@ internal class ServerSystemSupplyChunks : ServerSystem
  						obj.serverMapChunk = orCreateMapChunk;
  						obj.MarkFresh();
  					}
@@ -1458,7 +1459,7 @@ index f644852..995d8f0 100644
  				ServerEventAPI eventapi = server.api.eventapi;
  				ServerMapChunk mapChunk = orCreateMapChunk;
  				int chunkX = chunkRequest.chunkX;
-@@ -404,117 +1455,105 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -404,117 +1456,105 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					ServerMain.Logger.Error("Repair mode is enabled so will delete the entire chunk column.");
  					GenerateNewChunkColumn(orCreateMapChunk, chunkRequest);
  					return false;
@@ -1606,7 +1607,7 @@ index f644852..995d8f0 100644
  				try
  				{
  					serverChunk.Unpack();
-@@ -529,10 +1568,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -529,10 +1569,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
  						ServerMain.FrameProfiler.Leave();
  						return;
  					}
@@ -1619,7 +1620,7 @@ index f644852..995d8f0 100644
  			{
  				for (int j = 0; j < serverChunk.Entities.Length; j++)
  				{
-@@ -548,10 +1589,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -548,10 +1590,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					{
  						if (server.LoadEntity(entity, num2))
  						{
@@ -1631,7 +1632,7 @@ index f644852..995d8f0 100644
  						{
  							string text = "-";
  							try
-@@ -564,14 +1606,18 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -564,14 +1607,18 @@ internal class ServerSystemSupplyChunks : ServerSystem
  							ServerMain.Logger.Log(EnumLogType.Worldgen, "In " + server.WorldName + ", villager " + text + " removed at " + entity.Pos.AsBlockPos?.ToString() + " due to an exception on loading");
  						}
  					}
@@ -1650,7 +1651,7 @@ index f644852..995d8f0 100644
  			{
  				BlockEntity value = blockEntity.Value;
  				if (value == null)
-@@ -580,10 +1626,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -580,10 +1627,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				}
  				try
  				{
@@ -1662,7 +1663,7 @@ index f644852..995d8f0 100644
  						serverChunk.serverMapChunk.NewBlockEntities.Remove(value.Pos);
  						value.OnBlockPlaced();
  					}
-@@ -594,23 +1641,33 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -594,23 +1642,33 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					ServerMain.Logger.Notification("Exception thrown when trying to initialize a block entity @{0}: {1}", value.Pos, ex3);
  					value.UnregisterAllTickListeners();
  				}
@@ -1696,7 +1697,7 @@ index f644852..995d8f0 100644
  		mapChunk.NeighboursLoaded = default(SmallBoolArray);
  		mapChunk.SelfLoaded = true;
  		for (int i = 0; i < Cardinal.ALL.Length; i++)
-@@ -623,20 +1680,26 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -623,20 +1681,26 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				serverMapChunk.NeighboursLoaded[cardinal.Opposite.Index] = true;
  			}
  		}
@@ -1723,7 +1724,7 @@ index f644852..995d8f0 100644
  			serverMapChunk.NeighboursLoaded[4] = false;
  		}
  		if (serverMapChunk2 != null)
-@@ -667,12 +1730,17 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -667,12 +1731,17 @@ internal class ServerSystemSupplyChunks : ServerSystem
  		{
  			serverMapChunk8.NeighboursLoaded[3] = false;
  		}
@@ -1741,7 +1742,7 @@ index f644852..995d8f0 100644
  			for (int j = -1; j <= 1; j++)
  			{
  				bool flag = false;
-@@ -682,19 +1750,24 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -682,19 +1751,24 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				}
  				if (!flag)
  				{
@@ -1766,7 +1767,7 @@ index f644852..995d8f0 100644
  		int num = 0;
  		for (int i = -1; i <= 1; i++)
  		{
-@@ -707,60 +1780,78 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -707,60 +1781,78 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			}
  		}
  		return num == 8;
@@ -1846,7 +1847,7 @@ index f644852..995d8f0 100644
  				dictionary = value.ModData;
  				dictionary2 = value.OreMaps;
  				intDataMap2D = value.GeologicProvinceMap;
-@@ -770,12 +1861,14 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -770,12 +1862,14 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			{
  				flag = false;
  				value.loadedTotalMs = server.ElapsedMilliseconds;
@@ -1861,7 +1862,7 @@ index f644852..995d8f0 100644
  			if (list != null)
  			{
  				value.GeneratedStructures = list;
-@@ -798,35 +1891,48 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -798,35 +1892,48 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			}
  		}
  		return value;
@@ -1910,7 +1911,7 @@ index f644852..995d8f0 100644
  		byte[] array = chunkGenParams?.GetBytes("GeneratedStructures");
  		if (array == null)
  		{
-@@ -836,44 +1942,60 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -836,44 +1943,60 @@ internal class ServerSystemSupplyChunks : ServerSystem
  		long key = server.api.WorldManager.MapRegionIndex2D(regionX, regionZ);
  		if (!dictionary.TryGetValue(key, out var value) || value == null)
  		{
@@ -1972,7 +1973,7 @@ index f644852..995d8f0 100644
  		long key = server.WorldMap.MapChunkIndex2D(chunkX, chunkZ);
  		server.loadedMapChunks.TryGetValue(key, out var value);
  		if (value != null)
-@@ -881,31 +2003,42 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -881,31 +2004,42 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			return value;
  		}
  		return TryLoadMapChunk(chunkX, chunkZ);
@@ -2015,7 +2016,7 @@ index f644852..995d8f0 100644
  			for (int j = 0; j < Cardinal.ALL.Length; j++)
  			{
  				Cardinal cardinal = Cardinal.ALL[j];
-@@ -918,47 +2051,111 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -918,47 +2052,111 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					}
  					chunkRequest.NeighbourTerrainHeight[j] = serverMapChunk.WorldGenTerrainHeightMap;
  				}
@@ -2143,7 +2144,7 @@ index f644852..995d8f0 100644
  			foreach (ServerChunk serverChunk in array)
  			{
  				if (serverChunk != null)
-@@ -967,10 +2164,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -967,10 +2165,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					serverChunk.MarkModified();
  					serverChunk.TryPackAndCommit();
  				}
@@ -2156,7 +2157,7 @@ index f644852..995d8f0 100644
  			ServerMain.Logger.Error("Loaded some but not all chunks of a column? Discarding whole column.");
  			return null;
  		}
-@@ -979,18 +2178,22 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -979,18 +2179,22 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			return null;
  		}
  		return array;
@@ -2179,7 +2180,7 @@ index f644852..995d8f0 100644
  					serverMapChunk.YMax = (ushort)(server.SaveGameData.MapSizeY - 1);
  				}
  				return serverMapChunk;
-@@ -1011,10 +2214,13 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1011,10 +2215,13 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			}
  		}
  		return null;
@@ -2193,7 +2194,7 @@ index f644852..995d8f0 100644
  		byte[] mapRegion = chunkthread.gameDatabase.GetMapRegion(regionX, regionZ);
  		try
  		{
-@@ -1035,14 +2241,26 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1035,14 +2242,27 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			throw;
  		}
  		return null;
@@ -2212,6 +2213,7 @@ index f644852..995d8f0 100644
 +		// comment for why this defaults to disabling concurrency rather than
 +		// trusting unknown code.
 +		EnforceStageConcurrencySafety(StratumWorldGenStages.PreDone, "PreDone");
++		EnforceStageConcurrencySafety(StratumWorldGenStages.TerrainLate, "TerrainLate");
  		ServerMain.Logger.Event("Loading {0}x{1}x{2} spawn chunks...", MagicNum.SpawnChunksWidth, MagicNum.SpawnChunksWidth, server.WorldMap.ChunkMapSizeY);
 +
 +		// Initialize "story" messages for display during loading
@@ -2220,7 +2222,7 @@ index f644852..995d8f0 100644
  			storyChunkSpawnEvents = new string[15]
  			{
  				Lang.Get("...the carved mountains"),
-@@ -1060,23 +2278,27 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1060,23 +2280,27 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				Lang.Get("...a misty sunrise"),
  				Lang.Get("...dew drops on a blade of grass"),
  				Lang.Get("...a soft breeze")
@@ -2248,7 +2250,7 @@ index f644852..995d8f0 100644
  					double value = random.NextDouble() * 6.2831854820251465;
  					double num7 = num6 * GameMath.Sin(value);
  					double num8 = num6 * GameMath.Cos(value);
-@@ -1096,10 +2318,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1096,10 +2320,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					server.api.Logger.Notification("Trying another spawn location ({0}/{1})...", i + 2, num3);
  				}
  			}
@@ -2260,7 +2262,7 @@ index f644852..995d8f0 100644
  				if (!server.blockAccessor.GetBlock(blockPos).SideSolid[BlockFacing.UP.Index])
  				{
  					server.blockAccessor.SetBlock(server.blockAccessor.GetBlock(new AssetLocation("planks-oak-we")).Id, blockPos);
-@@ -1107,13 +2330,16 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1107,13 +2332,16 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				blockPos.Y++;
  			}
  		}
@@ -2277,7 +2279,7 @@ index f644852..995d8f0 100644
  			x = blockPos.X,
  			y = blockPos.Y,
  			z = blockPos.Z
-@@ -1123,10 +2349,14 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1123,10 +2351,14 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			server.mapMiddleSpawnPos.y = null;
  		}
  		server.api.Logger.VerboseDebug("Done spawn chunk");
@@ -2292,7 +2294,7 @@ index f644852..995d8f0 100644
  		int num = 60;
  		int num2 = 0;
  		int num3 = 0;
-@@ -1137,36 +2367,47 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1137,36 +2369,47 @@ internal class ServerSystemSupplyChunks : ServerSystem
  		{
  			num4 = GameMath.Clamp(num2 + pos.X, 0, server.WorldMap.MapSizeX - 1);
  			num6 = GameMath.Clamp(num3 + pos.Z, 0, server.WorldMap.MapSizeZ - 1);
@@ -2341,7 +2343,7 @@ index f644852..995d8f0 100644
  		{
  			for (int k = -num2; k <= num2; k++)
  			{
-@@ -1174,18 +2415,22 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1174,18 +2417,22 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				{
  					long index2d = server.WorldMap.MapChunkIndex2D(x + j, y + k);
  					int regionX = (x + j) / MagicNum.ChunkRegionSizeInChunks;
@@ -2365,7 +2367,7 @@ index f644852..995d8f0 100644
  					};
  					chunkColumnLoadRequest.MapChunk = mapChunk;
  					GenerateNewChunkColumn(mapChunk, chunkColumnLoadRequest);
-@@ -1196,10 +2441,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1196,10 +2443,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
  						chunkthread.peekingChunkColumns.Enqueue(chunkColumnLoadRequest);
  					}
  				}
@@ -2378,7 +2380,7 @@ index f644852..995d8f0 100644
  		{
  			num4 = num - i;
  			for (int l = -num4; l <= num4; l++)
-@@ -1212,10 +2459,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1212,10 +2461,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
  						runGenerators(chunkRequest, i);
  					}
  				}
@@ -2391,7 +2393,7 @@ index f644852..995d8f0 100644
  		{
  			for (int n = -num2; n <= num2; n++)
  			{
-@@ -1232,61 +2481,111 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1232,61 +2483,111 @@ internal class ServerSystemSupplyChunks : ServerSystem
  						dictionary2[key] = chunks;
  					}
  				}
@@ -2505,7 +2507,7 @@ index f644852..995d8f0 100644
  				millisecondsSinceStart = server.totalUnpausedTime.ElapsedMilliseconds;
  				float num4 = 100f * ((float)server.loadedChunks.Count / (float)server.WorldMap.ChunkMapSizeY - (float)num) / (float)num2;
  				ServerMain.Logger.Event(num4.ToString("0.#") + "% ({0} in queue)", chunkthread.requestedChunkColumns.Count);
-@@ -1298,37 +2597,84 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1298,37 +2599,84 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				{
  					ServerMain.Logger.StoryEvent("...");
  				}
@@ -2593,7 +2595,7 @@ index f644852..995d8f0 100644
  				foreach (ChunkColumnLoadRequest requestedChunkColumn3 in chunkthread.requestedChunkColumns)
  				{
  					if (requestedChunkColumn3 != null)
-@@ -1340,16 +2686,25 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1340,16 +2688,25 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				throw new Exception("Somehow worldgen has become stuck in an endless loop, please report this as a bug!  Additional data in the server-main log");
  			}
  		}
@@ -2619,7 +2621,7 @@ index f644852..995d8f0 100644
  				if (chunkRequest.CurrentIncompletePass == EnumWorldGenPass.Terrain)
  				{
  					ushort sunLight = (ushort)server.sunBrightness;
-@@ -1359,32 +2714,62 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1359,32 +2716,62 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					}
  				}
  			}
@@ -2684,7 +2686,7 @@ index f644852..995d8f0 100644
  			return;
  		}
  		for (int i = 0; i < list.Count; i++)
-@@ -1396,89 +2781,117 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1396,89 +2783,117 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			catch (Exception ex)
  			{
  				ServerMain.Logger.Worldgen("An error was thrown in pass {5} when generating chunk column X={0},Z={1} in world '{3}' with seed {4}\nException {2}\n\n", chunkRequest.chunkX, chunkRequest.chunkZ, ex, server.SaveGameData.WorldName, server.SaveGameData.Seed, chunkRequest.CurrentIncompletePass.ToString());
@@ -2819,7 +2821,7 @@ index f644852..995d8f0 100644
  			chunkthread.requestedChunkColumns.Enqueue(curRequest);
  			return true;
  		}
-@@ -1490,13 +2903,19 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1490,13 +2905,19 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				ServerMain.Logger.VerboseDebug("Un-pausing all worldgen threads.");
  			}
  		}
@@ -2839,7 +2841,7 @@ index f644852..995d8f0 100644
  			if (requestedChunkColumn != null && !requestedChunkColumn.Disposed)
  			{
  				server.loadedMapChunks.Remove(requestedChunkColumn.mapIndex2d);
-@@ -1505,104 +2924,181 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1505,104 +2926,181 @@ internal class ServerSystemSupplyChunks : ServerSystem
  		}
  		chunkthread.requestedChunkColumns.Clear();
  		ServerMain.Logger.VerboseDebug("Incomplete chunks stored and wiped.");


### PR DESCRIPTION
TerrainLate is the second-heaviest stage, 21.9% of pregen time. This lets it run several columns at once, after fixing its four generators for it.

## The four generators

TerrainLate is Stratum's own second half of the split Terrain pass, so everything here registers through `StratumTerrainSplit` rather than the vanilla pass API.

| Generator | Fix |
| --- | --- |
| `GenRockStrata` | per-column scratch to thread-local; region province cache `Dictionary` → `ConcurrentDictionary` |
| `GenCaves` | per-column-reseeded `LCGRandom` to thread-local |
| `GenBlockLayers` | per-column scratch to thread-local |
| `GenDevastationLayer` | none needed, already call-local or read from the per-request `chunks` array |

Each had its own version of the same hazard: per-column scratch, or a per-column-reseeded `Random`, living in a shared instance field, written in one method and read a few calls later in another, all within one column's processing.

`GenRockStrata`'s province cache needed a different treatment from the rest. It is not per-column scratch but a genuine region-level cache, and once two columns from different, not-yet-cached regions can run together they can legitimately race on it, so it became a `ConcurrentDictionary` rather than moving to thread-local storage.

`GenCaves` and `GenRockStrata` use `ThreadLocal` instance fields rather than `[ThreadStatic]` statics, because they extend `GenPartial`, which has more than one live instance: `ProPickWorkSpace` constructs a second one for prospecting-pick probing. A static field would leak across those instances.

## The shared dispatcher fix: `dispatchClaimed`

Every branch that raises a stage cap needs this, and each carries it independently so they stay separately reviewable.

`stratumStageActiveCount[stage]` caps how many *claims* a stage has in flight, but nothing stopped **the same request** being claimed twice concurrently. At cap 1 that was invisible. Above 1 it is live: two workers claim the same column, both run `PopulateChunk`, which unconditionally does `currentpass++`, driving `currentpass` past `Done`. `ToVanilla()` shifts by exactly 1 and can never map back down from there, so `blockingRequestsRemaining` leaks forever and the 12s "worldgen has become stuck" watchdog fires.

Fixed with a per-request `Interlocked.CompareExchange` guard (`ChunkColumnLoadRequest.dispatchClaimed`), released at every site that already decrements `stratumStageActiveCount`. Same pattern C2ME-fabric's `StatusAdvancingScheduler`/`BusyRefCounter` uses for the same problem, lock-free here rather than `synchronized`.

This is what caused the 3m52s / 178-stuck-column run recorded against an earlier version of the PreDone branch. It was not a generator bug, which is why fixing generators never moved it.

## The mod-safety fallback

Raising a cap is only safe if everything registered at that pass tolerates two columns at once. Stratum has fixed this exact bug repeatedly in its own generators; assuming third-party code is safer would be wishful. But refusing to run alongside mods is not an option either, so this detects and falls back instead of breaking, and says so in the log.

`EnforceStageConcurrencySafety` runs once, right after `TriggerInitWorldGen` populates `worldgenHandler` (the first point every mod has registered), walks the real handler list for the raised pass, and drops that one pass back to cap 1 if it finds foreign code. Two things count, because there are two distinct ways foreign code ends up executing concurrently inside a raised stage:

| Axis | Catches | How |
| --- | --- | --- |
| 1 | A mod registered **its own** handler at the pass | assembly name, not a per-generator allowlist, so no upkeep as Stratum's generators change |
| 2 | A mod **Harmony-patched Stratum's** handler at the pass | `Harmony.GetPatchInfo` on the handler's own `MethodInfo` |

Axis 1 is not hypothetical. Structural analysis of the most-downloaded worldgen mods found real instances of the same shared-state shape fixed here: Rivers and VSRiverGen both keep `columnResults`/`layerFullySolid`/`layerFullyEmpty` as shared instance fields in their `NewGenTerra` at the Terrain pass, and VS Village keeps a shared `LCGRandom` in `VillageGenerator` at TerrainFeatures. Reports drafted for those authors separately; this is the server-side half.

Axis 2 is the narrow, tractable version of the cross-reference `research/gap-mod-patch-conflict-visibility.md` gave up on. That doc's blocker was needing a build-time manifest of every method Stratum source-patches, which needs real Roslyn tooling and permanent upkeep. No manifest is needed here: the only methods that matter for a cap raise are the handlers registered at the raised stage, and they are already in hand as live `MethodInfo`.

**One deliberate deviation from `StratumHarmonyVisibility`'s heuristic.** That code treats transpilers as the risky category and prefix/postfix as safe, which is right for *its* question: whether a transpiler's IL pattern match still lands after Stratum reshaped a method. Prefixes and postfixes survive that because they wrap the call rather than rewriting it. The question here is a different one, though: whether the mod's injected code is thread-safe when the same generator runs on several columns at once. A prefix touching shared mod state fails there exactly as badly as a transpiler. So any patch kind triggers the fallback, while the kind is still named in the log, because that is what triage needs.

**Two honest limits**, neither of which makes the fallback direction unsafe:

- It only sees patches applied by the time worldgen starts. A mod deferring `PatchAll` past that is invisible, the same caveat `StratumHarmonyVisibility` already documents.
- It inspects the handler methods themselves, not everything they call. Following the full call tree is the manifest-shaped problem this deliberately avoids.

Both mean the check can **miss**, never that it wrongly clears a mod. A false positive costs throughput on one pass; a false negative corrupts world generation. Erring toward capping is the point.

The log line names the mod, what it did, what Stratum did about it, and that worldgen stays correct:

```
[Stratum] Same-stage concurrency for the TerrainFeatures worldgen pass is now disabled, falling back to
1 column at a time: Stratum's own worldgen handler GenPonds.OnChunkColumnGen is Harmony-patched (prefix
from 'safeguardtestmod'), so that mod's code would run inside a generator Stratum audited only in its own
form, on several columns at once. Stratum cannot verify third-party code is safe under that. World
generation stays correct, it just gives up this pass's speedup. If you are the author of that mod and have
verified it is safe to run concurrently across columns, get in touch so it can be allowlisted.
```

The block is **byte-identical across all four cap-raise branches** (verified by hash), so whichever merges first, the rest resolve trivially against it. Unifying the signature to `(int, string)` was not cosmetic: TerrainLate has no `EnumWorldGenPass` value of its own, since both Terrain and TerrainLate map to vanilla `Terrain`.
## Performance, restated after @tehtelev's review

**The stage shares this PR originally quoted were wrong**, and they mattered because they were used to justify which stage to attack first. They came from a radius-20 profile. At @tehtelev's radius-100 scale the profile is different:

| Stage | radius 100 (@tehtelev) | radius 20 (original claim) | Neighbour-gated |
| --- | --- | --- | --- |
| Terrain | 17.9% | 42.7% | no |
| TerrainLate | 29.9% | 21.9% | no |
| TerrainFeatures | 16.3% | 16.2% | **yes** |
| Vegetation | 27.7% | 16.5% | **yes** |
| NeighbourSunLightFlood | 8.1% | 2.5% | **yes** |
| PreDone | 0.1% | 0.2% | **yes** |
| | **47.8% ungated** | 64.6% ungated | |

At realistic pregen scale TerrainLate and Vegetation dominate, not Terrain. Treat the radius-100 column as the real one.

### The neighbour-parity gate, and why it splits the stages

`ensurePrettyNeighbourhood` returns `true` immediately for stages at or below TerrainLate. Above that it requires **all 8 neighbours to have reached the same pass or later** before a column may advance.

So a raised cap on a gated stage only binds when many columns happen to have all 8 neighbours caught up at once, which the wavefront geometry limits. That explains the review results better than stage cost did: #190 and #191 raise caps on gated stages and both measured flat, which is what a non-binding cap looks like.

This is @tehtelev's point from Discord, and it checks out in the code. Instrumenting the gate confirmed it directly: **Terrain and TerrainLate block exactly 0 times in every run**, matching the code path, while the gated stages block heavily.

### The queue was measured and ruled out

@tehtelev also suggested the default `RequestChunkColumnsQueueSize` of 2000 was the limiter. Measured at radius 60, 3 threads, 4 interleaved samples per config:

| Queue | Samples (s) | Median | Queue-exhaustion warnings |
| --- | --- | --- | --- |
| 2000 | 145, 166, 175, 184 | 170.5s | 2 of 4 runs |
| 8000 | 156, 165, 175, 190 | 170.0s | 0 of 4 runs |

A 0.5s median gap against 34-39s spreads, with fully overlapping ranges. The exhaustion warnings are real and do disappear, but removing them buys no throughput.

Worth flagging for anyone reading old numbers in this initiative: every earlier radius-20 measurement ran 1,681 columns against a 2,000 slot queue, so **none of them could ever have stressed that constraint**.

### Honest framing

The value is concentrated in the two ungated stages. Caps on gated stages are latent capability: correct and safe after the audits, and worth nothing measurable until the gate constraint moves. Reviewing one stage at a time makes it easy to reject each on "shows no gain", so that is worth saying plainly rather than leaving to be inferred.

All measurements: same seed, stray `MSBuild.dll`/`VBCSCompiler` processes killed before every run (this project has been burned by a fake 4.4x regression from exactly that), distinct data directory per run, raw per-run numbers reported rather than medians alone.

## One detail specific to this stage

Three of these generators do not declare their own handler; they inherit `GenChunkColumn` from `GenPartial`. A delegate over an unoverridden virtual reports the declaring type, so `handler.Method` resolves to `GenPartial.GenChunkColumn`, which is also the only method Harmony will let a mod patch there.

That was confirmed rather than assumed. Trying to patch `GenCaves.GenChunkColumn` is rejected by Harmony itself ("You can only patch implemented methods/constructors"), and patching the declared `GenPartial.GenChunkColumn` is both what a real mod has to do and what the safeguard catches.

## Verification

Three cases, end to end, at `MaxWorldgenThreads=4`, with a real minimal test mod built for this (own assembly, references `0Harmony`, dropped into `Mods/` for these tests only):

| Case | Expected | Result |
| --- | --- | --- |
| No mod | full concurrency, no warning | 0 fallback warnings, reached RunGame |
| Mod registers own handler via `StratumTerrainSplit` | fall back, name the assembly | warned naming `SafeguardTestMod`, cap 1 |
| Mod Harmony-prefixes `GenPartial.GenChunkColumn` | fall back, name mod + kind + method | warned naming `safeguardtestmod`, prefix, `GenPartial.GenChunkColumn` |

All three reached RunGame with zero real crashes and the same 2 known false-positive log lines each (a class literally named `ErrorReporter`, and a line reading "no errors").

Also 3 repeated boot trials at `MaxWorldgenThreads=4`: 0 stuck-column lines, 0 watchdog throws. Rebased onto current `indev` and re-verified after rebase: bootstrap clean, build 0 errors, smoke test reaches RunGame.

## Merge ordering

Independent of the other three cap-raise branches; merges cleanly into `indev` today. The shared `dispatchClaimed` and safeguard blocks are identical across all four, so the rest resolve trivially against whichever lands first.

Split out of #179 per @tehtelev's request to review same-stage concurrency one stage at a time.

/cc @tehtelev
