### PR TITLE
Let PreDone run several columns at once, with a two-axis mod-safety fallback

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,16 @@ bootstrap: ## Download, decompile, and apply patches
 
 build: ## Build Release (runs bootstrap if working tree is missing)
 	@if [ ! -f VintagestoryApi/VintagestoryAPI.csproj ]; then $(MAKE) bootstrap; fi
-	dotnet build VintageStory.slnx -c $(CONFIGURATION) -p:EmbedPatchedFiles=$(EMBED_PATCHED_FILES)
+	dotnet build VintageStory.slnx -c $(CONFIGURATION)
+# Second pass, only if embedding is on: StratumServer's EmbeddedResource list
+# points at sibling projects' bin output by raw path, not a ProjectReference,
+# so on a build where those outputs do not exist yet (a fresh bootstrap, or
+# after clean/refresh) the embed can race the projects that produce them.
+# The pass above guarantees every output exists before this one tries to
+# embed it.
+ifeq ($(EMBED_PATCHED_FILES),true)
+	dotnet build VintageStory.slnx -c $(CONFIGURATION) -p:EmbedPatchedFiles=true
+endif
 
 smoke: build ## Build and boot-test the server
 	bash scripts/smoke-test.sh

--- a/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/93.GenCreatures.cs.patch
+++ b/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/93.GenCreatures.cs.patch
@@ -1,0 +1,252 @@
+diff --git a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/93.GenCreatures.cs b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/93.GenCreatures.cs
+index 647310c..8df05ba 100644
+--- a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/93.GenCreatures.cs
++++ b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/93.GenCreatures.cs
+@@ -20,35 +20,42 @@ namespace Vintagestory.ServerMods
+     }
+ 
+     public class GenCreatures : ModStdWorldGen
+     {
+         protected ICoreServerAPI api;
+-        protected Random rnd;
+         protected int worldheight;
+         protected IWorldGenBlockAccessor wgenBlockAccessor;
+         protected Dictionary<EntityProperties, EntityProperties[]> entityTypeGroups = new Dictionary<EntityProperties, EntityProperties[]>();
+ 
+         public Dictionary<string, MapLayerBase> animalMapGens = new Dictionary<string, MapLayerBase>();
+         protected int noiseSizeDensityMap;
+         protected int regionSize;
+ 
+-
+-        protected int climateUpLeft;
+-        protected int climateUpRight;
+-        protected int climateBotLeft;
+-        protected int climateBotRight;
+-
+-        protected int forestUpLeft;
+-        protected int forestUpRight;
+-        protected int forestBotLeft;
+-        protected int forestBotRight;
+-
+-        protected int shrubsUpLeft;
+-        protected int shrubsUpRight;
+-        protected int shrubsBotLeft;
+-        protected int shrubsBotRight;
+-        protected List<SpawnOppurtunity> spawnPositions = new List<SpawnOppurtunity>();
++        // Stratum start: this generator can now run concurrently for distant columns
++        // on different worker threads (see StratumWorldGenStages / PreDone concurrency
++        // cap). Everything that used to be a plain instance field here was written by
++        // OnChunkColumnGen and read a few calls later by TrySpawnGroupAt/CreateEntity,
++        // all within the processing of ONE column; sharing the field across threads
++        // let two concurrently-processed columns clobber each other's climate/forest/
++        // shrub readings and creature-position scratch list. [ThreadStatic] keeps each
++        // field private to the thread that is currently inside OnChunkColumnGen for a
++        // given column, at zero cost for the still-common case of one thread at a time.
++        //
++        // rnd needed a different fix, not just isolation: the old field was a single
++        // Random seeded once for the whole world and advanced across every column in
++        // whatever order the dispatcher happened to hand them out, so two runs of the
++        // same seed could already spawn different creatures depending on processing
++        // order, with or without concurrency. Seeding a fresh Random per column from a
++        // hash of (world seed, chunkX, chunkZ) removes that order dependency and is
++        // safe under concurrency for the same reason it is safe today: two different
++        // columns always get two different seeds.
++        [ThreadStatic] private static Random stratumRnd;
++        [ThreadStatic] private static int stratumClimateUpLeft, stratumClimateUpRight, stratumClimateBotLeft, stratumClimateBotRight;
++        [ThreadStatic] private static int stratumForestUpLeft, stratumForestUpRight, stratumForestBotLeft, stratumForestBotRight;
++        [ThreadStatic] private static int stratumShrubsUpLeft, stratumShrubsUpRight, stratumShrubsBotLeft, stratumShrubsBotRight;
++        [ThreadStatic] private static List<SpawnOppurtunity> stratumSpawnPositions;
++        // Stratum end
+ 
+ 
+         public override bool ShouldLoad(EnumAppSide side) => side == EnumAppSide.Server;
+         public override double ExecuteOrder() => 0.1;
+ 
+@@ -96,12 +103,11 @@ namespace Vintagestory.ServerMods
+ 
+ 
+         protected void initWorldGen()
+         {
+             LoadGlobalConfig(api);
+-            rnd = new Random(api.WorldManager.Seed - 18722);
+-            worldheight = api.WorldManager.MapSizeY;
++            worldheight = api.WorldManager.MapSizeY; // Stratum: stratumRnd is now seeded per column in OnChunkColumnGen, not once here
+ 
+             Dictionary<AssetLocation, EntityProperties> entityTypesByCode = new Dictionary<AssetLocation, EntityProperties>();
+ 
+             for (int i = 0; i < api.World.EntityTypes.Count; i++)
+             {
+@@ -180,61 +186,68 @@ namespace Vintagestory.ServerMods
+ 
+             if (GetIntersectingStructure(chunkX * chunksize + chunksize / 2, chunkZ * chunksize + chunksize / 2, CreaturesHashCode) != null)
+             {
+                 return;
+             }
++
++            // Stratum: reseed per column instead of reading a shared, world-lifetime
++            // Random. Two different columns always get two different seeds, so this
++            // stays correct whether this stage runs one column at a time or several
++            // concurrently, and it removes the old dependency on processing order.
++            stratumRnd = new Random(GameMath.MurmurHash3(api.WorldManager.Seed, chunkX, chunkZ) - 18722);
++
+             wgenBlockAccessor.BeginColumn();
+             IntDataMap2D climateMap = chunks[0].MapChunk.MapRegion.ClimateMap;
+             ushort[] heightMap = chunks[0].MapChunk.WorldGenTerrainHeightMap;
+ 
+             int regionChunkSize = api.WorldManager.RegionSize / chunksize;
+             int rlX = chunkX % regionChunkSize;
+             int rlZ = chunkZ % regionChunkSize;
+ 
+             float facC = (float)climateMap.InnerSize / regionChunkSize;
+-            climateUpLeft = climateMap.GetUnpaddedInt((int)(rlX * facC), (int)(rlZ * facC));
+-            climateUpRight = climateMap.GetUnpaddedInt((int)(rlX * facC + facC), (int)(rlZ * facC));
+-            climateBotLeft = climateMap.GetUnpaddedInt((int)(rlX * facC), (int)(rlZ * facC + facC));
+-            climateBotRight = climateMap.GetUnpaddedInt((int)(rlX * facC + facC), (int)(rlZ * facC + facC));
++            stratumClimateUpLeft = climateMap.GetUnpaddedInt((int)(rlX * facC), (int)(rlZ * facC));
++            stratumClimateUpRight = climateMap.GetUnpaddedInt((int)(rlX * facC + facC), (int)(rlZ * facC));
++            stratumClimateBotLeft = climateMap.GetUnpaddedInt((int)(rlX * facC), (int)(rlZ * facC + facC));
++            stratumClimateBotRight = climateMap.GetUnpaddedInt((int)(rlX * facC + facC), (int)(rlZ * facC + facC));
+ 
+             IntDataMap2D forestMap = chunks[0].MapChunk.MapRegion.ForestMap;
+             float facF = (float)forestMap.InnerSize / regionChunkSize;
+-            forestUpLeft = forestMap.GetUnpaddedInt((int)(rlX * facF), (int)(rlZ * facF));
+-            forestUpRight = forestMap.GetUnpaddedInt((int)(rlX * facF + facF), (int)(rlZ * facF));
+-            forestBotLeft = forestMap.GetUnpaddedInt((int)(rlX * facF), (int)(rlZ * facF + facF));
+-            forestBotRight = forestMap.GetUnpaddedInt((int)(rlX * facF + facF), (int)(rlZ * facF + facF));
++            stratumForestUpLeft = forestMap.GetUnpaddedInt((int)(rlX * facF), (int)(rlZ * facF));
++            stratumForestUpRight = forestMap.GetUnpaddedInt((int)(rlX * facF + facF), (int)(rlZ * facF));
++            stratumForestBotLeft = forestMap.GetUnpaddedInt((int)(rlX * facF), (int)(rlZ * facF + facF));
++            stratumForestBotRight = forestMap.GetUnpaddedInt((int)(rlX * facF + facF), (int)(rlZ * facF + facF));
+ 
+             IntDataMap2D shrubMap = chunks[0].MapChunk.MapRegion.ShrubMap;
+             float facS = (float)shrubMap.InnerSize / regionChunkSize;
+-            shrubsUpLeft = shrubMap.GetUnpaddedInt((int)(rlX * facS), (int)(rlZ * facS));
+-            shrubsUpRight = shrubMap.GetUnpaddedInt((int)(rlX * facS + facS), (int)(rlZ * facS));
+-            shrubsBotLeft = shrubMap.GetUnpaddedInt((int)(rlX * facS), (int)(rlZ * facS + facS));
+-            shrubsBotRight = shrubMap.GetUnpaddedInt((int)(rlX * facS + facS), (int)(rlZ * facS + facS));
++            stratumShrubsUpLeft = shrubMap.GetUnpaddedInt((int)(rlX * facS), (int)(rlZ * facS));
++            stratumShrubsUpRight = shrubMap.GetUnpaddedInt((int)(rlX * facS + facS), (int)(rlZ * facS));
++            stratumShrubsBotLeft = shrubMap.GetUnpaddedInt((int)(rlX * facS), (int)(rlZ * facS + facS));
++            stratumShrubsBotRight = shrubMap.GetUnpaddedInt((int)(rlX * facS + facS), (int)(rlZ * facS + facS));
+ 
+             Vec3d posAsVec = new Vec3d();
+             BlockPos pos = new BlockPos(Dimensions.NormalWorld);
+ 
+             foreach (var val in entityTypeGroups)
+             {
+                 EntityProperties entitytype = val.Key;
+-                float tries = entitytype.Server.SpawnConditions.Worldgen.TriesPerChunk.nextFloat(1, rnd);
++                float tries = entitytype.Server.SpawnConditions.Worldgen.TriesPerChunk.nextFloat(1, stratumRnd);
+                 if (tries == 0f) continue;
+ 
+                 var scRuntime = entitytype.Server.SpawnConditions.Runtime;   // the Group ("hostile"/"neutral"/"passive") is only held in the Runtime spawn conditions
+                 if (scRuntime == null || scRuntime.Group != "hostile") tries *= gcfg.neutralCreatureSpawnMultiplier;
+ 
+-                while (tries-- > rnd.NextDouble())
++                while (tries-- > stratumRnd.NextDouble())
+                 {
+-                    int dx = rnd.Next(chunksize);
+-                    int dz = rnd.Next(chunksize);
++                    int dx = stratumRnd.Next(chunksize);
++                    int dz = stratumRnd.Next(chunksize);
+ 
+                     pos.Set(chunkX * chunksize + dx, 0, chunkZ * chunksize + dz);
+ 
+                     pos.Y =
+                         entitytype.Server.SpawnConditions.Worldgen.TryOnlySurface ?
+                         heightMap[dz * chunksize + dx] + 1 :
+-                        rnd.Next(worldheight)
++                        stratumRnd.Next(worldheight)
+                     ;
+                     posAsVec.Set(pos.X + 0.5, pos.Y + 0.005, pos.Z + 0.5);
+ 
+                     TrySpawnGroupAt(request.Chunks[0].MapChunk.MapRegion, pos, posAsVec, entitytype, val.Value);
+                 }
+@@ -244,10 +257,11 @@ namespace Vintagestory.ServerMods
+ 
+ 
+ 
+         protected void TrySpawnGroupAt(IMapRegion mr, BlockPos origin, Vec3d posAsVec, EntityProperties entityType, EntityProperties[] grouptypes)
+         {
++            List<SpawnOppurtunity> spawnPositions = stratumSpawnPositions ??= new List<SpawnOppurtunity>(); // Stratum: per-thread, see the field declaration
+             BlockPos pos = origin.Copy();
+             int climate;
+             float temp;
+             float rain;
+             float forestDensity;
+@@ -268,11 +282,11 @@ namespace Vintagestory.ServerMods
+             {
+                 float val = sc.HerdSize.nextFloat();
+ #if PERFTEST
+                 val *= 40;
+ #endif
+-                nextGroupSize = (int)val + ((val - (int)val) > rnd.NextDouble() ? 1 : 0);
++                nextGroupSize = (int)val + ((val - (int)val) > stratumRnd.NextDouble() ? 1 : 0);
+             }
+ 
+ 
+             for (int i = 0; i < nextGroupSize * 4 + 5; i++)
+             {
+@@ -281,13 +295,13 @@ namespace Vintagestory.ServerMods
+                 EntityProperties typeToSpawn = entityType;
+ 
+                 // First entity with valid spawnpos (typically the male) must be the dominant creature, every subsequent only 20% chance for males (or even lower if more than 5 companion types)
+                 double dominantChance = spawned == 0 ? 1 : Math.Min(0.2, 1f / grouptypes.Length);
+ 
+-                if (grouptypes.Length > 1 && rnd.NextDouble() > dominantChance)
++                if (grouptypes.Length > 1 && stratumRnd.NextDouble() > dominantChance)
+                 {
+-                    typeToSpawn = grouptypes[1 + rnd.Next(grouptypes.Length - 1)];
++                    typeToSpawn = grouptypes[1 + stratumRnd.Next(grouptypes.Length - 1)];
+                 }
+ 
+                 IBlockAccessor blockAccessor = wgenBlockAccessor.GetChunkAtBlockPos(pos) == null ? api.World.BlockAccessor : wgenBlockAccessor;
+ 
+                 IMapChunk mapchunk = blockAccessor.GetMapChunkAtBlockPos(pos);
+@@ -305,15 +319,15 @@ namespace Vintagestory.ServerMods
+ 
+                         xRel = (float)(posAsVec.X % chunksize) / chunksize;
+                         zRel = (float)(posAsVec.Z % chunksize) / chunksize;
+ 
+                         // We check temperature at 109% of sea level for the sake of consistency (no polar bears on tall mountains)
+-                        climate = GameMath.BiLerpRgbColor(xRel, zRel, climateUpLeft, climateUpRight, climateBotLeft, climateBotRight);
++                        climate = GameMath.BiLerpRgbColor(xRel, zRel, stratumClimateUpLeft, stratumClimateUpRight, stratumClimateBotLeft, stratumClimateBotRight);
+                         temp = Climate.GetScaledAdjustedTemperatureFloat((climate >> 16) & 0xff, (int)(TerraGenConfig.seaLevel * 0.09));
+                         rain = ((climate >> 8) & 0xff) / 255f;
+-                        forestDensity = GameMath.BiLerp(forestUpLeft, forestUpRight, forestBotLeft, forestBotRight, xRel, zRel) / 255f;
+-                        shrubDensity = GameMath.BiLerp(shrubsUpLeft, shrubsUpRight, shrubsBotLeft, shrubsBotRight, xRel, zRel) / 255f;
++                        forestDensity = GameMath.BiLerp(stratumForestUpLeft, stratumForestUpRight, stratumForestBotLeft, stratumForestBotRight, xRel, zRel) / 255f;
++                        shrubDensity = GameMath.BiLerp(stratumShrubsUpLeft, stratumShrubsUpRight, stratumShrubsBotLeft, stratumShrubsBotRight, xRel, zRel) / 255f;
+ 
+ 
+                         if (CanSpawnAtConditions(blockAccessor, typeToSpawn, pos, posAsVec, sc, rain, temp, forestDensity, shrubDensity))
+                         {
+                             spawnPositions.Add(new SpawnOppurtunity() { ForType = typeToSpawn, Pos = posAsVec.Clone() });
+@@ -321,12 +335,12 @@ namespace Vintagestory.ServerMods
+                         }
+ 
+                     }
+                 }
+ 
+-                pos.X = origin.X + ((rnd.Next(11) - 5) + (rnd.Next(11) - 5)) / 2;
+-                pos.Z = origin.Z + ((rnd.Next(11) - 5) + (rnd.Next(11) - 5)) / 2;
++                pos.X = origin.X + ((stratumRnd.Next(11) - 5) + (stratumRnd.Next(11) - 5)) / 2;
++                pos.Z = origin.Z + ((stratumRnd.Next(11) - 5) + (stratumRnd.Next(11) - 5)) / 2;
+             }
+ 
+ 
+             // Only spawn if the group reached the minimum group size
+             if (spawnPositions.Count >= nextGroupSize)
+@@ -362,11 +376,11 @@ namespace Vintagestory.ServerMods
+ 
+         protected Entity CreateEntity(EntityProperties entityType, Vec3d spawnPosition)
+         {
+             Entity entity = api.ClassRegistry.CreateEntity(entityType);
+             entity.Pos.SetPosWithDimension(spawnPosition);
+-            entity.Pos.SetYaw((float)rnd.NextDouble() * GameMath.TWOPI);
++            entity.Pos.SetYaw((float)stratumRnd.NextDouble() * GameMath.TWOPI);
+             entity.PositionBeforeFalling.Set(entity.Pos.X, entity.Pos.Y, entity.Pos.Z);
+             entity.Attributes.SetString("origin", "worldgen");
+             return entity;
+         }
+ 

--- a/patches/VintagestoryLib/Vintagestory.Server/ChunkColumnLoadRequest.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/ChunkColumnLoadRequest.cs.patch
@@ -1,30 +1,50 @@
 diff --git a/VintagestoryLib/Vintagestory.Server/ChunkColumnLoadRequest.cs b/VintagestoryLib/Vintagestory.Server/ChunkColumnLoadRequest.cs
-index 04b25be..052df79 100644
+index 04b25be..bea4514 100644
 --- a/VintagestoryLib/Vintagestory.Server/ChunkColumnLoadRequest.cs
 +++ b/VintagestoryLib/Vintagestory.Server/ChunkColumnLoadRequest.cs
-@@ -34,25 +34,45 @@ public class ChunkColumnLoadRequest : ILongIndex, IChunkColumnGenerateRequest
+@@ -34,25 +34,65 @@ public class ChunkColumnLoadRequest : ILongIndex, IChunkColumnGenerateRequest
  
  	internal bool prettified;
  
  	internal bool blockingRequest;
  
-+	// Stratum: guards against the same request being claimed for its current
-+	// stage by two concurrent TryClaimStage callers at once. stratumStageActiveCount
-+	// only caps the aggregate number of concurrent claims *per stage*, across all
-+	// requests; it says nothing about a single request being claimed twice. With
-+	// a stage cap of 1 that was masked, since the aggregate counter degenerated
-+	// into a full mutex for that stage. Raising a cap above 1 (PreDone) exposed
-+	// it: two racing claims can both read the same CurrentIncompletePass_AsInt,
-+	// both pass every TryClaimStage check (neither has run PopulateChunk yet, so
-+	// the pass hasn't moved), and both get dispatched. PopulateChunk always does
-+	// currentpass++ regardless of whether it actually ran a generator for that
-+	// pass, so the second, redundant run drives currentpass one past what it
-+	// should be. For a request whose last stage is PreDone, that means Done+1,
-+	// and ToVanilla() only ever shifts by exactly 1, so it never maps back down
-+	// to vanilla Done again, the request is never recognised as complete, and it
-+	// leaks forever, one live count in blockingRequestsRemaining. 0 = free, 1 =
-+	// claimed. CompareExchange'd in TryClaimStage; released everywhere
-+	// stratumStageActiveCount[stage] is released.
++	// Stratum: guards against the same request being processed by two
++	// concurrent callers at once, at any pass. stratumStageActiveCount only
++	// caps the aggregate number of concurrent claims *per worker stage*,
++	// across all requests; it says nothing about a single request being
++	// claimed twice. With a stage cap of 1 that was masked, since the
++	// aggregate counter degenerated into a full mutex for that stage. Raising
++	// a cap above 1 (PreDone) exposed it: two racing claims can both read the
++	// same CurrentIncompletePass_AsInt, both pass every TryClaimStage check
++	// (neither has run PopulateChunk yet, so the pass hasn't moved), and both
++	// get dispatched. PopulateChunk always does currentpass++ regardless of
++	// whether it actually ran a generator for that pass, so the second,
++	// redundant run drives currentpass one past what it should be. For a
++	// request whose last stage is PreDone, that means Done+1, and
++	// ToVanilla() only ever shifts by exactly 1, so it never maps back down
++	// to vanilla Done again, the request is never recognised as complete,
++	// and it leaks forever, one live count in blockingRequestsRemaining.
++	//
++	// The same missing-claim shape exists in vanilla's own dispatch code for
++	// the None/Done boundary passes (GenerateChunkColumns_OnSeparateThread,
++	// tryLoadOrGenerateChunkColumnsInQueue, loadChunkAreaBlocking's own
++	// boundary scan all pick a candidate and act on it with no atomic claim
++	// in between), matching a currently open, unfixed upstream issue
++	// (anegostudios/VintageStory-Issues#5143, "changing MaxWorldgenThreads to
++	// any other value than 1 results in an error", open since 2025-01-27).
++	// Not reachable today in Stratum's own None/Done boundary scans, since
++	// every caller of loadOrGenerateChunkColumn_OnChunkThread for those
++	// passes runs on the chunk thread's own OnSeparateThreadTick, either
++	// gated off by the RunPhase != RunGame check during startup or
++	// sequenced after loadChunkAreaBlocking's fastChunkQueue call within the
++	// same tick, so this field is claimed there too, ahead of any future
++	// change to that threading assumption rather than after a second live
++	// bug is found.
++	//
++	// 0 = free, 1 = claimed. CompareExchange'd in TryClaimStage and at each
++	// None/Done boundary-scan call site; released everywhere
++	// stratumStageActiveCount[stage] is released, and immediately after each
++	// boundary-scan call returns.
 +	internal int dispatchClaimed;
 +
  	private static long counter;
@@ -51,7 +71,7 @@ index 04b25be..052df79 100644
  		}
  		set
  		{
-@@ -62,13 +82,14 @@ public class ChunkColumnLoadRequest : ILongIndex, IChunkColumnGenerateRequest
+@@ -62,13 +102,14 @@ public class ChunkColumnLoadRequest : ILongIndex, IChunkColumnGenerateRequest
  
  	public int CurrentIncompletePass_AsInt
  	{

--- a/patches/VintagestoryLib/Vintagestory.Server/ChunkColumnLoadRequest.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/ChunkColumnLoadRequest.cs.patch
@@ -1,8 +1,33 @@
 diff --git a/VintagestoryLib/Vintagestory.Server/ChunkColumnLoadRequest.cs b/VintagestoryLib/Vintagestory.Server/ChunkColumnLoadRequest.cs
-index 04b25be..a990f2a 100644
+index 04b25be..052df79 100644
 --- a/VintagestoryLib/Vintagestory.Server/ChunkColumnLoadRequest.cs
 +++ b/VintagestoryLib/Vintagestory.Server/ChunkColumnLoadRequest.cs
-@@ -40,19 +40,20 @@ public class ChunkColumnLoadRequest : ILongIndex, IChunkColumnGenerateRequest
+@@ -34,25 +34,45 @@ public class ChunkColumnLoadRequest : ILongIndex, IChunkColumnGenerateRequest
+ 
+ 	internal bool prettified;
+ 
+ 	internal bool blockingRequest;
+ 
++	// Stratum: guards against the same request being claimed for its current
++	// stage by two concurrent TryClaimStage callers at once. stratumStageActiveCount
++	// only caps the aggregate number of concurrent claims *per stage*, across all
++	// requests; it says nothing about a single request being claimed twice. With
++	// a stage cap of 1 that was masked, since the aggregate counter degenerated
++	// into a full mutex for that stage. Raising a cap above 1 (PreDone) exposed
++	// it: two racing claims can both read the same CurrentIncompletePass_AsInt,
++	// both pass every TryClaimStage check (neither has run PopulateChunk yet, so
++	// the pass hasn't moved), and both get dispatched. PopulateChunk always does
++	// currentpass++ regardless of whether it actually ran a generator for that
++	// pass, so the second, redundant run drives currentpass one past what it
++	// should be. For a request whose last stage is PreDone, that means Done+1,
++	// and ToVanilla() only ever shifts by exactly 1, so it never maps back down
++	// to vanilla Done again, the request is never recognised as complete, and it
++	// leaks forever, one live count in blockingRequestsRemaining. 0 = free, 1 =
++	// claimed. CompareExchange'd in TryClaimStage; released everywhere
++	// stratumStageActiveCount[stage] is released.
++	internal int dispatchClaimed;
++
+ 	private static long counter;
  
  	internal bool Disposed => (disposeOrRequeueFlags & 1) == 1;
  
@@ -26,7 +51,7 @@ index 04b25be..a990f2a 100644
  		}
  		set
  		{
-@@ -62,13 +63,14 @@ public class ChunkColumnLoadRequest : ILongIndex, IChunkColumnGenerateRequest
+@@ -62,13 +82,14 @@ public class ChunkColumnLoadRequest : ILongIndex, IChunkColumnGenerateRequest
  
  	public int CurrentIncompletePass_AsInt
  	{

--- a/patches/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs.patch
@@ -1,8 +1,19 @@
 diff --git a/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs b/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs
-index f644852..e06acca 100644
+index f644852..995d8f0 100644
 --- a/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs
 +++ b/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs
-@@ -9,131 +9,920 @@ using Vintagestory.API.Datastructures;
+@@ -1,139 +1,1028 @@
+ using System;
+ using System.Collections.Generic;
+ using System.Linq;
++using System.Reflection;
++using System.Text;
+ using System.Threading;
++using HarmonyLib;
+ using Vintagestory.API.Common;
+ using Vintagestory.API.Common.Entities;
+ using Vintagestory.API.Config;
+ using Vintagestory.API.Datastructures;
  using Vintagestory.API.MathTools;
  using Vintagestory.API.Server;
  using Vintagestory.API.Util;
@@ -130,22 +141,54 @@ index f644852..e06acca 100644
 +	/// <summary>
 +	/// Stratum: same-stage concurrency for a pass is only safe if every handler
 +	/// registered at that pass tolerates two different columns running it at
-+	/// once. Stratum has fixed six instances of exactly this bug in its own
-+	/// vanilla-derived generators this session (a shared Random or shared
-+	/// instance array reused across columns, safe only by accident while every
-+	/// stage stayed at cap 1); there is no reason to assume third-party mod
-+	/// generators are any safer, and Stratum cannot inspect or verify their
-+	/// code. Rather than raise a cap and hope, this walks the real registered
-+	/// handler list for the pass (after TriggerInitWorldGen, so every mod has
-+	/// already registered) and falls back that one pass to cap 1, loudly, the
-+	/// moment it finds a handler from outside Stratum's own assemblies. A
-+	/// false positive here (a mod that happens to be safe getting capped
-+	/// anyway) costs some throughput; a false negative would corrupt world
-+	/// generation for every player on the affected columns, so the fallback
-+	/// direction is deliberate. Called once per raised stage from
-+	/// InitWorldgenAndSpawnChunks, right after worldgenHandler is populated.
++	/// once. Stratum has fixed this exact bug repeatedly in its own
++	/// vanilla-derived generators (a shared Random or shared instance array
++	/// reused across columns, safe only by accident while every stage stayed at
++	/// cap 1); there is no reason to assume third-party code is any safer, and
++	/// Stratum cannot inspect or verify it. Rather than raise a cap and hope,
++	/// this walks the real registered handler list for the pass and falls that
++	/// one pass back to cap 1, loudly, if it finds foreign code in the way.
++	///
++	/// Two things count as foreign code here, because there are two distinct
++	/// ways it ends up running concurrently inside a raised stage:
++	///
++	/// 1. A mod registered its own handler at this pass. Caught by assembly
++	///    name, not by a per-generator allowlist, so it needs no upkeep as
++	///    Stratum's own generator set changes.
++	/// 2. A mod Harmony-patched one of Stratum's own handlers at this pass, so
++	///    mod code executes inside a generator that was only ever audited in
++	///    its Stratum form. Caught by asking Harmony directly what is patched.
++	///
++	/// The second check is the narrow, tractable version of the cross-reference
++	/// research/gap-mod-patch-conflict-visibility.md gave up on: that doc needed
++	/// a build-time manifest of every method Stratum source-patches, which needs
++	/// real Roslyn tooling. This needs no manifest, because the only methods that
++	/// matter for a cap raise are the handlers for the raised stage, and those
++	/// are already in hand as live MethodInfo.
++	///
++	/// Deliberately does not make the transpiler-vs-prefix/postfix distinction
++	/// StratumHarmonyVisibility makes. That distinction is about whether a
++	/// transpiler's IL pattern match still lands after Stratum reshaped a method,
++	/// which prefixes and postfixes survive. The risk here is a different one:
++	/// whether the mod's injected code is thread-safe when the same generator
++	/// runs on several columns at once. A prefix touching shared mod state fails
++	/// exactly as badly as a transpiler would, so any patch kind triggers the
++	/// fallback. The kind is still named in the log, since that is what triage
++	/// needs.
++	///
++	/// Two honest limits, neither of which the fallback direction makes unsafe:
++	/// this only sees patches applied by the time worldgen starts (a mod that
++	/// defers PatchAll past that is invisible, same caveat as
++	/// StratumHarmonyVisibility), and it only inspects the handler methods
++	/// themselves, not everything they call. Both mean it can miss, never that it
++	/// wrongly clears. A false positive costs throughput on one pass; a false
++	/// negative corrupts world generation, so erring toward capping is deliberate.
++	///
++	/// Called once per raised stage from InitWorldgenAndSpawnChunks, right after
++	/// worldgenHandler is populated, which is the first point every mod has
++	/// registered.
 +	/// </summary>
-+	private void EnforceStageConcurrencySafety(int internalStage, EnumWorldGenPass vanillaPass)
++	private void EnforceStageConcurrencySafety(int internalStage, string stageName)
 +	{
 +		int desiredCap = stratumStageMaxConcurrent[internalStage];
 +		if (desiredCap <= 1) return;
@@ -157,19 +200,84 @@ index f644852..e06acca 100644
 +
 +		foreach (ChunkColumnGenerationDelegate handler in handlers)
 +		{
-+			string asmName = handler?.Method?.DeclaringType?.Assembly?.GetName()?.Name;
++			MethodInfo method = handler?.Method;
++			string asmName = method?.DeclaringType?.Assembly?.GetName()?.Name;
++
 +			if (asmName == null || !stratumKnownSafeAssemblies.Contains(asmName))
 +			{
-+				stratumStageMaxConcurrent[internalStage] = 1;
-+				ServerMain.Logger.Warning(
-+					"[Stratum] Same-stage concurrency for " + vanillaPass + " disabled (falling back to 1 concurrent column): "
-+					+ "a worldgen handler from assembly '" + (asmName ?? "<unknown>") + "' is registered at this pass, "
-+					+ "and Stratum cannot verify third-party code is safe to run concurrently across columns. "
-+					+ "If you are the author of that mod and have verified your generator handles this correctly, "
-+					+ "please get in touch so it can be allowlisted.");
++				FallBackStageToSerial(internalStage, stageName,
++					"a worldgen handler from assembly '" + (asmName ?? "<unknown>") + "' is registered at this pass, "
++					+ "and Stratum cannot verify third-party code is safe to run concurrently across columns");
++				return;
++			}
++
++			string modPatches = DescribeModPatches(method);
++			if (modPatches != null)
++			{
++				FallBackStageToSerial(internalStage, stageName,
++					"Stratum's own worldgen handler " + DescribeMethod(method) + " is Harmony-patched (" + modPatches + "), "
++					+ "so that mod's code would run inside a generator Stratum audited only in its own form, "
++					+ "on several columns at once. Stratum cannot verify third-party code is safe under that");
 +				return;
 +			}
 +		}
++	}
++
++	/// <summary>
++	/// Stratum: drops one stage back to serial execution and says why, in terms an
++	/// operator reading the log can act on without reading this source.
++	/// </summary>
++	private void FallBackStageToSerial(int internalStage, string stageName, string reason)
++	{
++		stratumStageMaxConcurrent[internalStage] = 1;
++		ServerMain.Logger.Warning(
++			"[Stratum] Same-stage concurrency for the " + stageName + " worldgen pass is now disabled, "
++			+ "falling back to 1 column at a time: " + reason + ". "
++			+ "World generation stays correct, it just gives up this pass's speedup. "
++			+ "If you are the author of that mod and have verified it is safe to run concurrently across "
++			+ "columns, get in touch so it can be allowlisted.");
++	}
++
++	/// <summary>
++	/// Stratum: lists every mod-owned Harmony patch on one method, or null when
++	/// there are none. Stratum applies no Harmony patches of its own (its changes
++	/// are compiled in, see StratumHarmonyVisibility), so anything found here is
++	/// third-party by construction.
++	/// </summary>
++	private static string DescribeModPatches(MethodBase method)
++	{
++		if (method == null) return null;
++
++		Patches info = Harmony.GetPatchInfo(method);
++		if (info == null) return null;
++
++		StringBuilder sb = null;
++		AppendPatchOwners(ref sb, info.Transpilers, "transpiler");
++		AppendPatchOwners(ref sb, info.Prefixes, "prefix");
++		AppendPatchOwners(ref sb, info.Postfixes, "postfix");
++		AppendPatchOwners(ref sb, info.Finalizers, "finalizer");
++		return sb?.ToString();
++	}
++
++	private static void AppendPatchOwners(ref StringBuilder sb, IReadOnlyCollection<Patch> patches, string kind)
++	{
++		if (patches == null) return;
++
++		foreach (Patch patch in patches)
++		{
++			if (sb == null) sb = new StringBuilder();
++			else sb.Append(", ");
++
++			sb.Append(kind).Append(" from '")
++				.Append(string.IsNullOrWhiteSpace(patch.owner) ? "(unknown mod)" : patch.owner)
++				.Append('\'');
++		}
++	}
++
++	private static string DescribeMethod(MethodBase method)
++	{
++		string typeName = method?.DeclaringType?.Name;
++		return (typeName == null ? "" : typeName + ".") + (method?.Name ?? "<unknown>");
 +	}
 +
 +	// Cumulative Stopwatch ticks and column counts spent generating each internal
@@ -330,12 +438,12 @@ index f644852..e06acca 100644
 +			{
 +				// Queue is empty — wait longer
 +				dispatcherWake.WaitOne(100);
-+			}
-+		}
+ 			}
+ 		}
 +
 +		ServerMain.Logger.VerboseDebug("Chunk dispatcher thread stopped");
-+	}
-+
+ 	}
+ 
 +
 +	/// <summary>
 +	/// Signals the dispatcher that state may have changed
