### PR TITLE
Let TerrainFeatures run several columns at once, and fix the two things that blocked it

### DIFF
--- a/patches/VintagestoryLib/Vintagestory.Common/ChunkDataLayer.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Common/ChunkDataLayer.cs.patch
@@ -1,8 +1,81 @@
 diff --git a/VintagestoryLib/Vintagestory.Common/ChunkDataLayer.cs b/VintagestoryLib/Vintagestory.Common/ChunkDataLayer.cs
-index 4d0bf91..e9e511f 100644
+index 4d0bf91..caad0da 100644
 --- a/VintagestoryLib/Vintagestory.Common/ChunkDataLayer.cs
 +++ b/VintagestoryLib/Vintagestory.Common/ChunkDataLayer.cs
-@@ -56,103 +56,81 @@ public class ChunkDataLayer
+@@ -25,10 +25,72 @@ public class ChunkDataLayer
+ 
+ 	protected int bitsize;
+ 
+ 	public FastRWLock readWriteLock;
+ 
++	// Stratum: serialises every writer that can grow the palette or flip plane bits.
++	//
++	// The palette grows by MakeSpaceInPalette, which reassigns the palette field,
++	// claims dataBits[bitsize], and then does a non-atomic bitsize++. Vanilla guards
++	// the Set path with `lock (palette)`, which cannot work: the lock statement
++	// evaluates its argument once at entry, so once MakeSpaceInPalette has swapped
++	// the field, the next thread through locks the NEW array, a different monitor,
++	// and both critical sections run at once. SetUnsafe takes no lock at all.
++	//
++	// Two threads growing together make bitsize advance twice for one allocated
++	// plane. dataBits is a fixed int[15][], so the symptom is either
++	// IndexOutOfRangeException on dataBits[15] or NullReferenceException on a plane
++	// that was skipped, depending on the interleaving. Both were observed once
++	// TerrainFeatures ran several columns at once.
++	//
++	// Vanilla never exposed this because it never ran two threads into one
++	// ChunkDataLayer; the code here is byte-identical to vanilla's, so this is an
++	// upstream latent bug, not something the fork introduced. Locking rather than
++	// swapping in a concurrent structure because palette and dataBits ARE the
++	// on-disk and wire format (see CompressUsing/Decompress), so their shape cannot
++	// change without breaking saves and clients.
++	//
++	// On the granularity, since the obvious objection is that this locks per block
++	// written on a worldgen hot path. Two coarser designs were considered and are
++	// recorded here so they are not re-proposed from theory alone:
++	//
++	//   1. A per-chunk lock taken by callers and held across a whole generator or
++	//      structure-placement call, acquiring every touched chunk's lock up front
++	//      in index order to avoid deadlock. This is what C2ME does for Minecraft
++	//      (AsyncCombinedLock/FlowSched), and it cuts lock acquisitions by orders of
++	//      magnitude rather than shaving the per-acquisition cost.
++	//   2. Single-writer-per-chunk confinement, so no lock is needed at all. This is
++	//      what vanilla Minecraft assumes — its PalettedContainer does not
++	//      synchronise, it uses ThreadingDetector to deliberately crash when two
++	//      threads touch one container — and Paper's Moonrise fork deletes even that
++	//      check once ownership is provable.
++	//
++	// Both are better in the abstract. Neither was adopted, and the honest reason is
++	// structural rather than performance, because the performance case is weaker than
++	// it first looked. Measured at radius 100, same seed and configuration, single
++	// runs: 8m22s with this lock against 7m34s without, so about +10%. Mid-run
++	// progress looked identical (40.4% against 40.8% at three minutes), which is what
++	// made an earlier note here claim the cost was nil — it is not. The figure sits
++	// inside this machine's run-to-run spread, which ranged 6m06s to 7m42s across
++	// comparable configurations the same day, so n=1 cannot separate a real 10% from
++	// noise; treat it as an unresolved upper bound, not a measured cost. Interleaved
++	// sampling is owed before anyone claims either way. Part of the cost is avoided
++	// already: bulk terrain goes through SetBulk, which takes the lock once per bulk
++	// operation rather than once per block, so the per-block callers are deposits and
++	// structures, a minority of total writes.
++	//
++	// Structural, and the part that actually decided it: options 1
++	// and 2 both push correctness onto every caller, and a caller that forgets is
++	// exactly how this bug class keeps recurring here — ServerMapChunk.NewBlockEntities
++	// was locked for precisely this reason while the block write two lines above it in
++	// BlockAccessorWorldGen.SetSolidBlock was not, which is one of the paths that
++	// crashed. Locking centrally protects present and future writers without that
++	// audit. Revisit if profiling ever shows this lock hot, or if the worldgen
++	// scheduler grows a real per-chunk ownership model, at which point option 2 makes
++	// this deletable.
++	private readonly object stratumWriteLock = new object();
++
+ 	public Func<int, int> Get;
+ 
+ 	protected int[] dataBit0;
+ 
+ 	protected int[] dataBit1;
+@@ -56,103 +118,81 @@ public class ChunkDataLayer
  		Get = GetFromBits0;
  		readWriteLock = new FastRWLock(chunkDataPool);
  		pool = chunkDataPool;
