### PR TITLE
Release both claims when the neighbour gate throws, which wedged worldgen

### DIFF
--- a/patches/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs.patch
@@ -1,8 +1,8 @@
 diff --git a/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs b/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs
-index f644852..bff98da 100644
+index f644852..e6df6b1 100644
 --- a/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs
 +++ b/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs
-@@ -1,139 +1,1045 @@
+@@ -1,139 +1,1064 @@
  using System;
  using System.Collections.Generic;
  using System.Linq;
@@ -562,33 +562,52 @@ index f644852..bff98da 100644
 +			return false;
 +		}
 +
-+		// Re-verify: currentpass may have changed between the read and the CAS
-+		if (req.CurrentIncompletePass_AsInt != stage)
++		// Stratum: from here on both claims are held, so every exit has to release
++		// them. The checks below can THROW, not just return false:
++		// ensurePrettyNeighbourhood reaches EnsureMinimumWorldgenPassAt, which
++		// enqueues lagging neighbours and throws "Indexed Fifo Queue overflow" when
++		// the request queue is full. Without this finally that exception escaped with
++		// dispatchClaimed still 1 and the stage's active count still incremented,
++		// which is unrecoverable rather than merely noisy: the column could never be
++		// claimed again by anyone, and a stage whose cap is 1 lost its only slot
++		// permanently, so worldgen wedged with every thread asleep and no watchdog on
++		// the pregen path to notice. Observed as a hard stall part-way through a
++		// radius-100 pregen once Terrain's cap was raised.
++		int claimedStage = stage;
++		bool claimHeld = true;
++		try
 +		{
-+			Interlocked.Decrement(ref stratumStageActiveCount[stage]);
-+			Volatile.Write(ref req.dispatchClaimed, 0);
-+			stage = -1;
-+			return false;
-+		}
++			// Re-verify: currentpass may have changed between the read and the CAS
++			if (req.CurrentIncompletePass_AsInt != stage)
++			{
++				stage = -1;
++				return false;
+ 			}
 +
-+		if (stage >= req.untilPass)
++			if (stage >= req.untilPass)
++			{
++				req.FlagToRequeue();
++				stage = -1;
++				return false;
++			}
++
++			if (!ensurePrettyNeighbourhood(req))
++			{
++				stage = -1;
++				return false;
++			}
++
++			claimHeld = false;   // handed off to the caller, which owns the release
++			return true;
++		}
++		finally
 +		{
-+			req.FlagToRequeue();
-+			Interlocked.Decrement(ref stratumStageActiveCount[stage]);
-+			Volatile.Write(ref req.dispatchClaimed, 0);
-+			stage = -1;
-+			return false;
++			if (claimHeld)
++			{
++				Interlocked.Decrement(ref stratumStageActiveCount[stage < 0 ? claimedStage : stage]);
++				Volatile.Write(ref req.dispatchClaimed, 0);
++			}
 +		}
-+
-+		if (!ensurePrettyNeighbourhood(req))
-+		{
-+			Interlocked.Decrement(ref stratumStageActiveCount[stage]);
-+			Volatile.Write(ref req.dispatchClaimed, 0);
-+			stage = -1;
-+			return false;
-+		}
-+
-+		return true;
 +	}
 +
 +	/// <summary>
@@ -614,10 +633,10 @@ index f644852..bff98da 100644
 +			{
 +				Interlocked.Decrement(ref stratumStageActiveCount[stage]);
 +				Volatile.Write(ref req.dispatchClaimed, 0);
- 			}
- 		}
- 	}
- 
++			}
++		}
++	}
++
 +	/// <summary>
 +	/// Stratum: CallerRunsPolicy-style fallback for loadChunkAreaBlocking's
 +	/// wait loop (see the comment there for when this gets called). TPS01-J
@@ -670,10 +689,10 @@ index f644852..bff98da 100644
 +				SignalDispatcher();
 +			}
 +			return true;
-+		}
+ 		}
 +		return false;
