### PR TITLE
Restore field visibility for third-party worldgen patches

### DIFF
--- a/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/2.GenRockStrata/GenRockStrata.cs.patch
+++ b/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/2.GenRockStrata/GenRockStrata.cs.patch
@@ -1,5 +1,5 @@
 diff --git a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/2.GenRockStrata/GenRockStrata.cs b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/2.GenRockStrata/GenRockStrata.cs
-index cb9eefa..dcb6063 100644
+index cb9eefa..cb95600 100644
 --- a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/2.GenRockStrata/GenRockStrata.cs
 +++ b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/2.GenRockStrata/GenRockStrata.cs
 @@ -1,7 +1,9 @@
@@ -41,14 +41,12 @@ index cb9eefa..dcb6063 100644
          }
  
  
-@@ -134,24 +139,38 @@ namespace Vintagestory.ServerMods
+@@ -134,24 +139,54 @@ namespace Vintagestory.ServerMods
          }
  
  
          // Cheap ugly code for better performance :<
          #region
--        float[] rockGroupMaxThickness = new float[4];
--        int[] rockGroupCurrentThickness = new int[4];
 +        // Stratum start: TerrainLate can now run concurrently for distant columns
 +        // (see StratumWorldGenStages). preLoad/genBlockColumn always run back-to-back
 +        // on the same worker thread for a given column (no internal Parallel.For
@@ -62,36 +60,47 @@ index cb9eefa..dcb6063 100644
 +            public float[] rockGroupMaxThickness = new float[4];
 +            public int[] rockGroupCurrentThickness = new int[4];
 +            public float[] indicesBuf; // resized lazily once province count is known
- 
--        IMapChunk mapChunk;
--        ushort[] heightMap;
--        int rdx;
--        int rdz;
++
 +            public IMapChunk mapChunk;
 +            public ushort[] heightMap;
 +            public int rdx;
 +            public int rdz;
- 
--        LerpedWeightedIndex2DMap map;
--        float lerpMapInv;
--        float chunkInRegionX;
--        float chunkInRegionZ;
++
 +            public LerpedWeightedIndex2DMap map;
 +            public float lerpMapInv;
 +            public float chunkInRegionX;
 +            public float chunkInRegionZ;
- 
--        GeologicProvinces provinces = NoiseGeoProvince.provinces;
++
 +            public GeologicProvinces provinces;
 +        }
 +        readonly ThreadLocal<ThreadLocalScratch> scratchThreadLocal = new ThreadLocal<ThreadLocalScratch>(() => new ThreadLocalScratch());
++
++        // Stratum start: compatibility shims for third-party Harmony patches that
++        // inject or reflect on these fields (e.g. Rock Strata Variety). Values are
++        // written from the per-thread scratch at method entry, valid only within
++        // that call's scope on the current thread. Fixes #201.
+         float[] rockGroupMaxThickness = new float[4];
+         int[] rockGroupCurrentThickness = new int[4];
+-
+         IMapChunk mapChunk;
+         ushort[] heightMap;
+         int rdx;
+         int rdz;
+-
+         LerpedWeightedIndex2DMap map;
+         float lerpMapInv;
+         float chunkInRegionX;
+         float chunkInRegionZ;
+-
+-        GeologicProvinces provinces = NoiseGeoProvince.provinces;
++        GeologicProvinces provinces;
 +        // Stratum end
          #endregion
  
          internal void GenChunkColumn(IChunkColumnGenerateRequest request)
          {
              var chunks = request.Chunks;
-@@ -169,42 +188,60 @@ namespace Vintagestory.ServerMods
+@@ -169,42 +204,71 @@ namespace Vintagestory.ServerMods
              }
          }
  
@@ -120,6 +129,17 @@ index cb9eefa..dcb6063 100644
 +            s.chunkInRegionZ = (chunkZ % regionChunkSize) * s.lerpMapInv * chunksize;
 +
 +            s.provinces = NoiseGeoProvince.provinces;