@@ -489,10 +597,10 @@ index f644852..e06acca 100644
 +			{
 +				Interlocked.Decrement(ref stratumStageActiveCount[stage]);
 +				Volatile.Write(ref req.dispatchClaimed, 0);
- 			}
- 		}
- 	}
- 
++			}
++		}
++	}
++
 +	/// <summary>
 +	/// Stratum: CallerRunsPolicy-style fallback for loadChunkAreaBlocking's
 +	/// wait loop (see the comment there for when this gets called). TPS01-J
@@ -945,7 +1053,7 @@ index f644852..e06acca 100644
  			if (!tryLoadOrGenerateChunkColumnsInQueue())
  			{
  				break;
-@@ -143,39 +932,59 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -143,39 +1032,59 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				break;
  			}
  		}
@@ -1007,7 +1115,7 @@ index f644852..e06acca 100644
  				ServerChunk serverChunk = (ServerChunk)server.WorldMap.GetChunk(x, i, z);
  				if (serverChunk != null)
  				{
-@@ -183,11 +992,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -183,11 +1092,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					for (int j = 0; j < entities.Length; j++)
  					{
  						Entity entity = entities[j];
@@ -1020,7 +1128,7 @@ index f644852..e06acca 100644
  						{
  							if (j >= serverChunk.EntitiesCount)
  							{
-@@ -211,19 +1020,23 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -211,19 +1120,23 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				});
  			}
  			list2.Add(item);
@@ -1045,7 +1153,7 @@ index f644852..e06acca 100644
  		{
  			ChunkPos item2 = server.WorldMap.MapRegionPosFromIndex2D(result2);
  			if (hashSet == null)
-@@ -237,28 +1050,46 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -237,28 +1150,46 @@ internal class ServerSystemSupplyChunks : ServerSystem
  		{
  			chunkthread.gameDatabase.DeleteMapRegions(hashSet);
  		}
@@ -1097,7 +1205,7 @@ index f644852..e06acca 100644
  		ServerMapChunk orCreateMapChunk = chunkthread.loadsavechunks.GetOrCreateMapChunk(request);
  		if (orCreateMapChunk == null)
  		{
-@@ -267,94 +1098,203 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -267,94 +1198,203 @@ internal class ServerSystemSupplyChunks : ServerSystem
  		ServerChunk[] array = chunkthread.loadsavechunks.TryLoadChunkColumn(request);
  		if (array == null)
  		{
@@ -1307,7 +1415,7 @@ index f644852..e06acca 100644
  				chunkRequest.Chunks = TryLoadChunkColumn(chunkRequest);
  				if (chunkRequest.Chunks != null)
  				{
-@@ -364,31 +1304,42 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -364,31 +1404,42 @@ internal class ServerSystemSupplyChunks : ServerSystem
  						obj.serverMapChunk = orCreateMapChunk;
  						obj.MarkFresh();
  					}
@@ -1350,7 +1458,7 @@ index f644852..e06acca 100644
  				ServerEventAPI eventapi = server.api.eventapi;
  				ServerMapChunk mapChunk = orCreateMapChunk;
  				int chunkX = chunkRequest.chunkX;
-@@ -404,117 +1355,105 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -404,117 +1455,105 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					ServerMain.Logger.Error("Repair mode is enabled so will delete the entire chunk column.");
  					GenerateNewChunkColumn(orCreateMapChunk, chunkRequest);
  					return false;
@@ -1498,7 +1606,7 @@ index f644852..e06acca 100644
  				try
  				{
  					serverChunk.Unpack();
-@@ -529,10 +1468,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -529,10 +1568,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
  						ServerMain.FrameProfiler.Leave();
  						return;
  					}
@@ -1511,7 +1619,7 @@ index f644852..e06acca 100644
  			{
  				for (int j = 0; j < serverChunk.Entities.Length; j++)
  				{
-@@ -548,10 +1489,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -548,10 +1589,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					{
  						if (server.LoadEntity(entity, num2))
  						{
@@ -1523,7 +1631,7 @@ index f644852..e06acca 100644
  						{
  							string text = "-";
  							try
-@@ -564,14 +1506,18 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -564,14 +1606,18 @@ internal class ServerSystemSupplyChunks : ServerSystem
  							ServerMain.Logger.Log(EnumLogType.Worldgen, "In " + server.WorldName + ", villager " + text + " removed at " + entity.Pos.AsBlockPos?.ToString() + " due to an exception on loading");
  						}
  					}
@@ -1542,7 +1650,7 @@ index f644852..e06acca 100644
  			{
  				BlockEntity value = blockEntity.Value;
  				if (value == null)
-@@ -580,10 +1526,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -580,10 +1626,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				}
  				try
  				{
@@ -1554,7 +1662,7 @@ index f644852..e06acca 100644
  						serverChunk.serverMapChunk.NewBlockEntities.Remove(value.Pos);
  						value.OnBlockPlaced();
  					}
-@@ -594,23 +1541,33 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -594,23 +1641,33 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					ServerMain.Logger.Notification("Exception thrown when trying to initialize a block entity @{0}: {1}", value.Pos, ex3);
  					value.UnregisterAllTickListeners();
  				}
@@ -1588,7 +1696,7 @@ index f644852..e06acca 100644
  		mapChunk.NeighboursLoaded = default(SmallBoolArray);
  		mapChunk.SelfLoaded = true;
  		for (int i = 0; i < Cardinal.ALL.Length; i++)
-@@ -623,20 +1580,26 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -623,20 +1680,26 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				serverMapChunk.NeighboursLoaded[cardinal.Opposite.Index] = true;
  			}
  		}
@@ -1615,7 +1723,7 @@ index f644852..e06acca 100644
  			serverMapChunk.NeighboursLoaded[4] = false;
  		}
  		if (serverMapChunk2 != null)
-@@ -667,12 +1630,17 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -667,12 +1730,17 @@ internal class ServerSystemSupplyChunks : ServerSystem
  		{
  			serverMapChunk8.NeighboursLoaded[3] = false;
  		}
@@ -1633,7 +1741,7 @@ index f644852..e06acca 100644
  			for (int j = -1; j <= 1; j++)
  			{
  				bool flag = false;
-@@ -682,19 +1650,24 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -682,19 +1750,24 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				}
  				if (!flag)
  				{
@@ -1658,7 +1766,7 @@ index f644852..e06acca 100644
  		int num = 0;
  		for (int i = -1; i <= 1; i++)
  		{
-@@ -707,60 +1680,78 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -707,60 +1780,78 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			}
  		}
  		return num == 8;
@@ -1738,7 +1846,7 @@ index f644852..e06acca 100644
  				dictionary = value.ModData;
  				dictionary2 = value.OreMaps;
  				intDataMap2D = value.GeologicProvinceMap;
-@@ -770,12 +1761,14 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -770,12 +1861,14 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			{
  				flag = false;
  				value.loadedTotalMs = server.ElapsedMilliseconds;
@@ -1753,7 +1861,7 @@ index f644852..e06acca 100644
  			if (list != null)
  			{
  				value.GeneratedStructures = list;
-@@ -798,35 +1791,48 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -798,35 +1891,48 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			}
  		}
  		return value;
@@ -1802,7 +1910,7 @@ index f644852..e06acca 100644
  		byte[] array = chunkGenParams?.GetBytes("GeneratedStructures");
  		if (array == null)
  		{
-@@ -836,44 +1842,60 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -836,44 +1942,60 @@ internal class ServerSystemSupplyChunks : ServerSystem
  		long key = server.api.WorldManager.MapRegionIndex2D(regionX, regionZ);
  		if (!dictionary.TryGetValue(key, out var value) || value == null)
  		{
@@ -1864,7 +1972,7 @@ index f644852..e06acca 100644
  		long key = server.WorldMap.MapChunkIndex2D(chunkX, chunkZ);
  		server.loadedMapChunks.TryGetValue(key, out var value);
  		if (value != null)
-@@ -881,31 +1903,42 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -881,31 +2003,42 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			return value;
  		}
  		return TryLoadMapChunk(chunkX, chunkZ);
@@ -1907,7 +2015,7 @@ index f644852..e06acca 100644
  			for (int j = 0; j < Cardinal.ALL.Length; j++)
  			{
  				Cardinal cardinal = Cardinal.ALL[j];
-@@ -918,47 +1951,111 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -918,47 +2051,111 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					}
  					chunkRequest.NeighbourTerrainHeight[j] = serverMapChunk.WorldGenTerrainHeightMap;
  				}
@@ -2035,7 +2143,7 @@ index f644852..e06acca 100644
  			foreach (ServerChunk serverChunk in array)
  			{
  				if (serverChunk != null)
-@@ -967,10 +2064,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -967,10 +2164,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					serverChunk.MarkModified();
  					serverChunk.TryPackAndCommit();
  				}
@@ -2048,7 +2156,7 @@ index f644852..e06acca 100644
  			ServerMain.Logger.Error("Loaded some but not all chunks of a column? Discarding whole column.");
  			return null;
  		}
-@@ -979,18 +2078,22 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -979,18 +2178,22 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			return null;
  		}
  		return array;
@@ -2071,7 +2179,7 @@ index f644852..e06acca 100644
  					serverMapChunk.YMax = (ushort)(server.SaveGameData.MapSizeY - 1);
  				}
  				return serverMapChunk;
