### PR TITLE
Add PvP combat log prevention (opt-in)

### DIFF
--- a/patches/VSEssentials/Entities/EntityProjectileBase.cs.patch
+++ b/patches/VSEssentials/Entities/EntityProjectileBase.cs.patch
@@ -1,0 +1,22 @@
+diff --git a/VSEssentials/Entities/EntityProjectileBase.cs b/VSEssentials/Entities/EntityProjectileBase.cs
+index 64c42af..0d724ce 100644
+--- a/VSEssentials/Entities/EntityProjectileBase.cs
++++ b/VSEssentials/Entities/EntityProjectileBase.cs
+@@ -263,10 +263,17 @@ namespace Vintagestory.GameContent
+                 DamageTier = DamageTier,
+                 IgnoreInvFrames = IgnoreInvFrames,
+                 KnockbackStrength = Weight * (float)Pos.Motion.Length() * knockbackFactor
+             }, damage);
+ 
++            // Stratum: notify combat log system on confirmed PvP projectile hit
++            if (didDamage && fromPlayer && target is EntityPlayer targetPlayer)
++            {
++                StratumCombatLogHook.OnProjectilePvPHit?.Invoke(
++                    ((EntityPlayer)FiredBy).PlayerUID, targetPlayer.PlayerUID);
++            }
++
+             return didDamage;
+         }
+ 
+         protected virtual void ApplyModifiers(ref float damage, Entity target)
+         {

--- a/patches/VintagestoryLib/Vintagestory.Server/ServerSystemCommands.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/ServerSystemCommands.cs.patch
@@ -1,8 +1,8 @@
 diff --git a/VintagestoryLib/Vintagestory.Server/ServerSystemCommands.cs b/VintagestoryLib/Vintagestory.Server/ServerSystemCommands.cs
-index 1d4be19..2b9936e 100644
+index 1d4be19..e8394a8 100644
 --- a/VintagestoryLib/Vintagestory.Server/ServerSystemCommands.cs
 +++ b/VintagestoryLib/Vintagestory.Server/ServerSystemCommands.cs
-@@ -21,10 +21,17 @@ internal class ServerSystemCommands : ServerSystem
+@@ -21,10 +21,20 @@ internal class ServerSystemCommands : ServerSystem
  		new CmdEntity(server);
  		new CmdGive(server);
  		new CmdDebug(server);
@@ -13,6 +13,9 @@ index 1d4be19..2b9936e 100644
 +		new CmdStratumEssentials(server);
 +		new CmdStratumStaffCommands(server);
 +		new StratumLoginProtection(server);
++		new StratumCombatLogSystem(server);
++		new StratumCombatLogSystem(server);
++		new StratumCombatLogSystem(server);
 +		new StratumNametags(server);
 +		new StratumEntityCaps(server);
  		new CmdInfo(server);
@@ -20,7 +23,7 @@ index 1d4be19..2b9936e 100644
  		new CmdModDBUtil(server);
  		if (!server.IsDedicatedServer)
  		{
-@@ -33,6 +40,10 @@ internal class ServerSystemCommands : ServerSystem
+@@ -33,6 +43,10 @@ internal class ServerSystemCommands : ServerSystem
  		new CmdSetBlock(server);
  		new CmdExecuteAs(server);
  		new CmdActivate(server);

--- a/sources/VintagestoryApi/Server/StratumCombatLogHook.cs
+++ b/sources/VintagestoryApi/Server/StratumCombatLogHook.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace Vintagestory.API.Server;
+
+// Bridge for the combat log system. EntityProjectileBase (in VSEssentials) calls the static
+// delegate after confirming a PvP projectile hit. StratumCombatLogSystem sets the delegate
+// at construction. When the system is disabled or not loaded, the delegate is null and the
+// call site is a single null check per projectile impact (free).
+public static class StratumCombatLogHook
+{
+	// Args: attackerPlayerUid, victimPlayerUid. Set by StratumCombatLogSystem.
+	public static Action<string, string> OnProjectilePvPHit;
+}

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumCombatLogConfig.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumCombatLogConfig.cs
@@ -1,0 +1,61 @@
+using System;
+
+namespace Vintagestory.Server;
+
+internal enum EnumCombatLogPenalty
+{
+	/// <summary>Kill the player on disconnect. Inventory drops on the spot.</summary>
+	Kill,
+	/// <summary>Kill the player when they rejoin. Inventory drops at their rejoin position.</summary>
+	KillOnRejoin,
+	/// <summary>Log only. No gameplay penalty. For monitoring.</summary>
+	LogOnly
+}
+
+internal sealed class StratumCombatLogConfig
+{
+	/// <summary>Enable PvP combat log prevention. Off by default (opt-in).</summary>
+	public bool Enabled { get; set; } = false;
+
+	/// <summary>How long the combat tag lasts after a PvP hit, in seconds.</summary>
+	public int TagDurationSeconds { get; set; } = 15;
+
+	/// <summary>What happens when a tagged player disconnects.</summary>
+	public EnumCombatLogPenalty Penalty { get; set; } = EnumCombatLogPenalty.Kill;
+
+	/// <summary>Tag the attacker as well as the victim. Prevents hit-and-run logouts.</summary>
+	public bool TagAttacker { get; set; } = true;
+
+	/// <summary>Send the tagged player a warning message when they enter combat.</summary>
+	public bool NotifyOnTag { get; set; } = true;
+
+	/// <summary>Send the player a message when their combat tag expires.</summary>
+	public bool NotifyOnExpiry { get; set; } = true;
+
+	/// <summary>Broadcast to the server when someone combat logs.</summary>
+	public bool BroadcastOnCombatLog { get; set; } = true;
+
+	/// <summary>Alert online staff when someone combat logs.</summary>
+	public bool AlertStaff { get; set; } = true;
+
+	/// <summary>Message sent to a player when they are combat tagged. {0} = seconds.</summary>
+	public string TagMessage { get; set; } = "Combat tagged for {0}s. Disconnecting now will kill you.";
+
+	/// <summary>Message sent when the combat tag expires.</summary>
+	public string ExpiryMessage { get; set; } = "Combat tag expired. You may disconnect safely.";
+
+	/// <summary>Broadcast message when a player combat logs. {0} = player name.</summary>
+	public string CombatLogBroadcast { get; set; } = "{0} combat logged and was killed.";
+
+	/// <summary>Privilege that exempts a player from combat tagging.</summary>
+	public string ExemptPrivilege { get; set; } = "stratum.combatlog.exempt";
+
+	public void EnsureSane()
+	{
+		TagDurationSeconds = Math.Clamp(TagDurationSeconds, 5, 120);
+		ExemptPrivilege ??= "stratum.combatlog.exempt";
+		TagMessage ??= "Combat tagged for {0}s. Disconnecting now will kill you.";
+		ExpiryMessage ??= "Combat tag expired. You may disconnect safely.";
+		CombatLogBroadcast ??= "{0} combat logged and was killed.";
+	}
+}

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumCombatLogSystem.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumCombatLogSystem.cs
@@ -1,0 +1,314 @@
+using System;
+using System.Collections.Generic;
+using Vintagestory.API.Common;
+using Vintagestory.API.Common.Entities;
+using Vintagestory.API.Config;
+using Vintagestory.API.MathTools;
+using Vintagestory.API.Server;
+
+namespace Vintagestory.Server;
+
+// PvP combat log prevention. Tags players who engage in PvP for a configurable window.
+// Disconnecting while tagged applies the configured penalty (kill on disconnect, kill on
+// rejoin, or log-only). Opt-in, disabled by default.
+//
+// Hook points:
+//   - OnPlayerInteractEntity (mode == 0): covers melee attacks.
+//   - EntityProjectileBase.ImpactOnEntity via a patched callback: covers arrows, thrown
+//     stones, spears, and any projectile with a player CauseEntity.
+//
+// The melee hook fires on the attack attempt (before damage lands). This matches industry
+// convention: swing intent = combat. The projectile hook fires after impact confirms.
+// Both renew the tag on every hit.
+internal sealed class StratumCombatLogSystem
+{
+	private readonly ServerMain server;
+	private readonly Dictionary<string, CombatTagEntry> activeTags = new Dictionary<string, CombatTagEntry>(StringComparer.Ordinal);
+	private readonly HashSet<string> pendingKillOnRejoin = new HashSet<string>(StringComparer.Ordinal);
+
+	private struct CombatTagEntry
+	{
+		public long ExpiresAtMs;
+		public string OpponentName;
+	}
+
+	public StratumCombatLogSystem(ServerMain server)
+	{
+		this.server = server;
+		server.EventManager.OnPlayerInteractEntity += OnPlayerInteractEntity;
+		server.EventManager.OnPlayerDisconnect += OnPlayerDisconnect;
+		server.EventManager.OnPlayerJoin += OnPlayerJoin;
+		server.RegisterGameTickListener(OnTick, 1000);
+
+		// Expose a static hook for the projectile patch (lives in VSEssentials, bridges through VintagestoryAPI).
+		StratumCombatLogHook.OnProjectilePvPHit = OnProjectileHit;
+
+		IChatCommand root = server.api.ChatCommands.Get("stratum");
+		if (root != null)
+		{
+			root.BeginSubCommand("combatlog")
+				.WithDescription("Combat log prevention status and testing")
+				.RequiresPrivilege("controlserver")
+				.BeginSubCommand("status")
+					.WithDescription("Show active combat tags")
+					.HandleWith(CmdStatus)
+				.EndSubCommand()
+				.BeginSubCommand("tag")
+					.WithDescription("Tag yourself for testing (simulates a PvP hit)")
+					.HandleWith(CmdTagSelf)
+				.EndSubCommand()
+			.EndSubCommand();
+		}
+	}
+
+	private StratumCombatLogConfig Cfg => StratumRuntime.Config?.CombatLog;
+
+	// --- Melee hook (fires on attack attempt against another player) ---
+
+	private void OnPlayerInteractEntity(Entity target, IPlayer byPlayer, ItemSlot slot, Vec3d hitPosition, int mode, ref EnumHandling handling)
+	{
+		if (mode != 0) return;
+
+		StratumCombatLogConfig cfg = Cfg;
+		if (cfg == null || !cfg.Enabled) return;
+
+		if (target is not EntityPlayer targetPlayer) return;
+		if (byPlayer?.Entity == null) return;
+
+		IServerPlayer attacker = byPlayer as IServerPlayer;
+		IServerPlayer victim = server.PlayerByUid(targetPlayer.PlayerUID) as IServerPlayer;
+		if (attacker == null || victim == null) return;
+		if (attacker.PlayerUID == victim.PlayerUID) return;
+
+		if (IsExempt(attacker) || IsExempt(victim)) return;
+
+		long expiresAt = server.ElapsedMilliseconds + cfg.TagDurationSeconds * 1000L;
+		TagPlayer(victim, attacker.PlayerName, expiresAt, cfg);
+		if (cfg.TagAttacker) TagPlayer(attacker, victim.PlayerName, expiresAt, cfg);
+	}
+
+	// --- Projectile hook (called from patched EntityProjectileBase after a PvP hit confirms) ---
+
+	private void OnProjectileHit(string attackerUid, string victimUid)
+	{
+		StratumCombatLogConfig cfg = Cfg;
+		if (cfg == null || !cfg.Enabled) return;
+
+		IServerPlayer attacker = server.PlayerByUid(attackerUid) as IServerPlayer;
+		IServerPlayer victim = server.PlayerByUid(victimUid) as IServerPlayer;
+		if (attacker == null || victim == null) return;
+		if (attackerUid == victimUid) return;
+
+		if (IsExempt(attacker) || IsExempt(victim)) return;
+
+		long expiresAt = server.ElapsedMilliseconds + cfg.TagDurationSeconds * 1000L;
+		TagPlayer(victim, attacker.PlayerName, expiresAt, cfg);
+		if (cfg.TagAttacker) TagPlayer(attacker, victim.PlayerName, expiresAt, cfg);
+	}
+
+	// --- Disconnect penalty ---
+
+	private void OnPlayerDisconnect(IServerPlayer player)
+	{
+		if (player == null) return;
+
+		StratumCombatLogConfig cfg = Cfg;
+		if (cfg == null || !cfg.Enabled) return;
+
+		string uid = player.PlayerUID;
+		if (!activeTags.TryGetValue(uid, out CombatTagEntry entry)) return;
+
+		long now = server.ElapsedMilliseconds;
+		if (now >= entry.ExpiresAtMs)
+		{
+			activeTags.Remove(uid);
+			return;
+		}
+
+		activeTags.Remove(uid);
+		long secondsRemaining = (entry.ExpiresAtMs - now) / 1000;
+		string logLine = player.PlayerName + " combat logged (opponent: " + entry.OpponentName + ", " + secondsRemaining + "s remaining)";
+
+		switch (cfg.Penalty)
+		{
+			case EnumCombatLogPenalty.Kill:
+				KillPlayer(player);
+				break;
+			case EnumCombatLogPenalty.KillOnRejoin:
+				pendingKillOnRejoin.Add(uid);
+				break;
+			case EnumCombatLogPenalty.LogOnly:
+				break;
+		}
+
+		StratumRuntime.LogInfo(logLine);
+
+		if (cfg.BroadcastOnCombatLog && cfg.Penalty != EnumCombatLogPenalty.LogOnly)
+		{
+			server.BroadcastMessageToAllGroups(string.Format(cfg.CombatLogBroadcast, player.PlayerName), EnumChatType.Notification);
+		}
+
+		if (cfg.AlertStaff)
+		{
+			string staffMsg = StratumCommandText.Pill("Combat Log", StratumCommandText.Bad)
+				+ " " + StratumCommandText.Warning(player.PlayerName)
+				+ " disconnected while tagged (opponent: "
+				+ StratumCommandText.Escape(entry.OpponentName)
+				+ ", " + secondsRemaining + "s remaining, penalty: " + cfg.Penalty + ")";
+			foreach (ConnectedClient client in server.Clients.Values)
+			{
+				if (client?.Player != null && client.Player.HasPrivilege("controlserver"))
+				{
+					client.Player.SendMessage(GlobalConstants.GeneralChatGroup, staffMsg, EnumChatType.Notification);
+				}
+			}
+		}
+	}
+
+	// --- Rejoin penalty ---
+
+	private void OnPlayerJoin(IServerPlayer player)
+	{
+		if (player == null) return;
+
+		StratumCombatLogConfig cfg = Cfg;
+		if (cfg == null || !cfg.Enabled) return;
+		if (cfg.Penalty != EnumCombatLogPenalty.KillOnRejoin) return;
+
+		if (pendingKillOnRejoin.Remove(player.PlayerUID))
+		{
+			server.RegisterCallback(dt => KillPlayer(player), 2000);
+			StratumRuntime.LogInfo(player.PlayerName + " killed on rejoin (combat log penalty)");
+		}
+	}
+
+	// --- Tick: expire old tags ---
+
+	private void OnTick(float dt)
+	{
+		StratumCombatLogConfig cfg = Cfg;
+		if (cfg == null || activeTags.Count == 0) return;
+
+		long now = server.ElapsedMilliseconds;
+		List<string> expired = null;
+
+		foreach (KeyValuePair<string, CombatTagEntry> kv in activeTags)
+		{
+			if (now >= kv.Value.ExpiresAtMs)
+			{
+				expired ??= new List<string>();
+				expired.Add(kv.Key);
+			}
+		}
+
+		if (expired == null) return;
+
+		for (int i = 0; i < expired.Count; i++)
+		{
+			activeTags.Remove(expired[i]);
+
+			if (cfg.NotifyOnExpiry)
+			{
+				IServerPlayer player = server.PlayerByUid(expired[i]) as IServerPlayer;
+				if (player != null && player.ConnectionState == EnumClientState.Playing)
+				{
+					player.SendMessage(GlobalConstants.GeneralChatGroup, cfg.ExpiryMessage, EnumChatType.Notification);
+				}
+			}
+		}
+	}
+
+	// --- Helpers ---
+
+	private void TagPlayer(IServerPlayer player, string opponentName, long expiresAt, StratumCombatLogConfig cfg)
+	{
+		string uid = player.PlayerUID;
+		bool isNew = !activeTags.TryGetValue(uid, out CombatTagEntry existing) || existing.ExpiresAtMs < server.ElapsedMilliseconds;
+
+		activeTags[uid] = new CombatTagEntry
+		{
+			ExpiresAtMs = expiresAt,
+			OpponentName = opponentName
+		};
+
+		if (isNew && cfg.NotifyOnTag)
+		{
+			player.SendMessage(GlobalConstants.GeneralChatGroup, string.Format(cfg.TagMessage, cfg.TagDurationSeconds), EnumChatType.Notification);
+		}
+	}
+
+	private void KillPlayer(IServerPlayer player)
+	{
+		if (player?.Entity == null || !player.Entity.Alive) return;
+		player.Entity.Die(EnumDespawnReason.Death, new DamageSource
+		{
+			Source = EnumDamageSource.Internal,
+			Type = EnumDamageType.PiercingAttack
+		});
+	}
+
+	private bool IsExempt(IServerPlayer player)
+	{
+		EnumGameMode mode = player.WorldData.CurrentGameMode;
+		if (mode == EnumGameMode.Creative || mode == EnumGameMode.Spectator) return true;
+
+		StratumCombatLogConfig cfg = Cfg;
+		if (cfg != null && !string.IsNullOrEmpty(cfg.ExemptPrivilege) && player.HasPrivilege(cfg.ExemptPrivilege))
+		{
+			return true;
+		}
+		return false;
+	}
+
+	// --- Admin commands ---
+
+	private TextCommandResult CmdStatus(TextCommandCallingArgs args)
+	{
+		StratumCombatLogConfig cfg = Cfg;
+		if (cfg == null || !cfg.Enabled)
+		{
+			return TextCommandResult.Success("Combat log prevention is disabled.");
+		}
+
+		if (activeTags.Count == 0)
+		{
+			return TextCommandResult.Success("Enabled, penalty: " + cfg.Penalty + ", no active tags.");
+		}
+
+		long now = server.ElapsedMilliseconds;
+		string result = "Active tags (" + activeTags.Count + "), penalty: " + cfg.Penalty + "\n";
+		foreach (KeyValuePair<string, CombatTagEntry> kv in activeTags)
+		{
+			IServerPlayer p = server.PlayerByUid(kv.Key) as IServerPlayer;
+			string name = p?.PlayerName ?? kv.Key;
+			long remaining = Math.Max(0, (kv.Value.ExpiresAtMs - now) / 1000);
+			result += "  " + name + " vs " + kv.Value.OpponentName + " (" + remaining + "s)\n";
+		}
+		return TextCommandResult.Success(result);
+	}
+
+	private TextCommandResult CmdTagSelf(TextCommandCallingArgs args)
+	{
+		StratumCombatLogConfig cfg = Cfg;
+		if (cfg == null || !cfg.Enabled)
+		{
+			return TextCommandResult.Error("Combat log prevention is disabled.");
+		}
+
+		IServerPlayer caller = args.Caller.Player as IServerPlayer;
+		if (caller == null)
+		{
+			return TextCommandResult.Error("Must be called by a player.");
+		}
+
+		long expiresAt = server.ElapsedMilliseconds + cfg.TagDurationSeconds * 1000L;
+		activeTags[caller.PlayerUID] = new CombatTagEntry
+		{
+			ExpiresAtMs = expiresAt,
+			OpponentName = "[test]"
+		};
+
+		caller.SendMessage(GlobalConstants.GeneralChatGroup, string.Format(cfg.TagMessage, cfg.TagDurationSeconds), EnumChatType.Notification);
+		return TextCommandResult.Success("Tagged for " + cfg.TagDurationSeconds + "s. Disconnect to test.");
+	}
+}

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumConfig.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumConfig.cs
@@ -48,6 +48,8 @@ internal class StratumConfig
 
 	public StratumAnnouncementsConfig Announcements { get; set; } = new StratumAnnouncementsConfig();
 
+	public StratumCombatLogConfig CombatLog { get; set; } = new StratumCombatLogConfig();
+
 	public StratumServerStatsConfig ServerStats { get; set; } = new StratumServerStatsConfig();
 
 	public void EnsurePopulated()
@@ -71,6 +73,7 @@ internal class StratumConfig
 		Nametags ??= new StratumNametagsConfig();
 		Backup ??= new StratumBackupConfig();
 		Announcements ??= new StratumAnnouncementsConfig();
+		CombatLog ??= new StratumCombatLogConfig();
 		ServerStats ??= new StratumServerStatsConfig();
 		PacketLimits.EnsureSane();
 		PacketBackPressure.EnsureSane();
@@ -88,6 +91,7 @@ internal class StratumConfig
 		Nametags.EnsurePopulated();
 		Backup.EnsureSane();
 		Announcements.EnsureSane();
+		CombatLog.EnsureSane();
 		ServerStats.EnsureSane();
 		UpdateChecker.EnsureSane();
 		MigrateLegacyDefaults();


### PR DESCRIPTION
Adds a combat tagging system that kills players who disconnect during PvP. Disabled by default. Operators enable it with `CombatLog.Enabled = true` in stratum.json.

When a player hits another player (melee or projectile), both sides get tagged for 15 seconds. Each hit renews the timer. If a tagged player disconnects, the server kills them on the spot and their inventory drops where they stood. The attacker can loot.

Two hook points cover all PvP damage: OnPlayerInteractEntity for melee (fires on left-click attack against a player entity), and a one-line callback in EntityProjectileBase for arrows, thrown stones, and spears (fires after ReceiveDamage confirms the hit landed). The projectile hook is a static delegate that is null when the system is off, so disabled servers pay nothing.

Config section in stratum.json:

```json
{
  "CombatLog": {
    "Enabled": false,
    "TagDurationSeconds": 15,
    "Penalty": "Kill",
    "TagAttacker": true,
    "NotifyOnTag": true,
    "NotifyOnExpiry": true,
    "BroadcastOnCombatLog": true,
    "AlertStaff": true,
    "ExemptPrivilege": "stratum.combatlog.exempt"
  }
}
```

Penalty options: `Kill` (instant death on disconnect, default), `KillOnRejoin` (death delayed until the player reconnects), `LogOnly` (staff alert only, no gameplay effect).

Players in creative/spectator mode and players with the exempt privilege are never tagged. Staff see a formatted alert when someone combat logs, including opponent name and seconds remaining.

Admin commands for testing: `/stratum combatlog status` shows active tags, `/stratum combatlog tag` tags yourself so you can test the disconnect penalty with a real client.

Known limitation: the KillOnRejoin penalty lives in memory and is lost if the server restarts before the player reconnects. Kill (the default) has no persistence requirement since it executes at disconnect time.

Fixes #202