++
++            // Stratum: populate compat shim fields for third-party Harmony patches (#201)
++            mapChunk = s.mapChunk;
++            heightMap = s.heightMap;
++            rdx = s.rdx;
++            rdz = s.rdz;
++            map = s.map;
++            lerpMapInv = s.lerpMapInv;
++            chunkInRegionX = s.chunkInRegionX;
++            chunkInRegionZ = s.chunkInRegionZ;
++            provinces = s.provinces;
          }
  
          public void genBlockColumn(IServerChunk[] chunks, int chunkX, int chunkZ, int lx, int lz)
@@ -171,7 +191,7 @@ index cb9eefa..dcb6063 100644
                  GeologicProvinceRockStrata[] localstrata = provinces.Variants[i].RockStrataIndexed;
  
                  rockGroupMaxThickness[0] += localstrata[0].ScaledMaxThickness * w;
-@@ -227,24 +264,24 @@ namespace Vintagestory.ServerMods
+@@ -227,24 +291,24 @@ namespace Vintagestory.ServerMods
              while (ylower <= yupper)
              {
                  if (--strataThickness <= 0f)
@@ -200,7 +220,7 @@ index cb9eefa..dcb6063 100644
                      // In 1.21 we ought to simply use normalized noise * rockmapsize
                      nx = Math.Max(nx, -1.499f);
                      nz = Math.Max(nz, -1.499f);
-@@ -312,21 +349,23 @@ namespace Vintagestory.ServerMods
+@@ -312,21 +376,23 @@ namespace Vintagestory.ServerMods
  
          LerpedWeightedIndex2DMap GetOrLoadLerpedProvinceMap(IMapChunk mapchunk, int chunkX, int chunkZ)
          {

--- a/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/4.GenBlockLayers/GenBlockLayers.cs.patch
+++ b/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/4.GenBlockLayers/GenBlockLayers.cs.patch
@@ -1,5 +1,5 @@
 diff --git a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/4.GenBlockLayers/GenBlockLayers.cs b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/4.GenBlockLayers/GenBlockLayers.cs
-index 55b134c..0a3927d 100644
+index 55b134c..220eed6 100644
 --- a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/4.GenBlockLayers/GenBlockLayers.cs
 +++ b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/4.GenBlockLayers/GenBlockLayers.cs
 @@ -1,7 +1,8 @@
@@ -11,14 +11,13 @@ index 55b134c..0a3927d 100644
  using Vintagestory.API.MathTools;
  using Vintagestory.API.Server;
  
-@@ -12,19 +13,31 @@ namespace Vintagestory.ServerMods
+@@ -12,19 +13,39 @@ namespace Vintagestory.ServerMods
  
      public class GenBlockLayers : ModStdWorldGen
      {
          private ICoreServerAPI api;
  
 -        List<int> BlockLayersIds = new List<int>();
--        LCGRandom rnd;
 +        // Stratum: TerrainLate can now run concurrently for distant columns. rnd gets
 +        // reseeded per column at the top of OnChunkColumnGeneration, then LoadBlockLayers
 +        // writes BlockLayersIds/layersUnderWater and PutLayers reads them back a few
@@ -35,6 +34,14 @@ index 55b134c..0a3927d 100644
 +            public int[] layersUnderWater = Array.Empty<int>();
 +        }
 +        ThreadLocal<ThreadLocalScratch> scratchThreadLocal;
++
++        // Stratum start: compatibility shim for third-party Harmony patches that
++        // reflect on this field (e.g. Watersheds uses GetField("rnd")). Value is
++        // written from the per-thread scratch at OnChunkColumnGeneration entry,
++        // valid only within that call's scope on the current thread. Fixes #201.
+         LCGRandom rnd;
++        // Stratum end
++
          int mapheight;
          ClampedSimplexNoise grassDensity;
          ClampedSimplexNoise grassHeight;
@@ -47,7 +54,7 @@ index 55b134c..0a3927d 100644
          public SimplexNoise distort2dz;
  
          public override bool ShouldLoad(EnumAppSide side)
-@@ -46,11 +59,11 @@ namespace Vintagestory.ServerMods
+@@ -46,11 +67,11 @@ namespace Vintagestory.ServerMods
              //this.api.Event.MapRegionGeneration(OnMapRegionGen, "standard");   // 8.2.24 commented out because the method has no code
  
  
@@ -60,7 +67,7 @@ index 55b134c..0a3927d 100644
              distort2dz = new SimplexNoise(new double[] { 14, 9, 6, 3 }, new double[] { 1 / 100.0, 1 / 50.0, 1 / 25.0, 1 / 12.5 }, api.World.SeaLevel + 20981);
          }
  
-@@ -81,13 +94,15 @@ namespace Vintagestory.ServerMods
+@@ -81,13 +102,15 @@ namespace Vintagestory.ServerMods
              LoadGlobalConfig(api);
  
              api.ObjectCache.Remove(BlockLayerConfig.cacheKey);
@@ -79,7 +86,7 @@ index 55b134c..0a3927d 100644
  
              boilingWaterBlockId = gcfg.boilingWaterBlockId;
          }