@@ -170,3 +243,106 @@ index 4d0bf91..e9e511f 100644
  		{
  			return GetFromBits0;
  		}
+@@ -287,10 +327,18 @@ public class ChunkDataLayer
+ 			throw new Exception("ChunkDataLayer: other null exception, bitsize is " + bitsize);
+ 		}
+ 	}
+ 
+ 	public void Set(int index3d, int value)
++	{
++		lock (stratumWriteLock)
++		{
++			SetCore(index3d, value);
++		}
++	}
++
++	private void SetCore(int index3d, int value)
+ 	{
+ 		if (index3d == (index3d & 0x7FFF))
+ 		{
+ 			int num;
+ 			if (palette != null)
+@@ -314,19 +362,19 @@ public class ChunkDataLayer
+ 									break;
+ 								}
+ 								num++;
+ 								continue;
+ 							}
+-							lock (palette)
++							// Stratum: was `lock (palette)`, which locked the very field
++							// MakeSpaceInPalette reassigns and so guarded nothing. The
++							// caller now holds stratumWriteLock across the whole method.
++							if (num == palette.Length)
+ 							{
+-								if (num == palette.Length)
+-								{
+-									num = MakeSpaceInPalette();
+-								}
+-								palette[num] = value;
+-								paletteCount++;
++								num = MakeSpaceInPalette();
+ 							}
++							palette[num] = value;
++							paletteCount++;
+ 							break;
+ 						}
+ 						setBlockIndexCached = num;
+ 						setBlockValueCached = value;
+ 					}
+@@ -377,10 +425,18 @@ public class ChunkDataLayer
+ 		}
+ 		throw new IndexOutOfRangeException("Chunk blocks index3d must be between 0 and " + 32767 + ", was " + index3d);
+ 	}
+ 
+ 	public void SetUnsafe(int index3d, int value)
++	{
++		lock (stratumWriteLock)
++		{
++			SetUnsafeCore(index3d, value);
++		}
++	}
++
++	private void SetUnsafeCore(int index3d, int value)
+ 	{
+ 		int num = 1 << index3d;
+ 		index3d /= 32;
+ 		int num2 = ~num;
+ 		if (value != 0)
+@@ -450,10 +506,18 @@ public class ChunkDataLayer
+ 			}
+ 		}
+ 	}
+ 
+ 	public void SetZero(int index3d)
++	{
++		lock (stratumWriteLock)
++		{
++			SetZeroCore(index3d);
++		}
++	}
++
++	private void SetZeroCore(int index3d)
+ 	{
+ 		if (palette != null)
+ 		{
+ 			int num = 1 << index3d;
+ 			index3d /= 32;
+@@ -465,10 +529,18 @@ public class ChunkDataLayer
+ 			}
+ 		}
+ 	}
+ 
+ 	public void SetBulk(int index3d, int lenX, int lenZ, int value)
++	{
++		lock (stratumWriteLock)
++		{
++			SetBulkCore(index3d, lenX, lenZ, value);
++		}
++	}
++
++	private void SetBulkCore(int index3d, int lenX, int lenZ, int value)
+ 	{
+ 		int num;
+ 		if (value != 0)
+ 		{
+ 			if (value == setBlockValueCached)

--- a/patches/VintagestoryLib/Vintagestory.Server/MagicNum.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/MagicNum.cs.patch
@@ -1,0 +1,24 @@
+diff --git a/VintagestoryLib/Vintagestory.Server/MagicNum.cs b/VintagestoryLib/Vintagestory.Server/MagicNum.cs
+index 3963235..60ef753 100644
+--- a/VintagestoryLib/Vintagestory.Server/MagicNum.cs
++++ b/VintagestoryLib/Vintagestory.Server/MagicNum.cs
+@@ -93,11 +93,18 @@ public class MagicNum
+ 		FileName = Path.Combine(GamePaths.Config, "servermagicnumbers.json");
+ 		DefaultEntityTrackingRange = 4;
+ 		DefaultSimulationRange = 128;
+ 		ServerChunkSize = 32;
+ 		ServerChunkSizeMask = 31;
+-		RequestChunkColumnsQueueSize = 2000;
++		// Stratum: raised from vanilla's 2000. TerrainFeatures is a neighbour-gated
++		// pass, so ensurePrettyNeighbourhood actually enqueues lagging neighbours for
++		// it; running several of its columns at once multiplies those nudges and
++		// exhausts a 2000-entry queue outright. Measured at radius 100, seed
++		// 1027995113, 3 worldgen threads: 2000 gives 3091 "Indexed Fifo Queue
++		// overflow" throws and wedges at 7.8%, while 8000 completes with zero. The
++		// ungated passes never needed it, which is why this only surfaced now.
++		RequestChunkColumnsQueueSize = 8000;
+ 		ReadyChunksQueueSize = 200;
+ 		ChunksColumnsToRequestPerTick = 4;
+ 		ChunksToSendPerTick = 192;
+ 		ChunkRequestTickTime = 20;
+ 		ChunkColumnsToGeneratePerThreadTick = 30;

--- a/patches/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs.patch
@@ -1,8 +1,8 @@
 diff --git a/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs b/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs
-index f644852..ca95d5b 100644
+index f644852..feed548 100644
 --- a/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs
 +++ b/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs
-@@ -1,139 +1,1065 @@
+@@ -1,139 +1,1094 @@
  using System;
  using System.Collections.Generic;
  using System.Linq;
@@ -358,6 +358,7 @@ index f644852..ca95d5b 100644
 +		stratumStageMaxConcurrent[StratumWorldGenStages.PreDone] = Math.Max(1, chunkthread.additionalWorldGenThreadsCount);
 +		stratumStageMaxConcurrent[StratumWorldGenStages.TerrainLate] = Math.Max(1, chunkthread.additionalWorldGenThreadsCount);
 +		stratumStageMaxConcurrent[StratumWorldGenStages.Terrain] = Math.Max(1, chunkthread.additionalWorldGenThreadsCount);
++		stratumStageMaxConcurrent[StratumWorldGenStages.TerrainFeatures] = Math.Max(1, chunkthread.additionalWorldGenThreadsCount);
  	}
  
 +	/// <summary>
@@ -572,8 +573,36 @@ index f644852..ca95d5b 100644
 +		// which is unrecoverable rather than merely noisy: the column could never be
 +		// claimed again by anyone, and a stage whose cap is 1 lost its only slot
 +		// permanently, so worldgen wedged with every thread asleep and no watchdog on
-+		// the pregen path to notice. Observed as a hard stall part-way through a
-+		// radius-100 pregen once Terrain's cap was raised.
++		// the pregen path to notice.
++		//
++		// This finally makes the throw survivable. It does NOT stop the queue from
++		// exhausting, and that distinction cost a full day to learn, so it is written
++		// down here rather than rediscovered.
++		//
++		// An earlier attempt guarded the two enqueues in EnsureMinimumWorldgenPassAt
++		// so the throw could not be reached at all, reporting the neighbour as lagging
++		// instead. It was rejected on measurement: it cost roughly a third of the wall
++		// clock and introduced out-of-range block reads that neither clean indev nor
++		// this fix produce. **That measurement was taken in configurations where the
++		// queue never exhausts** — Terrain and TerrainLate are not neighbour-gated, so
++		// ensurePrettyNeighbourhood returns true for them immediately and never
++		// enqueues anything. All the guard did there was refuse work in a regime that
++		// was already fine. Eight full radius-100 pregens produced zero overflows, so
++		// the rejection looked safe.
++		//
++		// Raising TerrainFeatures' cap proved it was not the whole story. That pass IS
++		// gated, so it really does enqueue lagging neighbours, and at cap 4 it produced
++		// 3091 overflow throws and wedged at 7.8% of a radius-100 pregen. The claims
++		// were released correctly every time — the finally works — but the outer catch
++		// in ScheduleReadyTasks abandons the entire dispatch pass on any exception, so
++		// a permanent wedge became a livelock instead. What actually fixed that was
++		// raising RequestChunkColumnsQueueSize, see MagicNum.
++		//
++		// The lesson worth keeping: an optimisation measured only where its problem
++		// does not occur will always look like pure cost. Before rejecting a guard on
++		// this path again, check whether the configuration under test has a gated
++		// stage running concurrently, because that is the only regime where the queue
++		// is under real pressure.
 +		int claimedStage = stage;
 +		bool claimHeld = true;
 +		try
@@ -1090,7 +1119,7 @@ index f644852..ca95d5b 100644
  			if (!tryLoadOrGenerateChunkColumnsInQueue())
  			{
  				break;
-@@ -143,39 +1069,59 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -143,39 +1098,59 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				break;
  			}
  		}
