### PR TITLE
Hold the neighbourhood resident while a worldgen stage claim lasts

### DIFF
--- a/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/1.GenTerra/GenTerraPostProcess.cs.patch
+++ b/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/1.GenTerra/GenTerraPostProcess.cs.patch
@@ -1,8 +1,8 @@
 diff --git a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/1.GenTerra/GenTerraPostProcess.cs b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/1.GenTerra/GenTerraPostProcess.cs
-index 79c481d..691b108 100644
+index 79c481d..c7a1523 100644
 --- a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/1.GenTerra/GenTerraPostProcess.cs
 +++ b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/1.GenTerra/GenTerraPostProcess.cs
-@@ -13,12 +13,24 @@ namespace Vintagestory.ServerMods
+@@ -13,12 +13,25 @@ namespace Vintagestory.ServerMods
      public class GenTerraPostProcess : ModStdWorldGen
      {
          ICoreServerAPI api;
@@ -13,7 +13,8 @@ index 79c481d..691b108 100644
 +        // Stratum: every field below used to be a plain instance field, written
 +        // and read within the processing of a single column (OnChunkColumnGen ->
 +        // deletePotentialFloatingBlocks -> AddToChunkVisitedNodesIfSameChunk),
-+        // unsafe once TerrainFeatures' same-stage cap moves off 1. Matches the
++        // unsafe once TerrainFeatures' same-stage cap moved off 1, which it since has
++        // (see ServerSystemSupplyChunks.stratumStageMaxConcurrent). Matches the
 +        // InvalidOperationException: Collection was modified crash reported
 +        // against this class: two columns concurrently mutating the same shared
 +        // HashSet/List. [ThreadStatic] since GenTerraPostProcess is a singleton
@@ -29,7 +30,7 @@ index 79c481d..691b108 100644
          {
              return side == EnumAppSide.Server;
          }
-@@ -56,10 +68,11 @@ namespace Vintagestory.ServerMods
+@@ -56,10 +69,11 @@ namespace Vintagestory.ServerMods
              const int chunksize = GlobalConstants.ChunkSize;
              const int chunksizeSquared = chunksize * chunksize;
              int chunkY = seaLevel / chunksize;
@@ -41,7 +42,7 @@ index 79c481d..691b108 100644
              for (int cy = chunkY; cy < cyMax; cy++)
              {
                  IChunkBlocks chunkdata = chunks[cy].Data;
-@@ -106,28 +119,29 @@ namespace Vintagestory.ServerMods
+@@ -106,28 +120,29 @@ namespace Vintagestory.ServerMods
              }
          }
  
@@ -75,7 +76,7 @@ index 79c481d..691b108 100644
  
              int baseX = X - halfSize;
              int baseY = Y - halfSize;
-@@ -225,11 +239,11 @@ namespace Vintagestory.ServerMods
+@@ -225,11 +240,11 @@ namespace Vintagestory.ServerMods
              if (((nposZ ^ origZ) & chunkMask) != 0) return;
              if (((nposY ^ origY) & chunkMask) != 0) return;
  

--- a/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/5.GenDeposits/GenDeposits.cs.patch
+++ b/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/5.GenDeposits/GenDeposits.cs.patch
@@ -1,8 +1,8 @@
 diff --git a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/5.GenDeposits/GenDeposits.cs b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/5.GenDeposits/GenDeposits.cs
-index b6ab588..e497139 100644
+index b6ab588..aaa2055 100644
 --- a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/5.GenDeposits/GenDeposits.cs
 +++ b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/5.GenDeposits/GenDeposits.cs
-@@ -26,10 +26,26 @@ namespace Vintagestory.ServerMods
+@@ -26,10 +26,27 @@ namespace Vintagestory.ServerMods
  
          IBlockAccessor blockAccessor;
  
@@ -18,10 +18,11 @@ index b6ab588..e497139 100644
 +        // depositRand reference existed on whichever thread ran initAssets, not the one
 +        // reseeded on the thread actually generating. A lock preserves the existing
 +        // object-identity relationship exactly, at the cost of serializing GeneratePartial
-+        // calls once TerrainFeatures' same-stage cap ever rises off 1 (it stays at 1
-+        // today, so this is not a live race yet, only a landmine closed early). Also
-+        // covers subDepositsToPlace and tmpPos below, cleared/set at the top of every
-+        // GeneratePartial call and safe to keep as plain fields under the same lock.
++        // calls under TerrainFeatures' same-stage cap, which has since risen off 1 (see
++        // ServerSystemSupplyChunks.stratumStageMaxConcurrent); this closed the landmine
++        // before that happened. Also covers subDepositsToPlace and tmpPos below,
++        // cleared/set at the top of every GeneratePartial call and safe to keep as
++        // plain fields under the same lock.
 +        private readonly object stratumGenDepositsLock = new object();
 +
          BlockPos tmpPos = new BlockPos(API.Config.Dimensions.NormalWorld);
@@ -29,7 +30,7 @@ index b6ab588..e497139 100644
          NormalizedSimplexNoise depositShapeDistortNoise;
          Dictionary<BlockPos, DepositVariant> subDepositsToPlace = new Dictionary<BlockPos, DepositVariant>();
          MapLayerBase verticalDistortTop;
-@@ -207,48 +223,51 @@ namespace Vintagestory.ServerMods
+@@ -207,48 +224,51 @@ namespace Vintagestory.ServerMods
              base.GenChunkColumn(request);
          }
  

--- a/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/6.GenStructures/GenStructures.cs.patch
+++ b/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/6.GenStructures/GenStructures.cs.patch
@@ -1,8 +1,8 @@
 diff --git a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/6.GenStructures/GenStructures.cs b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/6.GenStructures/GenStructures.cs
-index 95025db..8320886 100644
+index 95025db..e14044e 100644
 --- a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/6.GenStructures/GenStructures.cs
 +++ b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/6.GenStructures/GenStructures.cs
-@@ -35,33 +35,38 @@ namespace Vintagestory.ServerMods
+@@ -35,33 +35,55 @@ namespace Vintagestory.ServerMods
          ICoreServerAPI api;
  
          int worldheight;
@@ -22,8 +22,8 @@ index 95025db..8320886 100644
 +        // OnChunkColumnGen/DoGenStructures and read a few calls later in the same
 +        // column's processing (TryGenerate, TryGenVillages), the same shape of bug as
 +        // GenVegetationAndPatches' equivalent fields and GenCreatures' original one for
-+        // PreDone. TerrainFeatures (this class's stage) stays at same-stage cap 1 today,
-+        // so this was not a live race yet, but a landmine for whoever raises that cap,
++        // PreDone. This landmine went off: TerrainFeatures (this class's stage) got
++        // raised off same-stage cap 1 (see ServerSystemSupplyChunks.stratumStageMaxConcurrent),
 +        // same framing as treeAndShrubSupressingStructures below. [ThreadStatic] keeps
 +        // every field private to whichever thread is currently inside OnChunkColumnGen
 +        // for a given column, at zero cost while only one thread at a time is in here.
@@ -37,6 +37,23 @@ index 95025db..8320886 100644
 +        [ThreadStatic] private static int stratumForestUpLeft, stratumForestUpRight, stratumForestBotLeft, stratumForestBotRight;
 +        [ThreadStatic] private static LCGRandom stratumStrucRand;
 +        [ThreadStatic] private static WorldGenStructure[] stratumShuffledStructures;
++
++        // Stratum: struc.TryGenerate (both the ruins loop below and GenVillage) does
++        // three things that were never safe to run on two columns at once: it reads
++        // region.GeneratedStructures through WorldGenStructure.WouldOverlapAt to decide
++        // whether the spot is free, it writes shared mutable state on the WorldGenStructure
++        // instance itself (rand, tmpPos, climate fields, LastPlacedSchematicLocation,
++        // LastPlacedSchematic; those instances live once in scfg.Structures /
++        // vcfg.VillageTypes, not per-thread), and only then does the caller read
++        // LastPlacedSchematicLocation/LastPlacedSchematic back out and register the
++        // result. Two threads placing structures at the same time can both pass the
++        // overlap check against a region list neither has registered into yet (both
++        // place, the schematics land on top of each other), or one thread's read of
++        // LastPlaced* can land after a second thread already overwrote it on the same
++        // shared struc. Raising TerrainFeatures' cap made this reachable; the fix is to
++        // serialize the whole decide-place-register sequence, which is also the fix for
++        // WorldGenStructure's un-[ThreadStatic]'d static tmpLoc scratch field.
++        readonly object stratumStructurePlacementLock = new object();
  
          public event PeventSchematicAtDelegate OnPreventSchematicPlaceAt;
  
@@ -55,7 +72,7 @@ index 95025db..8320886 100644
          public override double ExecuteOrder() { return 0.3; }
  
          public override void StartServerSide(ICoreServerAPI api)
-@@ -111,12 +116,10 @@ namespace Vintagestory.ServerMods
+@@ -111,12 +133,10 @@ namespace Vintagestory.ServerMods
  
              worldheight = api.WorldManager.MapSizeY;
              regionChunkSize = api.WorldManager.RegionSize / chunksize;
@@ -68,7 +85,7 @@ index 95025db..8320886 100644
  
              var genStoryStructures = api.World.Config.GetAsString("loreContent", "true").ToBool(true);
              if (!genStoryStructures) return;
-@@ -202,11 +205,11 @@ namespace Vintagestory.ServerMods
+@@ -202,11 +222,11 @@ namespace Vintagestory.ServerMods
                  structures.AddRange(conf.Structures);
              }
  
@@ -81,7 +98,7 @@ index 95025db..8320886 100644
          }
  
          private void LoadVillages()
