### PR TITLE
Stop the schematic remap map from clearing another schematic's BlockCodes

### DIFF
--- a/patches/VSEssentials/Systems/WorldGen/Standard/Datastructures/BlockSchematicStructure.cs.patch
+++ b/patches/VSEssentials/Systems/WorldGen/Standard/Datastructures/BlockSchematicStructure.cs.patch
@@ -1,51 +1,77 @@
 diff --git a/VSEssentials/Systems/WorldGen/Standard/Datastructures/BlockSchematicStructure.cs b/VSEssentials/Systems/WorldGen/Standard/Datastructures/BlockSchematicStructure.cs
-index 7573f32..03c54ee 100644
+index 7573f32..27a7943 100644
 --- a/VSEssentials/Systems/WorldGen/Standard/Datastructures/BlockSchematicStructure.cs
 +++ b/VSEssentials/Systems/WorldGen/Standard/Datastructures/BlockSchematicStructure.cs
-@@ -12,11 +12,19 @@ using Vintagestory.ServerMods.NoObf;
+@@ -12,11 +12,30 @@ using Vintagestory.ServerMods.NoObf;
  
  namespace Vintagestory.ServerMods
  {
      public class BlockSchematicStructure : BlockSchematic
      {
 -        public Dictionary<int, AssetLocation> BlockCodesTmpForRemap = new();
-+        // Stratum: was a shared instance field, written by resolveReplaceRemapsForBlockEntities
-+        // and read a few lines later by PlaceEntitiesAndBlockEntities, both within the same
-+        // placement call. Different columns placing the same cached schematic concurrently
-+        // could interleave: one placement's remap overwrites another's before the first reads it
-+        // back, or reassigns the field to a different dictionary entirely (the replaceBlocks
-+        // == null fast path below). Nothing about this needs to outlive a single placement
-+        // call, so it moved to thread-local scratch instead of instance state.
++        // Stratum: scratch storage for the remapped block-code map built below, used only
++        // when replaceBlocks is non-null. It must never be handed a reference to BlockCodes.
++        //
++        // This field used to hold either the scratch dictionary OR BlockCodes itself, and
++        // being [ThreadStatic] on a static it is shared by every BlockSchematicStructure on
++        // the thread, not one per schematic the way the original instance field was. So a
++        // placement with replaceBlocks == null pointed it at that schematic's permanent
++        // BlockCodes, and the next placement on the same thread with replaceBlocks != null
++        // saw a non-null value that did not match ITS OWN BlockCodes and called Clear() on
++        // it, wiping a different schematic's permanent id-to-code map for the rest of the
++        // process. Downstream that surfaces as "block id N not found in block registry"
++        // warnings and a KeyNotFoundException from BlockSchematic.PlaceOneDecor, which
++        // indexes BlockCodes directly, and the wrong blocks it places are persisted.
++        //
++        // Now the resolve method returns the map instead of publishing it here, and the
++        // null-replaceBlocks path returns BlockCodes untouched, matching what vanilla
++        // BlockSchematic does. This field can therefore only ever hold its own scratch
++        // dictionary, which makes clearing and reusing it safe.
 +        [ThreadStatic]
-+        private static Dictionary<int, AssetLocation> stratumBlockCodesTmpForRemap;
++        private static Dictionary<int, AssetLocation> stratumBlockCodesRemapScratch;
  
          public AssetLocation FromFile;
  
          public Block[,,] blocksByPos;
          public Dictionary<int, Block> FluidBlocksByPos;
-@@ -306,35 +314,38 @@ namespace Vintagestory.ServerMods
+@@ -125,11 +144,11 @@ namespace Vintagestory.ServerMods
+             IMapChunk mapchunk = blockAccessor.GetMapChunkAtBlockPos(curPos);
+             int centerrockblockid = mapchunk.TopRockIdMap[(curPos.Z % chunksize) * chunksize + curPos.X % chunksize];
+ 
+             IWorldAccessor worldgenWorldAccessor = blockAccessor is IWorldGenBlockAccessor wgba ? wgba.WorldgenWorldAccessor : worldForCollectibleResolve;
+ 
+-            resolveReplaceRemapsForBlockEntities(blockAccessor, worldForCollectibleResolve, replaceBlocks, centerrockblockid);
++            Dictionary<int, AssetLocation> blockCodesForRemap = resolveReplaceRemapsForBlockEntities(blockAccessor, worldForCollectibleResolve, replaceBlocks, centerrockblockid);
+ 
+             Dictionary<BlockPos, Block> layerBlockForBlockEntities = new Dictionary<BlockPos, Block>();
+ 
+             for (int x = 0; x < SizeX; x++)
+             {
+@@ -306,38 +325,43 @@ namespace Vintagestory.ServerMods
                      }
                  }
              }
  
              PlaceDecors(blockAccessor, startPos);
 -            PlaceEntitiesAndBlockEntities(blockAccessor, worldForCollectibleResolve, startPos, BlockCodesTmpForRemap, ItemCodes, replaceBlockEntities, replaceBlocks, centerrockblockid, layerBlockForBlockEntities, replaceMetaBlocks);
