### PR TITLE
Count columns turned away by the neighbour-parity gate, per stage

### DIFF
--- a/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/7.GenPonds/GenPonds.cs.patch
+++ b/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/7.GenPonds/GenPonds.cs.patch
@@ -1,5 +1,5 @@
 diff --git a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/7.GenPonds/GenPonds.cs b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/7.GenPonds/GenPonds.cs
-index acfac74..1bb1cce 100644
+index acfac74..ecbfb47 100644
 --- a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/7.GenPonds/GenPonds.cs
 +++ b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/7.GenPonds/GenPonds.cs
 @@ -9,27 +9,37 @@ using Vintagestory.API.Server;
@@ -144,7 +144,22 @@ index acfac74..1bb1cce 100644
              while (pondPositions.Count > 0)
              {
                  int p = pondPositions.Dequeue();
-@@ -300,14 +312,14 @@ namespace Vintagestory.ServerMods
+@@ -281,10 +293,14 @@ namespace Vintagestory.ServerMods
+                 // Get correct chunk and correct climate data if we don't have it already
+                 if (curChunkX != prevChunkX || curChunkZ != prevChunkZ)
+                 {
+                     chunk = (IServerChunk)blockAccessor.GetChunk(curChunkX, pondYPos / chunksize, curChunkZ);
+                     if (chunk == null) chunk = api.WorldManager.GetChunk(curChunkX, pondYPos / chunksize, curChunkZ);
++                    // Stratum: the fallback lookup can still return null (e.g. a neighbour column that's absent or mid-unload
++                    // while multiple columns run TerrainFeatures concurrently); the sibling chunkOneBlockBelow lookup just
++                    // below already guards this way, so bail out here too instead of NRE'ing on Unpack().
++                    if (chunk == null) return;
+                     chunk.Unpack();
+ 
+                     if (ly == 0)
+                     {
+                         chunkOneBlockBelow = ((IServerChunk)blockAccessor.GetChunk(curChunkX, (pondYPos - 1) / chunksize, curChunkZ));
+@@ -300,14 +316,14 @@ namespace Vintagestory.ServerMods
  
                      float fac = (float)climateMap.InnerSize / regionChunkSize;
                      int rlX = curChunkX % regionChunkSize;
@@ -163,7 +178,7 @@ index acfac74..1bb1cce 100644
                      prevChunkZ = curChunkZ;
  
                      chunkOneBlockBelow.MarkModified();
-@@ -317,11 +329,11 @@ namespace Vintagestory.ServerMods
+@@ -317,11 +333,11 @@ namespace Vintagestory.ServerMods
  
                  // Raise heightmap by 1 (only relevant for above-ground ponds)
                  if (mapchunk.RainHeightMap[lz * chunksize + lx] < pondYPos) mapchunk.RainHeightMap[lz * chunksize + lx] = (ushort)pondYPos;
@@ -176,7 +191,7 @@ index acfac74..1bb1cce 100644
  
                  // 1. Place water or ice block
                  int index3d = (ly * chunksize + lz) * chunksize + lx;
-@@ -355,11 +367,11 @@ namespace Vintagestory.ServerMods
+@@ -355,11 +371,11 @@ namespace Vintagestory.ServerMods
  
                  float rainRel = Climate.GetRainFall((climate >> 8) & 0xff, pondYPos) / 255f;
                  int rockBlockId = mapchunk.TopRockIdMap[lz * chunksize + lx];

--- a/patches/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs.patch
@@ -1,8 +1,8 @@
 diff --git a/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs b/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs
-index f644852..34e6266 100644
+index f644852..bff98da 100644
 --- a/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs
 +++ b/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs
-@@ -1,139 +1,1029 @@
+@@ -1,139 +1,1045 @@
  using System;
  using System.Collections.Generic;
  using System.Linq;
@@ -288,6 +288,13 @@ index f644852..34e6266 100644
 +	private readonly long[] stratumStageTicks = new long[StratumWorldGenStages.Done];
 +	private readonly long[] stratumStageColumnCounts = new long[StratumWorldGenStages.Done];
 +
++	// Stratum: how many times a column was turned away by the neighbour-parity gate, per
++	// stage. ensurePrettyNeighbourhood lets stages at or below TerrainLate through
++	// unconditionally and otherwise requires all 8 neighbours to have reached the same pass,
++	// so this is where a raised concurrency cap stops paying off. Counts refused dispatch
++	// attempts, not distinct columns, since the dispatcher retries a blocked column later.
++	private readonly long[] stratumGateBlockedCounts = new long[StratumWorldGenStages.Done];
++
 +	// Channel of ready-to-execute tasks (dispatcher → workers)
 +	private BlockingCollection<DispatchedTask> readyTasksQueue;
 +
@@ -499,7 +506,16 @@ index f644852..34e6266 100644
 +			string name = i < names.Length ? names[i] : "stage" + i;
 +			parts.Add($"{name}={pct:0.#}% ({cols} cols, {msPerColumn:0.###}ms/col)");
 +		}
-+		return string.Join(" ", parts);
++
++		// Stratum: same line reports where time went and where columns waited on neighbours.
++		// Stages at or below TerrainLate are expected to read 0 always.
++		List<string> gateParts = new List<string>();
++		for (int i = 1; i < stratumGateBlockedCounts.Length; i++)
++		{
++			string gname = i < names.Length ? names[i] : "stage" + i;
++			gateParts.Add($"{gname}={Interlocked.Read(ref stratumGateBlockedCounts[i])}");
++		}
++		return string.Join(" ", parts) + " | gate blocked: " + string.Join(" ", gateParts);
 +	}
 +
 +
@@ -1054,7 +1070,7 @@ index f644852..34e6266 100644
  			if (!tryLoadOrGenerateChunkColumnsInQueue())
  			{
  				break;
-@@ -143,39 +1033,59 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -143,39 +1049,59 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				break;
  			}
  		}