-@@ -268,24 +271,24 @@ namespace Vintagestory.ServerMods
+@@ -268,24 +288,24 @@ namespace Vintagestory.ServerMods
              // rlX, rlZ goes from 0..16 pixel
              // facF = 16/16 = 1
              // Get 4 pixels for chunkx, chunkz, chunkx+1 and chunkz+1 inside the map
@@ -115,7 +132,7 @@ index 95025db..8320886 100644
              if (structure == null)
              {
                  TryGenVillages(region, chunkX, chunkZ, false, request.ChunkGenParams);
-@@ -298,22 +301,22 @@ namespace Vintagestory.ServerMods
+@@ -298,22 +318,22 @@ namespace Vintagestory.ServerMods
              // which is crucial for the translocator to find an exit point
              if (locationCode != null)
              {
@@ -142,7 +159,7 @@ index 95025db..8320886 100644
  
              ITreeAttribute chanceModTree = null;
              ITreeAttribute maxQuantityModTree = null;
-@@ -326,17 +329,17 @@ namespace Vintagestory.ServerMods
+@@ -326,17 +346,17 @@ namespace Vintagestory.ServerMods
              {
                  maxQuantityModTree = chunkGenParams["structureMaxCount"] as TreeAttribute;
              }
@@ -164,7 +181,7 @@ index 95025db..8320886 100644
                  float chance = struc.Chance * scfg.ChanceMultiplier;
                  int toGenerate = 9999;
                  if (chanceModTree != null)
-@@ -348,26 +351,26 @@ namespace Vintagestory.ServerMods
+@@ -348,26 +368,26 @@ namespace Vintagestory.ServerMods
                  {
                      toGenerate = maxQuantityModTree.GetInt(struc.Code, 9999);
                  }
@@ -197,7 +214,7 @@ index 95025db..8320886 100644
                      else
                      {
                          startPos.Set(chunkX * chunksize + dx, ySurface, chunkZ * chunksize + dz);
-@@ -393,12 +396,12 @@ namespace Vintagestory.ServerMods
+@@ -393,50 +413,57 @@ namespace Vintagestory.ServerMods
                          {
                              continue;
                          }
@@ -206,13 +223,87 @@ index 95025db..8320886 100644
 -                    int forest = GameMath.BiLerpRgbColor((float)(startPos.X % chunksize) / chunksize, (float)(startPos.Z % chunksize) / chunksize, forestUpLeft, forestUpRight, forestBotLeft, forestBotRight);
 -                    if (struc.TryGenerate(worldgenBlockAccessor, api.World, startPos, climateUpLeft, climateUpRight, climateBotLeft, climateBotRight, forest, locationCode))
 +                    int forest = GameMath.BiLerpRgbColor((float)(startPos.X % chunksize) / chunksize, (float)(startPos.Z % chunksize) / chunksize, stratumForestUpLeft, stratumForestUpRight, stratumForestBotLeft, stratumForestBotRight);
-+                    if (struc.TryGenerate(worldgenBlockAccessor, api.World, startPos, stratumClimateUpLeft, stratumClimateUpRight, stratumClimateBotLeft, stratumClimateBotRight, forest, locationCode))
++                    bool didGenerate;
++                    lock (stratumStructurePlacementLock)
                      {
-                         if(locationCode != null && location != null)
+-                        if(locationCode != null && location != null)
++                        didGenerate = struc.TryGenerate(worldgenBlockAccessor, api.World, startPos, stratumClimateUpLeft, stratumClimateUpRight, stratumClimateBotLeft, stratumClimateBotRight, forest, locationCode);
++                        if (didGenerate)
                          {
-                             if (location.SchematicsSpawned?.TryGetValue(struc.Group, out var spawnedSchematics) == true)
+-                            if (location.SchematicsSpawned?.TryGetValue(struc.Group, out var spawnedSchematics) == true)
++                            if(locationCode != null && location != null)
                              {
-@@ -446,18 +449,18 @@ namespace Vintagestory.ServerMods
+-                                location.SchematicsSpawned[struc.Group] = spawnedSchematics + 1;
++                                if (location.SchematicsSpawned?.TryGetValue(struc.Group, out var spawnedSchematics) == true)
++                                {
++                                    location.SchematicsSpawned[struc.Group] = spawnedSchematics + 1;
++                                }
++                                else
++                                {
++                                    location.SchematicsSpawned ??= new Dictionary<string, int>();
++                                    location.SchematicsSpawned[struc.Group] = 1;
++                                }
+                             }
+-                            else
+-                            {
+-                                location.SchematicsSpawned ??= new Dictionary<string, int>();
+-                                location.SchematicsSpawned[struc.Group] = 1;
+-                            }
+-                        }
+-                        Cuboidi loc = struc.LastPlacedSchematicLocation;
++                            Cuboidi loc = struc.LastPlacedSchematicLocation;
+ 
+-                        string code = (struc.LastPlacedSchematic == null ? "" : struc.LastPlacedSchematic.FromFile.GetNameWithDomain()) + "/" + struc.Code;
++                            string code = (struc.LastPlacedSchematic == null ? "" : struc.LastPlacedSchematic.FromFile.GetNameWithDomain()) + "/" + struc.Code;
+ 
+-                        region.AddGeneratedStructure(new GeneratedStructure() {
+-                            Code = code,
+-                            Group = struc.Group,
+-                            Location = loc.Clone(),
+-                            SuppressTreesAndShrubs = struc.SuppressTrees,
+-                            SuppressRivulets = struc.SuppressWaterfalls
+-                        });
++                            region.AddGeneratedStructure(new GeneratedStructure() {
++                                Code = code,
++                                Group = struc.Group,
++                                Location = loc.Clone(),
++                                SuppressTreesAndShrubs = struc.SuppressTrees,
++                                SuppressRivulets = struc.SuppressWaterfalls
++                            });
+ 
+-                        if (struc.BuildProtected)
+-                        {
+-                            api.World.Claims.Add(new LandClaim()
++                            if (struc.BuildProtected)
+                             {
+-                                Areas = new List<Cuboidi>() { loc.Clone() },
+-                                Description = struc.BuildProtectionDesc,
+-                                ProtectionLevel = struc.ProtectionLevel,
+-                                LastKnownOwnerName = struc.BuildProtectionName,
+-                                AllowUseEveryone = struc.AllowUseEveryone,
+-                                AllowTraverseEveryone = struc.AllowTraverseEveryone
+-                            });
++                                api.World.Claims.Add(new LandClaim()
++                                {
++                                    Areas = new List<Cuboidi>() { loc.Clone() },
++                                    Description = struc.BuildProtectionDesc,
++                                    ProtectionLevel = struc.ProtectionLevel,
++                                    LastKnownOwnerName = struc.BuildProtectionName,
++                                    AllowUseEveryone = struc.AllowUseEveryone,
++                                    AllowTraverseEveryone = struc.AllowTraverseEveryone
++                                });
++                            }
+                         }
+-
++                    }
++                    if (didGenerate)
++                    {
+                         toGenerate--;
+                     }
+                 }
+             }
+         }
+@@ -446,18 +473,18 @@ namespace Vintagestory.ServerMods
  
  
  
@@ -233,7 +324,7 @@ index 95025db..8320886 100644
                  }
              }
          }
-@@ -466,16 +469,16 @@ namespace Vintagestory.ServerMods
+@@ -466,67 +493,89 @@ namespace Vintagestory.ServerMods
          {
              BlockPos pos = new BlockPos(Dimensions.NormalWorld);
  
@@ -246,15 +337,45 @@ index 95025db..8320886 100644
              pos.Set(chunkX * chunksize + dx, ySurface, chunkZ * chunksize + dz);
  
 -            return struc.TryGenerate(blockAccessor, api.World, pos, climateUpLeft, climateUpRight, climateBotLeft, climateBotRight, (loc, schematic) =>
-+            return struc.TryGenerate(blockAccessor, api.World, pos, stratumClimateUpLeft, stratumClimateUpRight, stratumClimateBotLeft, stratumClimateBotRight, (loc, schematic) =>
++            // Stratum: same lock as the ruins loop in DoGenStructures. Villages and
++            // ruins share the same region.GeneratedStructures overlap check, so they
++            // need to serialize against each other, not just against their own kind.
++            lock (stratumStructurePlacementLock)
              {
-                 string code = (schematic == null ? "" : schematic.FromFile.GetNameWithDomain()) + "/" + struc.Code;
+-                string code = (schematic == null ? "" : schematic.FromFile.GetNameWithDomain()) + "/" + struc.Code;
++                return struc.TryGenerate(blockAccessor, api.World, pos, stratumClimateUpLeft, stratumClimateUpRight, stratumClimateBotLeft, stratumClimateBotRight, (loc, schematic) =>
++                {
++                    string code = (schematic == null ? "" : schematic.FromFile.GetNameWithDomain()) + "/" + struc.Code;
  
-                 region.AddGeneratedStructure(new GeneratedStructure() { Code = code, Group = struc.Group, Location = loc.Clone() });
+-                region.AddGeneratedStructure(new GeneratedStructure() { Code = code, Group = struc.Group, Location = loc.Clone() });
++                    region.AddGeneratedStructure(new GeneratedStructure() { Code = code, Group = struc.Group, Location = loc.Clone() });
  
-@@ -493,40 +496,56 @@ namespace Vintagestory.ServerMods
-                 }
-             }, spawnPos);
+-                if (struc.BuildProtected)
+-                {
+-                    api.World.Claims.Add(new LandClaim()
++                    if (struc.BuildProtected)
+                     {
+-                        Areas = new List<Cuboidi>() { loc.Clone() },
+-                        Description = struc.BuildProtectionDesc,
+-                        ProtectionLevel = struc.ProtectionLevel,
+-                        LastKnownOwnerName = struc.BuildProtectionName,
+-                        AllowUseEveryone = struc.AllowUseEveryone,
+-                        AllowTraverseEveryone = struc.AllowTraverseEveryone
+-                    });
+-                }
+-            }, spawnPos);
++                        api.World.Claims.Add(new LandClaim()
++                        {
++                            Areas = new List<Cuboidi>() { loc.Clone() },
++                            Description = struc.BuildProtectionDesc,
++                            ProtectionLevel = struc.ProtectionLevel,
++                            LastKnownOwnerName = struc.BuildProtectionName,
++                            AllowUseEveryone = struc.AllowUseEveryone,
++                            AllowTraverseEveryone = struc.AllowTraverseEveryone
++                        });
++                    }
++                }, spawnPos);
++            }
          }
  
  