-@@ -1011,10 +2114,13 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1011,10 +2214,13 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			}
  		}
  		return null;
@@ -2085,7 +2193,7 @@ index f644852..e06acca 100644
  		byte[] mapRegion = chunkthread.gameDatabase.GetMapRegion(regionX, regionZ);
  		try
  		{
-@@ -1035,14 +2141,26 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1035,14 +2241,26 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			throw;
  		}
  		return null;
@@ -2103,7 +2211,7 @@ index f644852..e06acca 100644
 +		// listening at a same-stage-concurrent pass. See the method's own
 +		// comment for why this defaults to disabling concurrency rather than
 +		// trusting unknown code.
-+		EnforceStageConcurrencySafety(StratumWorldGenStages.PreDone, EnumWorldGenPass.PreDone);
++		EnforceStageConcurrencySafety(StratumWorldGenStages.PreDone, "PreDone");
  		ServerMain.Logger.Event("Loading {0}x{1}x{2} spawn chunks...", MagicNum.SpawnChunksWidth, MagicNum.SpawnChunksWidth, server.WorldMap.ChunkMapSizeY);
 +
 +		// Initialize "story" messages for display during loading
@@ -2112,7 +2220,7 @@ index f644852..e06acca 100644
  			storyChunkSpawnEvents = new string[15]
  			{
  				Lang.Get("...the carved mountains"),
-@@ -1060,23 +2178,27 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1060,23 +2278,27 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				Lang.Get("...a misty sunrise"),
  				Lang.Get("...dew drops on a blade of grass"),
  				Lang.Get("...a soft breeze")
@@ -2140,7 +2248,7 @@ index f644852..e06acca 100644
  					double value = random.NextDouble() * 6.2831854820251465;
  					double num7 = num6 * GameMath.Sin(value);
  					double num8 = num6 * GameMath.Cos(value);
-@@ -1096,10 +2218,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1096,10 +2318,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					server.api.Logger.Notification("Trying another spawn location ({0}/{1})...", i + 2, num3);
  				}
  			}
@@ -2152,7 +2260,7 @@ index f644852..e06acca 100644
  				if (!server.blockAccessor.GetBlock(blockPos).SideSolid[BlockFacing.UP.Index])
  				{
  					server.blockAccessor.SetBlock(server.blockAccessor.GetBlock(new AssetLocation("planks-oak-we")).Id, blockPos);
-@@ -1107,13 +2230,16 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1107,13 +2330,16 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				blockPos.Y++;
  			}
  		}
@@ -2169,7 +2277,7 @@ index f644852..e06acca 100644
  			x = blockPos.X,
  			y = blockPos.Y,
  			z = blockPos.Z
-@@ -1123,10 +2249,14 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1123,10 +2349,14 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			server.mapMiddleSpawnPos.y = null;
  		}
  		server.api.Logger.VerboseDebug("Done spawn chunk");
@@ -2184,7 +2292,7 @@ index f644852..e06acca 100644
  		int num = 60;
  		int num2 = 0;
  		int num3 = 0;
-@@ -1137,36 +2267,47 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1137,36 +2367,47 @@ internal class ServerSystemSupplyChunks : ServerSystem
  		{
  			num4 = GameMath.Clamp(num2 + pos.X, 0, server.WorldMap.MapSizeX - 1);
  			num6 = GameMath.Clamp(num3 + pos.Z, 0, server.WorldMap.MapSizeZ - 1);
@@ -2233,7 +2341,7 @@ index f644852..e06acca 100644
  		{
  			for (int k = -num2; k <= num2; k++)
  			{
-@@ -1174,18 +2315,22 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1174,18 +2415,22 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				{
  					long index2d = server.WorldMap.MapChunkIndex2D(x + j, y + k);
  					int regionX = (x + j) / MagicNum.ChunkRegionSizeInChunks;
@@ -2257,7 +2365,7 @@ index f644852..e06acca 100644
  					};
  					chunkColumnLoadRequest.MapChunk = mapChunk;
  					GenerateNewChunkColumn(mapChunk, chunkColumnLoadRequest);
-@@ -1196,10 +2341,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1196,10 +2441,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
  						chunkthread.peekingChunkColumns.Enqueue(chunkColumnLoadRequest);
  					}
  				}
@@ -2270,7 +2378,7 @@ index f644852..e06acca 100644
  		{
  			num4 = num - i;
  			for (int l = -num4; l <= num4; l++)
-@@ -1212,10 +2359,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1212,10 +2459,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
  						runGenerators(chunkRequest, i);
  					}
  				}
@@ -2283,7 +2391,7 @@ index f644852..e06acca 100644
  		{
  			for (int n = -num2; n <= num2; n++)
  			{
-@@ -1232,61 +2381,111 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1232,61 +2481,111 @@ internal class ServerSystemSupplyChunks : ServerSystem
  						dictionary2[key] = chunks;
  					}
  				}
@@ -2397,7 +2505,7 @@ index f644852..e06acca 100644
  				millisecondsSinceStart = server.totalUnpausedTime.ElapsedMilliseconds;
  				float num4 = 100f * ((float)server.loadedChunks.Count / (float)server.WorldMap.ChunkMapSizeY - (float)num) / (float)num2;
  				ServerMain.Logger.Event(num4.ToString("0.#") + "% ({0} in queue)", chunkthread.requestedChunkColumns.Count);
-@@ -1298,37 +2497,84 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1298,37 +2597,84 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				{
  					ServerMain.Logger.StoryEvent("...");
  				}
@@ -2485,7 +2593,7 @@ index f644852..e06acca 100644
  				foreach (ChunkColumnLoadRequest requestedChunkColumn3 in chunkthread.requestedChunkColumns)
  				{
  					if (requestedChunkColumn3 != null)
-@@ -1340,16 +2586,25 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1340,16 +2686,25 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				throw new Exception("Somehow worldgen has become stuck in an endless loop, please report this as a bug!  Additional data in the server-main log");
  			}
  		}
@@ -2511,7 +2619,7 @@ index f644852..e06acca 100644
  				if (chunkRequest.CurrentIncompletePass == EnumWorldGenPass.Terrain)
  				{
  					ushort sunLight = (ushort)server.sunBrightness;
-@@ -1359,32 +2614,62 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1359,32 +2714,62 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					}
  				}
  			}
@@ -2576,7 +2684,7 @@ index f644852..e06acca 100644
  			return;
  		}
  		for (int i = 0; i < list.Count; i++)
-@@ -1396,89 +2681,117 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1396,89 +2781,117 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			catch (Exception ex)
  			{
  				ServerMain.Logger.Worldgen("An error was thrown in pass {5} when generating chunk column X={0},Z={1} in world '{3}' with seed {4}\nException {2}\n\n", chunkRequest.chunkX, chunkRequest.chunkZ, ex, server.SaveGameData.WorldName, server.SaveGameData.Seed, chunkRequest.CurrentIncompletePass.ToString());
@@ -2711,7 +2819,7 @@ index f644852..e06acca 100644
  			chunkthread.requestedChunkColumns.Enqueue(curRequest);
  			return true;
  		}
-@@ -1490,13 +2803,19 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1490,13 +2903,19 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				ServerMain.Logger.VerboseDebug("Un-pausing all worldgen threads.");
  			}
  		}
@@ -2731,7 +2839,7 @@ index f644852..e06acca 100644
  			if (requestedChunkColumn != null && !requestedChunkColumn.Disposed)
  			{
  				server.loadedMapChunks.Remove(requestedChunkColumn.mapIndex2d);
-@@ -1505,104 +2824,181 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1505,104 +2924,181 @@ internal class ServerSystemSupplyChunks : ServerSystem
  		}
  		chunkthread.requestedChunkColumns.Clear();
  		ServerMain.Logger.VerboseDebug("Incomplete chunks stored and wiped.");

--- a/patches/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs.patch
@@ -1,8 +1,8 @@
 diff --git a/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs b/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs
-index f644852..a299f06 100644
+index f644852..5a5d371 100644
 --- a/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs
 +++ b/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs
-@@ -9,131 +9,760 @@ using Vintagestory.API.Datastructures;
+@@ -9,131 +9,865 @@ using Vintagestory.API.Datastructures;
  using Vintagestory.API.MathTools;
  using Vintagestory.API.Server;
  using Vintagestory.API.Util;
@@ -253,7 +253,7 @@ index f644852..a299f06 100644
 -				num++;
 +				Thread.Sleep(15);
 +				continue;
-+			}
+ 			}
 +
 +			if (chunkthread.requestedChunkColumns.Count > 0 && !server.Suspended)
 +			{
@@ -303,10 +303,10 @@ index f644852..a299f06 100644
 +		for (int stage = 1; stage < StratumWorldGenStages.Done; stage++)
 +		{
 +			if (Volatile.Read(ref stratumStageActiveCount[stage]) < stratumStageMaxConcurrent[stage]) return true;
-+		}
+ 		}
 +		return false;
-+	}
-+
+ 	}
+ 
 +
 +	/// <summary>
 +	/// Stratum: formats the cumulative per-stage generation time as a one-line
@@ -340,43 +340,89 @@ index f644852..a299f06 100644
 +
 +
 +	/// <summary>
-+	/// Attempts to claim the request's current stage and hand it to a worker.
-+	/// Returns true when the task was enqueued. Shared by the priority pass
-+	/// and the FIFO scan in ScheduleReadyTasks; runs under dispatcherLock.
++	/// Stratum: everything TryDispatchRequest and TryRunOneReadyRequestInline
++	/// share: claim the request itself first (req.dispatchClaimed), then a
++	/// concurrency slot for its current stage, then run the checks that can
++	/// still say no even after both are held (stage advanced under us,
++	/// untilPass, neighbour readiness). On true the caller owns both claims and
++	/// MUST release both exactly once (Interlocked.Decrement on
++	/// stratumStageActiveCount[stage] AND Volatile.Write(req.dispatchClaimed, 0)),
++	/// in a finally block, once it has either enqueued the request or finished
++	/// running it. On false both claims have already been released internally;
++	/// the caller does nothing further.
 +	/// </summary>
-+	private bool TryDispatchRequest(ChunkColumnLoadRequest req)
++	private bool TryClaimStage(ChunkColumnLoadRequest req, out int stage)
 +	{
++		stage = -1;
 +		if (req == null || req.Disposed) return false;
 +
 +		// Determine the current incomplete generation stage
-+		int stage = req.CurrentIncompletePass_AsInt;
-+		if (stage < 1 || stage >= StratumWorldGenStages.Done) return false;
++		stage = req.CurrentIncompletePass_AsInt;
++		if (stage < 1 || stage >= StratumWorldGenStages.Done) { stage = -1; return false; }
++
++		// Claim this specific request first. stratumStageActiveCount below only
++		// caps how many claims are concurrently active *for the stage*; it does
++		// nothing to stop this exact request being claimed a second time by
++		// another concurrent caller before either claim has run PopulateChunk to
++		// advance CurrentIncompletePass_AsInt. See dispatchClaimed's own comment
++		// on ChunkColumnLoadRequest for what that double-claim does once it lands.
++		if (Interlocked.CompareExchange(ref req.dispatchClaimed, 1, 0) != 0)
++		{
++			stage = -1;
++			return false;
++		}
 +
 +		// Atomically claim a concurrency slot for this stage, if one is free
 +		int cap = stratumStageMaxConcurrent[stage];
 +		if (Interlocked.Increment(ref stratumStageActiveCount[stage]) > cap)
 +		{
 +			Interlocked.Decrement(ref stratumStageActiveCount[stage]);
++			Volatile.Write(ref req.dispatchClaimed, 0);
++			stage = -1;
 +			return false;
 +		}
 +
-+		// ── Everything that can throw is wrapped in try/finally ──
++		// Re-verify: currentpass may have changed between the read and the CAS
++		if (req.CurrentIncompletePass_AsInt != stage)
++		{
++			Interlocked.Decrement(ref stratumStageActiveCount[stage]);
++			Volatile.Write(ref req.dispatchClaimed, 0);
++			stage = -1;
++			return false;
++		}
++
++		if (stage >= req.untilPass)
++		{
++			req.FlagToRequeue();
++			Interlocked.Decrement(ref stratumStageActiveCount[stage]);
++			Volatile.Write(ref req.dispatchClaimed, 0);
++			stage = -1;
++			return false;
++		}
++
++		if (!ensurePrettyNeighbourhood(req))
++		{
++			Interlocked.Decrement(ref stratumStageActiveCount[stage]);
++			Volatile.Write(ref req.dispatchClaimed, 0);
++			stage = -1;
++			return false;
++		}
++
++		return true;
++	}
++
++	/// <summary>
++	/// Attempts to claim the request's current stage and hand it to a worker.
++	/// Returns true when the task was enqueued. Shared by the priority pass
++	/// and the FIFO scan in ScheduleReadyTasks; runs under dispatcherLock.
++	/// </summary>
++	private bool TryDispatchRequest(ChunkColumnLoadRequest req)
++	{
++		if (!TryClaimStage(req, out int stage)) return false;
++
 +		bool handedOff = false;
 +		try
 +		{
-+			// Re-verify: currentpass may have changed between the read and the CAS
-+			if (req.CurrentIncompletePass_AsInt != stage)
-+				return false; // finally will release
-+
-+			if (stage >= req.untilPass)
-+			{
-+				req.FlagToRequeue();
-+				return false; // finally will release
-+			}
-+
-+			if (!ensurePrettyNeighbourhood(req))
-+				return false; // finally will release
-+
 +			// Pass the stage TOGETHER with the request
 +			readyTasksQueue.Add(new DispatchedTask(req, stage));
 +			handedOff = true; // ownership transferred to the worker
@@ -387,8 +433,65 @@ index f644852..a299f06 100644
 +			if (!handedOff)
 +			{
 +				Interlocked.Decrement(ref stratumStageActiveCount[stage]);
++				Volatile.Write(ref req.dispatchClaimed, 0);
 +			}
 +		}
++	}
++
++	/// <summary>
++	/// Stratum: CallerRunsPolicy-style fallback for loadChunkAreaBlocking's
++	/// wait loop (see the comment there for when this gets called). TPS01-J
++	/// (SEI CERT): do not execute interdependent tasks in a bounded thread
++	/// pool. loadChunkAreaBlocking is exactly that shape once workers exist:
++	/// it waits for worker-stage requests (Terrain..PreDone) that live in the
++	/// same bounded worker pool its own caller is not part of, and
++	/// ensurePrettyNeighbourhood makes those requests interdependent on each
++	/// other (a column can't advance past TerrainLate until its neighbours
++	/// have too). If every worker thread happens to be transiently busy with
++	/// claims that don't advance the specific neighbourhood this call is
++	/// waiting on, that wait can stall for a long time with nothing forcing
++	/// progress, which is what the 12-second "worldgen has become stuck"
++	/// throw further down exists to catch as a last resort. Raising any one
++	/// stage's own concurrency cap (e.g. PreDone's, to match the full worker
++	/// count) makes it measurably more likely one stage's claims saturate the
++	/// shared worker pool for a moment, since the other stages ensurePrettyNeighbourhood
++	/// actually depends on keep their own cap of 1.
++	///
++	/// Rather than only polling ScheduleReadyTasks() and hoping a worker frees
++	/// up, this lets the calling thread claim and run one ready request
++	/// itself: the exact same claim protocol TryDispatchRequest uses (so it
++	/// can never double-claim a stage slot a worker also holds), just
++	/// executed synchronously on this thread instead of handed to the
++	/// channel. Uses loadOrGenerateChunkColumn_OnChunkThread rather than
++	/// PopulateChunk directly since that already carries the requeue-on-failure
++	/// bookkeeping loadChunkAreaBlocking's own boundary-stage handling above
++	/// relies on; the extra CanGenerateChunkColumn re-check inside it is
++	/// redundant with TryClaimStage's own ensurePrettyNeighbourhood call but
++	/// cheap, and keeps this path behaviourally identical to the worker path
++	/// instead of a second, subtly different implementation.
++	/// </summary>
++	private bool TryRunOneReadyRequestInline()
++	{
++		foreach (ChunkColumnLoadRequest req in chunkthread.requestedChunkColumns)
++		{
++			if (!TryClaimStage(req, out int stage)) continue;
++
++			try
++			{
++				loadOrGenerateChunkColumn_OnChunkThread(req, stage);
++			}
++			finally
++			{
++				// Ran inline instead of handing off to a worker: nothing else
++				// will release this claim, so release it here, then wake the
++				// dispatcher exactly like a worker's own finally block does.
++				Interlocked.Decrement(ref stratumStageActiveCount[stage]);
++				Volatile.Write(ref req.dispatchClaimed, 0);
++				SignalDispatcher();
++			}
++			return true;
++		}
++		return false;
 +	}
 +
 +