@@ -1152,7 +1181,7 @@ index f644852..ca95d5b 100644
  				ServerChunk serverChunk = (ServerChunk)server.WorldMap.GetChunk(x, i, z);
  				if (serverChunk != null)
  				{
-@@ -183,11 +1129,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -183,11 +1158,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					for (int j = 0; j < entities.Length; j++)
  					{
  						Entity entity = entities[j];
@@ -1165,7 +1194,7 @@ index f644852..ca95d5b 100644
  						{
  							if (j >= serverChunk.EntitiesCount)
  							{
-@@ -211,19 +1157,23 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -211,19 +1186,23 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				});
  			}
  			list2.Add(item);
@@ -1190,7 +1219,7 @@ index f644852..ca95d5b 100644
  		{
  			ChunkPos item2 = server.WorldMap.MapRegionPosFromIndex2D(result2);
  			if (hashSet == null)
-@@ -237,28 +1187,46 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -237,28 +1216,46 @@ internal class ServerSystemSupplyChunks : ServerSystem
  		{
  			chunkthread.gameDatabase.DeleteMapRegions(hashSet);
  		}
@@ -1242,7 +1271,7 @@ index f644852..ca95d5b 100644
  		ServerMapChunk orCreateMapChunk = chunkthread.loadsavechunks.GetOrCreateMapChunk(request);
  		if (orCreateMapChunk == null)
  		{
-@@ -267,94 +1235,203 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -267,94 +1264,203 @@ internal class ServerSystemSupplyChunks : ServerSystem
  		ServerChunk[] array = chunkthread.loadsavechunks.TryLoadChunkColumn(request);
  		if (array == null)
  		{
@@ -1452,7 +1481,7 @@ index f644852..ca95d5b 100644
  				chunkRequest.Chunks = TryLoadChunkColumn(chunkRequest);
  				if (chunkRequest.Chunks != null)
  				{
-@@ -364,31 +1441,42 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -364,31 +1470,42 @@ internal class ServerSystemSupplyChunks : ServerSystem
  						obj.serverMapChunk = orCreateMapChunk;
  						obj.MarkFresh();
  					}
@@ -1495,7 +1524,7 @@ index f644852..ca95d5b 100644
  				ServerEventAPI eventapi = server.api.eventapi;
  				ServerMapChunk mapChunk = orCreateMapChunk;
  				int chunkX = chunkRequest.chunkX;
-@@ -404,117 +1492,105 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -404,117 +1521,105 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					ServerMain.Logger.Error("Repair mode is enabled so will delete the entire chunk column.");
  					GenerateNewChunkColumn(orCreateMapChunk, chunkRequest);
  					return false;
@@ -1643,7 +1672,7 @@ index f644852..ca95d5b 100644
  				try
  				{
  					serverChunk.Unpack();
-@@ -529,10 +1605,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -529,10 +1634,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
  						ServerMain.FrameProfiler.Leave();
  						return;
  					}
@@ -1656,7 +1685,7 @@ index f644852..ca95d5b 100644
  			{
  				for (int j = 0; j < serverChunk.Entities.Length; j++)
  				{
-@@ -548,10 +1626,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -548,10 +1655,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					{
  						if (server.LoadEntity(entity, num2))
  						{
@@ -1668,7 +1697,7 @@ index f644852..ca95d5b 100644
  						{
  							string text = "-";
  							try
-@@ -564,14 +1643,18 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -564,14 +1672,18 @@ internal class ServerSystemSupplyChunks : ServerSystem
  							ServerMain.Logger.Log(EnumLogType.Worldgen, "In " + server.WorldName + ", villager " + text + " removed at " + entity.Pos.AsBlockPos?.ToString() + " due to an exception on loading");
  						}
  					}
@@ -1687,7 +1716,7 @@ index f644852..ca95d5b 100644
  			{
  				BlockEntity value = blockEntity.Value;
  				if (value == null)
-@@ -580,13 +1663,23 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -580,13 +1692,23 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				}
  				try
  				{
@@ -1713,7 +1742,7 @@ index f644852..ca95d5b 100644
  					ServerMain.FrameProfiler.Leave();
  				}
  				catch (Exception ex3)
-@@ -594,23 +1687,33 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -594,23 +1716,33 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					ServerMain.Logger.Notification("Exception thrown when trying to initialize a block entity @{0}: {1}", value.Pos, ex3);
  					value.UnregisterAllTickListeners();
  				}
@@ -1747,7 +1776,7 @@ index f644852..ca95d5b 100644
  		mapChunk.NeighboursLoaded = default(SmallBoolArray);
  		mapChunk.SelfLoaded = true;
  		for (int i = 0; i < Cardinal.ALL.Length; i++)
-@@ -623,20 +1726,26 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -623,20 +1755,26 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				serverMapChunk.NeighboursLoaded[cardinal.Opposite.Index] = true;
  			}
  		}
@@ -1774,7 +1803,7 @@ index f644852..ca95d5b 100644
  			serverMapChunk.NeighboursLoaded[4] = false;
  		}
  		if (serverMapChunk2 != null)
-@@ -667,12 +1776,17 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -667,12 +1805,17 @@ internal class ServerSystemSupplyChunks : ServerSystem
  		{
  			serverMapChunk8.NeighboursLoaded[3] = false;
  		}
@@ -1792,7 +1821,7 @@ index f644852..ca95d5b 100644
  			for (int j = -1; j <= 1; j++)
  			{
  				bool flag = false;
-@@ -682,19 +1796,24 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -682,19 +1825,24 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				}
  				if (!flag)
  				{
@@ -1817,7 +1846,7 @@ index f644852..ca95d5b 100644
  		int num = 0;
  		for (int i = -1; i <= 1; i++)
  		{
-@@ -707,60 +1826,78 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -707,60 +1855,78 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			}
  		}
  		return num == 8;
@@ -1897,7 +1926,7 @@ index f644852..ca95d5b 100644
  				dictionary = value.ModData;
  				dictionary2 = value.OreMaps;
  				intDataMap2D = value.GeologicProvinceMap;
-@@ -770,12 +1907,14 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -770,12 +1936,14 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			{
  				flag = false;
  				value.loadedTotalMs = server.ElapsedMilliseconds;
@@ -1912,7 +1941,7 @@ index f644852..ca95d5b 100644
  			if (list != null)
  			{
  				value.GeneratedStructures = list;
-@@ -798,35 +1937,48 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -798,35 +1966,48 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			}
  		}
  		return value;
@@ -1961,7 +1990,7 @@ index f644852..ca95d5b 100644
  		byte[] array = chunkGenParams?.GetBytes("GeneratedStructures");
  		if (array == null)
  		{
-@@ -836,44 +1988,60 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -836,44 +2017,60 @@ internal class ServerSystemSupplyChunks : ServerSystem
  		long key = server.api.WorldManager.MapRegionIndex2D(regionX, regionZ);
  		if (!dictionary.TryGetValue(key, out var value) || value == null)
  		{
@@ -2023,7 +2052,7 @@ index f644852..ca95d5b 100644
  		long key = server.WorldMap.MapChunkIndex2D(chunkX, chunkZ);
  		server.loadedMapChunks.TryGetValue(key, out var value);
  		if (value != null)
-@@ -881,31 +2049,42 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -881,31 +2078,42 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			return value;
  		}
  		return TryLoadMapChunk(chunkX, chunkZ);
@@ -2066,7 +2095,7 @@ index f644852..ca95d5b 100644
  			for (int j = 0; j < Cardinal.ALL.Length; j++)
  			{
  				Cardinal cardinal = Cardinal.ALL[j];
-@@ -918,47 +2097,111 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -918,47 +2126,111 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					}
  					chunkRequest.NeighbourTerrainHeight[j] = serverMapChunk.WorldGenTerrainHeightMap;
  				}
@@ -2194,7 +2223,7 @@ index f644852..ca95d5b 100644
  			foreach (ServerChunk serverChunk in array)
  			{
  				if (serverChunk != null)
-@@ -967,10 +2210,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -967,10 +2239,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					serverChunk.MarkModified();
  					serverChunk.TryPackAndCommit();
  				}
@@ -2207,7 +2236,7 @@ index f644852..ca95d5b 100644
  			ServerMain.Logger.Error("Loaded some but not all chunks of a column? Discarding whole column.");
  			return null;
  		}
-@@ -979,18 +2224,22 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -979,18 +2253,22 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			return null;
  		}
  		return array;
@@ -2230,7 +2259,7 @@ index f644852..ca95d5b 100644
  					serverMapChunk.YMax = (ushort)(server.SaveGameData.MapSizeY - 1);
  				}
  				return serverMapChunk;