--- a/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/7.GenPonds/GenPonds.cs.patch
+++ b/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/7.GenPonds/GenPonds.cs.patch
@@ -1,8 +1,8 @@
 diff --git a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/7.GenPonds/GenPonds.cs b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/7.GenPonds/GenPonds.cs
-index acfac74..ecbfb47 100644
+index acfac74..44cd890 100644
 --- a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/7.GenPonds/GenPonds.cs
 +++ b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/7.GenPonds/GenPonds.cs
-@@ -9,27 +9,37 @@ using Vintagestory.API.Server;
+@@ -9,27 +9,38 @@ using Vintagestory.API.Server;
  namespace Vintagestory.ServerMods
  {
      public class GenPonds : ModStdWorldGen
@@ -11,8 +11,9 @@ index acfac74..ecbfb47 100644
 -        LCGRandom rand;
 +        // Stratum: every field below used to be a plain instance field, written by
 +        // OnChunkColumnGen/TryPlacePondAt for one column and read a few calls later
-+        // in the same call chain, unsafe once TerrainFeatures' same-stage cap moves
-+        // off 1. [ThreadStatic] since GenPonds is a singleton ModSystem with no
++        // in the same call chain, unsafe once TerrainFeatures' same-stage cap moved
++        // off 1, which it since has (see ServerSystemSupplyChunks.stratumStageMaxConcurrent).
++        // [ThreadStatic] since GenPonds is a singleton ModSystem with no
 +        // second live instance anywhere in the codebase (confirmed by search).
 +        // rand needs lazy per-thread construction with the same world-seed offset
 +        // the old shared instance used (see stratumWorldSeed below), since it's
@@ -50,7 +51,7 @@ index acfac74..ecbfb47 100644
  
          public override double ExecuteOrder()
          {
-@@ -65,17 +75,16 @@ namespace Vintagestory.ServerMods
+@@ -65,17 +76,16 @@ namespace Vintagestory.ServerMods
  
          public void initWorldGen()
          {
@@ -69,7 +70,7 @@ index acfac74..ecbfb47 100644
  
              lakebedLayerConfig = blockLayerConfig.LakeBedLayer;
          }
-@@ -88,11 +97,11 @@ namespace Vintagestory.ServerMods
+@@ -88,11 +98,11 @@ namespace Vintagestory.ServerMods
              if (GetIntersectingStructure(chunkX * chunksize + chunksize / 2, chunkZ * chunksize + chunksize / 2, PondsHashCode) != null)
              {
                  return;
@@ -82,7 +83,7 @@ index acfac74..ecbfb47 100644
              int pondYPos;
  
              ushort[] heightmap = chunks[0].MapChunk.RainHeightMap;
-@@ -102,16 +111,16 @@ namespace Vintagestory.ServerMods
+@@ -102,16 +112,16 @@ namespace Vintagestory.ServerMods
              int regionChunkSize = api.WorldManager.RegionSize / chunksize;
              float fac = (float)climateMap.InnerSize / regionChunkSize;
              int rlX = chunkX % regionChunkSize;
@@ -104,7 +105,7 @@ index acfac74..ecbfb47 100644
              // 8-15 bits = Green = rain
              // 0-7 bits = Blue = humidity
  
-@@ -184,10 +193,13 @@ namespace Vintagestory.ServerMods
+@@ -184,10 +194,13 @@ namespace Vintagestory.ServerMods
              int searchSize = this.searchSize;
              int minBoundary = this.minBoundary;
              int maxBoundary = this.maxBoundary;
@@ -118,7 +119,7 @@ index acfac74..ecbfb47 100644
  
              int basePosX = chunkX * chunksize;
              int basePosZ = chunkZ * chunksize;
-@@ -195,11 +207,11 @@ namespace Vintagestory.ServerMods
+@@ -195,11 +208,11 @@ namespace Vintagestory.ServerMods
  
              // The starting block is an air block
              int arrayIndex = (dz + mapOffset) * searchSize + dx + mapOffset;
@@ -131,7 +132,7 @@ index acfac74..ecbfb47 100644
              BlockPos tmpPos = new BlockPos(API.Config.Dimensions.NormalWorld);
  
              while (searchPositionsDeltas.Count > 0)
-@@ -262,11 +274,11 @@ namespace Vintagestory.ServerMods
+@@ -262,11 +275,11 @@ namespace Vintagestory.ServerMods
              IServerChunk chunk = null;
              IServerChunk chunkOneBlockBelow = null;
  
@@ -144,7 +145,7 @@ index acfac74..ecbfb47 100644
              while (pondPositions.Count > 0)
              {
                  int p = pondPositions.Dequeue();
-@@ -281,10 +293,14 @@ namespace Vintagestory.ServerMods
+@@ -281,10 +294,14 @@ namespace Vintagestory.ServerMods
                  // Get correct chunk and correct climate data if we don't have it already
                  if (curChunkX != prevChunkX || curChunkZ != prevChunkZ)
                  {
@@ -159,7 +160,7 @@ index acfac74..ecbfb47 100644
                      if (ly == 0)
                      {
                          chunkOneBlockBelow = ((IServerChunk)blockAccessor.GetChunk(curChunkX, (pondYPos - 1) / chunksize, curChunkZ));
-@@ -300,14 +316,14 @@ namespace Vintagestory.ServerMods
+@@ -300,14 +317,14 @@ namespace Vintagestory.ServerMods
  
                      float fac = (float)climateMap.InnerSize / regionChunkSize;
                      int rlX = curChunkX % regionChunkSize;
@@ -178,7 +179,7 @@ index acfac74..ecbfb47 100644
                      prevChunkZ = curChunkZ;
  
                      chunkOneBlockBelow.MarkModified();
-@@ -317,11 +333,11 @@ namespace Vintagestory.ServerMods
+@@ -317,11 +334,11 @@ namespace Vintagestory.ServerMods
  
                  // Raise heightmap by 1 (only relevant for above-ground ponds)
                  if (mapchunk.RainHeightMap[lz * chunksize + lx] < pondYPos) mapchunk.RainHeightMap[lz * chunksize + lx] = (ushort)pondYPos;
@@ -191,7 +192,7 @@ index acfac74..ecbfb47 100644
  
                  // 1. Place water or ice block
                  int index3d = (ly * chunksize + lz) * chunksize + lx;
-@@ -355,11 +371,11 @@ namespace Vintagestory.ServerMods
+@@ -355,11 +372,11 @@ namespace Vintagestory.ServerMods
  
                  float rainRel = Climate.GetRainFall((climate >> 8) & 0xff, pondYPos) / 255f;
                  int rockBlockId = mapchunk.TopRockIdMap[lz * chunksize + lx];

--- a/patches/VSSurvivalMod/Systems/WorldGen/Standard/ChunkGen/6.GenStructures/GenDungeons.cs.patch
+++ b/patches/VSSurvivalMod/Systems/WorldGen/Standard/ChunkGen/6.GenStructures/GenDungeons.cs.patch
@@ -1,5 +1,5 @@
 diff --git a/VSSurvivalMod/Systems/WorldGen/Standard/ChunkGen/6.GenStructures/GenDungeons.cs b/VSSurvivalMod/Systems/WorldGen/Standard/ChunkGen/6.GenStructures/GenDungeons.cs
-index dfdae53..1f1ef56 100644
+index dfdae53..9c8c660 100644
 --- a/VSSurvivalMod/Systems/WorldGen/Standard/ChunkGen/6.GenStructures/GenDungeons.cs
 +++ b/VSSurvivalMod/Systems/WorldGen/Standard/ChunkGen/6.GenStructures/GenDungeons.cs
 @@ -1,5 +1,7 @@
@@ -10,7 +10,7 @@ index dfdae53..1f1ef56 100644
  using System.Linq;
  using ProtoBuf;
  using Vintagestory.API.Common;
-@@ -48,19 +50,40 @@ namespace Vintagestory.ServerMods
+@@ -48,19 +50,41 @@ namespace Vintagestory.ServerMods
      public class GenDungeons : ModStdWorldGen
      {
          private ModSystemTiledDungeons tiledDungeonsSys = null!;
@@ -21,8 +21,9 @@ index dfdae53..1f1ef56 100644
 -        private Dictionary<long, List<DungeonPlaceTask>> dungeonPlaceTasksByRegion = new Dictionary<long, List<DungeonPlaceTask>>();
 +        // Stratum: rand and grassRand used to be plain instance fields, reseeded
 +        // via InitPositionSeed per column/connector and read a few calls later in
-+        // the same call chain, unsafe once TerrainFeatures' same-stage cap moves
-+        // off 1. [ThreadStatic] since GenDungeons is a singleton ModSystem with no
++        // the same call chain, unsafe once TerrainFeatures' same-stage cap moved
++        // off 1, which it since has (see ServerSystemSupplyChunks.stratumStageMaxConcurrent).
++        // [ThreadStatic] since GenDungeons is a singleton ModSystem with no
 +        // second live instance anywhere in the codebase (confirmed by search), and
 +        // both need lazy per-thread construction with the same seed formula the
 +        // old shared instances used, since both are reseeded via InitPositionSeed
@@ -54,7 +55,7 @@ index dfdae53..1f1ef56 100644
  
          public override double ExecuteOrder() { return 0.12; }
  
-@@ -101,17 +124,15 @@ namespace Vintagestory.ServerMods
+@@ -101,17 +125,15 @@ namespace Vintagestory.ServerMods
              {
                  spawnPos = sapi.World.BlockAccessor.MapSize.AsBlockPos / 2;
              }
@@ -72,7 +73,7 @@ index dfdae53..1f1ef56 100644
  
          private void Event_MapRegionLoaded(Vec2i mapCoord, IMapRegion region)
          {
-@@ -131,21 +152,27 @@ namespace Vintagestory.ServerMods
+@@ -131,21 +153,27 @@ namespace Vintagestory.ServerMods
  
          private void Event_GameWorldSave()
          {
@@ -103,7 +104,7 @@ index dfdae53..1f1ef56 100644
  
          private void Event_MapRegionUnloaded(Vec2i mapCoord, IMapRegion region)
          {
-@@ -161,63 +188,69 @@ namespace Vintagestory.ServerMods
+@@ -161,63 +189,69 @@ namespace Vintagestory.ServerMods
              var mapRand = new LCGRandom(sapi.WorldManager.Seed ^ 8991827198);
              mapRand.InitPositionSeed(regionX * size, regionZ * size);
  
@@ -210,7 +211,7 @@ index dfdae53..1f1ef56 100644
  
          private static TiledDungeon pickDungeon(int[] dungeIndices, LCGRandom mapRand, List<TiledDungeon> dungeons)
          {
-@@ -363,10 +396,19 @@ namespace Vintagestory.ServerMods
+@@ -363,10 +397,19 @@ namespace Vintagestory.ServerMods
                      if (!dungeonPlaceTasksByRegion.TryGetValue(mapRegionIndex2D, out var dungePlaceTasks)) continue;
  
                      foreach (var placeTask in dungePlaceTasks)
@@ -230,7 +231,7 @@ index dfdae53..1f1ef56 100644
                          Block? rockBlock = null;
                          // get the rockblock for the first generating chunk and reuse that for each room
                          if (placeTask.RockBlockCode == null)
-@@ -408,10 +450,11 @@ namespace Vintagestory.ServerMods
+@@ -408,10 +451,11 @@ namespace Vintagestory.ServerMods
                              var height = sapi.World.BlockAccessor.GetTerrainMapheightAt(pos);
                              if (height == 0) continue;
                              // skip if we get our of range where we can generate, should not happen if the stairs and surface rooms are not larger than 2 chunks
@@ -242,7 +243,7 @@ index dfdae53..1f1ef56 100644
                              for (int i = 0; i < tileIndices.Length; i++) tileIndices[i] = i;
  
                              DungeonGenWorkspace dgd = new DungeonGenWorkspace(dungeon.StairCase, 0, 0, [], [], [], [], null);
-@@ -500,31 +543,32 @@ namespace Vintagestory.ServerMods
+@@ -500,31 +544,32 @@ namespace Vintagestory.ServerMods
  
                          if (placeTask.SurfacePlaceTasks != null)
                          {
@@ -278,7 +279,7 @@ index dfdae53..1f1ef56 100644
                      // Try any of the 4 sides and see which one can connect
                      for (var i = 0; i < 4; i++)
                      {
-@@ -579,11 +623,11 @@ namespace Vintagestory.ServerMods
+@@ -579,11 +624,11 @@ namespace Vintagestory.ServerMods
                  if (schematic == null) continue;
                  var placed = schematic.PlacePartial(chunks, worldgenBlockAccessor, sapi.World, chunkX, chunkZ, placeTask.Pos, EnumReplaceMode.ReplaceAll, null, GlobalConfig.ReplaceMetaBlocks, true, dungeon.resolvedRockTypeRemaps, dungeon.replacewithblocklayersBlockids, rockBlock);
                  if (placed > 0)

--- a/patches/VintagestoryLib/Vintagestory.Server/ChunkColumnLoadRequest.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/ChunkColumnLoadRequest.cs.patch
@@ -1,8 +1,8 @@
 diff --git a/VintagestoryLib/Vintagestory.Server/ChunkColumnLoadRequest.cs b/VintagestoryLib/Vintagestory.Server/ChunkColumnLoadRequest.cs
-index 04b25be..bea4514 100644
+index 04b25be..003c393 100644
 --- a/VintagestoryLib/Vintagestory.Server/ChunkColumnLoadRequest.cs
 +++ b/VintagestoryLib/Vintagestory.Server/ChunkColumnLoadRequest.cs
-@@ -34,25 +34,65 @@ public class ChunkColumnLoadRequest : ILongIndex, IChunkColumnGenerateRequest
+@@ -34,25 +34,75 @@ public class ChunkColumnLoadRequest : ILongIndex, IChunkColumnGenerateRequest
  
  	internal bool prettified;
  
@@ -47,6 +47,16 @@ index 04b25be..bea4514 100644
 +	// boundary-scan call returns.
 +	internal int dispatchClaimed;
 +
++	// Stratum: 0 = live, 1 = the unload pass has committed to dropping this column.
++	// Set before that pass touches loadedMapChunks or the request queue, so the two
++	// possible orderings both resolve: a pin that lands first makes the dropper back
++	// out and clear this, and a drop that commits first makes the neighbour gate treat
++	// the column as absent, which refuses the claim instead of granting one over a
++	// column that is about to disappear. Without it, the gate can observe a column the
++	// unload pass has already decided to remove, since deciding and removing are not
++	// one step.
++	internal int stratumDropping;
++
  	private static long counter;
  
  	internal bool Disposed => (disposeOrRequeueFlags & 1) == 1;
@@ -71,7 +81,7 @@ index 04b25be..bea4514 100644
  		}
  		set
  		{
-@@ -62,13 +102,14 @@ public class ChunkColumnLoadRequest : ILongIndex, IChunkColumnGenerateRequest
+@@ -62,13 +112,14 @@ public class ChunkColumnLoadRequest : ILongIndex, IChunkColumnGenerateRequest
  
  	public int CurrentIncompletePass_AsInt
  	{

--- a/patches/VintagestoryLib/Vintagestory.Server/ChunkServerThread.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/ChunkServerThread.cs.patch
@@ -1,8 +1,8 @@
 diff --git a/VintagestoryLib/Vintagestory.Server/ChunkServerThread.cs b/VintagestoryLib/Vintagestory.Server/ChunkServerThread.cs
-index ee7d12d..64084f2 100644
+index ee7d12d..a7b02bd 100644
 --- a/VintagestoryLib/Vintagestory.Server/ChunkServerThread.cs
 +++ b/VintagestoryLib/Vintagestory.Server/ChunkServerThread.cs
-@@ -12,10 +12,12 @@ namespace Vintagestory.Server;
+@@ -12,10 +12,23 @@ namespace Vintagestory.Server;
  
  public class ChunkServerThread : ServerThread, IChunkProvider
  {
@@ -10,12 +10,23 @@ index ee7d12d..64084f2 100644
  
 +	internal StratumChunkReadPool stratumReadPool;
 +
++	// Stratum: columns held against unloading while a neighbour of theirs runs a
++	// neighbour gated worldgen stage. EnsureMinimumWorldgenPassAt only passes a
++	// neighbour that is resident, either as a live request or as a loaded map chunk at
++	// pass Done, so the gate does establish residency. It establishes it once, at claim
++	// time, and nothing holds it for the length of the stage: the column can unload
++	// while the generator is still reading across the boundary, and then
++	// GetGeneratingChunk and the loaded chunks fallback both answer null. The count is
++	// per column because neighbourhoods overlap, so two columns generating side by side
++	// pin their shared neighbours twice and each releases its own.
++	internal readonly System.Collections.Concurrent.ConcurrentDictionary<long, int> stratumPinnedColumns = new System.Collections.Concurrent.ConcurrentDictionary<long, int>();
++
  	internal ConcurrentIndexedFifoQueue<ChunkColumnLoadRequest> requestedChunkColumns;
  
  	internal IndexedFifoQueue<ChunkColumnLoadRequest> peekingChunkColumns;
  
  	internal Dictionary<long, ServerMapRegion> peekingMapRegions = new Dictionary<long, ServerMapRegion>(8);
-@@ -39,13 +41,13 @@ public class ChunkServerThread : ServerThread, IChunkProvider
+@@ -39,13 +52,13 @@ public class ChunkServerThread : ServerThread, IChunkProvider
  	public ILogger Logger => ServerMain.Logger;
  
  	public ChunkServerThread(ServerMain server, string threadname, CancellationToken cancellationToken)
@@ -32,7 +43,7 @@ index ee7d12d..64084f2 100644
  		}
  		if (additionalWorldGenThreadsCount < 0)
  		{
-@@ -101,15 +103,21 @@ public class ChunkServerThread : ServerThread, IChunkProvider
+@@ -101,15 +114,21 @@ public class ChunkServerThread : ServerThread, IChunkProvider
  		return peekingChunkColumns.GetByIndex(index);
  	}
  
@@ -56,7 +67,7 @@ index ee7d12d..64084f2 100644
  	}
  
  	internal ServerMapChunk GetMapChunk(long index2d)
-@@ -143,19 +151,19 @@ public class ChunkServerThread : ServerThread, IChunkProvider
+@@ -143,19 +162,19 @@ public class ChunkServerThread : ServerThread, IChunkProvider
  	IWorldChunk IChunkProvider.GetUnpackedChunkFast(int chunkX, int chunkY, int chunkZ, bool notRecentlyAccessed)
  	{
  		ServerChunk generatingChunk = GetGeneratingChunk(chunkX, chunkY, chunkZ);
@@ -78,7 +89,7 @@ index ee7d12d..64084f2 100644
  		});
  	}
  
-@@ -186,38 +194,50 @@ public class ChunkServerThread : ServerThread, IChunkProvider
+@@ -186,38 +205,125 @@ public class ChunkServerThread : ServerThread, IChunkProvider
  			requestedChunkColumns.EnqueueWithoutAddingToIndex(chunkRequest);
  		}
  		return !orAdd.Disposed;
@@ -110,10 +121,83 @@ index ee7d12d..64084f2 100644
 -		}
 -		return true;
 -	}
--
--	public long ChunkIndex3D(int chunkX, int chunkY, int chunkZ)
++    /// <summary>
++    /// Stratum: holds the 3x3 neighbourhood of a column against unloading. Taken before the
++    /// neighbour gate runs, released when the stage finishes or the gate refuses. Pins the
++    /// column itself too, since it is the one whose own chunks the generator writes.
++    /// </summary>
++    internal void StratumPinNeighbourhood(int chunkX, int chunkZ)
++    {
++        int minX = Math.Max(chunkX - 1, 0);
++        int maxX = Math.Min(chunkX + 1, server.WorldMap.ChunkMapSizeX - 1);
++        int minZ = Math.Max(chunkZ - 1, 0);
++        int maxZ = Math.Min(chunkZ + 1, server.WorldMap.ChunkMapSizeZ - 1);
++        for (int x = minX; x <= maxX; x++)
++        {
++            for (int z = minZ; z <= maxZ; z++)
++            {
++                stratumPinnedColumns.AddOrUpdate(server.WorldMap.MapChunkIndex2D(x, z), 1, static (key, count) => count + 1);
++            }
++        }
++    }
++
++    /// <summary>
++    /// Stratum: releases what StratumPinNeighbourhood took. Must run on every path that
++    /// releases the stage claim, which is why it sits next to the stratumStageActiveCount
++    /// decrements rather than anywhere else.
++    /// </summary>
++    internal void StratumUnpinNeighbourhood(int chunkX, int chunkZ)
++    {
++        int minX = Math.Max(chunkX - 1, 0);
++        int maxX = Math.Min(chunkX + 1, server.WorldMap.ChunkMapSizeX - 1);
++        int minZ = Math.Max(chunkZ - 1, 0);
++        int maxZ = Math.Min(chunkZ + 1, server.WorldMap.ChunkMapSizeZ - 1);
++        for (int x = minX; x <= maxX; x++)
++        {
++            for (int z = minZ; z <= maxZ; z++)
++            {
++                long index2d = server.WorldMap.MapChunkIndex2D(x, z);
++                while (true)
++                {
++                    if (!stratumPinnedColumns.TryGetValue(index2d, out int count))
++                    {
++                        break;
++                    }
++                    if (count <= 1)
++                    {
++                        if (((System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<long, int>>)stratumPinnedColumns).Remove(new System.Collections.Generic.KeyValuePair<long, int>(index2d, count)))
++                        {
++                            break;
++                        }
++                        continue;
++                    }
++                    if (stratumPinnedColumns.TryUpdate(index2d, count - 1, count))
++                    {
++                        break;
++                    }
++                }
++            }
++        }
++    }
++
++    /// <summary>
++    /// Stratum: true while any column generating nearby needs this one to stay resident.
++    /// </summary>
++    internal bool StratumIsColumnPinned(long index2d)
++    {
++        return stratumPinnedColumns.ContainsKey(index2d);
++    }
++
 +    internal bool EnsureMinimumWorldgenPassAt(long index2d, int chunkX, int chunkZ, int minPass, long requirorTime)
 +    {
++        // Stratum: a column the unload pass has committed to dropping is absent as far
++        // as this gate is concerned, even while its map chunk is still in the registry.
++        // Deciding to drop and finishing the drop are not one step, and granting a claim
++        // in between is what let a generator read a column that vanished under it.
++        if (requestedChunkColumns.elementsByIndex.TryGetValue(index2d, out var dropCheck) && Volatile.Read(ref dropCheck.stratumDropping) != 0)
++        {
++            return false;
++        }
 +        server.loadedMapChunks.TryGetValue(index2d, out var value);
 +        if (value != null && value.CurrentIncompletePass == EnumWorldGenPass.Done)
 +        {
@@ -150,7 +234,8 @@ index ee7d12d..64084f2 100644
 +        // Stratum end
 +        return true;
 +    }
-+
+ 
+-	public long ChunkIndex3D(int chunkX, int chunkY, int chunkZ)
 +    public long ChunkIndex3D(int chunkX, int chunkY, int chunkZ)
  	{
  		return ((long)chunkY * (long)server.WorldMap.index3dMulZ + chunkZ) * server.WorldMap.index3dMulX + chunkX;

--- a/patches/VintagestoryLib/Vintagestory.Server/ServerMapRegion.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/ServerMapRegion.cs.patch
@@ -1,0 +1,62 @@
+diff --git a/VintagestoryLib/Vintagestory.Server/ServerMapRegion.cs b/VintagestoryLib/Vintagestory.Server/ServerMapRegion.cs
+index d06a399..b56c20c 100644
+--- a/VintagestoryLib/Vintagestory.Server/ServerMapRegion.cs
++++ b/VintagestoryLib/Vintagestory.Server/ServerMapRegion.cs
+@@ -272,27 +272,46 @@ public class ServerMapRegion : IMapRegion
+ 			createdGameVersion = "1.22.5",
+ 			DirtyForSaving = true
+ 		};
+ 	}
+ 
++	// Stratum: copy-on-write keeps GeneratedStructures safe for the many
++	// concurrent lock-free readers (WalkStructures, structure-overlap checks),
++	// since a reader always sees a complete list, old or new, never a torn
++	// one. It does not make two concurrent writers safe: both copy the same
++	// base list, both append, and whichever assignment to GeneratedStructures
++	// lands second silently discards the other's structure. GenStructures,
++	// WorldGenVillage and GenDungeons all call these two methods from
++	// worldgen threads that can now run the same stage concurrently (see
++	// GenStructures.stratumStructurePlacementLock for the matching read-side
++	// fix), so the write side needs its own lock here regardless of which
++	// caller's registration goes missing.
++	readonly object stratumGeneratedStructuresLock = new object();
++
+ 	public void AddGeneratedStructure(GeneratedStructure newStructure)
+ 	{
+-		List<GeneratedStructure> list = new List<GeneratedStructure>(GeneratedStructures.Count + 1);
+-		list.AddRange(GeneratedStructures);
+-		list.Add(newStructure);
+-		GeneratedStructures = list;
+-		DirtyForSaving = true;
++		lock (stratumGeneratedStructuresLock)
++		{
++			List<GeneratedStructure> list = new List<GeneratedStructure>(GeneratedStructures.Count + 1);
++			list.AddRange(GeneratedStructures);
++			list.Add(newStructure);
++			GeneratedStructures = list;
++			DirtyForSaving = true;
++		}
+ 	}
+ 
+ 	public void AddGeneratedStructures(IEnumerable<GeneratedStructure> newStructures)
+ 	{
+-		newStructures.TryGetNonEnumeratedCount(out var count);
+-		List<GeneratedStructure> list = new List<GeneratedStructure>(GeneratedStructures.Count + count);
+-		list.AddRange(GeneratedStructures);
+-		list.AddRange(newStructures);
+-		GeneratedStructures = list;
+-		DirtyForSaving = true;
++		lock (stratumGeneratedStructuresLock)
++		{
++			newStructures.TryGetNonEnumeratedCount(out var count);
++			List<GeneratedStructure> list = new List<GeneratedStructure>(GeneratedStructures.Count + count);
++			list.AddRange(GeneratedStructures);
++			list.AddRange(newStructures);
++			GeneratedStructures = list;
++			DirtyForSaving = true;
++		}
+ 	}
+ 
+ 	public static ServerMapRegion FromBytes(byte[] serializedMapRegion)
+ 	{
+ 		ServerMapRegion serverMapRegion = SerializerUtil.Deserialize<ServerMapRegion>(serializedMapRegion);

--- a/patches/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs.patch
@@ -1,8 +1,8 @@
 diff --git a/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs b/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs
-index f644852..feed548 100644
+index f644852..9bb2256 100644
 --- a/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs
 +++ b/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs
-@@ -1,139 +1,1094 @@
+@@ -1,139 +1,1125 @@
  using System;
  using System.Collections.Generic;
  using System.Linq;
@@ -605,6 +605,16 @@ index f644852..feed548 100644
 +		// is under real pressure.
 +		int claimedStage = stage;
 +		bool claimHeld = true;
++		// Stratum: pin before the gate runs, not after it passes. The gate establishes
++		// that the 8 neighbours are resident; holding them has to start before that
++		// check, or the unload pass can drop one in the gap between the check and the
++		// hold, which is the same check then use shape this pin exists to close. Pinning
++		// first costs nothing when the gate then refuses, since the finally releases it.
++		bool pinHeld = claimedStage > StratumWorldGenStages.TerrainLate;
++		if (pinHeld)
++		{
++			chunkthread.StratumPinNeighbourhood(req.chunkX, req.chunkZ);
++		}
 +		try
 +		{
 +			// Re-verify: currentpass may have changed between the read and the CAS
@@ -612,7 +622,7 @@ index f644852..feed548 100644
 +			{
 +				stage = -1;
 +				return false;
- 			}
++			}
 +
 +			if (stage >= req.untilPass)
 +			{
@@ -628,6 +638,7 @@ index f644852..feed548 100644
 +			}
 +
 +			claimHeld = false;   // handed off to the caller, which owns the release
++			pinHeld = false;     // the pin goes with it, released alongside the claim
 +			return true;
 +		}
 +		finally
@@ -636,6 +647,10 @@ index f644852..feed548 100644
 +			{
 +				Interlocked.Decrement(ref stratumStageActiveCount[stage < 0 ? claimedStage : stage]);
 +				Volatile.Write(ref req.dispatchClaimed, 0);
++			}
++			if (pinHeld)
++			{
++				chunkthread.StratumUnpinNeighbourhood(req.chunkX, req.chunkZ);
 +			}
 +		}
 +	}
@@ -662,6 +677,10 @@ index f644852..feed548 100644
 +			if (!handedOff)
 +			{
 +				Interlocked.Decrement(ref stratumStageActiveCount[stage]);
++				if (stage > StratumWorldGenStages.TerrainLate)
++				{
++					chunkthread.StratumUnpinNeighbourhood(req.chunkX, req.chunkZ); // Stratum: the pin travels with the claim
++				}
 +				Volatile.Write(ref req.dispatchClaimed, 0);
 +			}
 +		}
@@ -715,14 +734,18 @@ index f644852..feed548 100644
 +				// will release this claim, so release it here, then wake the
 +				// dispatcher exactly like a worker's own finally block does.
 +				Interlocked.Decrement(ref stratumStageActiveCount[stage]);
++				if (stage > StratumWorldGenStages.TerrainLate)
++				{
++					chunkthread.StratumUnpinNeighbourhood(req.chunkX, req.chunkZ); // Stratum: the pin travels with the claim
++				}
 +				Volatile.Write(ref req.dispatchClaimed, 0);
 +				SignalDispatcher();
 +			}
 +			return true;
- 		}
++		}
 +		return false;
- 	}
- 
++	}
++
 +
 +	/// <summary>
 +	/// Dispatcher: scans the request queue and sends ready tasks to the worker channel.