-+	}
-+
+ 	}
+ 
 +
 +	/// <summary>
 +	/// Dispatcher: scans the request queue and sends ready tasks to the worker channel.
@@ -1070,7 +1089,7 @@ index f644852..bff98da 100644
  			if (!tryLoadOrGenerateChunkColumnsInQueue())
  			{
  				break;
-@@ -143,39 +1049,59 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -143,39 +1068,59 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				break;
  			}
  		}
@@ -1132,7 +1151,7 @@ index f644852..bff98da 100644
  				ServerChunk serverChunk = (ServerChunk)server.WorldMap.GetChunk(x, i, z);
  				if (serverChunk != null)
  				{
-@@ -183,11 +1109,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -183,11 +1128,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					for (int j = 0; j < entities.Length; j++)
  					{
  						Entity entity = entities[j];
@@ -1145,7 +1164,7 @@ index f644852..bff98da 100644
  						{
  							if (j >= serverChunk.EntitiesCount)
  							{
-@@ -211,19 +1137,23 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -211,19 +1156,23 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				});
  			}
  			list2.Add(item);
@@ -1170,7 +1189,7 @@ index f644852..bff98da 100644
  		{
  			ChunkPos item2 = server.WorldMap.MapRegionPosFromIndex2D(result2);
  			if (hashSet == null)
-@@ -237,28 +1167,46 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -237,28 +1186,46 @@ internal class ServerSystemSupplyChunks : ServerSystem
  		{
  			chunkthread.gameDatabase.DeleteMapRegions(hashSet);
  		}
@@ -1222,7 +1241,7 @@ index f644852..bff98da 100644
  		ServerMapChunk orCreateMapChunk = chunkthread.loadsavechunks.GetOrCreateMapChunk(request);
  		if (orCreateMapChunk == null)
  		{
-@@ -267,94 +1215,203 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -267,94 +1234,203 @@ internal class ServerSystemSupplyChunks : ServerSystem
  		ServerChunk[] array = chunkthread.loadsavechunks.TryLoadChunkColumn(request);
  		if (array == null)
  		{
@@ -1432,7 +1451,7 @@ index f644852..bff98da 100644
  				chunkRequest.Chunks = TryLoadChunkColumn(chunkRequest);
  				if (chunkRequest.Chunks != null)
  				{
-@@ -364,31 +1421,42 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -364,31 +1440,42 @@ internal class ServerSystemSupplyChunks : ServerSystem
  						obj.serverMapChunk = orCreateMapChunk;
  						obj.MarkFresh();
  					}
@@ -1475,7 +1494,7 @@ index f644852..bff98da 100644
  				ServerEventAPI eventapi = server.api.eventapi;
  				ServerMapChunk mapChunk = orCreateMapChunk;
  				int chunkX = chunkRequest.chunkX;
-@@ -404,117 +1472,105 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -404,117 +1491,105 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					ServerMain.Logger.Error("Repair mode is enabled so will delete the entire chunk column.");
  					GenerateNewChunkColumn(orCreateMapChunk, chunkRequest);
  					return false;
@@ -1623,7 +1642,7 @@ index f644852..bff98da 100644
  				try
  				{
  					serverChunk.Unpack();
-@@ -529,10 +1585,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -529,10 +1604,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
  						ServerMain.FrameProfiler.Leave();
  						return;
  					}
@@ -1636,7 +1655,7 @@ index f644852..bff98da 100644
  			{
  				for (int j = 0; j < serverChunk.Entities.Length; j++)
  				{
-@@ -548,10 +1606,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -548,10 +1625,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					{
  						if (server.LoadEntity(entity, num2))
  						{
@@ -1648,7 +1667,7 @@ index f644852..bff98da 100644
  						{
  							string text = "-";
  							try
-@@ -564,14 +1623,18 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -564,14 +1642,18 @@ internal class ServerSystemSupplyChunks : ServerSystem
  							ServerMain.Logger.Log(EnumLogType.Worldgen, "In " + server.WorldName + ", villager " + text + " removed at " + entity.Pos.AsBlockPos?.ToString() + " due to an exception on loading");
  						}
  					}
@@ -1667,7 +1686,7 @@ index f644852..bff98da 100644
  			{
  				BlockEntity value = blockEntity.Value;
  				if (value == null)
-@@ -580,13 +1643,23 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -580,13 +1662,23 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				}
  				try
  				{
@@ -1693,7 +1712,7 @@ index f644852..bff98da 100644
  					ServerMain.FrameProfiler.Leave();
  				}
  				catch (Exception ex3)
-@@ -594,23 +1667,33 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -594,23 +1686,33 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					ServerMain.Logger.Notification("Exception thrown when trying to initialize a block entity @{0}: {1}", value.Pos, ex3);
  					value.UnregisterAllTickListeners();
  				}
@@ -1727,7 +1746,7 @@ index f644852..bff98da 100644
  		mapChunk.NeighboursLoaded = default(SmallBoolArray);
  		mapChunk.SelfLoaded = true;
  		for (int i = 0; i < Cardinal.ALL.Length; i++)
-@@ -623,20 +1706,26 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -623,20 +1725,26 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				serverMapChunk.NeighboursLoaded[cardinal.Opposite.Index] = true;
  			}
  		}
@@ -1754,7 +1773,7 @@ index f644852..bff98da 100644
  			serverMapChunk.NeighboursLoaded[4] = false;
  		}
  		if (serverMapChunk2 != null)
-@@ -667,12 +1756,17 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -667,12 +1775,17 @@ internal class ServerSystemSupplyChunks : ServerSystem
  		{
  			serverMapChunk8.NeighboursLoaded[3] = false;
  		}
@@ -1772,7 +1791,7 @@ index f644852..bff98da 100644
  			for (int j = -1; j <= 1; j++)
  			{
  				bool flag = false;
-@@ -682,19 +1776,24 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -682,19 +1795,24 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				}
  				if (!flag)
  				{
@@ -1797,7 +1816,7 @@ index f644852..bff98da 100644
  		int num = 0;
  		for (int i = -1; i <= 1; i++)
  		{
-@@ -707,60 +1806,78 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -707,60 +1825,78 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			}
  		}
  		return num == 8;
@@ -1877,7 +1896,7 @@ index f644852..bff98da 100644
  				dictionary = value.ModData;
  				dictionary2 = value.OreMaps;
  				intDataMap2D = value.GeologicProvinceMap;
-@@ -770,12 +1887,14 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -770,12 +1906,14 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			{
  				flag = false;
  				value.loadedTotalMs = server.ElapsedMilliseconds;
@@ -1892,7 +1911,7 @@ index f644852..bff98da 100644
  			if (list != null)
  			{
  				value.GeneratedStructures = list;
-@@ -798,35 +1917,48 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -798,35 +1936,48 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			}
  		}
  		return value;
@@ -1941,7 +1960,7 @@ index f644852..bff98da 100644
  		byte[] array = chunkGenParams?.GetBytes("GeneratedStructures");
  		if (array == null)
  		{
-@@ -836,44 +1968,60 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -836,44 +1987,60 @@ internal class ServerSystemSupplyChunks : ServerSystem
  		long key = server.api.WorldManager.MapRegionIndex2D(regionX, regionZ);
  		if (!dictionary.TryGetValue(key, out var value) || value == null)
  		{
@@ -2003,7 +2022,7 @@ index f644852..bff98da 100644
  		long key = server.WorldMap.MapChunkIndex2D(chunkX, chunkZ);
  		server.loadedMapChunks.TryGetValue(key, out var value);
  		if (value != null)
-@@ -881,31 +2029,42 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -881,31 +2048,42 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			return value;
  		}
  		return TryLoadMapChunk(chunkX, chunkZ);
@@ -2046,7 +2065,7 @@ index f644852..bff98da 100644
  			for (int j = 0; j < Cardinal.ALL.Length; j++)
  			{
  				Cardinal cardinal = Cardinal.ALL[j];
-@@ -918,47 +2077,111 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -918,47 +2096,111 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					}
  					chunkRequest.NeighbourTerrainHeight[j] = serverMapChunk.WorldGenTerrainHeightMap;
  				}
@@ -2174,7 +2193,7 @@ index f644852..bff98da 100644
  			foreach (ServerChunk serverChunk in array)
  			{
  				if (serverChunk != null)
-@@ -967,10 +2190,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -967,10 +2209,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					serverChunk.MarkModified();
  					serverChunk.TryPackAndCommit();
  				}
@@ -2187,7 +2206,7 @@ index f644852..bff98da 100644
  			ServerMain.Logger.Error("Loaded some but not all chunks of a column? Discarding whole column.");
  			return null;
  		}
-@@ -979,18 +2204,22 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -979,18 +2223,22 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			return null;
  		}
  		return array;
@@ -2210,7 +2229,7 @@ index f644852..bff98da 100644
  					serverMapChunk.YMax = (ushort)(server.SaveGameData.MapSizeY - 1);
  				}
  				return serverMapChunk;