@@ -1116,7 +1132,7 @@ index f644852..34e6266 100644
  				ServerChunk serverChunk = (ServerChunk)server.WorldMap.GetChunk(x, i, z);
  				if (serverChunk != null)
  				{
-@@ -183,11 +1093,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -183,11 +1109,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					for (int j = 0; j < entities.Length; j++)
  					{
  						Entity entity = entities[j];
@@ -1129,7 +1145,7 @@ index f644852..34e6266 100644
  						{
  							if (j >= serverChunk.EntitiesCount)
  							{
-@@ -211,19 +1121,23 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -211,19 +1137,23 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				});
  			}
  			list2.Add(item);
@@ -1154,7 +1170,7 @@ index f644852..34e6266 100644
  		{
  			ChunkPos item2 = server.WorldMap.MapRegionPosFromIndex2D(result2);
  			if (hashSet == null)
-@@ -237,28 +1151,46 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -237,28 +1167,46 @@ internal class ServerSystemSupplyChunks : ServerSystem
  		{
  			chunkthread.gameDatabase.DeleteMapRegions(hashSet);
  		}
@@ -1206,7 +1222,7 @@ index f644852..34e6266 100644
  		ServerMapChunk orCreateMapChunk = chunkthread.loadsavechunks.GetOrCreateMapChunk(request);
  		if (orCreateMapChunk == null)
  		{
-@@ -267,94 +1199,203 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -267,94 +1215,203 @@ internal class ServerSystemSupplyChunks : ServerSystem
  		ServerChunk[] array = chunkthread.loadsavechunks.TryLoadChunkColumn(request);
  		if (array == null)
  		{
@@ -1416,7 +1432,7 @@ index f644852..34e6266 100644
  				chunkRequest.Chunks = TryLoadChunkColumn(chunkRequest);
  				if (chunkRequest.Chunks != null)
  				{
-@@ -364,31 +1405,42 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -364,31 +1421,42 @@ internal class ServerSystemSupplyChunks : ServerSystem
  						obj.serverMapChunk = orCreateMapChunk;
  						obj.MarkFresh();
  					}
@@ -1459,7 +1475,7 @@ index f644852..34e6266 100644
  				ServerEventAPI eventapi = server.api.eventapi;
  				ServerMapChunk mapChunk = orCreateMapChunk;
  				int chunkX = chunkRequest.chunkX;
-@@ -404,117 +1456,105 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -404,117 +1472,105 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					ServerMain.Logger.Error("Repair mode is enabled so will delete the entire chunk column.");
  					GenerateNewChunkColumn(orCreateMapChunk, chunkRequest);
  					return false;
@@ -1607,7 +1623,7 @@ index f644852..34e6266 100644
  				try
  				{
  					serverChunk.Unpack();
-@@ -529,10 +1569,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -529,10 +1585,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
  						ServerMain.FrameProfiler.Leave();
  						return;
  					}
@@ -1620,7 +1636,7 @@ index f644852..34e6266 100644
  			{
  				for (int j = 0; j < serverChunk.Entities.Length; j++)
  				{
-@@ -548,10 +1590,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -548,10 +1606,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					{
  						if (server.LoadEntity(entity, num2))
  						{
@@ -1632,7 +1648,7 @@ index f644852..34e6266 100644
  						{
  							string text = "-";
  							try
-@@ -564,14 +1607,18 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -564,14 +1623,18 @@ internal class ServerSystemSupplyChunks : ServerSystem
  							ServerMain.Logger.Log(EnumLogType.Worldgen, "In " + server.WorldName + ", villager " + text + " removed at " + entity.Pos.AsBlockPos?.ToString() + " due to an exception on loading");
  						}
  					}
@@ -1651,7 +1667,7 @@ index f644852..34e6266 100644
  			{
  				BlockEntity value = blockEntity.Value;
  				if (value == null)
-@@ -580,13 +1627,23 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -580,13 +1643,23 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				}
  				try
  				{
@@ -1677,7 +1693,7 @@ index f644852..34e6266 100644
  					ServerMain.FrameProfiler.Leave();
  				}
  				catch (Exception ex3)
-@@ -594,23 +1651,33 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -594,23 +1667,33 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					ServerMain.Logger.Notification("Exception thrown when trying to initialize a block entity @{0}: {1}", value.Pos, ex3);
  					value.UnregisterAllTickListeners();
  				}
@@ -1711,7 +1727,7 @@ index f644852..34e6266 100644
  		mapChunk.NeighboursLoaded = default(SmallBoolArray);
  		mapChunk.SelfLoaded = true;
  		for (int i = 0; i < Cardinal.ALL.Length; i++)
-@@ -623,20 +1690,26 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -623,20 +1706,26 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				serverMapChunk.NeighboursLoaded[cardinal.Opposite.Index] = true;
  			}
  		}
@@ -1738,7 +1754,7 @@ index f644852..34e6266 100644
  			serverMapChunk.NeighboursLoaded[4] = false;
  		}
  		if (serverMapChunk2 != null)
-@@ -667,12 +1740,17 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -667,12 +1756,17 @@ internal class ServerSystemSupplyChunks : ServerSystem
  		{
  			serverMapChunk8.NeighboursLoaded[3] = false;
  		}
@@ -1756,7 +1772,7 @@ index f644852..34e6266 100644
  			for (int j = -1; j <= 1; j++)
  			{
  				bool flag = false;
-@@ -682,19 +1760,24 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -682,19 +1776,24 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				}
  				if (!flag)
  				{
@@ -1781,7 +1797,7 @@ index f644852..34e6266 100644
  		int num = 0;
  		for (int i = -1; i <= 1; i++)
  		{
-@@ -707,60 +1790,78 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -707,60 +1806,78 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			}
  		}
  		return num == 8;
@@ -1861,7 +1877,7 @@ index f644852..34e6266 100644
  				dictionary = value.ModData;
  				dictionary2 = value.OreMaps;
  				intDataMap2D = value.GeologicProvinceMap;
-@@ -770,12 +1871,14 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -770,12 +1887,14 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			{
  				flag = false;
  				value.loadedTotalMs = server.ElapsedMilliseconds;
@@ -1876,7 +1892,7 @@ index f644852..34e6266 100644
  			if (list != null)
  			{
  				value.GeneratedStructures = list;
-@@ -798,35 +1901,48 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -798,35 +1917,48 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			}
  		}
  		return value;
@@ -1925,7 +1941,7 @@ index f644852..34e6266 100644
  		byte[] array = chunkGenParams?.GetBytes("GeneratedStructures");
  		if (array == null)
  		{
-@@ -836,44 +1952,60 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -836,44 +1968,60 @@ internal class ServerSystemSupplyChunks : ServerSystem
  		long key = server.api.WorldManager.MapRegionIndex2D(regionX, regionZ);
  		if (!dictionary.TryGetValue(key, out var value) || value == null)
  		{
@@ -1987,7 +2003,7 @@ index f644852..34e6266 100644
  		long key = server.WorldMap.MapChunkIndex2D(chunkX, chunkZ);
  		server.loadedMapChunks.TryGetValue(key, out var value);
  		if (value != null)
-@@ -881,31 +2013,42 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -881,31 +2029,42 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			return value;
  		}
  		return TryLoadMapChunk(chunkX, chunkZ);
@@ -2030,7 +2046,7 @@ index f644852..34e6266 100644
  			for (int j = 0; j < Cardinal.ALL.Length; j++)
  			{
  				Cardinal cardinal = Cardinal.ALL[j];
-@@ -918,47 +2061,111 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -918,47 +2077,111 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					}
  					chunkRequest.NeighbourTerrainHeight[j] = serverMapChunk.WorldGenTerrainHeightMap;
  				}
@@ -2158,7 +2174,7 @@ index f644852..34e6266 100644
  			foreach (ServerChunk serverChunk in array)
  			{
  				if (serverChunk != null)
-@@ -967,10 +2174,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -967,10 +2190,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					serverChunk.MarkModified();
  					serverChunk.TryPackAndCommit();
  				}
@@ -2171,7 +2187,7 @@ index f644852..34e6266 100644
  			ServerMain.Logger.Error("Loaded some but not all chunks of a column? Discarding whole column.");
  			return null;
  		}
-@@ -979,18 +2188,22 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -979,18 +2204,22 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			return null;
  		}
  		return array;
@@ -2194,7 +2210,7 @@ index f644852..34e6266 100644
  					serverMapChunk.YMax = (ushort)(server.SaveGameData.MapSizeY - 1);
  				}
  				return serverMapChunk;