-@@ -1011,10 +2260,13 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1011,10 +2289,13 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			}
  		}
  		return null;
@@ -2244,7 +2273,7 @@ index f644852..ca95d5b 100644
  		byte[] mapRegion = chunkthread.gameDatabase.GetMapRegion(regionX, regionZ);
  		try
  		{
-@@ -1035,14 +2287,32 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1035,14 +2316,33 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			throw;
  		}
  		return null;
@@ -2269,6 +2298,7 @@ index f644852..ca95d5b 100644
 +		// raising its cap without this axis of the safeguard would be the one cap
 +		// raise that ships unprotected.
 +		EnforceStageConcurrencySafety(StratumWorldGenStages.Terrain, "Terrain");
++		EnforceStageConcurrencySafety(StratumWorldGenStages.TerrainFeatures, "TerrainFeatures");
  		ServerMain.Logger.Event("Loading {0}x{1}x{2} spawn chunks...", MagicNum.SpawnChunksWidth, MagicNum.SpawnChunksWidth, server.WorldMap.ChunkMapSizeY);
 +
 +		// Initialize "story" messages for display during loading
@@ -2277,7 +2307,7 @@ index f644852..ca95d5b 100644
  			storyChunkSpawnEvents = new string[15]
  			{
  				Lang.Get("...the carved mountains"),
-@@ -1060,23 +2330,27 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1060,23 +2360,27 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				Lang.Get("...a misty sunrise"),
  				Lang.Get("...dew drops on a blade of grass"),
  				Lang.Get("...a soft breeze")
@@ -2305,7 +2335,7 @@ index f644852..ca95d5b 100644
  					double value = random.NextDouble() * 6.2831854820251465;
  					double num7 = num6 * GameMath.Sin(value);
  					double num8 = num6 * GameMath.Cos(value);
-@@ -1096,10 +2370,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1096,10 +2400,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					server.api.Logger.Notification("Trying another spawn location ({0}/{1})...", i + 2, num3);
  				}
  			}