@@ -513,6 +616,7 @@ index f644852..a299f06 100644
 +				if (request.CurrentIncompletePass_AsInt != currentStage)
 +				{
 +					Interlocked.Decrement(ref stratumStageActiveCount[currentStage]);
++					Volatile.Write(ref request.dispatchClaimed, 0);
 +					SignalDispatcher(); // wake the dispatcher
 +					continue; // not holding — skip finally with holdingStage
 +				}
@@ -540,6 +644,7 @@ index f644852..a299f06 100644
 +				if (holdingStage && currentStage >= 0 && currentStage < stratumStageActiveCount.Length)
 +				{
 +					Interlocked.Decrement(ref stratumStageActiveCount[currentStage]);
++					Volatile.Write(ref request.dispatchClaimed, 0);
 +					SignalDispatcher(); // wake the dispatcher
 +				}
 +			}
@@ -627,8 +732,8 @@ index f644852..a299f06 100644
 +				// Closer than the farthest in top-K — replace
 +				stratumTopKHeap.Dequeue();
 +				stratumTopKHeap.Enqueue(r, -distSq);
- 			}
- 		}
++			}
++		}
 +
 +		// Extract from heap (farthest to nearest) and reverse
 +		while (stratumTopKHeap.Count > 0)
@@ -669,8 +774,8 @@ index f644852..a299f06 100644
 +			if (d < min) min = d;
 +		}
 +		return min;
- 	}
- 
++	}
++
 +
 +
 +
@@ -785,7 +890,7 @@ index f644852..a299f06 100644
  			if (!tryLoadOrGenerateChunkColumnsInQueue())
  			{
  				break;
-@@ -143,39 +772,59 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -143,39 +877,59 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				break;
  			}
  		}
@@ -847,7 +952,7 @@ index f644852..a299f06 100644
  				ServerChunk serverChunk = (ServerChunk)server.WorldMap.GetChunk(x, i, z);
  				if (serverChunk != null)
  				{
-@@ -183,11 +832,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -183,11 +937,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					for (int j = 0; j < entities.Length; j++)
  					{
  						Entity entity = entities[j];
@@ -860,7 +965,7 @@ index f644852..a299f06 100644
  						{
  							if (j >= serverChunk.EntitiesCount)
  							{
-@@ -211,19 +860,23 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -211,19 +965,23 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				});
  			}
  			list2.Add(item);
@@ -885,7 +990,7 @@ index f644852..a299f06 100644
  		{
  			ChunkPos item2 = server.WorldMap.MapRegionPosFromIndex2D(result2);
  			if (hashSet == null)
-@@ -237,28 +890,46 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -237,28 +995,46 @@ internal class ServerSystemSupplyChunks : ServerSystem
  		{
  			chunkthread.gameDatabase.DeleteMapRegions(hashSet);
  		}
@@ -937,7 +1042,7 @@ index f644852..a299f06 100644
  		ServerMapChunk orCreateMapChunk = chunkthread.loadsavechunks.GetOrCreateMapChunk(request);
  		if (orCreateMapChunk == null)
  		{
-@@ -267,44 +938,108 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -267,44 +1043,108 @@ internal class ServerSystemSupplyChunks : ServerSystem
  		ServerChunk[] array = chunkthread.loadsavechunks.TryLoadChunkColumn(request);
  		if (array == null)
  		{
@@ -1047,7 +1152,7 @@ index f644852..a299f06 100644
  				{
  					return false;
  				}
-@@ -315,46 +1050,63 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -315,46 +1155,63 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			}
  		}
  		return false;
@@ -1112,7 +1217,7 @@ index f644852..a299f06 100644
  				chunkRequest.Chunks = TryLoadChunkColumn(chunkRequest);
  				if (chunkRequest.Chunks != null)
  				{
-@@ -364,31 +1116,42 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -364,31 +1221,42 @@ internal class ServerSystemSupplyChunks : ServerSystem
  						obj.serverMapChunk = orCreateMapChunk;
  						obj.MarkFresh();
  					}
@@ -1155,7 +1260,7 @@ index f644852..a299f06 100644
  				ServerEventAPI eventapi = server.api.eventapi;
  				ServerMapChunk mapChunk = orCreateMapChunk;
  				int chunkX = chunkRequest.chunkX;
-@@ -404,117 +1167,105 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -404,117 +1272,105 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					ServerMain.Logger.Error("Repair mode is enabled so will delete the entire chunk column.");
  					GenerateNewChunkColumn(orCreateMapChunk, chunkRequest);
  					return false;
@@ -1303,7 +1408,7 @@ index f644852..a299f06 100644
  				try
  				{
  					serverChunk.Unpack();
-@@ -529,10 +1280,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -529,10 +1385,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
  						ServerMain.FrameProfiler.Leave();
  						return;
  					}
@@ -1316,7 +1421,7 @@ index f644852..a299f06 100644
  			{
  				for (int j = 0; j < serverChunk.Entities.Length; j++)
  				{
-@@ -548,10 +1301,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -548,10 +1406,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					{
  						if (server.LoadEntity(entity, num2))
  						{
@@ -1328,7 +1433,7 @@ index f644852..a299f06 100644
  						{
  							string text = "-";
  							try
-@@ -564,14 +1318,18 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -564,14 +1423,18 @@ internal class ServerSystemSupplyChunks : ServerSystem
  							ServerMain.Logger.Log(EnumLogType.Worldgen, "In " + server.WorldName + ", villager " + text + " removed at " + entity.Pos.AsBlockPos?.ToString() + " due to an exception on loading");
  						}
  					}
@@ -1347,7 +1452,7 @@ index f644852..a299f06 100644
  			{
  				BlockEntity value = blockEntity.Value;
  				if (value == null)
-@@ -580,10 +1338,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -580,10 +1443,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				}
  				try
  				{
@@ -1359,7 +1464,7 @@ index f644852..a299f06 100644
  						serverChunk.serverMapChunk.NewBlockEntities.Remove(value.Pos);
  						value.OnBlockPlaced();
  					}
-@@ -594,23 +1353,33 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -594,23 +1458,33 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					ServerMain.Logger.Notification("Exception thrown when trying to initialize a block entity @{0}: {1}", value.Pos, ex3);
  					value.UnregisterAllTickListeners();
  				}
@@ -1393,7 +1498,7 @@ index f644852..a299f06 100644
  		mapChunk.NeighboursLoaded = default(SmallBoolArray);
  		mapChunk.SelfLoaded = true;
  		for (int i = 0; i < Cardinal.ALL.Length; i++)
-@@ -623,20 +1392,26 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -623,20 +1497,26 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				serverMapChunk.NeighboursLoaded[cardinal.Opposite.Index] = true;
  			}
  		}
@@ -1420,7 +1525,7 @@ index f644852..a299f06 100644
  			serverMapChunk.NeighboursLoaded[4] = false;
  		}
  		if (serverMapChunk2 != null)
-@@ -667,12 +1442,17 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -667,12 +1547,17 @@ internal class ServerSystemSupplyChunks : ServerSystem
  		{
  			serverMapChunk8.NeighboursLoaded[3] = false;
  		}
@@ -1438,7 +1543,7 @@ index f644852..a299f06 100644
  			for (int j = -1; j <= 1; j++)
  			{
  				bool flag = false;
-@@ -682,19 +1462,24 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -682,19 +1567,24 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				}
  				if (!flag)
  				{
@@ -1463,7 +1568,7 @@ index f644852..a299f06 100644
  		int num = 0;
  		for (int i = -1; i <= 1; i++)
  		{
-@@ -707,60 +1492,78 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -707,60 +1597,78 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			}
  		}
  		return num == 8;
@@ -1543,7 +1648,7 @@ index f644852..a299f06 100644
  				dictionary = value.ModData;
  				dictionary2 = value.OreMaps;
  				intDataMap2D = value.GeologicProvinceMap;
-@@ -770,12 +1573,14 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -770,12 +1678,14 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			{
  				flag = false;
  				value.loadedTotalMs = server.ElapsedMilliseconds;
@@ -1558,7 +1663,7 @@ index f644852..a299f06 100644
  			if (list != null)
  			{
  				value.GeneratedStructures = list;
-@@ -798,35 +1603,48 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -798,35 +1708,48 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			}
  		}
  		return value;
@@ -1607,7 +1712,7 @@ index f644852..a299f06 100644
  		byte[] array = chunkGenParams?.GetBytes("GeneratedStructures");
  		if (array == null)
  		{
-@@ -836,44 +1654,60 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -836,44 +1759,60 @@ internal class ServerSystemSupplyChunks : ServerSystem
  		long key = server.api.WorldManager.MapRegionIndex2D(regionX, regionZ);
  		if (!dictionary.TryGetValue(key, out var value) || value == null)
  		{
@@ -1669,7 +1774,7 @@ index f644852..a299f06 100644
  		long key = server.WorldMap.MapChunkIndex2D(chunkX, chunkZ);
  		server.loadedMapChunks.TryGetValue(key, out var value);
  		if (value != null)
-@@ -881,31 +1715,42 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -881,31 +1820,42 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			return value;
  		}
  		return TryLoadMapChunk(chunkX, chunkZ);
@@ -1712,7 +1817,7 @@ index f644852..a299f06 100644
  			for (int j = 0; j < Cardinal.ALL.Length; j++)
  			{
  				Cardinal cardinal = Cardinal.ALL[j];
-@@ -918,47 +1763,111 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -918,47 +1868,111 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					}
  					chunkRequest.NeighbourTerrainHeight[j] = serverMapChunk.WorldGenTerrainHeightMap;
  				}
@@ -1840,7 +1945,7 @@ index f644852..a299f06 100644
  			foreach (ServerChunk serverChunk in array)
  			{
  				if (serverChunk != null)
-@@ -967,10 +1876,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -967,10 +1981,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					serverChunk.MarkModified();
  					serverChunk.TryPackAndCommit();
  				}
@@ -1853,7 +1958,7 @@ index f644852..a299f06 100644
  			ServerMain.Logger.Error("Loaded some but not all chunks of a column? Discarding whole column.");
  			return null;
  		}
-@@ -979,18 +1890,22 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -979,18 +1995,22 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			return null;
  		}
  		return array;
@@ -1876,7 +1981,7 @@ index f644852..a299f06 100644
  					serverMapChunk.YMax = (ushort)(server.SaveGameData.MapSizeY - 1);
  				}
  				return serverMapChunk;
-@@ -1011,10 +1926,13 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1011,10 +2031,13 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			}
  		}
  		return null;
@@ -1890,7 +1995,7 @@ index f644852..a299f06 100644
  		byte[] mapRegion = chunkthread.gameDatabase.GetMapRegion(regionX, regionZ);
  		try
  		{
-@@ -1035,14 +1953,20 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1035,14 +2058,20 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			throw;
  		}
  		return null;
@@ -1911,7 +2016,7 @@ index f644852..a299f06 100644
  			storyChunkSpawnEvents = new string[15]
  			{
  				Lang.Get("...the carved mountains"),
-@@ -1060,23 +1984,27 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1060,23 +2089,27 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				Lang.Get("...a misty sunrise"),
  				Lang.Get("...dew drops on a blade of grass"),
  				Lang.Get("...a soft breeze")
@@ -1939,7 +2044,7 @@ index f644852..a299f06 100644
  					double value = random.NextDouble() * 6.2831854820251465;
  					double num7 = num6 * GameMath.Sin(value);
  					double num8 = num6 * GameMath.Cos(value);
-@@ -1096,10 +2024,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1096,10 +2129,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					server.api.Logger.Notification("Trying another spawn location ({0}/{1})...", i + 2, num3);
  				}
  			}
@@ -1951,7 +2056,7 @@ index f644852..a299f06 100644
  				if (!server.blockAccessor.GetBlock(blockPos).SideSolid[BlockFacing.UP.Index])
  				{
  					server.blockAccessor.SetBlock(server.blockAccessor.GetBlock(new AssetLocation("planks-oak-we")).Id, blockPos);
-@@ -1107,13 +2036,16 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1107,13 +2141,16 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				blockPos.Y++;
  			}
  		}
@@ -1968,7 +2073,7 @@ index f644852..a299f06 100644
  			x = blockPos.X,
  			y = blockPos.Y,
  			z = blockPos.Z
-@@ -1123,10 +2055,14 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1123,10 +2160,14 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			server.mapMiddleSpawnPos.y = null;
  		}
  		server.api.Logger.VerboseDebug("Done spawn chunk");
@@ -1983,7 +2088,7 @@ index f644852..a299f06 100644
  		int num = 60;
  		int num2 = 0;
  		int num3 = 0;
-@@ -1137,36 +2073,47 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1137,36 +2178,47 @@ internal class ServerSystemSupplyChunks : ServerSystem
  		{
  			num4 = GameMath.Clamp(num2 + pos.X, 0, server.WorldMap.MapSizeX - 1);
  			num6 = GameMath.Clamp(num3 + pos.Z, 0, server.WorldMap.MapSizeZ - 1);
@@ -2032,7 +2137,7 @@ index f644852..a299f06 100644
  		{
  			for (int k = -num2; k <= num2; k++)
  			{
-@@ -1174,18 +2121,22 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1174,18 +2226,22 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				{
  					long index2d = server.WorldMap.MapChunkIndex2D(x + j, y + k);
  					int regionX = (x + j) / MagicNum.ChunkRegionSizeInChunks;
@@ -2056,7 +2161,7 @@ index f644852..a299f06 100644
  					};
  					chunkColumnLoadRequest.MapChunk = mapChunk;
  					GenerateNewChunkColumn(mapChunk, chunkColumnLoadRequest);
-@@ -1196,10 +2147,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1196,10 +2252,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
  						chunkthread.peekingChunkColumns.Enqueue(chunkColumnLoadRequest);
  					}
  				}
@@ -2069,7 +2174,7 @@ index f644852..a299f06 100644
  		{
  			num4 = num - i;
  			for (int l = -num4; l <= num4; l++)
-@@ -1212,10 +2165,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1212,10 +2270,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
  						runGenerators(chunkRequest, i);
  					}
  				}
@@ -2082,7 +2187,7 @@ index f644852..a299f06 100644
  		{
  			for (int n = -num2; n <= num2; n++)
  			{
-@@ -1232,61 +2187,107 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1232,61 +2292,111 @@ internal class ServerSystemSupplyChunks : ServerSystem
  						dictionary2[key] = chunks;
  					}
  				}
@@ -2171,6 +2276,10 @@ index f644852..a299f06 100644
 -		long num3 = Environment.TickCount + 12000;
 +
 +		long num3 = Environment.TickCount + 12000; // 12-second timeout without progress
++		// Stratum: CallerRunsPolicy-style fallback threshold, much shorter than
++		// the 12s hard-stuck timeout above. See TryRunOneReadyRequestInline's
++		// own comment for why this exists and what it protects against.
++		long stratumHelpThreshold = Environment.TickCount + 2000;
  		ServerMain.Logger.VerboseDebug("Starting area loading/generation: columns " + blockingRequestsRemaining + ", total queue length " + chunkthread.requestedChunkColumns.Count);
 +
 +		// Wait loop for all requests to complete
@@ -2192,7 +2301,7 @@ index f644852..a299f06 100644
  				millisecondsSinceStart = server.totalUnpausedTime.ElapsedMilliseconds;
  				float num4 = 100f * ((float)server.loadedChunks.Count / (float)server.WorldMap.ChunkMapSizeY - (float)num) / (float)num2;
  				ServerMain.Logger.Event(num4.ToString("0.#") + "% ({0} in queue)", chunkthread.requestedChunkColumns.Count);
-@@ -1298,37 +2299,48 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1298,37 +2408,62 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				{
  					ServerMain.Logger.StoryEvent("...");
  				}
@@ -2223,6 +2332,20 @@ index f644852..a299f06 100644
  				}
  			}
 +
++			// Stratum: CallerRunsPolicy-style fallback. The foreach above only
++			// ever processes stage None/Done directly (or every stage when
++			// noWorkers); everything in between (Terrain..PreDone) normally
++			// depends entirely on ScheduleReadyTasks() finding a free worker
++			// thread. If that has produced no visible progress for a couple
++			// seconds, this thread claims and runs one ready worker-stage
++			// request itself instead of only polling and hoping. See
++			// TryRunOneReadyRequestInline's own comment for the full reasoning.
++			if (!flag && !noWorkers && Environment.TickCount > stratumHelpThreshold)
++			{
++				flag |= TryRunOneReadyRequestInline();
++				stratumHelpThreshold = Environment.TickCount + 2000;
++			}
++
  			if (flag)
  			{
 -				num3 = Environment.TickCount + 12000;
@@ -2243,7 +2366,7 @@ index f644852..a299f06 100644
  				foreach (ChunkColumnLoadRequest requestedChunkColumn3 in chunkthread.requestedChunkColumns)
  				{
  					if (requestedChunkColumn3 != null)
-@@ -1340,16 +2352,25 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1340,16 +2475,25 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				throw new Exception("Somehow worldgen has become stuck in an endless loop, please report this as a bug!  Additional data in the server-main log");
  			}
  		}
@@ -2269,7 +2392,7 @@ index f644852..a299f06 100644
  				if (chunkRequest.CurrentIncompletePass == EnumWorldGenPass.Terrain)
  				{
  					ushort sunLight = (ushort)server.sunBrightness;
-@@ -1359,32 +2380,62 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1359,32 +2503,62 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					}
  				}
  			}
@@ -2334,7 +2457,7 @@ index f644852..a299f06 100644
  			return;
  		}
  		for (int i = 0; i < list.Count; i++)