-@@ -1011,10 +2224,13 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1011,10 +2240,13 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			}
  		}
  		return null;
@@ -2208,7 +2224,7 @@ index f644852..34e6266 100644
  		byte[] mapRegion = chunkthread.gameDatabase.GetMapRegion(regionX, regionZ);
  		try
  		{
-@@ -1035,14 +2251,27 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1035,14 +2267,27 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			throw;
  		}
  		return null;
@@ -2236,7 +2252,7 @@ index f644852..34e6266 100644
  			storyChunkSpawnEvents = new string[15]
  			{
  				Lang.Get("...the carved mountains"),
-@@ -1060,23 +2289,27 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1060,23 +2305,27 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				Lang.Get("...a misty sunrise"),
  				Lang.Get("...dew drops on a blade of grass"),
  				Lang.Get("...a soft breeze")
@@ -2264,7 +2280,7 @@ index f644852..34e6266 100644
  					double value = random.NextDouble() * 6.2831854820251465;
  					double num7 = num6 * GameMath.Sin(value);
  					double num8 = num6 * GameMath.Cos(value);
-@@ -1096,10 +2329,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1096,10 +2345,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					server.api.Logger.Notification("Trying another spawn location ({0}/{1})...", i + 2, num3);
  				}
  			}
@@ -2276,7 +2292,7 @@ index f644852..34e6266 100644
  				if (!server.blockAccessor.GetBlock(blockPos).SideSolid[BlockFacing.UP.Index])
  				{
  					server.blockAccessor.SetBlock(server.blockAccessor.GetBlock(new AssetLocation("planks-oak-we")).Id, blockPos);
-@@ -1107,13 +2341,16 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1107,13 +2357,16 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				blockPos.Y++;
  			}
  		}