-@@ -96,11 +111,12 @@ namespace Vintagestory.ServerMods
+@@ -96,11 +119,13 @@ namespace Vintagestory.ServerMods
          {
              var chunks = request.Chunks;
              int chunkX = request.ChunkX;
@@ -88,19 +95,20 @@ index 55b134c..0a3927d 100644
 -            rnd.InitPositionSeed(chunkX, chunkZ);
 +            ThreadLocalScratch s = scratchThreadLocal.Value; // Stratum: per-thread scratch, fetched once and threaded through for this column
 +            s.rnd.InitPositionSeed(chunkX, chunkZ);
++            rnd = s.rnd; // Stratum: populate compat shim for third-party reflection (#201)
  
              IntDataMap2D forestMap = chunks[0].MapChunk.MapRegion.ForestMap;
              IntDataMap2D climateMap = chunks[0].MapChunk.MapRegion.ClimateMap;
              IntDataMap2D beachMap = chunks[0].MapChunk.MapRegion.BeachMap;
              IntDataMap2D biomeMap = chunks[0].MapChunk.MapRegion.BiomeMap;
-@@ -201,19 +217,19 @@ namespace Vintagestory.ServerMods
+@@ -201,19 +226,19 @@ namespace Vintagestory.ServerMods
                          }
                      }
  
                      herePos.Y = posY;
                      int disty = (int)(distort2dx.Noise(-herePos.X, -herePos.Z) / 4.0);
 -                    posY = PutLayers(transitionRand, x, z, disty, herePos, chunks, rainRel, temp, tempUnscaled, heightMap, biome);
-+                    posY = PutLayers(s, transitionRand, x, z, disty, herePos, chunks, rainRel, temp, tempUnscaled, heightMap, biome);
++                    posY = StratumPutLayersInner(s, transitionRand, x, z, disty, herePos, chunks, rainRel, temp, tempUnscaled, heightMap, biome);
  
                      if (prevY == TerraGenConfig.seaLevel - 1)
                      {
@@ -115,20 +123,28 @@ index 55b134c..0a3927d 100644
                      // Try again to put layers if above sealevel and we found over 10 air blocks
                      int foundAir = 0;
                      while (posY >= TerraGenConfig.seaLevel - 1)
-@@ -255,11 +271,11 @@ namespace Vintagestory.ServerMods
+@@ -255,11 +280,20 @@ namespace Vintagestory.ServerMods
              distx = distort2dx.Noise(herePos.X, herePos.Z);
              distz = distort2dz.Noise(herePos.X, herePos.Z);
              return (int)(distx / 5);
          }
  