@@ -845,6 +868,10 @@ index f644852..feed548 100644
 +				if (request.CurrentIncompletePass_AsInt != currentStage)
 +				{
 +					Interlocked.Decrement(ref stratumStageActiveCount[currentStage]);
++					if (currentStage > StratumWorldGenStages.TerrainLate)
++					{
++						chunkthread.StratumUnpinNeighbourhood(request.chunkX, request.chunkZ); // Stratum
++					}
 +					Volatile.Write(ref request.dispatchClaimed, 0);
 +					SignalDispatcher(); // wake the dispatcher
 +					continue; // not holding — skip finally with holdingStage
@@ -873,16 +900,20 @@ index f644852..feed548 100644
 +				if (holdingStage && currentStage >= 0 && currentStage < stratumStageActiveCount.Length)
 +				{
 +					Interlocked.Decrement(ref stratumStageActiveCount[currentStage]);
++					if (currentStage > StratumWorldGenStages.TerrainLate)
++					{
++						chunkthread.StratumUnpinNeighbourhood(request.chunkX, request.chunkZ); // Stratum
++					}
 +					Volatile.Write(ref request.dispatchClaimed, 0);
 +					SignalDispatcher(); // wake the dispatcher
 +				}
-+			}
-+		}
+ 			}
+ 		}
 +
 +		// Release thread-local generation resources
 +		BlockAccessorWorldGen.ThreadDispose();