-@@ -1396,32 +2447,44 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1396,89 +2570,117 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			catch (Exception ex)
  			{
  				ServerMain.Logger.Worldgen("An error was thrown in pass {5} when generating chunk column X={0},Z={1} in world '{3}' with seed {4}\nException {2}\n\n", chunkRequest.chunkX, chunkRequest.chunkZ, ex, server.SaveGameData.WorldName, server.SaveGameData.Seed, chunkRequest.CurrentIncompletePass.ToString());
@@ -2381,15 +2504,31 @@ index f644852..a299f06 100644
  			for (int j = num3; j <= num4; j++)
  			{
  				if (i == chunkRequest.chunkX && j == chunkRequest.chunkZ)
-@@ -1431,54 +2494,59 @@ internal class ServerSystemSupplyChunks : ServerSystem
+ 				{
+ 					continue;
+ 				}
  				long index2d = server.WorldMap.MapChunkIndex2D(i, j);
++				// Stratum: was `if (!EnsureMinimumWorldgenPassAt(...)) { if (prettified) return false; }`,
++				// short-circuiting on the FIRST lagging neighbour once this request had
++				// been checked once before. EnsureMinimumWorldgenPassAt's failure branch
++				// is what actually enqueues/bumps untilPass for a lagging neighbour, so
++				// returning early skipped driving forward every neighbour after the first
++				// one found lagging, on every single retry. A column needing several
++				// neighbours to catch up only ever got one of them nudged per dispatch
++				// attempt instead of all of them, serializing what should be independent
++				// per-neighbour progress into a one-at-a-time crawl. A real inefficiency,
++				// worth keeping fixed, but NOT the cause of the reproducible watchdog
++				// stall on perf/predone-stage-concurrency: that turned out to be a
++				// separate bug entirely (the same request claimed twice concurrently once
++				// a stage's cap went above 1; see ChunkColumnLoadRequest.dispatchClaimed).
++				// This one-line change alone did not fix the stall (verified 3/3 trials,
++				// ~178 columns stuck, no change from baseline).
  				if (!chunkthread.EnsureMinimumWorldgenPassAt(index2d, i, j, currentIncompletePass_AsInt, chunkRequest.creationTime))
  				{
- 					if (chunkRequest.prettified)
- 					{
+-					if (chunkRequest.prettified)
+-					{
 -						return false;
-+						return false; // Already checked — neighbour hasn't caught up
- 					}
+-					}
  					result = false;
  				}
  			}
@@ -2453,7 +2592,7 @@ index f644852..a299f06 100644
  			chunkthread.requestedChunkColumns.Enqueue(curRequest);
  			return true;
  		}
-@@ -1490,13 +2558,19 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1490,13 +2692,19 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				ServerMain.Logger.VerboseDebug("Un-pausing all worldgen threads.");
  			}
  		}
@@ -2473,7 +2612,7 @@ index f644852..a299f06 100644
  			if (requestedChunkColumn != null && !requestedChunkColumn.Disposed)
  			{
  				server.loadedMapChunks.Remove(requestedChunkColumn.mapIndex2d);
-@@ -1505,104 +2579,181 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1505,104 +2713,181 @@ internal class ServerSystemSupplyChunks : ServerSystem
  		}
  		chunkthread.requestedChunkColumns.Clear();
  		ServerMain.Logger.VerboseDebug("Incomplete chunks stored and wiped.");

--- a/patches/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs.patch
@@ -1,8 +1,8 @@
 diff --git a/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs b/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs
-index f644852..2937256 100644
+index f644852..e06acca 100644
 --- a/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs
 +++ b/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs
-@@ -9,131 +9,865 @@ using Vintagestory.API.Datastructures;
+@@ -9,131 +9,920 @@ using Vintagestory.API.Datastructures;
  using Vintagestory.API.MathTools;
  using Vintagestory.API.Server;
  using Vintagestory.API.Util;
@@ -116,6 +116,61 @@ index f644852..2937256 100644
 +	// a target.
 +	private readonly int[] stratumStageActiveCount = new int[StratumWorldGenStages.Done];
 +	private readonly int[] stratumStageMaxConcurrent;
++
++	// Stratum: assemblies this build itself ships. Anything registered at a
++	// same-stage-concurrent pass from outside this set is third-party code
++	// Stratum has no way to verify is safe under concurrent execution across
++	// columns. Checked by name, not by a hardcoded per-generator allowlist,
++	// so it needs no maintenance as Stratum's own generator set changes.
++	private static readonly HashSet<string> stratumKnownSafeAssemblies = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
++	{
++		"VintagestoryLib", "VSEssentials", "VSSurvivalMod", "VSCreativeMod", "VintagestoryAPI"
++	};
++
++	/// <summary>
++	/// Stratum: same-stage concurrency for a pass is only safe if every handler
++	/// registered at that pass tolerates two different columns running it at
++	/// once. Stratum has fixed six instances of exactly this bug in its own
++	/// vanilla-derived generators this session (a shared Random or shared
++	/// instance array reused across columns, safe only by accident while every
++	/// stage stayed at cap 1); there is no reason to assume third-party mod
++	/// generators are any safer, and Stratum cannot inspect or verify their
++	/// code. Rather than raise a cap and hope, this walks the real registered
++	/// handler list for the pass (after TriggerInitWorldGen, so every mod has
++	/// already registered) and falls back that one pass to cap 1, loudly, the
++	/// moment it finds a handler from outside Stratum's own assemblies. A
++	/// false positive here (a mod that happens to be safe getting capped
++	/// anyway) costs some throughput; a false negative would corrupt world
++	/// generation for every player on the affected columns, so the fallback
++	/// direction is deliberate. Called once per raised stage from
++	/// InitWorldgenAndSpawnChunks, right after worldgenHandler is populated.
++	/// </summary>
++	private void EnforceStageConcurrencySafety(int internalStage, EnumWorldGenPass vanillaPass)
++	{
++		int desiredCap = stratumStageMaxConcurrent[internalStage];
++		if (desiredCap <= 1) return;
++
++		List<ChunkColumnGenerationDelegate> handlers = internalStage == StratumWorldGenStages.TerrainLate
++			? worldgenHandler.OnChunkColumnGenTerrainLate
++			: worldgenHandler.OnChunkColumnGen[StratumWorldGenStages.ToVanilla(internalStage)];
++		if (handlers == null) return;
++
++		foreach (ChunkColumnGenerationDelegate handler in handlers)
++		{
++			string asmName = handler?.Method?.DeclaringType?.Assembly?.GetName()?.Name;
++			if (asmName == null || !stratumKnownSafeAssemblies.Contains(asmName))
++			{
++				stratumStageMaxConcurrent[internalStage] = 1;
++				ServerMain.Logger.Warning(
++					"[Stratum] Same-stage concurrency for " + vanillaPass + " disabled (falling back to 1 concurrent column): "
++					+ "a worldgen handler from assembly '" + (asmName ?? "<unknown>") + "' is registered at this pass, "
++					+ "and Stratum cannot verify third-party code is safe to run concurrently across columns. "
++					+ "If you are the author of that mod and have verified your generator handles this correctly, "
++					+ "please get in touch so it can be allowlisted.");
++				return;
++			}
++		}
++	}
 +
 +	// Cumulative Stopwatch ticks and column counts spent generating each internal
 +	// stage, across every column and every worker thread since process start.
@@ -434,10 +489,10 @@ index f644852..2937256 100644
 +			{
 +				Interlocked.Decrement(ref stratumStageActiveCount[stage]);
 +				Volatile.Write(ref req.dispatchClaimed, 0);
-+			}
-+		}
-+	}
-+
+ 			}
+ 		}
+ 	}
+ 
 +	/// <summary>
 +	/// Stratum: CallerRunsPolicy-style fallback for loadChunkAreaBlocking's
 +	/// wait loop (see the comment there for when this gets called). TPS01-J
@@ -732,8 +787,8 @@ index f644852..2937256 100644
 +				// Closer than the farthest in top-K — replace
 +				stratumTopKHeap.Dequeue();
 +				stratumTopKHeap.Enqueue(r, -distSq);
- 			}
- 		}
++			}
++		}
 +
 +		// Extract from heap (farthest to nearest) and reverse
 +		while (stratumTopKHeap.Count > 0)
@@ -743,8 +798,8 @@ index f644852..2937256 100644
 +		target.Reverse(); // Now nearest to farthest
 +
 +		return PublishPriorityList(target);
- 	}
- 
++	}
++
 +
 +	/// <summary>
 +	/// Publishes the freshly built priority list for the dispatcher and
@@ -890,7 +945,7 @@ index f644852..2937256 100644
  			if (!tryLoadOrGenerateChunkColumnsInQueue())
  			{
  				break;
-@@ -143,39 +877,59 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -143,39 +932,59 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				break;
  			}
  		}
@@ -952,7 +1007,7 @@ index f644852..2937256 100644
  				ServerChunk serverChunk = (ServerChunk)server.WorldMap.GetChunk(x, i, z);
  				if (serverChunk != null)
  				{
-@@ -183,11 +937,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -183,11 +992,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					for (int j = 0; j < entities.Length; j++)
  					{
  						Entity entity = entities[j];
@@ -965,7 +1020,7 @@ index f644852..2937256 100644
  						{
  							if (j >= serverChunk.EntitiesCount)
  							{
-@@ -211,19 +965,23 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -211,19 +1020,23 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				});
  			}
  			list2.Add(item);
@@ -990,7 +1045,7 @@ index f644852..2937256 100644
  		{
  			ChunkPos item2 = server.WorldMap.MapRegionPosFromIndex2D(result2);
  			if (hashSet == null)
-@@ -237,28 +995,46 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -237,28 +1050,46 @@ internal class ServerSystemSupplyChunks : ServerSystem
  		{
  			chunkthread.gameDatabase.DeleteMapRegions(hashSet);
  		}
@@ -1042,7 +1097,7 @@ index f644852..2937256 100644
  		ServerMapChunk orCreateMapChunk = chunkthread.loadsavechunks.GetOrCreateMapChunk(request);
  		if (orCreateMapChunk == null)
  		{
-@@ -267,94 +1043,203 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -267,94 +1098,203 @@ internal class ServerSystemSupplyChunks : ServerSystem
  		ServerChunk[] array = chunkthread.loadsavechunks.TryLoadChunkColumn(request);
  		if (array == null)
  		{
@@ -1252,7 +1307,7 @@ index f644852..2937256 100644
  				chunkRequest.Chunks = TryLoadChunkColumn(chunkRequest);
  				if (chunkRequest.Chunks != null)
  				{
-@@ -364,31 +1249,42 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -364,31 +1304,42 @@ internal class ServerSystemSupplyChunks : ServerSystem
  						obj.serverMapChunk = orCreateMapChunk;
  						obj.MarkFresh();
  					}
@@ -1295,7 +1350,7 @@ index f644852..2937256 100644
  				ServerEventAPI eventapi = server.api.eventapi;
  				ServerMapChunk mapChunk = orCreateMapChunk;
  				int chunkX = chunkRequest.chunkX;
-@@ -404,117 +1300,105 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -404,117 +1355,105 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					ServerMain.Logger.Error("Repair mode is enabled so will delete the entire chunk column.");
  					GenerateNewChunkColumn(orCreateMapChunk, chunkRequest);
  					return false;
@@ -1443,7 +1498,7 @@ index f644852..2937256 100644
  				try
  				{
  					serverChunk.Unpack();
-@@ -529,10 +1413,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -529,10 +1468,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
  						ServerMain.FrameProfiler.Leave();
  						return;
  					}
@@ -1456,7 +1511,7 @@ index f644852..2937256 100644
  			{
  				for (int j = 0; j < serverChunk.Entities.Length; j++)
  				{
-@@ -548,10 +1434,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -548,10 +1489,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					{
  						if (server.LoadEntity(entity, num2))
  						{
@@ -1468,7 +1523,7 @@ index f644852..2937256 100644
  						{
  							string text = "-";
  							try
-@@ -564,14 +1451,18 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -564,14 +1506,18 @@ internal class ServerSystemSupplyChunks : ServerSystem
  							ServerMain.Logger.Log(EnumLogType.Worldgen, "In " + server.WorldName + ", villager " + text + " removed at " + entity.Pos.AsBlockPos?.ToString() + " due to an exception on loading");
  						}
  					}
@@ -1487,7 +1542,7 @@ index f644852..2937256 100644
  			{
  				BlockEntity value = blockEntity.Value;
  				if (value == null)
-@@ -580,10 +1471,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -580,10 +1526,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				}
  				try
  				{
@@ -1499,7 +1554,7 @@ index f644852..2937256 100644
  						serverChunk.serverMapChunk.NewBlockEntities.Remove(value.Pos);
  						value.OnBlockPlaced();
  					}
-@@ -594,23 +1486,33 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -594,23 +1541,33 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					ServerMain.Logger.Notification("Exception thrown when trying to initialize a block entity @{0}: {1}", value.Pos, ex3);
  					value.UnregisterAllTickListeners();
  				}
@@ -1533,7 +1588,7 @@ index f644852..2937256 100644
  		mapChunk.NeighboursLoaded = default(SmallBoolArray);
  		mapChunk.SelfLoaded = true;
  		for (int i = 0; i < Cardinal.ALL.Length; i++)
-@@ -623,20 +1525,26 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -623,20 +1580,26 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				serverMapChunk.NeighboursLoaded[cardinal.Opposite.Index] = true;
  			}
  		}
@@ -1560,7 +1615,7 @@ index f644852..2937256 100644
  			serverMapChunk.NeighboursLoaded[4] = false;
  		}
  		if (serverMapChunk2 != null)
-@@ -667,12 +1575,17 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -667,12 +1630,17 @@ internal class ServerSystemSupplyChunks : ServerSystem
  		{
  			serverMapChunk8.NeighboursLoaded[3] = false;
  		}
@@ -1578,7 +1633,7 @@ index f644852..2937256 100644
  			for (int j = -1; j <= 1; j++)
  			{
  				bool flag = false;
-@@ -682,19 +1595,24 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -682,19 +1650,24 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				}
  				if (!flag)
  				{
@@ -1603,7 +1658,7 @@ index f644852..2937256 100644
  		int num = 0;
  		for (int i = -1; i <= 1; i++)
  		{
-@@ -707,60 +1625,78 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -707,60 +1680,78 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			}
  		}
  		return num == 8;
@@ -1683,7 +1738,7 @@ index f644852..2937256 100644
  				dictionary = value.ModData;
  				dictionary2 = value.OreMaps;
  				intDataMap2D = value.GeologicProvinceMap;
-@@ -770,12 +1706,14 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -770,12 +1761,14 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			{
  				flag = false;
  				value.loadedTotalMs = server.ElapsedMilliseconds;
@@ -1698,7 +1753,7 @@ index f644852..2937256 100644
  			if (list != null)
  			{
  				value.GeneratedStructures = list;
-@@ -798,35 +1736,48 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -798,35 +1791,48 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			}
  		}
  		return value;
@@ -1747,7 +1802,7 @@ index f644852..2937256 100644
  		byte[] array = chunkGenParams?.GetBytes("GeneratedStructures");
  		if (array == null)
  		{
-@@ -836,44 +1787,60 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -836,44 +1842,60 @@ internal class ServerSystemSupplyChunks : ServerSystem
  		long key = server.api.WorldManager.MapRegionIndex2D(regionX, regionZ);
  		if (!dictionary.TryGetValue(key, out var value) || value == null)
  		{
@@ -1809,7 +1864,7 @@ index f644852..2937256 100644
  		long key = server.WorldMap.MapChunkIndex2D(chunkX, chunkZ);
  		server.loadedMapChunks.TryGetValue(key, out var value);
  		if (value != null)
-@@ -881,31 +1848,42 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -881,31 +1903,42 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			return value;
  		}
  		return TryLoadMapChunk(chunkX, chunkZ);
@@ -1852,7 +1907,7 @@ index f644852..2937256 100644
  			for (int j = 0; j < Cardinal.ALL.Length; j++)
  			{
  				Cardinal cardinal = Cardinal.ALL[j];
-@@ -918,47 +1896,111 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -918,47 +1951,111 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					}
  					chunkRequest.NeighbourTerrainHeight[j] = serverMapChunk.WorldGenTerrainHeightMap;
  				}
@@ -1980,7 +2035,7 @@ index f644852..2937256 100644
  			foreach (ServerChunk serverChunk in array)
  			{
  				if (serverChunk != null)
-@@ -967,10 +2009,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -967,10 +2064,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					serverChunk.MarkModified();
  					serverChunk.TryPackAndCommit();
  				}
@@ -1993,7 +2048,7 @@ index f644852..2937256 100644
  			ServerMain.Logger.Error("Loaded some but not all chunks of a column? Discarding whole column.");
  			return null;
  		}
-@@ -979,18 +2023,22 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -979,18 +2078,22 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			return null;
  		}
  		return array;
@@ -2016,7 +2071,7 @@ index f644852..2937256 100644
  					serverMapChunk.YMax = (ushort)(server.SaveGameData.MapSizeY - 1);
  				}
  				return serverMapChunk;
-@@ -1011,10 +2059,13 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1011,10 +2114,13 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			}
  		}
  		return null;
@@ -2030,7 +2085,7 @@ index f644852..2937256 100644
  		byte[] mapRegion = chunkthread.gameDatabase.GetMapRegion(regionX, regionZ);
  		try
  		{
-@@ -1035,14 +2086,20 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1035,14 +2141,26 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			throw;
  		}
  		return null;
@@ -2043,6 +2098,12 @@ index f644852..2937256 100644
  	public void InitWorldgenAndSpawnChunks()
  	{
  		worldgenHandler = (WorldGenHandler)server.api.Event.TriggerInitWorldGen();
++		// Stratum: every mod has registered its worldgen handlers by now, so
++		// this is the first point it's possible to check what's actually
++		// listening at a same-stage-concurrent pass. See the method's own
++		// comment for why this defaults to disabling concurrency rather than
++		// trusting unknown code.
++		EnforceStageConcurrencySafety(StratumWorldGenStages.PreDone, EnumWorldGenPass.PreDone);
  		ServerMain.Logger.Event("Loading {0}x{1}x{2} spawn chunks...", MagicNum.SpawnChunksWidth, MagicNum.SpawnChunksWidth, server.WorldMap.ChunkMapSizeY);
 +
 +		// Initialize "story" messages for display during loading
@@ -2051,7 +2112,7 @@ index f644852..2937256 100644
  			storyChunkSpawnEvents = new string[15]
  			{
  				Lang.Get("...the carved mountains"),
-@@ -1060,23 +2117,27 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1060,23 +2178,27 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				Lang.Get("...a misty sunrise"),
  				Lang.Get("...dew drops on a blade of grass"),
  				Lang.Get("...a soft breeze")
@@ -2079,7 +2140,7 @@ index f644852..2937256 100644
  					double value = random.NextDouble() * 6.2831854820251465;
  					double num7 = num6 * GameMath.Sin(value);
  					double num8 = num6 * GameMath.Cos(value);
-@@ -1096,10 +2157,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1096,10 +2218,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					server.api.Logger.Notification("Trying another spawn location ({0}/{1})...", i + 2, num3);
  				}
  			}
@@ -2091,7 +2152,7 @@ index f644852..2937256 100644
  				if (!server.blockAccessor.GetBlock(blockPos).SideSolid[BlockFacing.UP.Index])
  				{
  					server.blockAccessor.SetBlock(server.blockAccessor.GetBlock(new AssetLocation("planks-oak-we")).Id, blockPos);
-@@ -1107,13 +2169,16 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1107,13 +2230,16 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				blockPos.Y++;
  			}
  		}
@@ -2108,7 +2169,7 @@ index f644852..2937256 100644
  			x = blockPos.X,
  			y = blockPos.Y,
  			z = blockPos.Z
-@@ -1123,10 +2188,14 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1123,10 +2249,14 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			server.mapMiddleSpawnPos.y = null;
  		}
  		server.api.Logger.VerboseDebug("Done spawn chunk");
@@ -2123,7 +2184,7 @@ index f644852..2937256 100644
  		int num = 60;
  		int num2 = 0;
  		int num3 = 0;
-@@ -1137,36 +2206,47 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1137,36 +2267,47 @@ internal class ServerSystemSupplyChunks : ServerSystem
  		{
  			num4 = GameMath.Clamp(num2 + pos.X, 0, server.WorldMap.MapSizeX - 1);
  			num6 = GameMath.Clamp(num3 + pos.Z, 0, server.WorldMap.MapSizeZ - 1);
@@ -2172,7 +2233,7 @@ index f644852..2937256 100644
  		{
  			for (int k = -num2; k <= num2; k++)
  			{
-@@ -1174,18 +2254,22 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1174,18 +2315,22 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				{
  					long index2d = server.WorldMap.MapChunkIndex2D(x + j, y + k);
  					int regionX = (x + j) / MagicNum.ChunkRegionSizeInChunks;
@@ -2196,7 +2257,7 @@ index f644852..2937256 100644
  					};
  					chunkColumnLoadRequest.MapChunk = mapChunk;
  					GenerateNewChunkColumn(mapChunk, chunkColumnLoadRequest);
-@@ -1196,10 +2280,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1196,10 +2341,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
  						chunkthread.peekingChunkColumns.Enqueue(chunkColumnLoadRequest);
  					}
  				}
@@ -2209,7 +2270,7 @@ index f644852..2937256 100644
  		{
  			num4 = num - i;
  			for (int l = -num4; l <= num4; l++)
-@@ -1212,10 +2298,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1212,10 +2359,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
  						runGenerators(chunkRequest, i);
  					}
  				}