@@ -2293,7 +2309,7 @@ index f644852..34e6266 100644
  			x = blockPos.X,
  			y = blockPos.Y,
  			z = blockPos.Z
-@@ -1123,10 +2360,14 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1123,10 +2376,14 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			server.mapMiddleSpawnPos.y = null;
  		}
  		server.api.Logger.VerboseDebug("Done spawn chunk");
@@ -2308,7 +2324,7 @@ index f644852..34e6266 100644
  		int num = 60;
  		int num2 = 0;
  		int num3 = 0;
-@@ -1137,36 +2378,47 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1137,36 +2394,47 @@ internal class ServerSystemSupplyChunks : ServerSystem
  		{
  			num4 = GameMath.Clamp(num2 + pos.X, 0, server.WorldMap.MapSizeX - 1);
  			num6 = GameMath.Clamp(num3 + pos.Z, 0, server.WorldMap.MapSizeZ - 1);
@@ -2357,7 +2373,7 @@ index f644852..34e6266 100644
  		{
  			for (int k = -num2; k <= num2; k++)
  			{
-@@ -1174,18 +2426,22 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1174,18 +2442,22 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				{
  					long index2d = server.WorldMap.MapChunkIndex2D(x + j, y + k);
  					int regionX = (x + j) / MagicNum.ChunkRegionSizeInChunks;
@@ -2381,7 +2397,7 @@ index f644852..34e6266 100644
  					};
  					chunkColumnLoadRequest.MapChunk = mapChunk;
  					GenerateNewChunkColumn(mapChunk, chunkColumnLoadRequest);
-@@ -1196,10 +2452,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1196,10 +2468,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
  						chunkthread.peekingChunkColumns.Enqueue(chunkColumnLoadRequest);
  					}
  				}
@@ -2394,7 +2410,7 @@ index f644852..34e6266 100644
  		{
  			num4 = num - i;
  			for (int l = -num4; l <= num4; l++)
-@@ -1212,10 +2470,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1212,10 +2486,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
  						runGenerators(chunkRequest, i);
  					}
  				}