-+	}
-+
+ 	}
+ 
 +
 +	/// <summary>
 +	/// Stratum: Builds a priority list of chunks sorted by proximity to players.
@@ -1119,7 +1150,7 @@ index f644852..feed548 100644
  			if (!tryLoadOrGenerateChunkColumnsInQueue())
  			{
  				break;
-@@ -143,39 +1098,59 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -143,39 +1129,59 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				break;
  			}
  		}
@@ -1181,7 +1212,7 @@ index f644852..feed548 100644
  				ServerChunk serverChunk = (ServerChunk)server.WorldMap.GetChunk(x, i, z);
  				if (serverChunk != null)
  				{
-@@ -183,11 +1158,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -183,11 +1189,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					for (int j = 0; j < entities.Length; j++)
  					{
  						Entity entity = entities[j];
@@ -1194,7 +1225,7 @@ index f644852..feed548 100644
  						{
  							if (j >= serverChunk.EntitiesCount)
  							{
-@@ -211,19 +1186,23 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -211,19 +1217,23 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				});
  			}
  			list2.Add(item);
@@ -1219,7 +1250,7 @@ index f644852..feed548 100644
  		{
  			ChunkPos item2 = server.WorldMap.MapRegionPosFromIndex2D(result2);
  			if (hashSet == null)
-@@ -237,28 +1216,46 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -237,28 +1247,46 @@ internal class ServerSystemSupplyChunks : ServerSystem
  		{
  			chunkthread.gameDatabase.DeleteMapRegions(hashSet);
  		}
@@ -1271,7 +1302,7 @@ index f644852..feed548 100644
  		ServerMapChunk orCreateMapChunk = chunkthread.loadsavechunks.GetOrCreateMapChunk(request);
  		if (orCreateMapChunk == null)
  		{
-@@ -267,94 +1264,203 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -267,94 +1295,203 @@ internal class ServerSystemSupplyChunks : ServerSystem
  		ServerChunk[] array = chunkthread.loadsavechunks.TryLoadChunkColumn(request);
  		if (array == null)
  		{
@@ -1481,7 +1512,7 @@ index f644852..feed548 100644
  				chunkRequest.Chunks = TryLoadChunkColumn(chunkRequest);
  				if (chunkRequest.Chunks != null)
  				{
-@@ -364,31 +1470,42 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -364,31 +1501,42 @@ internal class ServerSystemSupplyChunks : ServerSystem
  						obj.serverMapChunk = orCreateMapChunk;
  						obj.MarkFresh();
  					}
@@ -1524,7 +1555,7 @@ index f644852..feed548 100644
  				ServerEventAPI eventapi = server.api.eventapi;
  				ServerMapChunk mapChunk = orCreateMapChunk;
  				int chunkX = chunkRequest.chunkX;
-@@ -404,117 +1521,105 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -404,117 +1552,105 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					ServerMain.Logger.Error("Repair mode is enabled so will delete the entire chunk column.");
  					GenerateNewChunkColumn(orCreateMapChunk, chunkRequest);
  					return false;
@@ -1672,7 +1703,7 @@ index f644852..feed548 100644
  				try
  				{
  					serverChunk.Unpack();
-@@ -529,10 +1634,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -529,10 +1665,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
  						ServerMain.FrameProfiler.Leave();
  						return;
  					}
@@ -1685,7 +1716,7 @@ index f644852..feed548 100644
  			{
  				for (int j = 0; j < serverChunk.Entities.Length; j++)
  				{
-@@ -548,10 +1655,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -548,10 +1686,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					{
  						if (server.LoadEntity(entity, num2))
  						{
@@ -1697,7 +1728,7 @@ index f644852..feed548 100644
  						{
  							string text = "-";
  							try
-@@ -564,14 +1672,18 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -564,14 +1703,18 @@ internal class ServerSystemSupplyChunks : ServerSystem
  							ServerMain.Logger.Log(EnumLogType.Worldgen, "In " + server.WorldName + ", villager " + text + " removed at " + entity.Pos.AsBlockPos?.ToString() + " due to an exception on loading");
  						}
  					}
@@ -1716,7 +1747,7 @@ index f644852..feed548 100644
  			{
  				BlockEntity value = blockEntity.Value;
  				if (value == null)
-@@ -580,13 +1692,23 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -580,13 +1723,23 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				}
  				try
  				{
@@ -1742,7 +1773,7 @@ index f644852..feed548 100644
  					ServerMain.FrameProfiler.Leave();
  				}
  				catch (Exception ex3)
-@@ -594,23 +1716,33 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -594,23 +1747,33 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					ServerMain.Logger.Notification("Exception thrown when trying to initialize a block entity @{0}: {1}", value.Pos, ex3);
  					value.UnregisterAllTickListeners();
  				}
@@ -1776,7 +1807,7 @@ index f644852..feed548 100644
  		mapChunk.NeighboursLoaded = default(SmallBoolArray);
  		mapChunk.SelfLoaded = true;
  		for (int i = 0; i < Cardinal.ALL.Length; i++)
-@@ -623,20 +1755,26 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -623,20 +1786,26 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				serverMapChunk.NeighboursLoaded[cardinal.Opposite.Index] = true;
  			}
  		}
@@ -1803,7 +1834,7 @@ index f644852..feed548 100644
  			serverMapChunk.NeighboursLoaded[4] = false;
  		}
  		if (serverMapChunk2 != null)
-@@ -667,12 +1805,17 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -667,12 +1836,17 @@ internal class ServerSystemSupplyChunks : ServerSystem
  		{
  			serverMapChunk8.NeighboursLoaded[3] = false;
  		}
@@ -1821,7 +1852,7 @@ index f644852..feed548 100644
  			for (int j = -1; j <= 1; j++)
  			{
  				bool flag = false;
-@@ -682,19 +1825,24 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -682,19 +1856,24 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				}
  				if (!flag)
  				{
@@ -1846,7 +1877,7 @@ index f644852..feed548 100644
  		int num = 0;
  		for (int i = -1; i <= 1; i++)
  		{
-@@ -707,60 +1855,78 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -707,60 +1886,78 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			}
  		}
  		return num == 8;
@@ -1926,7 +1957,7 @@ index f644852..feed548 100644
  				dictionary = value.ModData;
  				dictionary2 = value.OreMaps;
  				intDataMap2D = value.GeologicProvinceMap;
-@@ -770,12 +1936,14 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -770,12 +1967,14 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			{
  				flag = false;
  				value.loadedTotalMs = server.ElapsedMilliseconds;
@@ -1941,7 +1972,7 @@ index f644852..feed548 100644
  			if (list != null)
  			{
  				value.GeneratedStructures = list;
-@@ -798,35 +1966,48 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -798,35 +1997,48 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			}
  		}
  		return value;
@@ -1990,7 +2021,7 @@ index f644852..feed548 100644
  		byte[] array = chunkGenParams?.GetBytes("GeneratedStructures");
  		if (array == null)
  		{
-@@ -836,44 +2017,60 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -836,44 +2048,60 @@ internal class ServerSystemSupplyChunks : ServerSystem
  		long key = server.api.WorldManager.MapRegionIndex2D(regionX, regionZ);
  		if (!dictionary.TryGetValue(key, out var value) || value == null)
  		{
@@ -2052,7 +2083,7 @@ index f644852..feed548 100644
  		long key = server.WorldMap.MapChunkIndex2D(chunkX, chunkZ);
  		server.loadedMapChunks.TryGetValue(key, out var value);
  		if (value != null)
-@@ -881,31 +2078,42 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -881,31 +2109,42 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			return value;
  		}
  		return TryLoadMapChunk(chunkX, chunkZ);
@@ -2095,7 +2126,7 @@ index f644852..feed548 100644
  			for (int j = 0; j < Cardinal.ALL.Length; j++)
  			{
  				Cardinal cardinal = Cardinal.ALL[j];
-@@ -918,47 +2126,111 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -918,47 +2157,111 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					}
  					chunkRequest.NeighbourTerrainHeight[j] = serverMapChunk.WorldGenTerrainHeightMap;
  				}
@@ -2223,7 +2254,7 @@ index f644852..feed548 100644
  			foreach (ServerChunk serverChunk in array)
  			{
  				if (serverChunk != null)
-@@ -967,10 +2239,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -967,10 +2270,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					serverChunk.MarkModified();
  					serverChunk.TryPackAndCommit();
  				}
@@ -2236,7 +2267,7 @@ index f644852..feed548 100644
  			ServerMain.Logger.Error("Loaded some but not all chunks of a column? Discarding whole column.");
  			return null;
  		}
-@@ -979,18 +2253,22 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -979,18 +2284,22 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			return null;
  		}
  		return array;
@@ -2259,7 +2290,7 @@ index f644852..feed548 100644
  					serverMapChunk.YMax = (ushort)(server.SaveGameData.MapSizeY - 1);
  				}
  				return serverMapChunk;
