### PR TITLE
Feature: keep worldgen mods working when Stratum splits the Terrain pass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ Thumbs.db
 # Local-only docs scratch
 /wiki/
 /.wiki-push/
+/.mods/
 
 # Local secrets / per-machine config
 *.local.json

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Windows: use Git Bash, WSL, or run the .ps1 scripts directly.
 
 CONFIGURATION ?= Release
-VERSION ?= 1.22.5
+VERSION ?= 1.22.6
 SERVER_ARCHIVE ?=
 CLIENT_LIB_DIR ?=
 # Embeds this working tree's compiled DLLs into StratumServer so
@@ -20,7 +20,7 @@ endif
 ifneq ($(CLIENT_LIB_DIR),)
   BOOTSTRAP_ARGS += --client-lib-dir $(CLIENT_LIB_DIR)
 endif
-ifneq ($(VERSION),1.22.5)
+ifneq ($(VERSION),1.22.6)
   BOOTSTRAP_ARGS += --version $(VERSION)
 endif
 

--- a/forks.json
+++ b/forks.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Pinned upstream commits for each Anego open-source fork. Bump these when overlaying a new Vintage Story release. Bootstrap clones each repo at the listed ref into .baseline/<name>/ and the working <name>/ folder, then applies patches/<name>/*.patch on top.",
-  "vintageStoryVersion": "1.22.5",
+  "vintageStoryVersion": "1.22.6",
   "forks": [
     {
       "name": "VintagestoryApi",

--- a/patches/VintagestoryLib/Properties/AssemblyInfo.cs.patch
+++ b/patches/VintagestoryLib/Properties/AssemblyInfo.cs.patch
@@ -7,6 +7,6 @@ index 16759e7..d2530b6 100644
  [assembly: AssemblyCopyright("Copyright © 2016-2026 Anego Studios")]
  [assembly: ComVisible(false)]
  [assembly: Guid("8495b9b8-6974-45de-b896-87f195304ede")]
- [assembly: AssemblyFileVersion("1.22.5")]
--[assembly: AssemblyVersion("1.22.5.0")]
+ [assembly: AssemblyFileVersion("1.22.6")]
+-[assembly: AssemblyVersion("1.22.6.0")]
 +[assembly: AssemblyVersion("1.0.0.0")]

--- a/patches/VintagestoryLib/Vintagestory.Client/GuiScreenDownloadMods.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Client/GuiScreenDownloadMods.cs.patch
@@ -22,10 +22,10 @@ index 8659e0b..772d3c5 100644
  	}
  
 -	[GeneratedRegex("</?([\\w\\-]+)(?: .*?)?/?>")]
--	[GeneratedCode("System.Text.RegularExpressions.Generator", "10.0.13.11305")]
+-	[GeneratedCode("System.Text.RegularExpressions.Generator", "10.0.13.7005")]
  	private static Regex GetHtmlTagRegex()
  	{
--		return _003CRegexGenerator_g_003EF5E4070DDADCC3300604E0EF83A764699EE77ED70FD78E82B6CFF415D2F8056C5__GetHtmlTagRegex_0.Instance;
+-		return _003CRegexGenerator_g_003EF7C3416659A89DE69D307209EBAB141680463E82FA58DF94FA09D5F330FC4C71E__GetHtmlTagRegex_0.Instance;
 +		return new Regex("</?([\\w\\-]+)(?: .*?)?/?>", RegexOptions.Compiled);
  	}
  }

--- a/patches/VintagestoryLib/Vintagestory.Server/ServerConfig.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/ServerConfig.cs.patch
@@ -111,9 +111,13 @@ index 93750fa..6b4edf8 100644
  		ModDbUrl = "https://mods.vintagestory.at/";
  		VerifyPlayerAuth = true;
  		AdvertiseServer = false;
-@@ -390,11 +412,11 @@ public class ServerConfig : IServerConfig
+@@ -402,15 +424,15 @@ public class ServerConfig : IServerConfig
  		DisableModSafetyCheck = false;
  		DisableAutoRemap = false;
+ 		AntiAbuseBufferSize = 100;
+ 		AntiAbuseTriggerOnBlockBreakCount = 40;
+ 		AntiAbuseTriggerOnDurationMs = 2000;
+ 		AntiAbuseBlockBurstAbuseBanDays = 14.0;
  		WorldConfig = new StartServerArgs
  		{
  			SaveFileLocation = Path.Combine(GamePaths.Saves, GamePaths.DefaultSaveFilenameWithoutExtension + ".vcdbs"),

--- a/patches/VintagestoryLib/Vintagestory.Server/ServerEventAPI.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/ServerEventAPI.cs.patch
@@ -2,18 +2,27 @@ diff --git a/VintagestoryLib/Vintagestory.Server/ServerEventAPI.cs b/Vintagestor
 index fba8acc..c9c311a 100644
 --- a/VintagestoryLib/Vintagestory.Server/ServerEventAPI.cs
 +++ b/VintagestoryLib/Vintagestory.Server/ServerEventAPI.cs
-@@ -449,10 +449,14 @@ internal class ServerEventAPI : ServerAPIComponentBase, IServerEventAPI, IEventA
+@@ -449,10 +449,13 @@ internal class ServerEventAPI : ServerAPIComponentBase, IServerEventAPI, IEventA
  	}
  
  	public ServerEventAPI(ServerMain server)
  		: base(server)
  	{
-+		// Stratum: mods and the patched vanilla generators reach the late
-+		// Terrain sub-stage through this API-assembly hook, since mod
-+		// assemblies reference VintagestoryAPI, not VintagestoryLib.
-+		StratumTerrainSplit.RegisterLate = (handler, worldType) => server.ModEventManager.GetWorldGenHandler(worldType).OnChunkColumnGenTerrainLate.Add(handler);
++		// Stratum: mod assemblies reference VintagestoryAPI, not VintagestoryLib, so the late
++		// Terrain sub-stage is reached through this hook. StratumWorldgenCompat picks the shape.
++		StratumTerrainSplit.RegisterLate = (handler, worldType) => StratumWorldgenCompat.RegisterTerrainLate(server, handler, worldType);
  	}
  
  	public void Trigger<T>(Delegate[] delegates, string eventName, Action<T> onDele, Action onException = null) where T : Delegate
  	{
  		if (delegates == null)
+@@ -677,6 +680,9 @@ internal class ServerEventAPI : ServerAPIComponentBase, IServerEventAPI, IEventA
+ 			}
+ 		}
+ 		server.api.Logger.VerboseDebug("Done all worldgens");
++		// Stratum: every mod has registered by now, so this is where the Terrain split gets
++		// checked against what is actually listening.
++		StratumWorldgenCompat.ApplyTerrainSplitIfSafe(server, value);
+ 		return value;
+ 	}
+ 

--- a/patches/VintagestoryLib/Vintagestory.Server/ServerMain.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/ServerMain.cs.patch
@@ -313,8 +313,8 @@ index 1103a72..59a6cf9 100644
  		}
  		if ("1.22.6" != identification.NetworkVersion)
  		{
--			DisconnectPlayer(client, null, Lang.Get("disconnect-wrongversion", identification.ShortGameVersion, identification.NetworkVersion, "1.22.5", "1.22.6"));
-+			DisconnectPlayer(client, StratumServerTheme.WrongVersion(identification.ShortGameVersion, identification.NetworkVersion, "1.22.5", "1.22.6"));
+-			DisconnectPlayer(client, null, Lang.Get("disconnect-wrongversion", identification.ShortGameVersion, identification.NetworkVersion, "1.22.6", "1.22.6"));
++			DisconnectPlayer(client, StratumServerTheme.WrongVersion(identification.ShortGameVersion, identification.NetworkVersion, "1.22.6", "1.22.6"));
  			return;
  		}
  		if (!client.IsSinglePlayerClient && Config.IsPasswordProtected() && identification.ServerPassword != Config.Password)
@@ -396,14 +396,14 @@ index 1103a72..59a6cf9 100644
  	}
  
  	public ServerMain(StartServerArgs serverargs, string[] cmdlineArgsRaw, ServerProgramArgs progArgs, bool isDedicatedServer = true)
-@@ -1173,15 +1356,17 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -1173,16 +1356,18 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  		if (HeartbeatSystem == null)
  		{
  			HeartbeatSystem = new ServerSystemHeartbeat(this);
  		}
  		HeartbeatSystem.Launch();
--		Systems = new ServerSystem[32]
-+		Systems = new ServerSystem[34]
+-		Systems = new ServerSystem[33]
++		Systems = new ServerSystem[35]
  		{
  			new ServerSystemUpnp(this),
  			(clientAwarenessSystem = new ServerSystemClientAwareness(this)),
@@ -412,6 +412,7 @@ index 1103a72..59a6cf9 100644
 +			new ServerSystemStratumPregen(this),
  			new ServerSystemNotifyPing(this),
  			new ServerSystemKickAfkPlayers(this),
+ 			new PlayerAntiAbuseMonitor(this),
  			serverSystemModHandler,
  			new ServerySystemPlayerGroups(this),
  			new ServerSystemEntitySimulation(this),
@@ -424,9 +425,9 @@ index 1103a72..59a6cf9 100644
 -		Logger.Event("Launching server...");
  		PlayerDataManager.Load();
  		Logger.StoryEvent(Lang.Get("It senses..."));
--		Logger.Event("Server v1.22.5, network v1.22.6, api v1.22.0");
+-		Logger.Event("Server v1.22.6, network v1.22.6, api v1.22.0");
 +		Logger.Event("Powered by Stratum | Made by imtsubaki and contributors");
-+		Logger.Event("Vintagestory v1.22.5 | Network v1.22.6 | API v1.22.0");
++		Logger.Event("Vintagestory v1.22.6 | Network v1.22.6 | API v1.22.0");
 +		Logger.Event("Launching server...");
  		totalUnpausedTime.Start();
  		AssetManager = new AssetManager(GamePaths.AssetsPath, EnumAppSide.Server);

--- a/patches/VintagestoryLib/Vintagestory.Server/ServerProgram.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/ServerProgram.cs.patch
@@ -20,7 +20,7 @@ index b5942fe..9cbd88d 100644
  		if (progArgs.PrintVersion)
  		{
  			Console.WriteLine();
--			Console.Write("1.22.5");
+-			Console.Write("1.22.6");
 +			Console.Write(StratumInfo.FullName + " (Vintage Story " + StratumInfo.BaseGameVersion + ")");
  		}
  		else if (progArgs.PrintHelp)

--- a/patches/VintagestoryLib/Vintagestory.Server/ServerProgramArgs.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/ServerProgramArgs.cs.patch
@@ -39,13 +39,16 @@ index 08bc6af..d129b0a 100644
  	[Option("logPath", HelpText = "Default logs folder is in dataPath/Logs/. This option can only set an absolute path.")]
  	public string LogPath { get; set; }
  
-@@ -62,9 +62,10 @@ public class ServerProgramArgs
+@@ -62,12 +62,13 @@ public class ServerProgramArgs
  	public int ArchiveLogFileMaxSizeMb { get; set; } = 1024;
+ 
+ 	[Option("restoreLogsFolder", HelpText = "Used to revert removed blocks from server-build log files. You have to put a names.txt into the restoreLogsFolder, in there put the a name on each line. Further you may also put a optional blocks.txt with line separated block codes like game:soil-low-normal to filter only for specific blocks if needed. The server will not fully start and shutdown once finished.")]
+ 	public string RestoreLogsFolder { get; set; }
  
  	public string GetUsage(ParserResult<ServerProgramArgs> parser)
  	{
  		HelpText obj = HelpText.AutoBuild<ServerProgramArgs>(parser, (Func<HelpText, HelpText>)((HelpText h) => h), (Func<Example, Example>)((Example e) => e), false, 80);
--		obj.Heading = "Vintage Story Server 1.22.5";
+-		obj.Heading = "Vintage Story Server 1.22.6";
 +		obj.Heading = StratumInfo.FullName + " server (Vintage Story " + StratumInfo.BaseGameVersion + ")";
 +		obj.Copyright = string.Empty;
  		return ((object)obj).ToString();

--- a/patches/VintagestoryLib/Vintagestory.Server/ServerSystemLoadAndSaveGame.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/ServerSystemLoadAndSaveGame.cs.patch
@@ -236,7 +236,7 @@ index 455b85f..426a460 100644
  		server.SaveGameData.WillSave(reusableStream);
  		server.SaveGameData.UpdateLandClaims(server.WorldMap.All);
  		chunkthread.gameDatabase.StoreSaveGame(server.SaveGameData, reusableStream);
-@@ -151,14 +352,37 @@ internal class ServerSystemLoadAndSaveGame : ServerSystem, IChunkProviderThread
+@@ -153,18 +354,41 @@ internal class ServerSystemLoadAndSaveGame : ServerSystem, IChunkProviderThread
  				ServerMain.Logger.Event("Failed upgrading old savegame, giving up, sorry.");
  				throw new InvalidDataException("Failed upgrading savegame {0}", innerException);
  			}
@@ -244,6 +244,10 @@ index 455b85f..426a460 100644
  		chunkthread.gameDatabase.UpgradeToWriteAccess();
 +		TryStartStratumChunkReadPool();
  		server.ModEventManager.OnWorldgenStartup += OnWorldgenStartup;
+ 		if (!string.IsNullOrWhiteSpace(server.progArgs.RestoreLogsFolder))
+ 		{
+ 			server.ModEventManager.RegisterOnServerRunPhase(EnumServerRunPhase.RunGame, OnRestoreFromBuildLog);
+ 		}
  		LoadSaveGame();
  	}
  

--- a/patches/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs.patch
@@ -133,10 +133,10 @@ index f644852..bff98da 100644
 +	// Stratum has no way to verify is safe under concurrent execution across
 +	// columns. Checked by name, not by a hardcoded per-generator allowlist,
 +	// so it needs no maintenance as Stratum's own generator set changes.
-+	private static readonly HashSet<string> stratumKnownSafeAssemblies = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
-+	{
-+		"VintagestoryLib", "VSEssentials", "VSSurvivalMod", "VSCreativeMod", "VintagestoryAPI"
-+	};
++	// StratumModCompat owns the set. Read it from there instead of keeping a
++	// second copy, since the worldgen compatibility checks and this one have
++	// to agree on what counts as ours.
++	private static HashSet<string> stratumKnownSafeAssemblies => StratumModCompat.ShippedAssemblies;
 +
 +	/// <summary>
 +	/// Stratum: same-stage concurrency for a pass is only safe if every handler
@@ -1987,7 +1987,7 @@ index f644852..bff98da 100644
  		}
 +
 +		// Create a new MapChunk
- 		bool updateEarlierVersion = GameVersion.IsLowerVersionThan(server.SaveGameData.CreatedGameVersion, "1.22.5");
+ 		bool updateEarlierVersion = GameVersion.IsLowerVersionThan(server.SaveGameData.CreatedGameVersion, "1.22.6");
  		orCreateMapRegionEnsureNeighbours = GetOrCreateMapRegionEnsureNeighbours(chunkX, chunkZ, chunkRequest.chunkGenParams, updateEarlierVersion);
  		value = CreateMapChunk(chunkX, chunkZ, orCreateMapRegionEnsureNeighbours);
  		server.loadedMapChunks[key] = value;
@@ -2383,7 +2383,7 @@ index f644852..bff98da 100644
 +					// Get/create region (without storing in the global registry)
  					if (!dictionary.TryGetValue(num3, out var value))
  					{
- 						bool updateEarlierVersion = GameVersion.IsLowerVersionThan(server.SaveGameData.CreatedGameVersion, "1.22.5");
+ 						bool updateEarlierVersion = GameVersion.IsLowerVersionThan(server.SaveGameData.CreatedGameVersion, "1.22.6");
  						value = (dictionary[num3] = GetOrCreateMapRegionNoStore(regionX, regionZ, num3, chunkGenParams, updateEarlierVersion));
  						chunkthread.peekingMapRegions.TryAdd(num3, value);
  					}

--- a/scripts/bootstrap.ps1
+++ b/scripts/bootstrap.ps1
@@ -26,7 +26,7 @@ Force re-extract, re-decompile, and re-clone even if cached output already exist
 
 [CmdletBinding()]
 param(
-    [string]$Version = '1.22.5',
+    [string]$Version = '1.22.6',
     [string]$ServerZip,
     [switch]$Refresh
 )

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumConfig.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumConfig.cs
@@ -28,6 +28,8 @@ internal class StratumConfig
 
 	public StratumPerformanceConfig Performance { get; set; } = new StratumPerformanceConfig();
 
+	public StratumWorldgenConfig Worldgen { get; set; } = new StratumWorldgenConfig();
+
 	public StratumCommandsConfig Commands { get; set; } = new StratumCommandsConfig();
 
 	public StratumChatConfig Chat { get; set; } = new StratumChatConfig();
@@ -61,6 +63,7 @@ internal class StratumConfig
 		Anticheat ??= new StratumAnticheatConfig();
 		ClientModPolicy ??= new StratumClientModPolicyConfig();
 		Performance ??= new StratumPerformanceConfig();
+		Worldgen ??= new StratumWorldgenConfig();
 		Commands ??= new StratumCommandsConfig();
 		Chat ??= new StratumChatConfig();
 		Theme ??= new StratumThemeConfig();
@@ -437,10 +440,22 @@ internal class StratumDiagnosticsConfig
 
 	public bool LogPreflightWarnings { get; set; } = true;
 
-	// Logs every mod-owned Harmony patch at startup (grouped by mod, split by prefix/postfix/
-	// transpiler/finalizer). Visibility only, does not cross-reference against Stratum's own
-	// source-patched methods -- see StratumHarmonyVisibility.
-	public bool LogModHarmonyPatches { get; set; } = false;
+	// Logs every mod-owned Harmony patch at startup, grouped by mod. Visibility only, it does
+	// not cross-reference Stratum's own source-patched methods -- see StratumHarmonyVisibility.
+	// On by default because a mod patch landing on something Stratum reshaped usually goes
+	// missing silently rather than erroring, and this log is what makes it traceable.
+	public bool LogModHarmonyPatches { get; set; } = true;
+}
+
+internal class StratumWorldgenConfig
+{
+	// Runs the Terrain pass as two sub-stages so two threads can share it.
+	// Off gives the stock single-stage pass. See StratumWorldgenCompat.
+	public bool SplitTerrainPass { get; set; } = true;
+
+	// Drops back to the vanilla single-stage pass when a mod registers a handler there or
+	// patches a generator inside it. Leave on unless you have checked this server's mods.
+	public bool AutoDisableSplitForMods { get; set; } = true;
 }
 
 internal class StratumHardeningConfig
@@ -1355,8 +1370,8 @@ internal class StratumEntityTickingConfig
 	public List<string> ExcludedModDomains { get; set; } = new List<string> { "vsvillage" };
 
 	// Paper-style hard despawn: creatures that have been beyond HardDespawnDistanceBlocks
-	// from every player for HardDespawnGracePeriodSeconds get unloaded. Off by default —
-	// enable only on long-running worlds where stray mobs accumulate in old chunks.
+	// from every player for HardDespawnGracePeriodSeconds get unloaded. Off by default.
+	// Enable only on long-running worlds where stray mobs accumulate in old chunks.
 	public bool HardDespawnEnabled { get; set; } = false;
 
 	public int HardDespawnDistanceBlocks { get; set; } = 128;
@@ -1518,7 +1533,7 @@ internal class StratumChunkIoConfig
 // Reorders the next slice of pending chunk-column load requests by distance to the closest
 // online player (optionally forward-predicted along motion). The underlying request queue is
 // still consumed via the standard requeue/dispose flow, this only changes which request the
-// chunk thread picks up *first* on each tick — useful when many players are spreading load
+// chunk thread picks up *first* on each tick. Useful when many players are spreading load
 // across the world simultaneously and FIFO would otherwise round-robin them slowly.
 // sampling now correctly takes into account the entire queue via bounded max-heap, and not just its head
 internal class StratumChunkPriorityConfig

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumInfo.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumInfo.cs
@@ -9,14 +9,14 @@ internal static class StratumInfo
 
 	// Base Vintage Story release this build is patched against. Bump together with
 	// forks.json and the decompile target.
-	public const string BaseGameVersion = "1.22.5";
+	public const string BaseGameVersion = "1.22.6";
 
 	// Stratum revision on top of BaseGameVersion. Increment for every public release;
 	// reset to 1 when BaseGameVersion changes.
 	public const string StratumRevision = "1";
 
 	// Optional prerelease label appended after the revision ("rc.1", "dev", "").
-	public const string PreRelease = "";
+	public const string PreRelease = "indev.1";
 
 	public const string ProtocolMode = "vanilla-compatible";
 

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumModCompat.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumModCompat.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text;
+using HarmonyLib;
+
+namespace Vintagestory.Server;
+
+// Shared answer to "is third-party code involved in this path".
+// Stratum reshapes enough that mods can observe it in a lot of places, and each one needs the
+// same question settled before it turns an optimization on. Ask here, then fall back to the
+// vanilla shape and say so through ReportFallback so every subsystem reports it the same way.
+internal static class StratumModCompat
+{
+	// Assemblies this build ships. Anything else is code Stratum has no way to verify.
+	public static readonly HashSet<string> ShippedAssemblies = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+	{
+		"VintagestoryLib", "VSEssentials", "VSSurvivalMod", "VSCreativeMod", "VintagestoryAPI"
+	};
+
+	// Name of the assembly behind the first foreign handler, or null when they are all ours.
+	// Unknown counts as foreign, since a handler with no resolvable assembly is not ours either.
+	public static string FindForeignHandler(IEnumerable<Delegate> handlers)
+	{
+		if (handlers == null) return null;
+
+		foreach (Delegate handler in handlers)
+		{
+			string assemblyName = handler?.Method?.DeclaringType?.Assembly?.GetName()?.Name;
+			if (assemblyName == null || !ShippedAssemblies.Contains(assemblyName))
+			{
+				return assemblyName ?? "<unknown>";
+			}
+		}
+
+		return null;
+	}
+
+	// First mod-patched method under this namespace, described for a log, or null when clean.
+	// Catches mods that register nothing but patch code a Stratum fast path runs through.
+	public static string FindPatchedMethodUnder(string namespacePrefix)
+	{
+		foreach (MethodBase method in Harmony.GetAllPatchedMethods())
+		{
+			Type declaringType = method?.DeclaringType;
+			if (declaringType?.Namespace == null || !declaringType.Namespace.StartsWith(namespacePrefix, StringComparison.Ordinal))
+			{
+				continue;
+			}
+
+			string assemblyName = declaringType.Assembly?.GetName()?.Name;
+			if (assemblyName == null || !ShippedAssemblies.Contains(assemblyName)) continue;
+
+			string patches = DescribeModPatches(method);
+			if (patches != null)
+			{
+				return declaringType.Name + "." + method.Name + " (" + patches + ")";
+			}
+		}
+
+		return null;
+	}
+
+	// Every mod-owned Harmony patch on one method, or null when there are none. Stratum compiles
+	// its own changes in and applies no Harmony patches, so anything here is third-party.
+	public static string DescribeModPatches(MethodBase method)
+	{
+		if (method == null) return null;
+
+		Patches info = Harmony.GetPatchInfo(method);
+		if (info == null) return null;
+
+		StringBuilder sb = null;
+		AppendPatchOwners(ref sb, info.Transpilers, "transpiler");
+		AppendPatchOwners(ref sb, info.Prefixes, "prefix");
+		AppendPatchOwners(ref sb, info.Postfixes, "postfix");
+		AppendPatchOwners(ref sb, info.Finalizers, "finalizer");
+		return sb?.ToString();
+	}
+
+	// One message shape for every subsystem that gives up a speedup to stay compatible.
+	public static void ReportFallback(string subsystem, string feature, string reason, string overrideSetting)
+	{
+		StratumRuntime.LogWarning(
+			subsystem + ": " + feature + " is off because " + reason + ". "
+			+ "Behavior stays correct and vanilla-compatible, only the speedup is given up. "
+			+ "Set " + overrideSetting + " to false in stratum.json to force it on anyway.");
+	}
+
+	private static void AppendPatchOwners(ref StringBuilder sb, IReadOnlyCollection<Patch> patches, string kind)
+	{
+		if (patches == null) return;
+
+		foreach (Patch patch in patches)
+		{
+			if (sb == null) sb = new StringBuilder();
+			else sb.Append(", ");
+
+			sb.Append(kind).Append(" from '")
+				.Append(string.IsNullOrWhiteSpace(patch.owner) ? "(unknown mod)" : patch.owner)
+				.Append('\'');
+		}
+	}
+}

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumWorldgenCompat.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumWorldgenCompat.cs
@@ -1,0 +1,95 @@
+using System.Collections.Generic;
+using Vintagestory.API.Common;
+using Vintagestory.API.Server;
+
+namespace Vintagestory.Server;
+
+// Keeps the Terrain pass in its vanilla shape whenever a mod is watching it.
+// The split moves rock strata, caves and block layers into a later stage, so mod handlers
+// at Terrain stop running after them, and anything walking OnChunkColumnGen[Terrain] to
+// replace one of them finds nothing and quietly does nothing while Stratum still runs it.
+internal static class StratumWorldgenCompat
+{
+	// Where the vanilla generators and the noise and map layers they call live.
+	private const string worldgenNamespace = "Vintagestory.ServerMods";
+
+	// Handlers bound for the late sub-stage, per world type, in registration order.
+	private static readonly Dictionary<string, List<ChunkColumnGenerationDelegate>> pendingLateHandlers = new Dictionary<string, List<ChunkColumnGenerationDelegate>>();
+
+	public static void RegisterTerrainLate(ServerMain server, ChunkColumnGenerationDelegate handler, string worldType)
+	{
+		// Vanilla position for now. ApplyTerrainSplitIfSafe moves it later if that turns out safe.
+		server.ModEventManager.GetWorldGenHandler(worldType).OnChunkColumnGen[(int)EnumWorldGenPass.Terrain].Add(handler);
+
+		string key = worldType ?? string.Empty;
+		if (!pendingLateHandlers.TryGetValue(key, out List<ChunkColumnGenerationDelegate> late))
+		{
+			late = new List<ChunkColumnGenerationDelegate>();
+			pendingLateHandlers[key] = late;
+		}
+
+		late.Add(handler);
+	}
+
+	// Called once every OnInitWorldGen handler has run, which is the first point where every
+	// mod has finished registering.
+	public static void ApplyTerrainSplitIfSafe(ServerMain server, WorldGenHandler worldgenHandler)
+	{
+		if (worldgenHandler == null) return;
+
+		string key = server?.SaveGameData?.WorldType ?? string.Empty;
+		if (!pendingLateHandlers.TryGetValue(key, out List<ChunkColumnGenerationDelegate> late) || late.Count == 0)
+		{
+			return;
+		}
+
+		StratumRuntime.Config.EnsurePopulated();
+		string blocker = FindSplitBlocker(worldgenHandler, late, StratumRuntime.Config.Worldgen);
+		if (blocker != null)
+		{
+			StratumModCompat.ReportFallback("worldgen", "the Terrain pass split", blocker, "Worldgen.AutoDisableSplitForMods");
+			return;
+		}
+
+		List<ChunkColumnGenerationDelegate> terrain = worldgenHandler.OnChunkColumnGen[(int)EnumWorldGenPass.Terrain];
+		for (int i = 0; i < late.Count; i++)
+		{
+			terrain.Remove(late[i]);
+		}
+
+		worldgenHandler.OnChunkColumnGenTerrainLate.AddRange(late);
+		StratumRuntime.LogInfo($"worldgen: Terrain pass split in two, {late.Count} generator(s) moved to TerrainLate");
+	}
+
+	// Null when the split is safe, otherwise the reason, phrased for whoever reads the log.
+	private static string FindSplitBlocker(WorldGenHandler worldgenHandler, List<ChunkColumnGenerationDelegate> late, StratumWorldgenConfig config)
+	{
+		if (!config.SplitTerrainPass) return "Worldgen.SplitTerrainPass is disabled in stratum.json";
+		if (!config.AutoDisableSplitForMods) return null;
+
+		// One foreign handler is enough. Even if it registered before every late generator and
+		// would keep its order, it can still be walking the list looking for them.
+		string foreign = StratumModCompat.FindForeignHandler(worldgenHandler.OnChunkColumnGen[(int)EnumWorldGenPass.Terrain]);
+		if (foreign != null)
+		{
+			return "a worldgen handler from assembly '" + foreign + "' is registered at the Terrain pass";
+		}
+
+		for (int i = 0; i < late.Count; i++)
+		{
+			string patches = StratumModCompat.DescribeModPatches(late[i]?.Method);
+			if (patches != null)
+			{
+				return "a generator Stratum would move to the late sub-stage is Harmony patched (" + patches + ")";
+			}
+		}
+
+		string patched = StratumModCompat.FindPatchedMethodUnder(worldgenNamespace);
+		if (patched != null)
+		{
+			return "a mod Harmony patches " + patched + ", which runs inside the pass Stratum would split";
+		}
+
+		return null;
+	}
+}


### PR DESCRIPTION
Feature: StratumModCompat, shared checks for whether third-party code sits in a code path, reusable by any subsystem that wants to fall back instead of guess 

Feature: Worldgen config block, SplitTerrainPass and AutoDisableSplitForMods Fixed: handlers registered at EnumWorldGenPass.Terrain lost their ordering and could no longer find rock strata, caves or block layers in OnChunkColumnGen, so a mod replacing one of them silently did nothing while Stratum still ran it 

Fixed: eight patches that stopped applying against the 1.22.6 decompile Tweak: base game 1.22.6, version 1.22.6-stratum.1-indev.1 Tweak: LogModHarmonyPatches defaults on

Tweak: ServerSystemSupplyChunks reads the shipped assembly list from StratumModCompat instead of keeping its own copy

The split is now an optimization rather than the resting shape. Late generators register the vanilla way and only move once worldgen init proves nothing foreign is watching that pass. The scheduler is untouched.

Patches verified with git apply --check. Not built or booted yet, want to merge and get the latest commits on my end.