@@ -2317,7 +2347,7 @@ index f644852..ca95d5b 100644
  				if (!server.blockAccessor.GetBlock(blockPos).SideSolid[BlockFacing.UP.Index])
  				{
  					server.blockAccessor.SetBlock(server.blockAccessor.GetBlock(new AssetLocation("planks-oak-we")).Id, blockPos);
-@@ -1107,13 +2382,16 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1107,13 +2412,16 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				blockPos.Y++;
  			}
  		}
@@ -2334,7 +2364,7 @@ index f644852..ca95d5b 100644
  			x = blockPos.X,
  			y = blockPos.Y,
  			z = blockPos.Z
-@@ -1123,10 +2401,14 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1123,10 +2431,14 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			server.mapMiddleSpawnPos.y = null;
  		}
  		server.api.Logger.VerboseDebug("Done spawn chunk");
@@ -2349,7 +2379,7 @@ index f644852..ca95d5b 100644
  		int num = 60;
  		int num2 = 0;
  		int num3 = 0;
-@@ -1137,36 +2419,47 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1137,36 +2449,47 @@ internal class ServerSystemSupplyChunks : ServerSystem
  		{
  			num4 = GameMath.Clamp(num2 + pos.X, 0, server.WorldMap.MapSizeX - 1);
  			num6 = GameMath.Clamp(num3 + pos.Z, 0, server.WorldMap.MapSizeZ - 1);
@@ -2398,7 +2428,7 @@ index f644852..ca95d5b 100644
  		{
  			for (int k = -num2; k <= num2; k++)
  			{
-@@ -1174,18 +2467,22 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1174,18 +2497,22 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				{
  					long index2d = server.WorldMap.MapChunkIndex2D(x + j, y + k);
  					int regionX = (x + j) / MagicNum.ChunkRegionSizeInChunks;
@@ -2422,7 +2452,7 @@ index f644852..ca95d5b 100644
  					};
  					chunkColumnLoadRequest.MapChunk = mapChunk;
  					GenerateNewChunkColumn(mapChunk, chunkColumnLoadRequest);
-@@ -1196,10 +2493,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1196,10 +2523,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
  						chunkthread.peekingChunkColumns.Enqueue(chunkColumnLoadRequest);
  					}
  				}
@@ -2435,7 +2465,7 @@ index f644852..ca95d5b 100644
  		{
  			num4 = num - i;
  			for (int l = -num4; l <= num4; l++)
-@@ -1212,10 +2511,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1212,10 +2541,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
  						runGenerators(chunkRequest, i);
  					}
  				}