-+            PlaceEntitiesAndBlockEntities(blockAccessor, worldForCollectibleResolve, startPos, stratumBlockCodesTmpForRemap, ItemCodes, replaceBlockEntities, replaceBlocks, centerrockblockid, layerBlockForBlockEntities, replaceMetaBlocks);
++            PlaceEntitiesAndBlockEntities(blockAccessor, worldForCollectibleResolve, startPos, blockCodesForRemap, ItemCodes, replaceBlockEntities, replaceBlocks, centerrockblockid, layerBlockForBlockEntities, replaceMetaBlocks);
  
              return placed;
          }
  
-         private void resolveReplaceRemapsForBlockEntities(IBlockAccessor blockAccessor, IWorldAccessor worldForCollectibleResolve, Dictionary<int, Dictionary<int, int>> replaceBlocks, int centerrockblockid)
+-        private void resolveReplaceRemapsForBlockEntities(IBlockAccessor blockAccessor, IWorldAccessor worldForCollectibleResolve, Dictionary<int, Dictionary<int, int>> replaceBlocks, int centerrockblockid)
++        private Dictionary<int, AssetLocation> resolveReplaceRemapsForBlockEntities(IBlockAccessor blockAccessor, IWorldAccessor worldForCollectibleResolve, Dictionary<int, Dictionary<int, int>> replaceBlocks, int centerrockblockid)
          {
              if (replaceBlocks == null)
              {
 -                BlockCodesTmpForRemap = BlockCodes;
-+                stratumBlockCodesTmpForRemap = BlockCodes;
-                 return;
+-                return;
++                // Stratum: hand BlockCodes back directly and never store or mutate it, same as vanilla.
++                return BlockCodes;
              }
  
-+            if (stratumBlockCodesTmpForRemap == null || stratumBlockCodesTmpForRemap == BlockCodes) stratumBlockCodesTmpForRemap = new Dictionary<int, AssetLocation>();
-+            else stratumBlockCodesTmpForRemap.Clear();
++            if (stratumBlockCodesRemapScratch == null) stratumBlockCodesRemapScratch = new Dictionary<int, AssetLocation>();
++            else stratumBlockCodesRemapScratch.Clear();
 +
              foreach (var val in BlockCodes)
              {
@@ -53,27 +79,45 @@ index 7573f32..03c54ee 100644
                  if (origBlock == null) continue; // Invalid blocks
  
 -                BlockCodesTmpForRemap[val.Key] = val.Value;
-+                stratumBlockCodesTmpForRemap[val.Key] = val.Value;
++                stratumBlockCodesRemapScratch[val.Key] = val.Value;
  
                  if (replaceBlocks.TryGetValue(origBlock.Id, out var replaceByBlock))
                  {
                      if (replaceByBlock.TryGetValue(centerrockblockid, out int newBlockId))
                      {
 -                        BlockCodesTmpForRemap[val.Key] = blockAccessor.GetBlock(newBlockId).Code;
-+                        stratumBlockCodesTmpForRemap[val.Key] = blockAccessor.GetBlock(newBlockId).Code;
++                        stratumBlockCodesRemapScratch[val.Key] = blockAccessor.GetBlock(newBlockId).Code;
                      }
                  }
              }
++
++            return stratumBlockCodesRemapScratch;
          }
  