@@ -2222,7 +2283,7 @@ index f644852..2937256 100644
  		{
  			for (int n = -num2; n <= num2; n++)
  			{
-@@ -1232,61 +2320,111 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1232,61 +2381,111 @@ internal class ServerSystemSupplyChunks : ServerSystem
  						dictionary2[key] = chunks;
  					}
  				}
@@ -2336,7 +2397,7 @@ index f644852..2937256 100644
  				millisecondsSinceStart = server.totalUnpausedTime.ElapsedMilliseconds;
  				float num4 = 100f * ((float)server.loadedChunks.Count / (float)server.WorldMap.ChunkMapSizeY - (float)num) / (float)num2;
  				ServerMain.Logger.Event(num4.ToString("0.#") + "% ({0} in queue)", chunkthread.requestedChunkColumns.Count);
-@@ -1298,37 +2436,84 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1298,37 +2497,84 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				{
  					ServerMain.Logger.StoryEvent("...");
  				}
@@ -2424,7 +2485,7 @@ index f644852..2937256 100644
  				foreach (ChunkColumnLoadRequest requestedChunkColumn3 in chunkthread.requestedChunkColumns)
  				{
  					if (requestedChunkColumn3 != null)
-@@ -1340,16 +2525,25 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1340,16 +2586,25 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				throw new Exception("Somehow worldgen has become stuck in an endless loop, please report this as a bug!  Additional data in the server-main log");
  			}
  		}
@@ -2450,7 +2511,7 @@ index f644852..2937256 100644
  				if (chunkRequest.CurrentIncompletePass == EnumWorldGenPass.Terrain)
  				{
  					ushort sunLight = (ushort)server.sunBrightness;
-@@ -1359,32 +2553,62 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1359,32 +2614,62 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					}
  				}
  			}
@@ -2515,7 +2576,7 @@ index f644852..2937256 100644
  			return;
  		}
  		for (int i = 0; i < list.Count; i++)
-@@ -1396,89 +2620,117 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1396,89 +2681,117 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			catch (Exception ex)
  			{
  				ServerMain.Logger.Worldgen("An error was thrown in pass {5} when generating chunk column X={0},Z={1} in world '{3}' with seed {4}\nException {2}\n\n", chunkRequest.chunkX, chunkRequest.chunkZ, ex, server.SaveGameData.WorldName, server.SaveGameData.Seed, chunkRequest.CurrentIncompletePass.ToString());
@@ -2650,7 +2711,7 @@ index f644852..2937256 100644
  			chunkthread.requestedChunkColumns.Enqueue(curRequest);
  			return true;
  		}
-@@ -1490,13 +2742,19 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1490,13 +2803,19 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				ServerMain.Logger.VerboseDebug("Un-pausing all worldgen threads.");
  			}
  		}
@@ -2670,7 +2731,7 @@ index f644852..2937256 100644
  			if (requestedChunkColumn != null && !requestedChunkColumn.Disposed)
  			{
  				server.loadedMapChunks.Remove(requestedChunkColumn.mapIndex2d);
-@@ -1505,104 +2763,181 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1505,104 +2824,181 @@ internal class ServerSystemSupplyChunks : ServerSystem
  		}
  		chunkthread.requestedChunkColumns.Clear();
  		ServerMain.Logger.VerboseDebug("Incomplete chunks stored and wiped.");

--- a/patches/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs.patch
@@ -1,8 +1,8 @@
 diff --git a/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs b/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs
-index f644852..6fba6ce 100644
+index f644852..a299f06 100644
 --- a/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs
 +++ b/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs
-@@ -9,131 +9,729 @@ using Vintagestory.API.Datastructures;
+@@ -9,131 +9,760 @@ using Vintagestory.API.Datastructures;
  using Vintagestory.API.MathTools;
  using Vintagestory.API.Server;
  using Vintagestory.API.Util;
@@ -90,15 +90,37 @@ index f644852..6fba6ce 100644
 +	private readonly List<ChunkPos> stratumDeleteMapChunksList = new List<ChunkPos>(16);
 +	private readonly HashSet<ChunkPos> stratumDeleteRegionsSet = new HashSet<ChunkPos>();
 +
-+	// Generation stage occupancy array.
-+	// Indexes correspond to internal stages (Terrain..PreDone, see StratumWorldGenStages).
-+	// false = stage is free, true = stage is occupied by a thread.
-+	private volatile bool[] stratumStageBusy = new bool[StratumWorldGenStages.Done];
++	// Generation stage concurrency tracking. Indexes correspond to internal stages
++	// (Terrain..PreDone, see StratumWorldGenStages). stratumStageActiveCount is the
++	// current number of threads inside a stage; stratumStageMaxConcurrent is how many
++	// are allowed there at once.
++	//
++	// Every stage defaults to a cap of 1 (today's exclusive behavior, unchanged): the
++	// generators registered at TerrainLate, Terrain, TerrainFeatures, Vegetation, and
++	// NeighbourSunLightFlood were never audited for what happens if two threads enter
++	// them at the same time for two different columns.
++	//
++	// PreDone is the one audited exception. It hosts exactly one generator,
++	// GenCreatures, which used to keep its climate/forest/shrub readings and a
++	// spawn-position scratch list in plain instance fields written in one method
++	// and read a few calls later in another, all within the processing of a
++	// single column: safe with one thread at a time, not safe if a second thread
++	// starts a different column's PreDone before the first one finishes. Fixed by
++	// moving that state to [ThreadStatic] fields and reseeding its Random per
++	// column instead of advancing one shared sequence across the whole world (see
++	// GenCreatures.cs for the detail and why the old shared Random was already an
++	// order-dependent latent bug, not something concurrency introduced).
++	//
++	// PreDone's cap is raised to the worker thread count: the dispatcher cannot
++	// send more columns than that into a single stage, so this is a ceiling, not
++	// a target.
++	private readonly int[] stratumStageActiveCount = new int[StratumWorldGenStages.Done];
++	private readonly int[] stratumStageMaxConcurrent;
 +
 +	// Cumulative Stopwatch ticks and column counts spent generating each internal
 +	// stage, across every column and every worker thread since process start.
 +	// Written from PopulateChunk (any worker thread, one at a time per stage
-+	// thanks to stratumStageBusy, but Interlocked keeps cross-stage writes safe
++	// thanks to the per-stage concurrency cap, but Interlocked keeps cross-stage writes safe
 +	// without adding a lock). Read by GetStageTimingsReport for diagnostics.
 +	private readonly long[] stratumStageTicks = new long[StratumWorldGenStages.Done];
 +	private readonly long[] stratumStageColumnCounts = new long[StratumWorldGenStages.Done];
@@ -157,6 +179,13 @@ index f644852..6fba6ce 100644
 +
 +		readyTasksQueue = new BlockingCollection<DispatchedTask>
 +			(new ConcurrentQueue<DispatchedTask>());  // Stratum: Initialize the ready-tasks channel
++
++		// Stratum: every stage defaults to exclusive (cap 1); PreDone is the one
++		// audited-safe exception, see the field's own comment. Capped at the
++		// actual worker thread count, not left unbounded.
++		stratumStageMaxConcurrent = new int[StratumWorldGenStages.Done];
++		for (int i = 0; i < stratumStageMaxConcurrent.Length; i++) stratumStageMaxConcurrent[i] = 1;
++		stratumStageMaxConcurrent[StratumWorldGenStages.PreDone] = Math.Max(1, chunkthread.additionalWorldGenThreadsCount);
  	}
  
 +	/// <summary>
@@ -265,14 +294,15 @@ index f644852..6fba6ce 100644
 +
 +
 +	/// <summary>
-+	/// True while at least one worker stage (Terrain..PreDone) is unclaimed.
-+	/// Five array reads; used to skip full queue scans that cannot dispatch.
++	/// True while at least one worker stage (Terrain..PreDone) has room for another
++	/// concurrent claim. Five array reads; used to skip full queue scans that cannot
++	/// dispatch.
 +	/// </summary>
 +	private bool AnyWorkerStageFree()
 +	{
 +		for (int stage = 1; stage < StratumWorldGenStages.Done; stage++)
 +		{
-+			if (!stratumStageBusy[stage]) return true;
++			if (Volatile.Read(ref stratumStageActiveCount[stage]) < stratumStageMaxConcurrent[stage]) return true;
 +		}
 +		return false;
 +	}
@@ -322,12 +352,13 @@ index f644852..6fba6ce 100644
 +		int stage = req.CurrentIncompletePass_AsInt;
 +		if (stage < 1 || stage >= StratumWorldGenStages.Done) return false;
 +
-+		// Skip if the stage is already occupied by another thread
-+		if (stratumStageBusy[stage]) return false;
-+
-+		// Atomically claim the stage
-+		if (Interlocked.CompareExchange(ref stratumStageBusy[stage], true, false) != false)
++		// Atomically claim a concurrency slot for this stage, if one is free
++		int cap = stratumStageMaxConcurrent[stage];
++		if (Interlocked.Increment(ref stratumStageActiveCount[stage]) > cap)
++		{
++			Interlocked.Decrement(ref stratumStageActiveCount[stage]);
 +			return false;
++		}
 +
 +		// ── Everything that can throw is wrapped in try/finally ──
 +		bool handedOff = false;
@@ -355,7 +386,7 @@ index f644852..6fba6ce 100644
 +		{
 +			if (!handedOff)
 +			{
-+				stratumStageBusy[stage] = false;
++				Interlocked.Decrement(ref stratumStageActiveCount[stage]);
 +			}
 +		}
 +	}
@@ -481,7 +512,7 @@ index f644852..6fba6ce 100644
 +				// Safety check: the request may have advanced while sitting in the queue
 +				if (request.CurrentIncompletePass_AsInt != currentStage)
 +				{
-+					stratumStageBusy[currentStage] = false;
++					Interlocked.Decrement(ref stratumStageActiveCount[currentStage]);
 +					SignalDispatcher(); // wake the dispatcher
 +					continue; // not holding — skip finally with holdingStage
 +				}
@@ -506,18 +537,18 @@ index f644852..6fba6ce 100644
 +			}
 +			finally
 +			{
-+				if (holdingStage && currentStage >= 0 && currentStage < stratumStageBusy.Length)
++				if (holdingStage && currentStage >= 0 && currentStage < stratumStageActiveCount.Length)
 +				{
-+					stratumStageBusy[currentStage] = false;
++					Interlocked.Decrement(ref stratumStageActiveCount[currentStage]);
 +					SignalDispatcher(); // wake the dispatcher
 +				}
- 			}
- 		}
++			}
++		}
 +
 +		// Release thread-local generation resources
 +		BlockAccessorWorldGen.ThreadDispose();
- 	}
- 
++	}
++
 +
 +	/// <summary>
 +	/// Stratum: Builds a priority list of chunks sorted by proximity to players.
@@ -596,8 +627,8 @@ index f644852..6fba6ce 100644
 +				// Closer than the farthest in top-K — replace
 +				stratumTopKHeap.Dequeue();
 +				stratumTopKHeap.Enqueue(r, -distSq);
-+			}
-+		}
+ 			}
+ 		}
 +
 +		// Extract from heap (farthest to nearest) and reverse
 +		while (stratumTopKHeap.Count > 0)
@@ -638,8 +669,8 @@ index f644852..6fba6ce 100644
 +			if (d < min) min = d;
 +		}
 +		return min;
-+	}
-+
+ 	}
+ 
 +
 +
 +
@@ -754,7 +785,7 @@ index f644852..6fba6ce 100644
  			if (!tryLoadOrGenerateChunkColumnsInQueue())
  			{
  				break;
-@@ -143,39 +741,59 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -143,39 +772,59 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				break;
  			}
  		}
@@ -816,7 +847,7 @@ index f644852..6fba6ce 100644
  				ServerChunk serverChunk = (ServerChunk)server.WorldMap.GetChunk(x, i, z);
  				if (serverChunk != null)
  				{
-@@ -183,11 +801,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -183,11 +832,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					for (int j = 0; j < entities.Length; j++)
  					{
  						Entity entity = entities[j];
@@ -829,7 +860,7 @@ index f644852..6fba6ce 100644
  						{
  							if (j >= serverChunk.EntitiesCount)
  							{
-@@ -211,19 +829,23 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -211,19 +860,23 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				});
  			}
  			list2.Add(item);
@@ -854,7 +885,7 @@ index f644852..6fba6ce 100644
  		{
  			ChunkPos item2 = server.WorldMap.MapRegionPosFromIndex2D(result2);
  			if (hashSet == null)
-@@ -237,28 +859,46 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -237,28 +890,46 @@ internal class ServerSystemSupplyChunks : ServerSystem
  		{
  			chunkthread.gameDatabase.DeleteMapRegions(hashSet);
  		}
@@ -906,7 +937,7 @@ index f644852..6fba6ce 100644
  		ServerMapChunk orCreateMapChunk = chunkthread.loadsavechunks.GetOrCreateMapChunk(request);
  		if (orCreateMapChunk == null)
  		{
-@@ -267,44 +907,108 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -267,44 +938,108 @@ internal class ServerSystemSupplyChunks : ServerSystem
  		ServerChunk[] array = chunkthread.loadsavechunks.TryLoadChunkColumn(request);
  		if (array == null)
  		{
@@ -1016,7 +1047,7 @@ index f644852..6fba6ce 100644
  				{
  					return false;
  				}
-@@ -315,46 +1019,63 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -315,46 +1050,63 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			}
  		}
  		return false;
@@ -1081,7 +1112,7 @@ index f644852..6fba6ce 100644
  				chunkRequest.Chunks = TryLoadChunkColumn(chunkRequest);
  				if (chunkRequest.Chunks != null)
  				{
-@@ -364,31 +1085,42 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -364,31 +1116,42 @@ internal class ServerSystemSupplyChunks : ServerSystem
  						obj.serverMapChunk = orCreateMapChunk;
  						obj.MarkFresh();
  					}
@@ -1124,7 +1155,7 @@ index f644852..6fba6ce 100644
  				ServerEventAPI eventapi = server.api.eventapi;
  				ServerMapChunk mapChunk = orCreateMapChunk;
  				int chunkX = chunkRequest.chunkX;
-@@ -404,117 +1136,105 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -404,117 +1167,105 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					ServerMain.Logger.Error("Repair mode is enabled so will delete the entire chunk column.");
  					GenerateNewChunkColumn(orCreateMapChunk, chunkRequest);
  					return false;
@@ -1272,7 +1303,7 @@ index f644852..6fba6ce 100644
  				try
  				{
  					serverChunk.Unpack();
-@@ -529,10 +1249,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -529,10 +1280,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
  						ServerMain.FrameProfiler.Leave();
  						return;
  					}
@@ -1285,7 +1316,7 @@ index f644852..6fba6ce 100644
  			{
  				for (int j = 0; j < serverChunk.Entities.Length; j++)
  				{
-@@ -548,10 +1270,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -548,10 +1301,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					{
  						if (server.LoadEntity(entity, num2))
  						{
@@ -1297,7 +1328,7 @@ index f644852..6fba6ce 100644
  						{
  							string text = "-";
  							try
-@@ -564,14 +1287,18 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -564,14 +1318,18 @@ internal class ServerSystemSupplyChunks : ServerSystem
  							ServerMain.Logger.Log(EnumLogType.Worldgen, "In " + server.WorldName + ", villager " + text + " removed at " + entity.Pos.AsBlockPos?.ToString() + " due to an exception on loading");
  						}
  					}
@@ -1316,7 +1347,7 @@ index f644852..6fba6ce 100644
  			{
  				BlockEntity value = blockEntity.Value;
  				if (value == null)
-@@ -580,10 +1307,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -580,10 +1338,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				}
  				try
  				{
@@ -1328,7 +1359,7 @@ index f644852..6fba6ce 100644
  						serverChunk.serverMapChunk.NewBlockEntities.Remove(value.Pos);
  						value.OnBlockPlaced();
  					}
-@@ -594,23 +1322,33 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -594,23 +1353,33 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					ServerMain.Logger.Notification("Exception thrown when trying to initialize a block entity @{0}: {1}", value.Pos, ex3);
  					value.UnregisterAllTickListeners();
  				}
@@ -1362,7 +1393,7 @@ index f644852..6fba6ce 100644
  		mapChunk.NeighboursLoaded = default(SmallBoolArray);
  		mapChunk.SelfLoaded = true;
  		for (int i = 0; i < Cardinal.ALL.Length; i++)
-@@ -623,20 +1361,26 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -623,20 +1392,26 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				serverMapChunk.NeighboursLoaded[cardinal.Opposite.Index] = true;
  			}
  		}
@@ -1389,7 +1420,7 @@ index f644852..6fba6ce 100644
  			serverMapChunk.NeighboursLoaded[4] = false;
  		}
  		if (serverMapChunk2 != null)
-@@ -667,12 +1411,17 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -667,12 +1442,17 @@ internal class ServerSystemSupplyChunks : ServerSystem
  		{
  			serverMapChunk8.NeighboursLoaded[3] = false;
  		}
@@ -1407,7 +1438,7 @@ index f644852..6fba6ce 100644
  			for (int j = -1; j <= 1; j++)
  			{
  				bool flag = false;
-@@ -682,19 +1431,24 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -682,19 +1462,24 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				}
  				if (!flag)
  				{
@@ -1432,7 +1463,7 @@ index f644852..6fba6ce 100644
  		int num = 0;
  		for (int i = -1; i <= 1; i++)
  		{
-@@ -707,60 +1461,78 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -707,60 +1492,78 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			}
  		}
  		return num == 8;
@@ -1512,7 +1543,7 @@ index f644852..6fba6ce 100644
  				dictionary = value.ModData;
  				dictionary2 = value.OreMaps;
  				intDataMap2D = value.GeologicProvinceMap;
-@@ -770,12 +1542,14 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -770,12 +1573,14 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			{
  				flag = false;
  				value.loadedTotalMs = server.ElapsedMilliseconds;
@@ -1527,7 +1558,7 @@ index f644852..6fba6ce 100644
  			if (list != null)
  			{
  				value.GeneratedStructures = list;
-@@ -798,35 +1572,48 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -798,35 +1603,48 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			}
  		}
  		return value;
@@ -1576,7 +1607,7 @@ index f644852..6fba6ce 100644
  		byte[] array = chunkGenParams?.GetBytes("GeneratedStructures");
  		if (array == null)
  		{
-@@ -836,44 +1623,60 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -836,44 +1654,60 @@ internal class ServerSystemSupplyChunks : ServerSystem
  		long key = server.api.WorldManager.MapRegionIndex2D(regionX, regionZ);
  		if (!dictionary.TryGetValue(key, out var value) || value == null)
  		{
@@ -1638,7 +1669,7 @@ index f644852..6fba6ce 100644
  		long key = server.WorldMap.MapChunkIndex2D(chunkX, chunkZ);
  		server.loadedMapChunks.TryGetValue(key, out var value);
  		if (value != null)
-@@ -881,31 +1684,42 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -881,31 +1715,42 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			return value;
  		}
  		return TryLoadMapChunk(chunkX, chunkZ);
@@ -1681,7 +1712,7 @@ index f644852..6fba6ce 100644
  			for (int j = 0; j < Cardinal.ALL.Length; j++)
  			{
  				Cardinal cardinal = Cardinal.ALL[j];
-@@ -918,47 +1732,111 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -918,47 +1763,111 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					}
  					chunkRequest.NeighbourTerrainHeight[j] = serverMapChunk.WorldGenTerrainHeightMap;
  				}
@@ -1809,7 +1840,7 @@ index f644852..6fba6ce 100644
  			foreach (ServerChunk serverChunk in array)
  			{
  				if (serverChunk != null)
-@@ -967,10 +1845,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -967,10 +1876,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					serverChunk.MarkModified();
  					serverChunk.TryPackAndCommit();
  				}
@@ -1822,7 +1853,7 @@ index f644852..6fba6ce 100644
  			ServerMain.Logger.Error("Loaded some but not all chunks of a column? Discarding whole column.");
  			return null;
  		}