@@ -2407,7 +2423,7 @@ index f644852..34e6266 100644
  		{
  			for (int n = -num2; n <= num2; n++)
  			{
-@@ -1232,61 +2492,111 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1232,61 +2508,111 @@ internal class ServerSystemSupplyChunks : ServerSystem
  						dictionary2[key] = chunks;
  					}
  				}
@@ -2521,7 +2537,7 @@ index f644852..34e6266 100644
  				millisecondsSinceStart = server.totalUnpausedTime.ElapsedMilliseconds;
  				float num4 = 100f * ((float)server.loadedChunks.Count / (float)server.WorldMap.ChunkMapSizeY - (float)num) / (float)num2;
  				ServerMain.Logger.Event(num4.ToString("0.#") + "% ({0} in queue)", chunkthread.requestedChunkColumns.Count);
-@@ -1298,37 +2608,84 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1298,37 +2624,84 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				{
  					ServerMain.Logger.StoryEvent("...");
  				}
@@ -2609,7 +2625,7 @@ index f644852..34e6266 100644
  				foreach (ChunkColumnLoadRequest requestedChunkColumn3 in chunkthread.requestedChunkColumns)
  				{
  					if (requestedChunkColumn3 != null)
-@@ -1340,16 +2697,25 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1340,16 +2713,25 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				throw new Exception("Somehow worldgen has become stuck in an endless loop, please report this as a bug!  Additional data in the server-main log");
  			}
  		}
@@ -2635,7 +2651,7 @@ index f644852..34e6266 100644
  				if (chunkRequest.CurrentIncompletePass == EnumWorldGenPass.Terrain)
  				{
  					ushort sunLight = (ushort)server.sunBrightness;
-@@ -1359,32 +2725,62 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1359,32 +2741,62 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					}
  				}
  			}
@@ -2700,7 +2716,7 @@ index f644852..34e6266 100644
  			return;
  		}
  		for (int i = 0; i < list.Count; i++)
-@@ -1396,89 +2792,117 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1396,89 +2808,119 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			catch (Exception ex)
  			{
  				ServerMain.Logger.Worldgen("An error was thrown in pass {5} when generating chunk column X={0},Z={1} in world '{3}' with seed {4}\nException {2}\n\n", chunkRequest.chunkX, chunkRequest.chunkZ, ex, server.SaveGameData.WorldName, server.SaveGameData.Seed, chunkRequest.CurrentIncompletePass.ToString());
@@ -2777,6 +2793,8 @@ index f644852..34e6266 100644
  			}
  		}
  		chunkRequest.prettified = true;