@@ -2448,7 +2478,7 @@ index f644852..ca95d5b 100644
  		{
  			for (int n = -num2; n <= num2; n++)
  			{
-@@ -1232,61 +2533,111 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1232,61 +2563,111 @@ internal class ServerSystemSupplyChunks : ServerSystem
  						dictionary2[key] = chunks;
  					}
  				}
@@ -2562,7 +2592,7 @@ index f644852..ca95d5b 100644
  				millisecondsSinceStart = server.totalUnpausedTime.ElapsedMilliseconds;
  				float num4 = 100f * ((float)server.loadedChunks.Count / (float)server.WorldMap.ChunkMapSizeY - (float)num) / (float)num2;
  				ServerMain.Logger.Event(num4.ToString("0.#") + "% ({0} in queue)", chunkthread.requestedChunkColumns.Count);
-@@ -1298,37 +2649,84 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1298,37 +2679,84 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				{
  					ServerMain.Logger.StoryEvent("...");
  				}
@@ -2650,7 +2680,7 @@ index f644852..ca95d5b 100644
  				foreach (ChunkColumnLoadRequest requestedChunkColumn3 in chunkthread.requestedChunkColumns)
  				{
  					if (requestedChunkColumn3 != null)
-@@ -1340,16 +2738,25 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1340,16 +2768,25 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				throw new Exception("Somehow worldgen has become stuck in an endless loop, please report this as a bug!  Additional data in the server-main log");
  			}
  		}