-@@ -979,18 +1859,22 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -979,18 +1890,22 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			return null;
  		}
  		return array;
@@ -1845,7 +1876,7 @@ index f644852..6fba6ce 100644
  					serverMapChunk.YMax = (ushort)(server.SaveGameData.MapSizeY - 1);
  				}
  				return serverMapChunk;
-@@ -1011,10 +1895,13 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1011,10 +1926,13 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			}
  		}
  		return null;
@@ -1859,7 +1890,7 @@ index f644852..6fba6ce 100644
  		byte[] mapRegion = chunkthread.gameDatabase.GetMapRegion(regionX, regionZ);
  		try
  		{
-@@ -1035,14 +1922,20 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1035,14 +1953,20 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			throw;
  		}
  		return null;
@@ -1880,7 +1911,7 @@ index f644852..6fba6ce 100644
  			storyChunkSpawnEvents = new string[15]
  			{
  				Lang.Get("...the carved mountains"),
-@@ -1060,23 +1953,27 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1060,23 +1984,27 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				Lang.Get("...a misty sunrise"),
  				Lang.Get("...dew drops on a blade of grass"),
  				Lang.Get("...a soft breeze")
@@ -1908,7 +1939,7 @@ index f644852..6fba6ce 100644
  					double value = random.NextDouble() * 6.2831854820251465;
  					double num7 = num6 * GameMath.Sin(value);
  					double num8 = num6 * GameMath.Cos(value);
-@@ -1096,10 +1993,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1096,10 +2024,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					server.api.Logger.Notification("Trying another spawn location ({0}/{1})...", i + 2, num3);
  				}
  			}
@@ -1920,7 +1951,7 @@ index f644852..6fba6ce 100644
  				if (!server.blockAccessor.GetBlock(blockPos).SideSolid[BlockFacing.UP.Index])
  				{
  					server.blockAccessor.SetBlock(server.blockAccessor.GetBlock(new AssetLocation("planks-oak-we")).Id, blockPos);
-@@ -1107,13 +2005,16 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1107,13 +2036,16 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				blockPos.Y++;
  			}
  		}
@@ -1937,7 +1968,7 @@ index f644852..6fba6ce 100644
  			x = blockPos.X,
  			y = blockPos.Y,
  			z = blockPos.Z
-@@ -1123,10 +2024,14 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1123,10 +2055,14 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			server.mapMiddleSpawnPos.y = null;
  		}
  		server.api.Logger.VerboseDebug("Done spawn chunk");
@@ -1952,7 +1983,7 @@ index f644852..6fba6ce 100644
  		int num = 60;
  		int num2 = 0;
  		int num3 = 0;
-@@ -1137,36 +2042,47 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1137,36 +2073,47 @@ internal class ServerSystemSupplyChunks : ServerSystem
  		{
  			num4 = GameMath.Clamp(num2 + pos.X, 0, server.WorldMap.MapSizeX - 1);
  			num6 = GameMath.Clamp(num3 + pos.Z, 0, server.WorldMap.MapSizeZ - 1);
@@ -2001,7 +2032,7 @@ index f644852..6fba6ce 100644
  		{
  			for (int k = -num2; k <= num2; k++)
  			{
-@@ -1174,18 +2090,22 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1174,18 +2121,22 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				{
  					long index2d = server.WorldMap.MapChunkIndex2D(x + j, y + k);
  					int regionX = (x + j) / MagicNum.ChunkRegionSizeInChunks;
@@ -2025,7 +2056,7 @@ index f644852..6fba6ce 100644
  					};
  					chunkColumnLoadRequest.MapChunk = mapChunk;
  					GenerateNewChunkColumn(mapChunk, chunkColumnLoadRequest);
-@@ -1196,10 +2116,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1196,10 +2147,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
  						chunkthread.peekingChunkColumns.Enqueue(chunkColumnLoadRequest);
  					}
  				}
@@ -2038,7 +2069,7 @@ index f644852..6fba6ce 100644
  		{
  			num4 = num - i;
  			for (int l = -num4; l <= num4; l++)
-@@ -1212,10 +2134,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1212,10 +2165,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
  						runGenerators(chunkRequest, i);
  					}
  				}
@@ -2051,7 +2082,7 @@ index f644852..6fba6ce 100644
  		{
  			for (int n = -num2; n <= num2; n++)
  			{
-@@ -1232,61 +2156,107 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1232,61 +2187,107 @@ internal class ServerSystemSupplyChunks : ServerSystem
  						dictionary2[key] = chunks;
  					}
  				}
@@ -2161,7 +2192,7 @@ index f644852..6fba6ce 100644
  				millisecondsSinceStart = server.totalUnpausedTime.ElapsedMilliseconds;
  				float num4 = 100f * ((float)server.loadedChunks.Count / (float)server.WorldMap.ChunkMapSizeY - (float)num) / (float)num2;
  				ServerMain.Logger.Event(num4.ToString("0.#") + "% ({0} in queue)", chunkthread.requestedChunkColumns.Count);
-@@ -1298,37 +2268,48 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1298,37 +2299,48 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				{
  					ServerMain.Logger.StoryEvent("...");
  				}
@@ -2212,7 +2243,7 @@ index f644852..6fba6ce 100644
  				foreach (ChunkColumnLoadRequest requestedChunkColumn3 in chunkthread.requestedChunkColumns)
  				{
  					if (requestedChunkColumn3 != null)
-@@ -1340,16 +2321,25 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1340,16 +2352,25 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				throw new Exception("Somehow worldgen has become stuck in an endless loop, please report this as a bug!  Additional data in the server-main log");
  			}
  		}
@@ -2238,7 +2269,7 @@ index f644852..6fba6ce 100644
  				if (chunkRequest.CurrentIncompletePass == EnumWorldGenPass.Terrain)
  				{
  					ushort sunLight = (ushort)server.sunBrightness;
-@@ -1359,32 +2349,62 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1359,32 +2380,62 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					}
  				}
  			}
@@ -2303,7 +2334,7 @@ index f644852..6fba6ce 100644
  			return;
  		}
  		for (int i = 0; i < list.Count; i++)
-@@ -1396,32 +2416,44 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1396,32 +2447,44 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			catch (Exception ex)
  			{
  				ServerMain.Logger.Worldgen("An error was thrown in pass {5} when generating chunk column X={0},Z={1} in world '{3}' with seed {4}\nException {2}\n\n", chunkRequest.chunkX, chunkRequest.chunkZ, ex, server.SaveGameData.WorldName, server.SaveGameData.Seed, chunkRequest.CurrentIncompletePass.ToString());
@@ -2350,7 +2381,7 @@ index f644852..6fba6ce 100644
  			for (int j = num3; j <= num4; j++)
  			{
  				if (i == chunkRequest.chunkX && j == chunkRequest.chunkZ)
-@@ -1431,54 +2463,59 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1431,54 +2494,59 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				long index2d = server.WorldMap.MapChunkIndex2D(i, j);
  				if (!chunkthread.EnsureMinimumWorldgenPassAt(index2d, i, j, currentIncompletePass_AsInt, chunkRequest.creationTime))
  				{
@@ -2422,7 +2453,7 @@ index f644852..6fba6ce 100644
  			chunkthread.requestedChunkColumns.Enqueue(curRequest);
  			return true;
  		}
-@@ -1490,13 +2527,19 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1490,13 +2558,19 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				ServerMain.Logger.VerboseDebug("Un-pausing all worldgen threads.");
  			}
  		}
@@ -2442,7 +2473,7 @@ index f644852..6fba6ce 100644
  			if (requestedChunkColumn != null && !requestedChunkColumn.Disposed)
  			{
  				server.loadedMapChunks.Remove(requestedChunkColumn.mapIndex2d);
-@@ -1505,104 +2548,181 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1505,104 +2579,181 @@ internal class ServerSystemSupplyChunks : ServerSystem
  		}
  		chunkthread.requestedChunkColumns.Clear();
  		ServerMain.Logger.VerboseDebug("Incomplete chunks stored and wiped.");

--- a/patches/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs.patch
@@ -1,5 +1,5 @@
 diff --git a/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs b/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs
-index f644852..5a5d371 100644
+index f644852..2937256 100644
 --- a/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs
 +++ b/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs
 @@ -9,131 +9,865 @@ using Vintagestory.API.Datastructures;
@@ -253,7 +253,7 @@ index f644852..5a5d371 100644
 -				num++;
 +				Thread.Sleep(15);
 +				continue;
- 			}
++			}
 +
 +			if (chunkthread.requestedChunkColumns.Count > 0 && !server.Suspended)
 +			{
@@ -303,10 +303,10 @@ index f644852..5a5d371 100644
 +		for (int stage = 1; stage < StratumWorldGenStages.Done; stage++)
 +		{
 +			if (Volatile.Read(ref stratumStageActiveCount[stage]) < stratumStageMaxConcurrent[stage]) return true;
- 		}
++		}
 +		return false;
- 	}
- 
++	}
++
 +
 +	/// <summary>
 +	/// Stratum: formats the cumulative per-stage generation time as a one-line
@@ -732,8 +732,8 @@ index f644852..5a5d371 100644
 +				// Closer than the farthest in top-K — replace
 +				stratumTopKHeap.Dequeue();
 +				stratumTopKHeap.Enqueue(r, -distSq);
-+			}
-+		}
+ 			}
+ 		}
 +
 +		// Extract from heap (farthest to nearest) and reverse
 +		while (stratumTopKHeap.Count > 0)
@@ -743,8 +743,8 @@ index f644852..5a5d371 100644
 +		target.Reverse(); // Now nearest to farthest
 +
 +		return PublishPriorityList(target);
-+	}
-+
+ 	}
+ 
 +
 +	/// <summary>
 +	/// Publishes the freshly built priority list for the dispatcher and
@@ -1042,7 +1042,7 @@ index f644852..5a5d371 100644
  		ServerMapChunk orCreateMapChunk = chunkthread.loadsavechunks.GetOrCreateMapChunk(request);
  		if (orCreateMapChunk == null)
  		{
-@@ -267,44 +1043,108 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -267,94 +1043,203 @@ internal class ServerSystemSupplyChunks : ServerSystem
  		ServerChunk[] array = chunkthread.loadsavechunks.TryLoadChunkColumn(request);
  		if (array == null)
  		{
@@ -1081,10 +1081,12 @@ index f644852..5a5d371 100644
  		{
  			return false;
  		}
+-		CleanupRequestsQueue();
+-		int additionalWorldGenThreadsCount = chunkthread.additionalWorldGenThreadsCount;
 +
 +		// Clean up completed/requeued requests from the head of the queue
- 		CleanupRequestsQueue();
- 		int additionalWorldGenThreadsCount = chunkthread.additionalWorldGenThreadsCount;
++		CleanupRequestsQueue();
++		int additionalWorldGenThreadsCount = chunkthread.additionalWorldGenThreadsCount;
 +
 +		// Stratum start:
 +		//
@@ -1121,10 +1123,24 @@ index f644852..5a5d371 100644
 +					{
 +						return false;
 +					}
-+					if (loadOrGenerateChunkColumn_OnChunkThread(requestedChunkColumn, currentIncompletePass_AsInt) && chunkthread.additionalWorldGenThreadsCount == 0)
++					// Stratum: see loadChunkAreaBlocking's own boundary scan for
++					// why this guard exists (anegostudios/VintageStory-Issues#5143).
++					if (Interlocked.CompareExchange(ref requestedChunkColumn.dispatchClaimed, 1, 0) == 0)
 +					{
-+						stratumPriorityListCacheIdx++;
-+						return true;
++						bool ok;
++						try
++						{
++							ok = loadOrGenerateChunkColumn_OnChunkThread(requestedChunkColumn, currentIncompletePass_AsInt);
++						}
++						finally
++						{
++							Volatile.Write(ref requestedChunkColumn.dispatchClaimed, 0);
++						}
++						if (ok && chunkthread.additionalWorldGenThreadsCount == 0)
++						{
++							stratumPriorityListCacheIdx++;
++							return true;
++						}
 +					}
 +				}
 +			}
@@ -1152,7 +1168,26 @@ index f644852..5a5d371 100644
  				{
  					return false;
  				}
-@@ -315,46 +1155,63 @@ internal class ServerSystemSupplyChunks : ServerSystem
+-				if (loadOrGenerateChunkColumn_OnChunkThread(requestedChunkColumn, currentIncompletePass_AsInt) && chunkthread.additionalWorldGenThreadsCount == 0)
++				// Stratum: see loadChunkAreaBlocking's own boundary scan for why
++				// this guard exists (anegostudios/VintageStory-Issues#5143).
++				if (Interlocked.CompareExchange(ref requestedChunkColumn.dispatchClaimed, 1, 0) == 0)
+ 				{
+-					return true;
++					bool ok;
++					try
++					{
++						ok = loadOrGenerateChunkColumn_OnChunkThread(requestedChunkColumn, currentIncompletePass_AsInt);
++					}
++					finally
++					{
++						Volatile.Write(ref requestedChunkColumn.dispatchClaimed, 0);
++					}
++					if (ok && chunkthread.additionalWorldGenThreadsCount == 0)
++					{
++						return true;
++					}
+ 				}
  			}
  		}
  		return false;
@@ -1217,7 +1252,7 @@ index f644852..5a5d371 100644
  				chunkRequest.Chunks = TryLoadChunkColumn(chunkRequest);
  				if (chunkRequest.Chunks != null)
  				{
-@@ -364,31 +1221,42 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -364,31 +1249,42 @@ internal class ServerSystemSupplyChunks : ServerSystem
  						obj.serverMapChunk = orCreateMapChunk;
  						obj.MarkFresh();
  					}
@@ -1260,7 +1295,7 @@ index f644852..5a5d371 100644
  				ServerEventAPI eventapi = server.api.eventapi;
  				ServerMapChunk mapChunk = orCreateMapChunk;
  				int chunkX = chunkRequest.chunkX;
-@@ -404,117 +1272,105 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -404,117 +1300,105 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					ServerMain.Logger.Error("Repair mode is enabled so will delete the entire chunk column.");
  					GenerateNewChunkColumn(orCreateMapChunk, chunkRequest);
  					return false;
@@ -1408,7 +1443,7 @@ index f644852..5a5d371 100644
  				try
  				{
  					serverChunk.Unpack();
-@@ -529,10 +1385,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -529,10 +1413,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
  						ServerMain.FrameProfiler.Leave();
  						return;
  					}
@@ -1421,7 +1456,7 @@ index f644852..5a5d371 100644
  			{
  				for (int j = 0; j < serverChunk.Entities.Length; j++)
  				{
-@@ -548,10 +1406,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -548,10 +1434,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					{
  						if (server.LoadEntity(entity, num2))
  						{
@@ -1433,7 +1468,7 @@ index f644852..5a5d371 100644
  						{
  							string text = "-";
  							try
-@@ -564,14 +1423,18 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -564,14 +1451,18 @@ internal class ServerSystemSupplyChunks : ServerSystem
  							ServerMain.Logger.Log(EnumLogType.Worldgen, "In " + server.WorldName + ", villager " + text + " removed at " + entity.Pos.AsBlockPos?.ToString() + " due to an exception on loading");
  						}
  					}
@@ -1452,7 +1487,7 @@ index f644852..5a5d371 100644
  			{
  				BlockEntity value = blockEntity.Value;
  				if (value == null)
-@@ -580,10 +1443,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -580,10 +1471,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				}
  				try
  				{
@@ -1464,7 +1499,7 @@ index f644852..5a5d371 100644
  						serverChunk.serverMapChunk.NewBlockEntities.Remove(value.Pos);
  						value.OnBlockPlaced();
  					}
-@@ -594,23 +1458,33 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -594,23 +1486,33 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					ServerMain.Logger.Notification("Exception thrown when trying to initialize a block entity @{0}: {1}", value.Pos, ex3);
  					value.UnregisterAllTickListeners();
  				}
@@ -1498,7 +1533,7 @@ index f644852..5a5d371 100644
  		mapChunk.NeighboursLoaded = default(SmallBoolArray);
  		mapChunk.SelfLoaded = true;
  		for (int i = 0; i < Cardinal.ALL.Length; i++)
-@@ -623,20 +1497,26 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -623,20 +1525,26 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				serverMapChunk.NeighboursLoaded[cardinal.Opposite.Index] = true;
  			}
  		}
@@ -1525,7 +1560,7 @@ index f644852..5a5d371 100644
  			serverMapChunk.NeighboursLoaded[4] = false;
  		}
  		if (serverMapChunk2 != null)
-@@ -667,12 +1547,17 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -667,12 +1575,17 @@ internal class ServerSystemSupplyChunks : ServerSystem
  		{
  			serverMapChunk8.NeighboursLoaded[3] = false;
  		}
@@ -1543,7 +1578,7 @@ index f644852..5a5d371 100644
  			for (int j = -1; j <= 1; j++)
  			{
  				bool flag = false;
-@@ -682,19 +1567,24 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -682,19 +1595,24 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				}
  				if (!flag)
  				{
@@ -1568,7 +1603,7 @@ index f644852..5a5d371 100644
  		int num = 0;
  		for (int i = -1; i <= 1; i++)
  		{
-@@ -707,60 +1597,78 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -707,60 +1625,78 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			}
  		}
  		return num == 8;
@@ -1648,7 +1683,7 @@ index f644852..5a5d371 100644
  				dictionary = value.ModData;
  				dictionary2 = value.OreMaps;
  				intDataMap2D = value.GeologicProvinceMap;
-@@ -770,12 +1678,14 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -770,12 +1706,14 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			{
  				flag = false;
  				value.loadedTotalMs = server.ElapsedMilliseconds;
@@ -1663,7 +1698,7 @@ index f644852..5a5d371 100644
  			if (list != null)
  			{
  				value.GeneratedStructures = list;
-@@ -798,35 +1708,48 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -798,35 +1736,48 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			}
  		}
  		return value;
@@ -1712,7 +1747,7 @@ index f644852..5a5d371 100644
  		byte[] array = chunkGenParams?.GetBytes("GeneratedStructures");
  		if (array == null)
  		{
-@@ -836,44 +1759,60 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -836,44 +1787,60 @@ internal class ServerSystemSupplyChunks : ServerSystem
  		long key = server.api.WorldManager.MapRegionIndex2D(regionX, regionZ);
  		if (!dictionary.TryGetValue(key, out var value) || value == null)
  		{
@@ -1774,7 +1809,7 @@ index f644852..5a5d371 100644
  		long key = server.WorldMap.MapChunkIndex2D(chunkX, chunkZ);
  		server.loadedMapChunks.TryGetValue(key, out var value);
  		if (value != null)
-@@ -881,31 +1820,42 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -881,31 +1848,42 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			return value;
  		}
  		return TryLoadMapChunk(chunkX, chunkZ);
@@ -1817,7 +1852,7 @@ index f644852..5a5d371 100644
  			for (int j = 0; j < Cardinal.ALL.Length; j++)
  			{
  				Cardinal cardinal = Cardinal.ALL[j];
-@@ -918,47 +1868,111 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -918,47 +1896,111 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					}
  					chunkRequest.NeighbourTerrainHeight[j] = serverMapChunk.WorldGenTerrainHeightMap;
  				}
@@ -1945,7 +1980,7 @@ index f644852..5a5d371 100644
  			foreach (ServerChunk serverChunk in array)
  			{
  				if (serverChunk != null)
-@@ -967,10 +1981,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -967,10 +2009,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					serverChunk.MarkModified();
  					serverChunk.TryPackAndCommit();
  				}
@@ -1958,7 +1993,7 @@ index f644852..5a5d371 100644
  			ServerMain.Logger.Error("Loaded some but not all chunks of a column? Discarding whole column.");
  			return null;
  		}