-@@ -1011,10 +2240,13 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1011,10 +2259,13 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			}
  		}
  		return null;
@@ -2224,7 +2243,7 @@ index f644852..bff98da 100644
  		byte[] mapRegion = chunkthread.gameDatabase.GetMapRegion(regionX, regionZ);
  		try
  		{
-@@ -1035,14 +2267,27 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1035,14 +2286,27 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			throw;
  		}
  		return null;
@@ -2252,7 +2271,7 @@ index f644852..bff98da 100644
  			storyChunkSpawnEvents = new string[15]
  			{
  				Lang.Get("...the carved mountains"),
-@@ -1060,23 +2305,27 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1060,23 +2324,27 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				Lang.Get("...a misty sunrise"),
  				Lang.Get("...dew drops on a blade of grass"),
  				Lang.Get("...a soft breeze")
@@ -2280,7 +2299,7 @@ index f644852..bff98da 100644
  					double value = random.NextDouble() * 6.2831854820251465;
  					double num7 = num6 * GameMath.Sin(value);
  					double num8 = num6 * GameMath.Cos(value);
-@@ -1096,10 +2345,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1096,10 +2364,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					server.api.Logger.Notification("Trying another spawn location ({0}/{1})...", i + 2, num3);
  				}
  			}
@@ -2292,7 +2311,7 @@ index f644852..bff98da 100644
  				if (!server.blockAccessor.GetBlock(blockPos).SideSolid[BlockFacing.UP.Index])
  				{
  					server.blockAccessor.SetBlock(server.blockAccessor.GetBlock(new AssetLocation("planks-oak-we")).Id, blockPos);
-@@ -1107,13 +2357,16 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1107,13 +2376,16 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				blockPos.Y++;
  			}
  		}