@@ -2676,7 +2706,7 @@ index f644852..ca95d5b 100644
  				if (chunkRequest.CurrentIncompletePass == EnumWorldGenPass.Terrain)
  				{
  					ushort sunLight = (ushort)server.sunBrightness;
-@@ -1359,32 +2766,62 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1359,32 +2796,62 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					}
  				}
  			}
@@ -2741,7 +2771,7 @@ index f644852..ca95d5b 100644
  			return;
  		}
  		for (int i = 0; i < list.Count; i++)
-@@ -1396,89 +2833,119 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1396,89 +2863,119 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			catch (Exception ex)
  			{
  				ServerMain.Logger.Worldgen("An error was thrown in pass {5} when generating chunk column X={0},Z={1} in world '{3}' with seed {4}\nException {2}\n\n", chunkRequest.chunkX, chunkRequest.chunkZ, ex, server.SaveGameData.WorldName, server.SaveGameData.Seed, chunkRequest.CurrentIncompletePass.ToString());
@@ -2878,7 +2908,7 @@ index f644852..ca95d5b 100644
  			chunkthread.requestedChunkColumns.Enqueue(curRequest);
  			return true;
  		}
-@@ -1490,13 +2957,19 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1490,13 +2987,19 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				ServerMain.Logger.VerboseDebug("Un-pausing all worldgen threads.");
  			}
  		}
@@ -2898,7 +2928,7 @@ index f644852..ca95d5b 100644
  			if (requestedChunkColumn != null && !requestedChunkColumn.Disposed)
  			{
  				server.loadedMapChunks.Remove(requestedChunkColumn.mapIndex2d);
-@@ -1505,104 +2978,181 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1505,104 +3008,181 @@ internal class ServerSystemSupplyChunks : ServerSystem
  		}
  		chunkthread.requestedChunkColumns.Clear();
  		ServerMain.Logger.VerboseDebug("Incomplete chunks stored and wiped.");