-@@ -1011,10 +2289,13 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1011,10 +2320,13 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			}
  		}
  		return null;
@@ -2273,7 +2304,7 @@ index f644852..feed548 100644
  		byte[] mapRegion = chunkthread.gameDatabase.GetMapRegion(regionX, regionZ);
  		try
  		{
-@@ -1035,14 +2316,33 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1035,14 +2347,33 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			throw;
  		}
  		return null;
@@ -2307,7 +2338,7 @@ index f644852..feed548 100644
  			storyChunkSpawnEvents = new string[15]
  			{
  				Lang.Get("...the carved mountains"),
-@@ -1060,23 +2360,27 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1060,23 +2391,27 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				Lang.Get("...a misty sunrise"),
  				Lang.Get("...dew drops on a blade of grass"),
  				Lang.Get("...a soft breeze")
@@ -2335,7 +2366,7 @@ index f644852..feed548 100644
  					double value = random.NextDouble() * 6.2831854820251465;
  					double num7 = num6 * GameMath.Sin(value);
  					double num8 = num6 * GameMath.Cos(value);
-@@ -1096,10 +2400,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1096,10 +2431,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					server.api.Logger.Notification("Trying another spawn location ({0}/{1})...", i + 2, num3);
  				}
  			}
@@ -2347,7 +2378,7 @@ index f644852..feed548 100644
  				if (!server.blockAccessor.GetBlock(blockPos).SideSolid[BlockFacing.UP.Index])
  				{
  					server.blockAccessor.SetBlock(server.blockAccessor.GetBlock(new AssetLocation("planks-oak-we")).Id, blockPos);
-@@ -1107,13 +2412,16 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1107,13 +2443,16 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				blockPos.Y++;
  			}
  		}