-@@ -426,11 +437,11 @@ namespace Vintagestory.ServerMods
+ 
+ 
+ 
+@@ -358,11 +382,11 @@ namespace Vintagestory.ServerMods
+ 
+             const int chunksize = GlobalConstants.ChunkSize;
+             curPos.Set(SizeX / 2 + startPos.X, startPos.Y, SizeZ / 2 + startPos.Z);
+             IMapChunk mapchunk = blockAccessor.GetMapChunkAtBlockPos(curPos);
+             int centerrockblockid = rockBlockId ?? mapchunk.TopRockIdMap[(curPos.Z % chunksize) * chunksize + curPos.X % chunksize];
+-            resolveReplaceRemapsForBlockEntities(blockAccessor, worldForCollectibleResolve, replaceBlocks, centerrockblockid);
++            Dictionary<int, AssetLocation> blockCodesForRemap = resolveReplaceRemapsForBlockEntities(blockAccessor, worldForCollectibleResolve, replaceBlocks, centerrockblockid);
+ 
+ 
+             PlaceBlockDelegate handler = null;
+             switch (ReplaceMode)
+             {
+@@ -426,11 +450,11 @@ namespace Vintagestory.ServerMods
              }
  
              if (!(blockAccessor is IBlockAccessorRevertable))
              {
                  PlaceDecors(blockAccessor, startPos);
 -                PlaceEntitiesAndBlockEntities(blockAccessor, worldForCollectibleResolve, startPos, BlockCodesTmpForRemap, ItemCodes, false, null, centerrockblockid, null, GlobalConfig.ReplaceMetaBlocks);
-+                PlaceEntitiesAndBlockEntities(blockAccessor, worldForCollectibleResolve, startPos, stratumBlockCodesTmpForRemap, ItemCodes, false, null, centerrockblockid, null, GlobalConfig.ReplaceMetaBlocks);
++                PlaceEntitiesAndBlockEntities(blockAccessor, worldForCollectibleResolve, startPos, blockCodesForRemap, ItemCodes, false, null, centerrockblockid, null, GlobalConfig.ReplaceMetaBlocks);
              }
  
              return placed;


### PR DESCRIPTION
Fixes the `KeyNotFoundException` in `BlockSchematic.PlaceDecors` and the `block id N not found in block registry` warnings reported against **`v1.22.5-stratum.1`**, the current stable release.

One file. No behaviour change beyond the fix, no new API, none of the other worldgen work in flight, so it can ship as a patch release on its own.

## The bug

`BlockCodesTmpForRemap` used to be a **per-instance** field. It was converted to `[ThreadStatic] private static`, which is one slot per thread shared by **every** `BlockSchematicStructure` on that thread, and the field was made to hold either the scratch dictionary or `BlockCodes` itself depending on which branch ran:

```csharp
if (replaceBlocks == null)
{
    stratumBlockCodesTmpForRemap = BlockCodes;   // aliases THIS schematic's permanent map
    return;
}
if (stratumBlockCodesTmpForRemap == null || stratumBlockCodesTmpForRemap == BlockCodes) stratumBlockCodesTmpForRemap = new Dictionary<int, AssetLocation>();
else stratumBlockCodesTmpForRemap.Clear();      // clears whatever it points at
```

The identity guard only compares against **this** instance's `BlockCodes`, so it cannot tell the slot is aliasing a *different* schematic's map:

1. Schematic **A** places with `replaceBlocks == null`, and the slot now aliases `A.BlockCodes`.
2. Schematic **B** places on the same thread with `replaceBlocks != null`, the slot is non-null and `!= B.BlockCodes`, so it falls through and **clears `A.BlockCodes`**.

`BlockCodes` is the schematic's permanent id to `AssetLocation` map, loaded once and reused for the process lifetime, so A stays broken from then on. `BlockSchematic.PlaceOneDecor` indexes it bare (`BlockCodes[id]`), which is the `KeyNotFoundException`, and the wrong blocks placed before it throws are **written into the world and persist**.

**No concurrency is required.** `WorldGenStructure.resolvedRockTypeRemaps` starts `null` and is only populated when a structure configures a rock-type remap group, so structures without remaps supply step 1 and structures with them supply step 2, and a normal world has both. The crash lands in the **TerrainFeatures** pass, whose concurrency cap is 1 in the released build, which confirms this independently of any cap raise.

## The fix

Remove the shared publication point. `resolveReplaceRemapsForBlockEntities` returns the map, both callers hold it in a local and pass that local to `PlaceEntitiesAndBlockEntities`, and the `replaceBlocks == null` path returns `BlockCodes` untouched, which is what vanilla `BlockSchematic` already does at the equivalent call. The thread-static stays purely as reuse scratch for the remap case, where it can now only ever hold its own dictionary, so clearing and reusing it is safe.

## Verified by reproduction, not by reasoning

Radius 100 pregen, 3 worldgen threads, seed `1027995113`, identical settings both sides:

| | `indev` (before) | this branch (after) |
| --- | --- | --- |
| `KeyNotFoundException` in `PlaceDecors` | **2** | **0** |
| worldgen exceptions | **1** | **0** |
| pregen wall clock | 6m45s | 6m49s |

The reproduced stack trace matches the reported one line for line, down to `GenStructures.OnChunkColumnGenPostPass` → `TryGenerateAtSurface` → `PlaceRespectingBlockLayers` → `PlaceDecors`. Costs nothing measurable.

Build clean, `smoke-test.sh` reaches RunGame, exactly the 2 known false-positive log lines.