### PR DESCRIPTION
> [!NOTE]
> **Rebuilt on current `indev` (2026-07-27).** Four of the five commits this branch used to carry are already merged (via #186 and #187), which is why it showed 44 conflict markers against `indev`. Rather than resolve conflicts between commits and themselves, the branch was reset onto `indev` and now contains **one commit** with only what is genuinely new. It also sits on top of #199 and #188, both merged.

TerrainFeatures is the last worldgen pass whose cap is still 1 where raising it can bind. Getting there needed two other things fixed first, both found by actually running it.

## 1. The cap

Raised to the worker-thread count, with `EnforceStageConcurrencySafety` extended to the pass, matching every other raised cap.

## 2. Queue size 2000 → 8000

**TerrainFeatures is the first neighbour-gated pass to get a raised cap, and that is what makes this necessary.** `ensurePrettyNeighbourhood` returns `true` immediately for Terrain and TerrainLate, so they never enqueue anything. From TerrainFeatures up it requires all 8 neighbours at the same pass and **enqueues the laggards**. Running several of its columns at once multiplies those nudges.

Radius 100, seed `1027995113`, 3 worldgen threads:

| queue | result |
|---|---|
| 2000 | **3091** `Indexed Fifo Queue overflow` throws, frozen at 7.8% |
| 8000 | zero overflows |

The claim release from #199 works correctly throughout — no column is ever leaked — but `ScheduleReadyTasks` abandons its **whole dispatch pass** on any exception, so what #199 turned from a permanent wedge became a livelock instead. Raising the queue is what removes the cause.

## 3. Locking `ChunkDataLayer`'s writers

With the queue raised the run got further, and hit a different failure: **15 worldgen `NullReferenceException`s, 8 more on the read side, and a fatal one in `SaveDirtyUnloadedChunks` that killed the server two minutes in.**

**This one is vanilla's bug, not the fork's.** `MakeSpaceInPalette` is byte-identical to the decompiled original. It reassigns `palette`, allocates `dataBits[bitsize]`, then does a non-atomic `bitsize++`. Two threads growing together advance `bitsize` twice for one allocated plane, so a later grow either indexes `dataBits[15]` on a fixed-length `int[15][]`, or dereferences a plane nobody allocated — `IndexOutOfRangeException` and `NullReferenceException` respectively, both observed.

Vanilla's own guard cannot help:

```csharp
lock (palette)                      // locks the field...
{
    if (num == palette.Length) num = MakeSpaceInPalette();   // ...which this reassigns
    palette[num] = value;
}
```

A second thread entering after the reassignment locks a **different object**, and both critical sections run at once. `SetUnsafe` takes no lock at all — and it is the one `DiscDepositGenerator.GenDeposit` reaches.

Fixed with a dedicated per-layer lock held across the whole resolve-or-grow-then-write sequence in `Set`, `SetUnsafe`, `SetZero` and `SetBulk`, with the misleading `lock (palette)` removed. Locking rather than changing the structure because `palette` and `dataBits` **are** the on-disk and wire format — `CompressUsing`/`Decompress` serialise them directly and clients decode that same layout.

## Verification

Radius 100, seed `1027995113`, queue 8000, 3 worldgen threads, single variable against the crashing run:

| | without the lock | with it |
|---|---|---|
| result | **fatal at ~2 min** | completes, 31417/31417 columns |
| `NullReference` / `IndexOutOfRange` | 23 | **0** |
| `Server Fatal` | 1 | **0** |
| queue overflow | 0 | 0 |
| error/exception lines | 35 | 2 (the usual acceptable pair) |

Zero stuck columns and zero watchdog throws.

## On the lock's granularity

Per-block locking on a worldgen hot path is the obvious objection, so the alternatives are recorded in the code comment rather than left for someone to re-propose from theory:

1. **A per-chunk lock held across a whole generator call**, acquiring every touched chunk in index order to avoid deadlock. This is what C2ME does for Minecraft (`AsyncCombinedLock`/FlowSched). Cuts acquisitions by orders of magnitude.
2. **Single-writer-per-chunk confinement**, needing no lock at all. This is what vanilla Minecraft assumes — `PalettedContainer` does not synchronise, it uses `ThreadingDetector` to **deliberately crash** when two threads touch one container. Paper's Moonrise fork deletes even that check once ownership is provable.

Both are better in the abstract. Neither was adopted because both push correctness onto every caller, and a caller that forgets is exactly how this bug class keeps recurring here: `ServerMapChunk.NewBlockEntities` was locked for this same reason while the block write two lines above it in `BlockAccessorWorldGen.SetSolidBlock` was not — and that is one of the paths that crashed.

**The cost is not established.** 8m22s with the lock against 7m34s without, on single runs — about +10%, but that sits inside this machine's 6m06s–7m42s spread across comparable configurations the same day. Treat it as an unresolved upper bound, not a measured cost; interleaved sampling is owed before claiming either way.

## Disclosure

This branch produces `Tried to get block outside generating chunks!` notifications (2813 in the verifying run). Same class already disclosed on #188: every one comes from vanilla code reading across chunk boundaries, all are **reads**, and there are zero out-of-range **writes** in any run. `GetBlockId` returns air there, so the visible effect is a skipped or displaced loose rock. Not root-caused further.

## Upstream

The palette race is reachable in plain Vintage Story by anyone raising `MaxWorldgenThreads` — same class as `VintageStory-Issues#5143`. Worth reporting; not filed here.