@@ -2364,7 +2395,7 @@ index f644852..feed548 100644
  			x = blockPos.X,
  			y = blockPos.Y,
  			z = blockPos.Z
-@@ -1123,10 +2431,14 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1123,10 +2462,14 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			server.mapMiddleSpawnPos.y = null;
  		}
  		server.api.Logger.VerboseDebug("Done spawn chunk");
@@ -2379,7 +2410,7 @@ index f644852..feed548 100644
  		int num = 60;
  		int num2 = 0;
  		int num3 = 0;
-@@ -1137,36 +2449,47 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1137,36 +2480,47 @@ internal class ServerSystemSupplyChunks : ServerSystem
  		{
  			num4 = GameMath.Clamp(num2 + pos.X, 0, server.WorldMap.MapSizeX - 1);
  			num6 = GameMath.Clamp(num3 + pos.Z, 0, server.WorldMap.MapSizeZ - 1);
@@ -2428,7 +2459,7 @@ index f644852..feed548 100644
  		{
  			for (int k = -num2; k <= num2; k++)
  			{
-@@ -1174,18 +2497,22 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1174,18 +2528,22 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				{
  					long index2d = server.WorldMap.MapChunkIndex2D(x + j, y + k);
  					int regionX = (x + j) / MagicNum.ChunkRegionSizeInChunks;
@@ -2452,7 +2483,7 @@ index f644852..feed548 100644
  					};
  					chunkColumnLoadRequest.MapChunk = mapChunk;
  					GenerateNewChunkColumn(mapChunk, chunkColumnLoadRequest);
-@@ -1196,10 +2523,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1196,10 +2554,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
  						chunkthread.peekingChunkColumns.Enqueue(chunkColumnLoadRequest);
  					}
  				}
@@ -2465,7 +2496,7 @@ index f644852..feed548 100644
  		{
  			num4 = num - i;
  			for (int l = -num4; l <= num4; l++)
-@@ -1212,10 +2541,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1212,10 +2572,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
  						runGenerators(chunkRequest, i);
  					}
  				}
@@ -2478,7 +2509,7 @@ index f644852..feed548 100644
  		{
  			for (int n = -num2; n <= num2; n++)
  			{
-@@ -1232,61 +2563,111 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1232,61 +2594,111 @@ internal class ServerSystemSupplyChunks : ServerSystem
  						dictionary2[key] = chunks;
  					}
  				}
@@ -2592,7 +2623,7 @@ index f644852..feed548 100644
  				millisecondsSinceStart = server.totalUnpausedTime.ElapsedMilliseconds;
  				float num4 = 100f * ((float)server.loadedChunks.Count / (float)server.WorldMap.ChunkMapSizeY - (float)num) / (float)num2;
  				ServerMain.Logger.Event(num4.ToString("0.#") + "% ({0} in queue)", chunkthread.requestedChunkColumns.Count);
-@@ -1298,37 +2679,84 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1298,37 +2710,84 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				{
  					ServerMain.Logger.StoryEvent("...");
  				}
@@ -2680,7 +2711,7 @@ index f644852..feed548 100644
  				foreach (ChunkColumnLoadRequest requestedChunkColumn3 in chunkthread.requestedChunkColumns)
  				{
  					if (requestedChunkColumn3 != null)
-@@ -1340,16 +2768,25 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1340,16 +2799,25 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				throw new Exception("Somehow worldgen has become stuck in an endless loop, please report this as a bug!  Additional data in the server-main log");
  			}
  		}
@@ -2706,7 +2737,7 @@ index f644852..feed548 100644
  				if (chunkRequest.CurrentIncompletePass == EnumWorldGenPass.Terrain)
  				{
  					ushort sunLight = (ushort)server.sunBrightness;
-@@ -1359,32 +2796,62 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1359,32 +2827,62 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					}
  				}
  			}
@@ -2771,7 +2802,7 @@ index f644852..feed548 100644
  			return;
  		}
  		for (int i = 0; i < list.Count; i++)
-@@ -1396,89 +2863,119 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1396,89 +2894,119 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			catch (Exception ex)
  			{
  				ServerMain.Logger.Worldgen("An error was thrown in pass {5} when generating chunk column X={0},Z={1} in world '{3}' with seed {4}\nException {2}\n\n", chunkRequest.chunkX, chunkRequest.chunkZ, ex, server.SaveGameData.WorldName, server.SaveGameData.Seed, chunkRequest.CurrentIncompletePass.ToString());
@@ -2908,7 +2939,7 @@ index f644852..feed548 100644
  			chunkthread.requestedChunkColumns.Enqueue(curRequest);
  			return true;
  		}
-@@ -1490,13 +2987,19 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1490,13 +3018,19 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				ServerMain.Logger.VerboseDebug("Un-pausing all worldgen threads.");
  			}
  		}
@@ -2928,7 +2959,7 @@ index f644852..feed548 100644
  			if (requestedChunkColumn != null && !requestedChunkColumn.Disposed)
  			{
  				server.loadedMapChunks.Remove(requestedChunkColumn.mapIndex2d);
-@@ -1505,104 +3008,181 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1505,104 +3039,181 @@ internal class ServerSystemSupplyChunks : ServerSystem
  		}
  		chunkthread.requestedChunkColumns.Clear();
  		ServerMain.Logger.VerboseDebug("Incomplete chunks stored and wiped.");