@@ -2309,7 +2328,7 @@ index f644852..bff98da 100644
  			x = blockPos.X,
  			y = blockPos.Y,
  			z = blockPos.Z
-@@ -1123,10 +2376,14 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1123,10 +2395,14 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			server.mapMiddleSpawnPos.y = null;
  		}
  		server.api.Logger.VerboseDebug("Done spawn chunk");
@@ -2324,7 +2343,7 @@ index f644852..bff98da 100644
  		int num = 60;
  		int num2 = 0;
  		int num3 = 0;
-@@ -1137,36 +2394,47 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1137,36 +2413,47 @@ internal class ServerSystemSupplyChunks : ServerSystem
  		{
  			num4 = GameMath.Clamp(num2 + pos.X, 0, server.WorldMap.MapSizeX - 1);
  			num6 = GameMath.Clamp(num3 + pos.Z, 0, server.WorldMap.MapSizeZ - 1);
@@ -2373,7 +2392,7 @@ index f644852..bff98da 100644
  		{
  			for (int k = -num2; k <= num2; k++)
  			{
-@@ -1174,18 +2442,22 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1174,18 +2461,22 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				{
  					long index2d = server.WorldMap.MapChunkIndex2D(x + j, y + k);
  					int regionX = (x + j) / MagicNum.ChunkRegionSizeInChunks;
@@ -2397,7 +2416,7 @@ index f644852..bff98da 100644
  					};
  					chunkColumnLoadRequest.MapChunk = mapChunk;
  					GenerateNewChunkColumn(mapChunk, chunkColumnLoadRequest);
-@@ -1196,10 +2468,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1196,10 +2487,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
  						chunkthread.peekingChunkColumns.Enqueue(chunkColumnLoadRequest);
  					}
  				}
@@ -2410,7 +2429,7 @@ index f644852..bff98da 100644
  		{
  			num4 = num - i;
  			for (int l = -num4; l <= num4; l++)
-@@ -1212,10 +2486,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1212,10 +2505,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
  						runGenerators(chunkRequest, i);
  					}
  				}