++		// Stratum: see stratumGateBlockedCounts.
++		if (!result) Interlocked.Increment(ref stratumGateBlockedCounts[currentIncompletePass_AsInt]);
  		return result;
  	}
  
@@ -2835,7 +2853,7 @@ index f644852..34e6266 100644
  			chunkthread.requestedChunkColumns.Enqueue(curRequest);
  			return true;
  		}
-@@ -1490,13 +2914,19 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1490,13 +2932,19 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				ServerMain.Logger.VerboseDebug("Un-pausing all worldgen threads.");
  			}
  		}
@@ -2855,7 +2873,7 @@ index f644852..34e6266 100644
  			if (requestedChunkColumn != null && !requestedChunkColumn.Disposed)
  			{
  				server.loadedMapChunks.Remove(requestedChunkColumn.mapIndex2d);
-@@ -1505,104 +2935,181 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1505,104 +2953,181 @@ internal class ServerSystemSupplyChunks : ServerSystem
  		}
  		chunkthread.requestedChunkColumns.Clear();
  		ServerMain.Logger.VerboseDebug("Incomplete chunks stored and wiped.");


### PR DESCRIPTION
One counter, appended to a log line that already exists. Small on purpose.

## Why

`ensurePrettyNeighbourhood` is the reason a raised same-stage concurrency cap can stop paying off, and until now its effect was only visible by reading the source:

```csharp
// For early stages, neighbours don't matter
if (chunkRequest.CurrentIncompletePass_AsInt <= StratumWorldGenStages.TerrainLate)
{
    return true;
}
```

Above TerrainLate, all 8 neighbours must have reached the same pass or later before a column may advance. So past that point a column's eligibility is governed by the wavefront, not by the cap, and **a cap can only bind on columns that are actually eligible**.

That is @tehtelev's point from Discord ("no one removed the restriction that the current chunk can wait until its neighbors reach the same generation stage. This factor may also limit the effect"). He was right, and this turns it from a source-reading inference into a number.

## What it does

Counts refused dispatch attempts per stage and appends them to the line already emitted as `pregen stage timings`, so one line reports both where time went and where columns waited:

```
pregen stage timings: Terrain=44.3% (6181 cols, 11.558ms/col) TerrainLate=24.5% ... | gate blocked: Terrain=0 TerrainLate=0 TerrainFeatures=3271917 Vegetation=2540694 NeighbourSunLightFlood=3212235 PreDone=3759251
```

It counts **attempts, not distinct columns**, because the dispatcher retries a blocked column on later ticks. The field name and comment say so, to stop the number being misread as a column count.

The immediately useful property is that it makes an expectation checkable rather than assumed: **Terrain and TerrainLate must read 0 always**, since the gate returns before looking at them. In every run measured while writing this they did, and the stages above TerrainLate carried millions of refusals each.

## Cost

Measured before proposing it, since the increment sits on a path hit millions of times per pregen. Radius 40, 3 worldgen threads, same seed, stray `MSBuild.dll`/`VBCSCompiler` processes killed before each run, distinct data dir per run:

| Build | Samples (s) | Median |
| --- | --- | --- |
| current `indev` | 87, 91, 96 | 91s |
| this branch | 87, 87 | 87s |

No measurable overhead, which is what an uncontended `Interlocked.Increment` should look like on a path already doing a 3x3 neighbour scan with dictionary lookups per iteration.

## What it already surfaced

Roughly 2,000 refused attempts per generated column across the gated stages, each scanning up to 8 neighbours. That cost is **invisible in the stage timings**, which only measure time inside `PopulateChunk`, so it is pure dispatcher overhead on top. I have not tried to reduce it; this PR only makes it visible. It looks like the most concrete remaining lead for worldgen throughput, and it is not something I would have found without the counter.

## Scope

No behaviour change, no new public API, no config. One `long[]`, one increment, one appended string. Build clean, `smoke-test.sh` reaches RunGame, exactly the 2 known false-positive log lines (a class literally named `ErrorReporter`, and a line reading "no errors").

/cc @tehtelev