--        private int PutLayers(double posRand, int lx, int lz, int posyoffs, BlockPos pos, IServerChunk[] chunks, float rainRel, float temp, int unscaledTemp, ushort[] heightMap, int biome)
-+        private int PutLayers(ThreadLocalScratch s, double posRand, int lx, int lz, int posyoffs, BlockPos pos, IServerChunk[] chunks, float rainRel, float temp, int unscaledTemp, ushort[] heightMap, int biome)
++        // Stratum start: compatibility overload for third-party Harmony patches that
++        // bind PutLayers via GetMethod with the original parameter list (e.g. Watersheds).
++        // Resolves per-thread scratch internally, same pattern as the public PlaceTallGrass. Fixes #201.
+         private int PutLayers(double posRand, int lx, int lz, int posyoffs, BlockPos pos, IServerChunk[] chunks, float rainRel, float temp, int unscaledTemp, ushort[] heightMap, int biome)
++        {
++            return StratumPutLayersInner(scratchThreadLocal.Value, posRand, lx, lz, posyoffs, pos, chunks, rainRel, temp, unscaledTemp, heightMap, biome);
++        }
++        // Stratum end
++
++        private int StratumPutLayersInner(ThreadLocalScratch s, double posRand, int lx, int lz, int posyoffs, BlockPos pos, IServerChunk[] chunks, float rainRel, float temp, int unscaledTemp, ushort[] heightMap, int biome)
          {
              int i = 0;
              int j = 0;
              bool underWater = false;
              bool isOcean = false;
-@@ -302,24 +318,24 @@ namespace Vintagestory.ServerMods
+@@ -302,24 +336,24 @@ namespace Vintagestory.ServerMods
                      if (heightMap != null && first)
                      {
                          chunks[0].MapChunk.TopRockIdMap[lz * chunksize + lx] = blockId;
@@ -156,7 +172,7 @@ index 55b134c..0a3927d 100644
                  else
                  {
                      if ((i > 0 && temp > -18) || j > 0) return pos.Y;
-@@ -357,27 +373,36 @@ namespace Vintagestory.ServerMods
+@@ -357,27 +391,36 @@ namespace Vintagestory.ServerMods
                      }
                  }
              }
@@ -196,7 +212,7 @@ index 55b134c..0a3927d 100644
                      if (layers[i].Biome == -1 || layers[i].Biome == biome)
                      {
                          chunks[(posY + 1) / chunksize].Data[(chunksize * ((posY + 1) % chunksize) + z) * chunksize + x] = layers[i].BlockId;
-@@ -387,11 +412,11 @@ namespace Vintagestory.ServerMods
+@@ -387,11 +430,11 @@ namespace Vintagestory.ServerMods
              }
  
              if (blockLayerConfig.Tallgrass.BlockCodeByMin != null)
@@ -209,7 +225,7 @@ index 55b134c..0a3927d 100644
                  {
                      TallGrassBlockCodeByMin bcbymin = blockLayerConfig.Tallgrass.BlockCodeByMin[i];
  
-@@ -404,22 +429,23 @@ namespace Vintagestory.ServerMods
+@@ -404,22 +447,23 @@ namespace Vintagestory.ServerMods
                  }
              }
          }
@@ -235,7 +251,7 @@ index 55b134c..0a3927d 100644
              {
                  BlockLayer bl = blockLayerConfig.Blocklayers[j];
                  float yDist = bl.CalcYDistance(posY, mapheight);
-@@ -460,20 +486,20 @@ namespace Vintagestory.ServerMods
+@@ -460,20 +504,20 @@ namespace Vintagestory.ServerMods
              }
  
              int lakeBedId;


### PR DESCRIPTION
The ThreadLocalScratch refactoring in GenRockStrataNew and GenBlockLayers moved instance fields into per-thread scratch objects. Mods that access these fields via Harmony `___fieldName` injection or via reflection now crash because the fields no longer exist on the class instance.

Affected mods (confirmed): Rock Strata Variety 0.0.4 (heightMap, rockGroupMaxThickness, rockGroupCurrentThickness, provinces, map, etc.), Watersheds 6.4.3 (rnd via GetField, PutLayers via GetMethod with original signature).

The fix keeps the original instance fields alive as compatibility shims. `preLoad` and `OnChunkColumnGeneration` populate them from the scratch at entry. All internal Stratum code still routes through the ThreadLocal scratch, so the concurrency gains and the allocation reduction (646 MB to 90 MB per 10200 columns) stay intact. The shim cost is a handful of pointer copies per column call, not measurable against the method's actual work.

For PutLayers specifically: the internal method is renamed to `StratumPutLayersInner` and a compatibility overload with the original parameter list resolves the scratch internally, same pattern the public `PlaceTallGrass` already uses. This avoids an AmbiguousMatchException on `GetMethod("PutLayers", NonPublic)`.

Tested on a fresh world with both mods active. Server reaches RunGame, generates spawn chunks, zero exceptions.

Fixes #201