-@@ -979,18 +1995,22 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -979,18 +2023,22 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			return null;
  		}
  		return array;
@@ -1981,7 +2016,7 @@ index f644852..5a5d371 100644
  					serverMapChunk.YMax = (ushort)(server.SaveGameData.MapSizeY - 1);
  				}
  				return serverMapChunk;
-@@ -1011,10 +2031,13 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1011,10 +2059,13 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			}
  		}
  		return null;
@@ -1995,7 +2030,7 @@ index f644852..5a5d371 100644
  		byte[] mapRegion = chunkthread.gameDatabase.GetMapRegion(regionX, regionZ);
  		try
  		{
-@@ -1035,14 +2058,20 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1035,14 +2086,20 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			throw;
  		}
  		return null;
@@ -2016,7 +2051,7 @@ index f644852..5a5d371 100644
  			storyChunkSpawnEvents = new string[15]
  			{
  				Lang.Get("...the carved mountains"),
-@@ -1060,23 +2089,27 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1060,23 +2117,27 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				Lang.Get("...a misty sunrise"),
  				Lang.Get("...dew drops on a blade of grass"),
  				Lang.Get("...a soft breeze")
@@ -2044,7 +2079,7 @@ index f644852..5a5d371 100644
  					double value = random.NextDouble() * 6.2831854820251465;
  					double num7 = num6 * GameMath.Sin(value);
  					double num8 = num6 * GameMath.Cos(value);
-@@ -1096,10 +2129,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1096,10 +2157,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					server.api.Logger.Notification("Trying another spawn location ({0}/{1})...", i + 2, num3);
  				}
  			}
@@ -2056,7 +2091,7 @@ index f644852..5a5d371 100644
  				if (!server.blockAccessor.GetBlock(blockPos).SideSolid[BlockFacing.UP.Index])
  				{
  					server.blockAccessor.SetBlock(server.blockAccessor.GetBlock(new AssetLocation("planks-oak-we")).Id, blockPos);
-@@ -1107,13 +2141,16 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1107,13 +2169,16 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				blockPos.Y++;
  			}
  		}
@@ -2073,7 +2108,7 @@ index f644852..5a5d371 100644
  			x = blockPos.X,
  			y = blockPos.Y,
  			z = blockPos.Z
-@@ -1123,10 +2160,14 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1123,10 +2188,14 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			server.mapMiddleSpawnPos.y = null;
  		}
  		server.api.Logger.VerboseDebug("Done spawn chunk");
@@ -2088,7 +2123,7 @@ index f644852..5a5d371 100644
  		int num = 60;
  		int num2 = 0;
  		int num3 = 0;
-@@ -1137,36 +2178,47 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1137,36 +2206,47 @@ internal class ServerSystemSupplyChunks : ServerSystem
  		{
  			num4 = GameMath.Clamp(num2 + pos.X, 0, server.WorldMap.MapSizeX - 1);
  			num6 = GameMath.Clamp(num3 + pos.Z, 0, server.WorldMap.MapSizeZ - 1);
@@ -2137,7 +2172,7 @@ index f644852..5a5d371 100644
  		{
  			for (int k = -num2; k <= num2; k++)
  			{
-@@ -1174,18 +2226,22 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1174,18 +2254,22 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				{
  					long index2d = server.WorldMap.MapChunkIndex2D(x + j, y + k);
  					int regionX = (x + j) / MagicNum.ChunkRegionSizeInChunks;
@@ -2161,7 +2196,7 @@ index f644852..5a5d371 100644
  					};
  					chunkColumnLoadRequest.MapChunk = mapChunk;
  					GenerateNewChunkColumn(mapChunk, chunkColumnLoadRequest);
-@@ -1196,10 +2252,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1196,10 +2280,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
  						chunkthread.peekingChunkColumns.Enqueue(chunkColumnLoadRequest);
  					}
  				}
@@ -2174,7 +2209,7 @@ index f644852..5a5d371 100644
  		{
  			num4 = num - i;
  			for (int l = -num4; l <= num4; l++)
-@@ -1212,10 +2270,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1212,10 +2298,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
  						runGenerators(chunkRequest, i);
  					}
  				}
@@ -2187,7 +2222,7 @@ index f644852..5a5d371 100644
  		{
  			for (int n = -num2; n <= num2; n++)
  			{
-@@ -1232,61 +2292,111 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1232,61 +2320,111 @@ internal class ServerSystemSupplyChunks : ServerSystem
  						dictionary2[key] = chunks;
  					}
  				}
@@ -2301,7 +2336,7 @@ index f644852..5a5d371 100644
  				millisecondsSinceStart = server.totalUnpausedTime.ElapsedMilliseconds;
  				float num4 = 100f * ((float)server.loadedChunks.Count / (float)server.WorldMap.ChunkMapSizeY - (float)num) / (float)num2;
  				ServerMain.Logger.Event(num4.ToString("0.#") + "% ({0} in queue)", chunkthread.requestedChunkColumns.Count);
-@@ -1298,37 +2408,62 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1298,37 +2436,84 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				{
  					ServerMain.Logger.StoryEvent("...");
  				}
@@ -2328,7 +2363,30 @@ index f644852..5a5d371 100644
  					{
  						return;
  					}
- 					flag |= loadOrGenerateChunkColumn_OnChunkThread(requestedChunkColumn2, currentIncompletePass_AsInt);
+-					flag |= loadOrGenerateChunkColumn_OnChunkThread(requestedChunkColumn2, currentIncompletePass_AsInt);
++					// Stratum: same dispatchClaimed guard TryClaimStage uses for
++					// worker stages, ported to this boundary scan for None/Done
++					// (and every stage in noWorkers mode). Not live today: this
++					// call site and tryLoadOrGenerateChunkColumnsInQueue's own
++					// identical scan never actually run at the same time (see
++					// their shared comment on why), but that is exactly the
++					// unguarded double-scan-and-act shape vanilla's own
++					// SupplyChunks.cs has always had for MaxWorldgenThreads > 1
++					// (anegostudios/VintageStory-Issues#5143, open since
++					// 2025-01-27, same error, same file). Guarding here costs one
++					// CompareExchange and closes the landmine before either
++					// caller's threading model can change under it.
++					if (Interlocked.CompareExchange(ref requestedChunkColumn2.dispatchClaimed, 1, 0) == 0)
++					{
++						try
++						{
++							flag |= loadOrGenerateChunkColumn_OnChunkThread(requestedChunkColumn2, currentIncompletePass_AsInt);
++						}
++						finally
++						{
++							Volatile.Write(ref requestedChunkColumn2.dispatchClaimed, 0);
++						}
++					}
  				}
  			}
 +
@@ -2366,7 +2424,7 @@ index f644852..5a5d371 100644
  				foreach (ChunkColumnLoadRequest requestedChunkColumn3 in chunkthread.requestedChunkColumns)
  				{
  					if (requestedChunkColumn3 != null)
-@@ -1340,16 +2475,25 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1340,16 +2525,25 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				throw new Exception("Somehow worldgen has become stuck in an endless loop, please report this as a bug!  Additional data in the server-main log");
  			}
  		}
@@ -2392,7 +2450,7 @@ index f644852..5a5d371 100644
  				if (chunkRequest.CurrentIncompletePass == EnumWorldGenPass.Terrain)
  				{
  					ushort sunLight = (ushort)server.sunBrightness;
-@@ -1359,32 +2503,62 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1359,32 +2553,62 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					}
  				}
  			}
@@ -2457,7 +2515,7 @@ index f644852..5a5d371 100644
  			return;
  		}
  		for (int i = 0; i < list.Count; i++)
-@@ -1396,89 +2570,117 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1396,89 +2620,117 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			catch (Exception ex)
  			{
  				ServerMain.Logger.Worldgen("An error was thrown in pass {5} when generating chunk column X={0},Z={1} in world '{3}' with seed {4}\nException {2}\n\n", chunkRequest.chunkX, chunkRequest.chunkZ, ex, server.SaveGameData.WorldName, server.SaveGameData.Seed, chunkRequest.CurrentIncompletePass.ToString());
@@ -2592,7 +2650,7 @@ index f644852..5a5d371 100644
  			chunkthread.requestedChunkColumns.Enqueue(curRequest);
  			return true;
  		}
-@@ -1490,13 +2692,19 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1490,13 +2742,19 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				ServerMain.Logger.VerboseDebug("Un-pausing all worldgen threads.");
  			}
  		}
@@ -2612,7 +2670,7 @@ index f644852..5a5d371 100644
  			if (requestedChunkColumn != null && !requestedChunkColumn.Disposed)
  			{
  				server.loadedMapChunks.Remove(requestedChunkColumn.mapIndex2d);
-@@ -1505,104 +2713,181 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1505,104 +2763,181 @@ internal class ServerSystemSupplyChunks : ServerSystem
  		}
  		chunkthread.requestedChunkColumns.Clear();
  		ServerMain.Logger.VerboseDebug("Incomplete chunks stored and wiped.");


### PR DESCRIPTION
PreDone was the last worldgen stage still running one column at a time. This raises its cap, after making its single generator safe for it.

## `GenCreatures`

PreDone hosts exactly one generator, and nothing had audited whether it tolerates two columns at once. It does not. Climate, forest, and shrub readings live in plain instance fields that `OnChunkColumnGen` writes and `TrySpawnGroupAt` reads a few calls later, so a second thread starting a different column mid-flight overwrites the first thread's readings before it is done with them. The shared spawn-position list and the single world-lifetime `Random` have the same problem.

Every piece of per-column scratch moved to a `[ThreadStatic]` field, and the `Random` is now reseeded from a hash of the world seed and the column coordinates instead of advancing one shared sequence across the world.

That reseed also removes a dependency the old code already carried on dispatch order: two different columns always get two different seeds, so a column's result no longer depends on which column the dispatcher happened to hand out first.

## A pre-existing non-determinism, ruled out rather than assumed

Two full pregen runs of a 1257-column radius at a fixed seed both finished with zero worldgen exceptions and identical completion counts (1208 generated + 49 already loaded = 1257, both runs). But they did **not** produce identical per-column creature spawns, so that got chased down before trusting the fix.

A control pair of runs with the cap forced back to 1, serial dispatch, exactly what PreDone has always done, showed the same pattern. The cause sits outside this change: `entityTypeGroups` is a `Dictionary` keyed by `EntityProperties`, a reference type with no custom hash code, so its iteration order depends on each key's default object hash and is not stable across process launches. Every column loops that dictionary drawing random numbers in iteration order, so a different order gives a different sequence from an identical seed.

Pre-existing trait of the generator, confirmed at cap 1, out of scope here.

## The shared dispatcher fix: `dispatchClaimed`

Every branch that raises a stage cap needs this, and each carries it independently so they stay separately reviewable.

`stratumStageActiveCount[stage]` caps how many *claims* a stage has in flight, but nothing stopped **the same request** being claimed twice concurrently. At cap 1 that was invisible. Above 1 it is live: two workers claim the same column, both run `PopulateChunk`, which unconditionally does `currentpass++`, driving `currentpass` past `Done`. `ToVanilla()` shifts by exactly 1 and can never map back down from there, so `blockingRequestsRemaining` leaks forever and the 12s "worldgen has become stuck" watchdog fires.

Fixed with a per-request `Interlocked.CompareExchange` guard (`ChunkColumnLoadRequest.dispatchClaimed`), released at every site that already decrements `stratumStageActiveCount`. Same pattern C2ME-fabric's `StatusAdvancingScheduler`/`BusyRefCounter` uses for the same problem, lock-free here rather than `synchronized`.

This is what caused the 3m52s / 178-stuck-column run recorded against an earlier version of the PreDone branch. It was not a generator bug, which is why fixing generators never moved it.

## The mod-safety fallback

Raising a cap is only safe if everything registered at that pass tolerates two columns at once. Stratum has fixed this exact bug repeatedly in its own generators; assuming third-party code is safer would be wishful. But refusing to run alongside mods is not an option either, so this detects and falls back instead of breaking, and says so in the log.

`EnforceStageConcurrencySafety` runs once, right after `TriggerInitWorldGen` populates `worldgenHandler` (the first point every mod has registered), walks the real handler list for the raised pass, and drops that one pass back to cap 1 if it finds foreign code. Two things count, because there are two distinct ways foreign code ends up executing concurrently inside a raised stage:

| Axis | Catches | How |
| --- | --- | --- |
| 1 | A mod registered **its own** handler at the pass | assembly name, not a per-generator allowlist, so no upkeep as Stratum's generators change |
| 2 | A mod **Harmony-patched Stratum's** handler at the pass | `Harmony.GetPatchInfo` on the handler's own `MethodInfo` |

Axis 1 is not hypothetical. Structural analysis of the most-downloaded worldgen mods found real instances of the same shared-state shape fixed here: Rivers and VSRiverGen both keep `columnResults`/`layerFullySolid`/`layerFullyEmpty` as shared instance fields in their `NewGenTerra` at the Terrain pass, and VS Village keeps a shared `LCGRandom` in `VillageGenerator` at TerrainFeatures. Reports drafted for those authors separately; this is the server-side half.

Axis 2 is the narrow, tractable version of the cross-reference `research/gap-mod-patch-conflict-visibility.md` gave up on. That doc's blocker was needing a build-time manifest of every method Stratum source-patches, which needs real Roslyn tooling and permanent upkeep. No manifest is needed here: the only methods that matter for a cap raise are the handlers registered at the raised stage, and they are already in hand as live `MethodInfo`.

**One deliberate deviation from `StratumHarmonyVisibility`'s heuristic.** That code treats transpilers as the risky category and prefix/postfix as safe, which is right for *its* question: whether a transpiler's IL pattern match still lands after Stratum reshaped a method. Prefixes and postfixes survive that because they wrap the call rather than rewriting it. The question here is a different one, though: whether the mod's injected code is thread-safe when the same generator runs on several columns at once. A prefix touching shared mod state fails there exactly as badly as a transpiler. So any patch kind triggers the fallback, while the kind is still named in the log, because that is what triage needs.

**Two honest limits**, neither of which makes the fallback direction unsafe:

- It only sees patches applied by the time worldgen starts. A mod deferring `PatchAll` past that is invisible, the same caveat `StratumHarmonyVisibility` already documents.
- It inspects the handler methods themselves, not everything they call. Following the full call tree is the manifest-shaped problem this deliberately avoids.

Both mean the check can **miss**, never that it wrongly clears a mod. A false positive costs throughput on one pass; a false negative corrupts world generation. Erring toward capping is the point.

The log line names the mod, what it did, what Stratum did about it, and that worldgen stays correct:

```
[Stratum] Same-stage concurrency for the TerrainFeatures worldgen pass is now disabled, falling back to
1 column at a time: Stratum's own worldgen handler GenPonds.OnChunkColumnGen is Harmony-patched (prefix
from 'safeguardtestmod'), so that mod's code would run inside a generator Stratum audited only in its own
form, on several columns at once. Stratum cannot verify third-party code is safe under that. World
generation stays correct, it just gives up this pass's speedup. If you are the author of that mod and have
verified it is safe to run concurrently across columns, get in touch so it can be allowlisted.
```

The block is **byte-identical across all four cap-raise branches** (verified by hash), so whichever merges first, the rest resolve trivially against it. Unifying the signature to `(int, string)` was not cosmetic: TerrainLate has no `EnumWorldGenPass` value of its own, since both Terrain and TerrainLate map to vanilla `Terrain`.
## Performance, restated after @tehtelev's review

**The stage shares this PR originally quoted were wrong**, and they mattered because they were used to justify which stage to attack first. They came from a radius-20 profile. At @tehtelev's radius-100 scale the profile is different:

| Stage | radius 100 (@tehtelev) | radius 20 (original claim) | Neighbour-gated |
| --- | --- | --- | --- |
| Terrain | 17.9% | 42.7% | no |
| TerrainLate | 29.9% | 21.9% | no |
| TerrainFeatures | 16.3% | 16.2% | **yes** |
| Vegetation | 27.7% | 16.5% | **yes** |
| NeighbourSunLightFlood | 8.1% | 2.5% | **yes** |
| PreDone | 0.1% | 0.2% | **yes** |
| | **47.8% ungated** | 64.6% ungated | |

At realistic pregen scale TerrainLate and Vegetation dominate, not Terrain. Treat the radius-100 column as the real one.

### The neighbour-parity gate, and why it splits the stages

`ensurePrettyNeighbourhood` returns `true` immediately for stages at or below TerrainLate. Above that it requires **all 8 neighbours to have reached the same pass or later** before a column may advance.

So a raised cap on a gated stage only binds when many columns happen to have all 8 neighbours caught up at once, which the wavefront geometry limits. That explains the review results better than stage cost did: #190 and #191 raise caps on gated stages and both measured flat, which is what a non-binding cap looks like.

This is @tehtelev's point from Discord, and it checks out in the code. Instrumenting the gate confirmed it directly: **Terrain and TerrainLate block exactly 0 times in every run**, matching the code path, while the gated stages block heavily.

### The queue was measured and ruled out

@tehtelev also suggested the default `RequestChunkColumnsQueueSize` of 2000 was the limiter. Measured at radius 60, 3 threads, 4 interleaved samples per config:

| Queue | Samples (s) | Median | Queue-exhaustion warnings |
| --- | --- | --- | --- |
| 2000 | 145, 166, 175, 184 | 170.5s | 2 of 4 runs |
| 8000 | 156, 165, 175, 190 | 170.0s | 0 of 4 runs |

A 0.5s median gap against 34-39s spreads, with fully overlapping ranges. The exhaustion warnings are real and do disappear, but removing them buys no throughput.

Worth flagging for anyone reading old numbers in this initiative: every earlier radius-20 measurement ran 1,681 columns against a 2,000 slot queue, so **none of them could ever have stressed that constraint**.

### Honest framing

The value is concentrated in the two ungated stages. Caps on gated stages are latent capability: correct and safe after the audits, and worth nothing measurable until the gate constraint moves. Reviewing one stage at a time makes it easy to reject each on "shows no gain", so that is worth saying plainly rather than leaving to be inferred.

All measurements: same seed, stray `MSBuild.dll`/`VBCSCompiler` processes killed before every run (this project has been burned by a fake 4.4x regression from exactly that), distinct data directory per run, raw per-run numbers reported rather than medians alone.

## Set expectations for this branch specifically

PreDone is **0.2% of pregen time**. It hosts creature spawning and is the cheapest stage by a wide margin. This branch is a correctness prerequisite, not a throughput lever, and it will not show a gain on its own no matter how it is measured.

Its value is that it closes the last stage still pinned at cap 1, and that it carries the `dispatchClaimed` fix, which was root-caused on this branch and matters to all four.

## Verification

Three cases, end to end, at `MaxWorldgenThreads=4`, with a real minimal test mod built for this (own assembly, references `0Harmony`, dropped into `Mods/` for these tests only):

| Case | Expected | Result |
| --- | --- | --- |
| No mod | full concurrency, no warning | 0 fallback warnings, reached RunGame |
| Mod registers its own PreDone handler | fall back, name the assembly | warned naming `SafeguardTestMod`, cap 1 |
| Mod Harmony-prefixes `GenCreatures.OnChunkColumnGen` | fall back, name mod + kind + method | warned naming `safeguardtestmod`, prefix, `GenCreatures.OnChunkColumnGen` |

Since PreDone hosts one generator, that third case is the entire second axis for this stage in practice.

All three reached RunGame with zero real crashes and the same 2 known false-positive log lines each (a class literally named `ErrorReporter`, and a line reading "no errors"). Plus 3 repeated boot trials: 0 stuck-column lines, 0 watchdog throws.

## Merge ordering

Independent of the other three cap-raise branches; merges cleanly into `indev` today. The shared `dispatchClaimed` and safeguard blocks are identical across all four, so the rest resolve trivially against whichever lands first.

Split out of #179 per @tehtelev's request to review same-stage concurrency one stage at a time.

/cc @tehtelev