--- a/patches/VintagestoryLib/Vintagestory.Server/ServerSystemUnloadChunks.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/ServerSystemUnloadChunks.cs.patch
@@ -1,5 +1,5 @@
 diff --git a/VintagestoryLib/Vintagestory.Server/ServerSystemUnloadChunks.cs b/VintagestoryLib/Vintagestory.Server/ServerSystemUnloadChunks.cs
-index 642722c..2e8f0ad 100644
+index 642722c..9b46a7c 100644
 --- a/VintagestoryLib/Vintagestory.Server/ServerSystemUnloadChunks.cs
 +++ b/VintagestoryLib/Vintagestory.Server/ServerSystemUnloadChunks.cs
 @@ -34,15 +34,30 @@ internal class ServerSystemUnloadChunks : ServerSystem
@@ -103,7 +103,7 @@ index 642722c..2e8f0ad 100644
  		{
  			if (server.forceLoadedChunkColumns.Contains(mapChunkUnloadCandidate))
  			{
-@@ -354,122 +377,185 @@ internal class ServerSystemUnloadChunks : ServerSystem
+@@ -354,132 +377,225 @@ internal class ServerSystemUnloadChunks : ServerSystem
  			chunk.Dispose();
  		}
  		return flag;
@@ -138,6 +138,15 @@ index 642722c..2e8f0ad 100644
 +                {
 +                    continue;
 +                }
++                // Stratum: this loop, not the map chunk scan below, is what makes a finished
++                // column disappear from a generator's reach: it drops the request and the
++                // loaded map chunk together, so GetGeneratingChunk and the loaded chunks
++                // fallback both stop answering for it. Skip the ones a neighbour is
++                // generating against right now.
++                if (chunkthread.StratumIsColumnPinned(item.mapIndex2d))
++                {
++                    continue;
++                }
 +                for (int i = 0; i < item.Chunks.Length; i++)
 +                {
 +                    if (Environment.TickCount - item.Chunks[i].lastReadOrWrite < timeToLive)
@@ -162,6 +171,18 @@ index 642722c..2e8f0ad 100644
 +            FastMemoryStream ms = reusableStream ?? (reusableStream = new FastMemoryStream());
 +            foreach (ChunkColumnLoadRequest item2 in list)
 +            {
++                // Stratum: commit to the drop before touching anything, then look at the
++                // pin once more. A pin taken between the scan above and this point wins:
++                // the flag comes back down and the column stays. A pin taken after this
++                // point loses, and the neighbour gate refuses that claim because it reads
++                // the same flag. One of the two always happens, so no claim can be granted
++                // over a column this pass is in the middle of removing.
++                System.Threading.Interlocked.Exchange(ref item2.stratumDropping, 1);
++                if (chunkthread.StratumIsColumnPinned(item2.mapIndex2d))
++                {
++                    System.Threading.Volatile.Write(ref item2.stratumDropping, 0);
++                    continue;
++                }
 +                item2.generatingLock.AcquireReadLock();
 +                try
 +                {
@@ -198,9 +219,11 @@ index 642722c..2e8f0ad 100644
 +                }
 +                if (!chunkthread.requestedChunkColumns.Remove(item2.mapIndex2d))
 +                {
++                    System.Threading.Volatile.Write(ref item2.stratumDropping, 0); // Stratum: never leave a live request flagged
 +                    throw new Exception("Chunkrequest no longer in queue? Race condition?");
 +                }
 +                server.ChunkColumnRequested.Remove(item2.mapIndex2d);
++                System.Threading.Volatile.Write(ref item2.stratumDropping, 0); // Stratum: out of the queue, the flag has no further job
 +                num++;
 +            }
 +            if (list2.Count > 0)
@@ -379,7 +402,24 @@ index 642722c..2e8f0ad 100644
  			long key = server.WorldMap.MapChunkIndex2D(vec2i.X, vec2i.Y);
  			server.loadedMapChunks.TryGetValue(key, out value);
  			value?.MarkFresh();
-@@ -497,14 +583,16 @@ internal class ServerSystemUnloadChunks : ServerSystem
+ 		}
+ 		lock (mapChunkIndicesLock)
+ 		{
+ 			foreach (long mapChunkIndex in mapChunkIndices)
+ 			{
++				// Stratum: skip columns a neighbour is generating against. The neighbour gate
++				// checks residency once, at claim time, and unloading one of those columns
++				// mid stage leaves the generator reading a chunk nothing can resolve.
++				if (chunkthread.StratumIsColumnPinned(mapChunkIndex))
++				{
++					continue;
++				}
+ 				if (!server.forceLoadedChunkColumns.Contains(mapChunkIndex) && server.loadedMapChunks.TryGetValue(mapChunkIndex, out value) && value.CurrentIncompletePass == EnumWorldGenPass.Done)
+ 				{
+ 					if (value.IsOld())
+ 					{
+ 						mapChunkUnloadCandidates.Add(mapChunkIndex);
+@@ -497,14 +613,16 @@ internal class ServerSystemUnloadChunks : ServerSystem
  	{
  		if (server.unloadedChunks.IsEmpty)
  		{
@@ -398,7 +438,7 @@ index 642722c..2e8f0ad 100644
  			list2.Clear();
  			foreach (long item in list)
  			{
-@@ -545,12 +633,14 @@ internal class ServerSystemUnloadChunks : ServerSystem
+@@ -545,12 +663,14 @@ internal class ServerSystemUnloadChunks : ServerSystem
  		}
  	}
  


### PR DESCRIPTION
## The bug

`ensurePrettyNeighbourhood` checks that a column's 8 neighbours are resident before it grants a stage claim, and `EnsureMinimumWorldgenPassAt` backs that check: it passes a neighbour only when that neighbour is a live request or a loaded map chunk at pass Done. Residency holds at the moment of the check. Nothing holds it after.

The unload pass then drops one of those columns while the generator reads across the boundary. `GetGeneratingChunk` stops answering once the column leaves the request queue. The loaded chunks fallback stops answering once it leaves memory. `BlockAccessorWorldGen.GetBlockId` then returns 0, and generators take that 0 for an air block, so a failed read does not stop them, it hands them a wrong answer.

`GenPonds` shows it first. Its flood fill decides pond extent by walking air across the 3x3 column neighbourhood, so a neighbour it cannot resolve reads as open space.

## The fix, in two parts

Pin the 3x3 neighbourhood for the length of the claim. `TryClaimStage` takes the pin before the gate runs rather than after it passes, since a hold that starts after the check leaves open the gap the check exists to close. Every path that releases the claim releases the pin: both worker paths, the dispatch failure path, and the inline runner.

Interlock that pin against the unload pass. The pass decides and removes in two steps: it reads the pin, then it saves the chunks and drops the column. A pin landing in that window goes unseen, and the gate runs afterwards and sees a column about to disappear. The pass now sets `stratumDropping` before it touches anything and reads the pin once more, and the gate treats a flagged column as absent. A pin that lands first makes the pass back out. A drop that commits first makes the gate refuse the claim. Neither ordering grants a claim over a column under removal.

The second part carries its weight. Pinning on its own leaves the race open, and the numbers show it.

## Measurements

Radius 100, seed 1027995113, 3 worldgen threads, five runs per condition, counting reads that fell outside the generating set:

| condition | runs | median |
|---|---|---|
| no pin | 213, 382, 474, 622, 1086 | 474 |
| pin only | 35, 87, 125, 249, 677 | 125 |
| pin and flag | 0, 0, 0, 0, 0 | 0 |
| serial worldgen | 0 | 0 |

Pin and flag against no pin: complete separation, p about 0.008 on Mann-Whitney. Pin on its own against no pin misses significance at n = 5 per side, and every event that survived pinning alone landed inside the 3x3, at a column holding a pin when the read failed. That pointed at the window between the decision and the removal.

Serial worldgen produces zero here, at radius 40 and at radius 100, which makes this a concurrency regression rather than a limit of the base game.

Two more runs from a tree rebuilt out of these patches produced zero reads and zero worldgen errors, at 5m17s and 5m01s against 5m13s to 6m36s for the control. Holding the columns costs nothing I can measure. Active claims times nine bounds the pinned set.

## Notes for review

The release sites carry the risk. A leaked pin starves the unload pass, a missing one reopens the race, so every path that writes `dispatchClaimed` back to 0 also unpins, and the flag comes down even on the throw inside the removal. That symmetry follows the lesson of #199.

Single runs at this radius span 213 to 2786. Anything measured here needs repeats. An early version of this patch looked finished on one run and was not.

## On #224

@tehtelev this may well be your issue, and I would rather you check than take my word for it. #224 fails on `GetMapChunkAtBlockPos` returning null into `BlockSchematicStructure.PlaceRespectingBlockLayers`. That lookup resolves through the same two registries this patch keeps populated, `loadedMapChunks` and the request queue, so keeping the column resident should close it. Treat that as reasoning rather than measurement: your NRE never fired here, across more than ten pregen runs at radius 100 on seed 1027995113 with 3 and 6 worldgen threads, on Linux with .NET 10.0.301, all of them showing zero `error was thrown in pass TerrainFeatures` entries. The lighter symptom did show once, one `Could not import block entity data for schematic ... Possibly overlapping ruins` on the 6 thread run against 7 in your log. The trigger is thread scheduling, so Windows against Linux is my best guess for why it fires for you and not here.

If you have the time, two things would settle it. Does your repro throw on this branch, and does `Tried to get block outside generating chunks` show up in your logs on a run without it.