@@ -2423,7 +2442,7 @@ index f644852..bff98da 100644
  		{
  			for (int n = -num2; n <= num2; n++)
  			{
-@@ -1232,61 +2508,111 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1232,61 +2527,111 @@ internal class ServerSystemSupplyChunks : ServerSystem
  						dictionary2[key] = chunks;
  					}
  				}
@@ -2537,7 +2556,7 @@ index f644852..bff98da 100644
  				millisecondsSinceStart = server.totalUnpausedTime.ElapsedMilliseconds;
  				float num4 = 100f * ((float)server.loadedChunks.Count / (float)server.WorldMap.ChunkMapSizeY - (float)num) / (float)num2;
  				ServerMain.Logger.Event(num4.ToString("0.#") + "% ({0} in queue)", chunkthread.requestedChunkColumns.Count);
-@@ -1298,37 +2624,84 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1298,37 +2643,84 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				{
  					ServerMain.Logger.StoryEvent("...");
  				}
@@ -2625,7 +2644,7 @@ index f644852..bff98da 100644
  				foreach (ChunkColumnLoadRequest requestedChunkColumn3 in chunkthread.requestedChunkColumns)
  				{
  					if (requestedChunkColumn3 != null)
-@@ -1340,16 +2713,25 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1340,16 +2732,25 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				throw new Exception("Somehow worldgen has become stuck in an endless loop, please report this as a bug!  Additional data in the server-main log");
  			}
  		}
@@ -2651,7 +2670,7 @@ index f644852..bff98da 100644
  				if (chunkRequest.CurrentIncompletePass == EnumWorldGenPass.Terrain)
  				{
  					ushort sunLight = (ushort)server.sunBrightness;
-@@ -1359,32 +2741,62 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1359,32 +2760,62 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					}
  				}
  			}
@@ -2716,7 +2735,7 @@ index f644852..bff98da 100644
  			return;
  		}
  		for (int i = 0; i < list.Count; i++)
-@@ -1396,89 +2808,119 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1396,89 +2827,119 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			catch (Exception ex)
  			{
  				ServerMain.Logger.Worldgen("An error was thrown in pass {5} when generating chunk column X={0},Z={1} in world '{3}' with seed {4}\nException {2}\n\n", chunkRequest.chunkX, chunkRequest.chunkZ, ex, server.SaveGameData.WorldName, server.SaveGameData.Seed, chunkRequest.CurrentIncompletePass.ToString());
@@ -2853,7 +2872,7 @@ index f644852..bff98da 100644
  			chunkthread.requestedChunkColumns.Enqueue(curRequest);
  			return true;
  		}
-@@ -1490,13 +2932,19 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1490,13 +2951,19 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				ServerMain.Logger.VerboseDebug("Un-pausing all worldgen threads.");
  			}
  		}
@@ -2873,7 +2892,7 @@ index f644852..bff98da 100644
  			if (requestedChunkColumn != null && !requestedChunkColumn.Disposed)
  			{
  				server.loadedMapChunks.Remove(requestedChunkColumn.mapIndex2d);
-@@ -1505,104 +2953,181 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1505,104 +2972,181 @@ internal class ServerSystemSupplyChunks : ServerSystem
  		}
  		chunkthread.requestedChunkColumns.Clear();
  		ServerMain.Logger.VerboseDebug("Incomplete chunks stored and wiped.");


### PR DESCRIPTION
`TryClaimStage` acquires two claims before it has finished deciding: `req.dispatchClaimed`, then a slot in `stratumStageActiveCount[stage]`. Only after both are held does it run the checks that can still say no — and one of them does not merely return false, it can **throw**. `ensurePrettyNeighbourhood` reaches `EnsureMinimumWorldgenPassAt`, which enqueues lagging neighbours and throws `Indexed Fifo Queue overflow` when the request queue is full.

With no `try/finally`, that exception escaped with both claims still held. This is unrecoverable rather than noisy:

- the request keeps `dispatchClaimed` at 1, so **nothing can ever claim that column again**;
- the stage keeps its incremented active count, so a stage at cap 1 has **permanently lost its only slot** — every later `Interlocked.Increment` returns 2, fails the cap test, and backs out.

Worldgen then wedges with every thread parked. The caller catches and logs the exception as one more dispatcher error, so nothing in the log says the scheduler just lost a slot for good.

## The fix

Hold both claims across a `try/finally`, releasing them on every exit that has not handed them to the caller. `claimHeld` tracks that handoff, since the success path deliberately leaves both held and the caller owns them from there. The `finally` reads the stage from a local, because the failure branches set `stage = -1` as their return signal before it runs.

The exception itself still happens under queue pressure and is still logged. This only makes it survivable.

## Why this is demonstrated by fault injection

The real overflow is genuine but rare — it **did not fire once across eight full radius-100 pregens**. Shrinking `RequestChunkColumnsQueueSize` to 500 did not force it either: the vanilla free-space path relieves the queue before the ring overflows.

So the failure was injected instead: a temporary throw at the same point inside `TryClaimStage`, at **TerrainFeatures**, chosen because that stage is at cap 1, so leaking its single slot wedges it outright and the difference shows up as a stall rather than as a statistic. Same seed, same radius, same deterministic trigger, two builds differing only in the `try/finally`:

| | with the fix | without it |
|---|---|---|
| exception | logged as dispatcher error | logged as dispatcher error |
| queue | keeps draining | freezes |
| progress | completes, 5025/5025 columns, 1m54s | frozen at 23.48% across three consecutive 1-minute ticks |
| threads | working | all 43 in state `S` |

The injected exception unwinds through `TryClaimStage` → `TryDispatchRequest` → `ScheduleReadyTasks`, the same path the real overflow takes, so this exercises the actual failure rather than an approximation. The injection was removed, and the tree rebuilt from patches and verified clean before committing.

## Scope note

This is **not** claimed as the cause of the radius-100 stall reported against #188. That branch turns out never to have contained a Terrain cap raise at all, so whatever stalled there was its `GenTerra` changes, not stage concurrency. The leak fixed here is a mechanism that *can* produce that signature; tying it to that specific report would need the original logs, which are not available.

It is worth fixing on its own merit regardless: `indev` already ships raised caps for TerrainLate and PreDone, so this throw path is reachable in production today.

## Cost

None measurable. Clean `indev` completed a radius-100 pregen (seed 1027995113, queue 2000, 3 worldgen threads) in 7m42s; with this fix, 6m45s — ordinary run-to-run spread, in the fix's favour if anything. No change in out-of-range block reads, which stay at zero in both.

## Rejected alternative, recorded so it is not re-proposed

Guarding both neighbour-nudge enqueues in `EnsureMinimumWorldgenPassAt`, so the throw could not be reached on a hot path at all, was built and measured. A pregen **deliberately holds the request queue near capacity**, so a guard with any real slack fires more or less continuously and turns every neighbour nudge into a retry. It measured 10m16s against clean `indev`'s 7m42s on the same seed and radius, and introduced 87 out-of-range block reads that neither clean `indev` nor this fix produce. Single runs on a machine with wide spread, so treat the magnitude as indicative and the direction as the finding. A guard tight enough not to fire during a pregen would be indistinguishable from the throw it replaces.
