### PR TITLE
Feature: give each worldgen thread its own generator instead of ThreadLocal fields

### DIFF
--- a/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/1.GenTerra/GenTerra.cs.patch
+++ b/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/1.GenTerra/GenTerra.cs.patch
@@ -1,8 +1,8 @@
 diff --git a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/1.GenTerra/GenTerra.cs b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/1.GenTerra/GenTerra.cs
-index 5f759f1..b5956e7 100644
+index 5f759f1..1628cd9 100644
 --- a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/1.GenTerra/GenTerra.cs
 +++ b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/1.GenTerra/GenTerra.cs
-@@ -1,7 +1,8 @@
+@@ -1,9 +1,10 @@
  using System;
  using System.Collections;
 +using System.Collections.Concurrent;
@@ -11,31 +11,32 @@ index 5f759f1..b5956e7 100644
  using System.Threading;
  using System.Threading.Tasks;
  using Vintagestory.API.Common;
-@@ -27,26 +28,34 @@ namespace Vintagestory.ServerMods
- 
+ using Vintagestory.API.Config;
+ using Vintagestory.API.Datastructures;
+@@ -26,14 +27,20 @@ namespace Vintagestory.ServerMods
+         const double maxDistortionAmount = (55 + 40 + 30 + 10) * SimplexNoiseOctave.MAX_VALUE_2D_WARP;
+
          int maxThreads;
- 
+
          LandformsWorldProperty landforms;
          float[][] terrainYThresholds;
--        Dictionary<int, LerpedWeightedIndex2DMap> LandformMapByRegion = new Dictionary<int, LerpedWeightedIndex2DMap>(10);
-+        // Stratum: ConcurrentDictionary since Terrain can now run concurrently for
-+        // distant columns, same reasoning and same fix as GenRockStrata's province map.
-+        ConcurrentDictionary<int, LerpedWeightedIndex2DMap> LandformMapByRegion = new ConcurrentDictionary<int, LerpedWeightedIndex2DMap>();
-+        // Stratum: guards the lazy landforms/terrainYThresholds init below, a genuine
-+        // (if low-severity) race even at concurrency cap 1 vs other worldgen threads
-+        // touching NoiseLandforms.landforms at the same time; closed while this file
-+        // was already open for the concurrency work.
-+        readonly object landformsInitLock = new object();
+         Dictionary<int, LerpedWeightedIndex2DMap> LandformMapByRegion = new Dictionary<int, LerpedWeightedIndex2DMap>(10);
++
++        // Stratum: preserve the vanilla cache field while concurrent columns share its maps safely.
++        ConcurrentDictionary<int, LerpedWeightedIndex2DMap> stratumLandformMapsByRegion = new ConcurrentDictionary<int, LerpedWeightedIndex2DMap>();
++
++        // Stratum: protect the lazy shared landform setup when Terrain runs concurrently.
++        readonly object stratumLandformsInitLock = new object();
          int regionMapSize;
          float noiseScale;
          int terrainGenOctaves = 9;
- 
+
          NewNormalizedSimplexFractalNoise terrainNoise;
          SimplexNoise distort2dx;
          SimplexNoise distort2dz;
-         NormalizedSimplexNoise geoUpheavalNoise;
--        WeightedTaper[] taperMap;
- 
+@@ -41,33 +48,90 @@ namespace Vintagestory.ServerMods
+         WeightedTaper[] taperMap;
+
          struct ThreadLocalTempData
          {
              public double[] LerpedAmplitudes;
@@ -45,40 +46,26 @@ index 5f759f1..b5956e7 100644
 +            public bool[] LocalLayerFullyEmpty;   // Stratum: Thread-local buffer to avoid false sharing
          }
          ThreadLocal<ThreadLocalTempData> tempDataThreadLocal;
- 
+
          struct WeightedTaper
          {
-@@ -57,14 +66,65 @@ namespace Vintagestory.ServerMods
+             public float TerrainYPos;
+             public float Weight;
+         }
+
          struct ColumnResult
          {
              public BitArray ColumnBlockSolidities;
              public int WaterBlockID;
          }
--        ColumnResult[] columnResults;
--        bool[] layerFullySolid;     // We can't use BitArrays for these because code which writes to them is heavily multi-threaded; but anyhow they are only mapSizeY x 4 bytes
--        bool[] layerFullyEmpty;
--        int[] borderIndicesByCardinal;
 +
-+        // Stratum start: taperMap, columnResults, layerFullySolid and layerFullyEmpty
-+        // used to be plain instance fields, reused across every column processed by
-+        // this GenTerra instance. That is safe with one column in flight at a time
-+        // (which is all Terrain has ever allowed), but generate()'s own internal
-+        // Parallel.For already fans ONE column out across up to maxThreads workers,
-+        // writing into these arrays by chunkIndex2d — so the unit of isolation these
-+        // four buffers need is "the column being generated right now", not "the
-+        // calling thread". ThreadLocal, the fix used everywhere else this session,
-+        // gives per-thread storage; a single column's internal Parallel.For already
-+        // spreads across many threads, and two DIFFERENT columns' Parallel.For calls
-+        // can each land on the same physical thread at different moments, so
-+        // ThreadLocal here would not keep two concurrent columns' data apart.
-+        //
-+        // Instead, ColumnBuffers bundles the four arrays and OnChunkColumnGen rents
-+        // one per column from a pool, uses it for that column's full
-+        // OnChunkColumnGen + generate() call, and returns it when done. The pool
-+        // starts with one instance (matching today's steady state) and grows on
-+        // demand under a TryTake miss rather than blocking, so it self-sizes to
-+        // whatever concurrency actually happens regardless of the stage's configured
-+        // cap, and never risks a stall if that cap is retuned later.
+         ColumnResult[] columnResults;
+         bool[] layerFullySolid;     // We can't use BitArrays for these because code which writes to them is heavily multi-threaded; but anyhow they are only mapSizeY x 4 bytes
+         bool[] layerFullyEmpty;
+         int[] borderIndicesByCardinal;
+
++        // Stratum start: each concurrent Terrain column rents its own vanilla-shaped buffers.
++        // The fields remain mod-visible mirrors while Stratum carries the rented owner locally.
 +        class ColumnBuffers
 +        {
 +            public WeightedTaper[] TaperMap;
@@ -87,6 +74,15 @@ index 5f759f1..b5956e7 100644
 +            public bool[] LayerFullyEmpty;
 +        }
 +        ConcurrentBag<ColumnBuffers> columnBufferPool;
++
++        // Stratum: keep the original generate signature while selecting this call's pooled buffers.
++        struct StratumColumnBufferFrame
++        {
++            public GenTerra StratumOwner;
++            public ColumnBuffers StratumBuffers;
++        }
++
++        [ThreadStatic] private static Stack<StratumColumnBufferFrame> stratumColumnBufferFrames;
 +
 +        ColumnBuffers NewColumnBuffers()
 +        {
@@ -112,14 +108,33 @@ index 5f759f1..b5956e7 100644
 +        {
 +            columnBufferPool.Add(buf);
 +        }
++
++        void stratumPublishColumnBuffers(ColumnBuffers buf)
++        {
++            taperMap = buf.TaperMap;
++            columnResults = buf.ColumnResults;
++            layerFullySolid = buf.LayerFullySolid;
++            layerFullyEmpty = buf.LayerFullyEmpty;
++        }
 +        // Stratum end
- 
++
          public override bool ShouldLoad(EnumAppSide side)
          {
              return side == EnumAppSide.Server;
          }
-@@ -99,11 +159,31 @@ namespace Vintagestory.ServerMods
- 
+
+         public override double ExecuteOrder()
+         {
+@@ -92,20 +156,41 @@ namespace Vintagestory.ServerMods
+             api.Event.ChunkColumnGeneration(OnChunkColumnGen, EnumWorldGenPass.Terrain, "standard");
+         }
+
+         public void initWorldGen()
+         {
+             LoadGlobalConfig(api);
+             LandformMapByRegion.Clear();
++            stratumLandformMapsByRegion.Clear(); // Stratum: clear the concurrent owner with its vanilla view
+
              /*
               *  For info in 1.19 there are 7 running server threads: the main server ticking thread, chunkdbthread, ServerConsole, Relight, CompressChunks, ai-pathfinding, CheckLeafDecay.  There may also be multi-threaded worldgen adding 1-3 more active threads.  Typically 4 threads (ticking, chunkdbthread, ai-pathfinding and at least 1 worldgen thread) will be almost constantly active if there is worldgen demand
                  On a client, meanwhile, there will be at least the main rendering loop and the chunktesselator active.
@@ -147,12 +162,16 @@ index 5f759f1..b5956e7 100644
 +            // nothing while it stays.
 +            maxThreads = reservedThreadsBudget;
              if (api.Server.ReducedServerThreads && maxThreads > 1) maxThreads = 2;
- 
+
              regionMapSize = (int)Math.Ceiling((double)api.WorldManager.MapSizeX / api.WorldManager.RegionSize);
              noiseScale = Math.Max(1, api.WorldManager.MapSizeY / 256f);
              terrainGenOctaves = TerraGenConfig.GetTerrainOctaveCount(api.WorldManager.MapSizeY);
-@@ -136,23 +216,16 @@ namespace Vintagestory.ServerMods
- 
+
+             terrainNoise = NewNormalizedSimplexFractalNoise.FromDefaultOctaves(
+@@ -134,21 +219,22 @@ namespace Vintagestory.ServerMods
+                 api.World.Seed + 9876 + 1
+             );
+
              tempDataThreadLocal = new ThreadLocal<ThreadLocalTempData>(() => new ThreadLocalTempData
              {
                  LerpedAmplitudes = new double[terrainGenOctaves],
@@ -167,23 +186,23 @@ index 5f759f1..b5956e7 100644
 -            layerFullySolid = new bool[api.WorldManager.MapSizeY];
 -            taperMap = new WeightedTaper[chunksize * chunksize];
 -            for (int i = 0; i < chunksize * chunksize; i++) columnResults[i].ColumnBlockSolidities = new BitArray(api.WorldManager.MapSizeY);
--
--            borderIndicesByCardinal = new int[8];
--            borderIndicesByCardinal[Cardinal.NorthEast] = (chunksize - 1) * chunksize + 0;
--            borderIndicesByCardinal[Cardinal.SouthEast] = 0 + 0;
--            borderIndicesByCardinal[Cardinal.SouthWest] = 0 + chunksize - 1;
--            borderIndicesByCardinal[Cardinal.NorthWest] = (chunksize - 1) * chunksize + chunksize - 1;
 +            columnBufferPool = new ConcurrentBag<ColumnBuffers>();
-+            columnBufferPool.Add(NewColumnBuffers()); // matches today's steady-state allocation for the common case of one column at a time
- 
-             landforms = null;  // Reset this, useful when /wgen regen command reloads all the generators because landforms gets reloaded from file there
++            ColumnBuffers initialBuffers = NewColumnBuffers();
++            columnBufferPool.Add(initialBuffers); // Stratum: match vanilla's steady-state allocation
++            stratumPublishColumnBuffers(initialBuffers);
+
+             borderIndicesByCardinal = new int[8];
+             borderIndicesByCardinal[Cardinal.NorthEast] = (chunksize - 1) * chunksize + 0;
+             borderIndicesByCardinal[Cardinal.SouthEast] = 0 + 0;
+             borderIndicesByCardinal[Cardinal.SouthWest] = 0 + chunksize - 1;
+             borderIndicesByCardinal[Cardinal.NorthWest] = (chunksize - 1) * chunksize + chunksize - 1;
+
+@@ -166,122 +252,187 @@ namespace Vintagestory.ServerMods
          }
- 
-         private double[] scaleAdjustedFreqs(double[] vs, float horizontalScale)
-@@ -168,117 +241,149 @@ namespace Vintagestory.ServerMods
- 
- 
- 
+
+
+
+
          private void OnChunkColumnGen(IChunkColumnGenerateRequest request)
          {
 -            if (request.RequiresChunkBorderSmoothing && !PreventSmoothing(request.ChunkX, request.ChunkZ))
@@ -192,13 +211,29 @@ index 5f759f1..b5956e7 100644
 +            // ColumnResults/LayerFullySolid/LayerFullyEmpty) share the same instance for
 +            // this one column, and no other concurrently-running column's call can see it.
 +            ColumnBuffers buf = RentColumnBuffers();
++            Stack<StratumColumnBufferFrame> frames = stratumColumnBufferFrames ??= new Stack<StratumColumnBufferFrame>();
++            StratumColumnBufferFrame frame = new StratumColumnBufferFrame { StratumOwner = this, StratumBuffers = buf };
++            frames.Push(frame);
++            stratumPublishColumnBuffers(buf);
 +            try
              {
 -                var neibHeightMaps = request.NeighbourTerrainHeight;
 -
 -                // Ignore diagonals if direct adjacent faces are available, otherwise the corners get weighted too strongly
 -                if (neibHeightMaps[Cardinal.North] != null)
--                {
++                int[] currentBorderIndicesByCardinal = new int[8]; // Stratum: call-local, cheap enough not to pool
++                borderIndicesByCardinal = currentBorderIndicesByCardinal; // Stratum: keep the vanilla field current for mod code
++                // Diagonal corner indices never depend on dx/dz, so they used to be set
++                // once in initWorldGen(); now that this array is call-local they get set
++                // fresh here instead, once per column rather than once per generator
++                // lifetime.
++                currentBorderIndicesByCardinal[Cardinal.NorthEast] = (chunksize - 1) * chunksize + 0;
++                currentBorderIndicesByCardinal[Cardinal.SouthEast] = 0 + 0;
++                currentBorderIndicesByCardinal[Cardinal.SouthWest] = 0 + chunksize - 1;
++                currentBorderIndicesByCardinal[Cardinal.NorthWest] = (chunksize - 1) * chunksize + chunksize - 1;
++
++                if (request.RequiresChunkBorderSmoothing && !PreventSmoothing(request.ChunkX, request.ChunkZ))
+                 {
 -                    neibHeightMaps[Cardinal.NorthEast] = null;
 -                    neibHeightMaps[Cardinal.NorthWest] = null;
 -                }
@@ -213,35 +248,21 @@ index 5f759f1..b5956e7 100644
 -                    neibHeightMaps[Cardinal.SouthEast] = null;
 -                }
 -                if (neibHeightMaps[Cardinal.West] != null)
-+                int[] borderIndicesByCardinal = new int[8]; // Stratum: call-local, cheap enough not to pool
-+                // Diagonal corner indices never depend on dx/dz, so they used to be set
-+                // once in initWorldGen(); now that this array is call-local they get set
-+                // fresh here instead, once per column rather than once per generator
-+                // lifetime.
-+                borderIndicesByCardinal[Cardinal.NorthEast] = (chunksize - 1) * chunksize + 0;
-+                borderIndicesByCardinal[Cardinal.SouthEast] = 0 + 0;
-+                borderIndicesByCardinal[Cardinal.SouthWest] = 0 + chunksize - 1;
-+                borderIndicesByCardinal[Cardinal.NorthWest] = (chunksize - 1) * chunksize + chunksize - 1;
-+
-+                if (request.RequiresChunkBorderSmoothing && !PreventSmoothing(request.ChunkX, request.ChunkZ))
-                 {
+-                {
 -                    neibHeightMaps[Cardinal.SouthWest] = null;
 -                    neibHeightMaps[Cardinal.NorthWest] = null;
 -                }
--
++                    var neibHeightMaps = request.NeighbourTerrainHeight;
+
 -                for (int dx = 0; dx < chunksize; dx++)
 -                {
 -                    borderIndicesByCardinal[Cardinal.North] = (chunksize - 1) * chunksize + dx;
 -                    borderIndicesByCardinal[Cardinal.South] = 0 + dx;
-+                    var neibHeightMaps = request.NeighbourTerrainHeight;
- 
+-
 -                    for (int dz = 0; dz < chunksize; dz++)
 +                    // Ignore diagonals if direct adjacent faces are available, otherwise the corners get weighted too strongly
 +                    if (neibHeightMaps[Cardinal.North] != null)
-                     {
--                        double sumWeight = 0;
--                        double ypos = 0;
--                        float maxWeight = 0;
++                    {
 +                        neibHeightMaps[Cardinal.NorthEast] = null;
 +                        neibHeightMaps[Cardinal.NorthWest] = null;
 +                    }
@@ -251,7 +272,10 @@ index 5f759f1..b5956e7 100644
 +                        neibHeightMaps[Cardinal.SouthEast] = null;
 +                    }
 +                    if (neibHeightMaps[Cardinal.South] != null)
-+                    {
+                     {
+-                        double sumWeight = 0;
+-                        double ypos = 0;
+-                        float maxWeight = 0;
 +                        neibHeightMaps[Cardinal.SouthWest] = null;
 +                        neibHeightMaps[Cardinal.SouthEast] = null;
 +                    }
@@ -260,14 +284,14 @@ index 5f759f1..b5956e7 100644
 +                        neibHeightMaps[Cardinal.SouthWest] = null;
 +                        neibHeightMaps[Cardinal.NorthWest] = null;
 +                    }
- 
+
 -                        borderIndicesByCardinal[Cardinal.East] = dz * chunksize + 0;
 -                        borderIndicesByCardinal[Cardinal.West] = dz * chunksize + chunksize - 1;
 +                    for (int dx = 0; dx < chunksize; dx++)
 +                    {
-+                        borderIndicesByCardinal[Cardinal.North] = (chunksize - 1) * chunksize + dx;
-+                        borderIndicesByCardinal[Cardinal.South] = 0 + dx;
- 
++                        currentBorderIndicesByCardinal[Cardinal.North] = (chunksize - 1) * chunksize + dx;
++                        currentBorderIndicesByCardinal[Cardinal.South] = 0 + dx;
+
 -                        for (int i = 0; i < Cardinal.ALL.Length; i++)
 +                        for (int dz = 0; dz < chunksize; dz++)
                          {
@@ -276,11 +300,11 @@ index 5f759f1..b5956e7 100644
 +                            double sumWeight = 0;
 +                            double ypos = 0;
 +                            float maxWeight = 0;
- 
+
 -                            float distToEdge=0;
-+                            borderIndicesByCardinal[Cardinal.East] = dz * chunksize + 0;
-+                            borderIndicesByCardinal[Cardinal.West] = dz * chunksize + chunksize - 1;
- 
++                            currentBorderIndicesByCardinal[Cardinal.East] = dz * chunksize + 0;
++                            currentBorderIndicesByCardinal[Cardinal.West] = dz * chunksize + chunksize - 1;
+
 -                            switch (i)
 +                            for (int i = 0; i < Cardinal.ALL.Length; i++)
                              {
@@ -343,13 +367,13 @@ index 5f759f1..b5956e7 100644
 +
 +                                float baseWeight = Math.Max(0, 1 - distToEdge);
 +                                float cardinalWeight = baseWeight * baseWeight;
-+                                var neibYPos = neibMap[borderIndicesByCardinal[i]] + 0.5f;
++                                var neibYPos = neibMap[currentBorderIndicesByCardinal[i]] + 0.5f;
 +
 +                                ypos += neibYPos * Math.Max(0.0001, cardinalWeight);
 +                                sumWeight += cardinalWeight;
 +                                maxWeight = Math.Max(maxWeight, cardinalWeight);
                              }
- 
+
 -                            float baseWeight = Math.Max(0, 1 - distToEdge);
 -                            float cardinalWeight = baseWeight * baseWeight;
 -                            var neibYPos = neibMap[borderIndicesByCardinal[i]] + 0.5f;
@@ -361,7 +385,7 @@ index 5f759f1..b5956e7 100644
                          }
 +                    }
 +                }
- 
+
 -                        taperMap[dz * chunksize + dx] = new WeightedTaper() { TerrainYPos = (float)(ypos / Math.Max(0.0001, sumWeight)), Weight = maxWeight };
 +                if (landforms == null)    // This only needs to be done once, but cannot be done during initWorldGen() because NoiseLandforms.landforms is sometimes not yet setup at that point (depends on random order of ModSystems registering to events)
 +                {
@@ -369,7 +393,7 @@ index 5f759f1..b5956e7 100644
 +                    // commit (both racing threads would compute the same result from the
 +                    // same static NoiseLandforms.landforms), closed properly while this
 +                    // file was already open for the concurrency work.
-+                    lock (landformsInitLock)
++                    lock (stratumLandformsInitLock)
 +                    {
 +                        if (landforms == null)
 +                        {
@@ -380,45 +404,77 @@ index 5f759f1..b5956e7 100644
                      }
                  }
 -            }
- 
+
 -            if (landforms == null)    // This only needs to be done once, but cannot be done during initWorldGen() because NoiseLandforms.landforms is sometimes not yet setup at that point (depends on random order of ModSystems registering to events)
-+                generate(request.Chunks, request.ChunkX, request.ChunkZ, request.RequiresChunkBorderSmoothing, buf);
++                stratumPublishColumnBuffers(buf);
++                borderIndicesByCardinal = currentBorderIndicesByCardinal;
++                try
++                {
++                    generate(request.Chunks, request.ChunkX, request.ChunkZ, request.RequiresChunkBorderSmoothing);
++                }
++                finally
++                {
++                    // Stratum: a same-thread nested call may have published another frame.
++                    stratumPublishColumnBuffers(buf);
++                    borderIndicesByCardinal = currentBorderIndicesByCardinal;
++                }
 +            }
 +            finally
              {
 -                landforms = NoiseLandforms.landforms;
 -                terrainYThresholds = new float[landforms.LandFormsByIndex.Length][];
 -                for (int i = 0; i < landforms.LandFormsByIndex.Length; i++) terrainYThresholds[i] = landforms.LandFormsByIndex[i].TerrainYThresholds;
++                frames.Pop();
 +                ReturnColumnBuffers(buf);
              }
 -
 -            generate(request.Chunks, request.ChunkX, request.ChunkZ, request.RequiresChunkBorderSmoothing);
          }
- 
+
          private bool PreventSmoothing(int chunkX, int chunkZ)
          {
              BoolRef result = new BoolRef();
              api.Event.IsTerrainHeightSmoothingPrevented(chunkX, chunkZ, result);
              return result.GetValue();
          }
- 
--        private void generate(IServerChunk[] chunks, int chunkX, int chunkZ, bool requiresChunkBorderSmoothing)
-+        private void generate(IServerChunk[] chunks, int chunkX, int chunkZ, bool requiresChunkBorderSmoothing, ColumnBuffers buf)
+
+         private void generate(IServerChunk[] chunks, int chunkX, int chunkZ, bool requiresChunkBorderSmoothing)
          {
++            ColumnBuffers buf;
++            if (stratumColumnBufferFrames?.Count > 0 && stratumColumnBufferFrames.Peek().StratumOwner == this)
++            {
++                buf = stratumColumnBufferFrames.Peek().StratumBuffers;
++            }
++            else
++            {
++                // Stratum: reverse patches and reflection can call the vanilla method outside the registered handler.
++                buf = new ColumnBuffers
++                {
++                    TaperMap = this.taperMap,
++                    ColumnResults = this.columnResults,
++                    LayerFullySolid = this.layerFullySolid,
++                    LayerFullyEmpty = this.layerFullyEmpty
++                };
++            }
              IMapChunk mapchunk = chunks[0].MapChunk;
              const int chunksize = GlobalConstants.ChunkSize;
- 
+
              int upheavalMapUpLeft = 0;
-@@ -356,121 +461,161 @@ namespace Vintagestory.ServerMods
+             int upheavalMapUpRight = 0;
+             int upheavalMapBotLeft = 0;
+             int upheavalMapBotRight = 0;
+@@ -354,125 +505,165 @@ namespace Vintagestory.ServerMods
+             double geoUpheavalAmplitude = 255;
+
              //int cblockId = api.World.GetBlock(new AssetLocation("creativeblock-35")).Id;
- 
+
              const float chunkBlockDelta = 1.0f / chunksize;
              float chunkPixelBlockStep = chunkPixelSize * chunkBlockDelta;
              double verticalNoiseRelativeFrequency = 0.5 / TerraGenConfig.terrainNoiseVerticalScale;
 -            for (int y = 0; y < layerFullySolid.Length; y++) layerFullySolid[y] = true;   // Fill with true; later if any block in the layer is non-solid we will set it to false
 -            for (int y = 0; y < layerFullyEmpty.Length; y++) layerFullyEmpty[y] = true;   // Fill with true; later if any block in the layer is non-solid we will set it to false
 -            layerFullyEmpty[mapsizeY - 1] = false;  // The top block is always empty (air), leaving space for grass, snowlayer etc.
--
+
 -            Parallel.For(0, chunksize * chunksize, new ParallelOptions() { MaxDegreeOfParallelism = maxThreads }, chunkIndex2d => {
 -                int lX = chunkIndex2d % chunksize;
 -                int lZ = chunkIndex2d / chunksize;
@@ -441,7 +497,7 @@ index 5f759f1..b5956e7 100644
 -                VectorXZ dist = NewDistortionNoise(worldX, worldZ);
 -                VectorXZ distTerrain = ApplyIsotropicDistortionThreshold(dist * terrainDistortionMultiplier, terrainDistortionThreshold,
 -                    terrainDistortionMultiplier * maxDistortionAmount);
- 
+-
 -                // Get Y distortion from oceanicity and upheaval
 -                float upHeavalStrength = GameMath.BiLerp(upheavalMapUpLeft, upheavalMapUpRight, upheavalMapBotLeft, upheavalMapBotRight, lX * chunkBlockDelta, lZ * chunkBlockDelta);
 -                float oceanicity = GameMath.BiLerp(oceanUpLeft, oceanUpRight, oceanBotLeft, oceanBotRight, lX * chunkBlockDelta, lZ * chunkBlockDelta) * oceanicityFac;
@@ -460,10 +516,10 @@ index 5f759f1..b5956e7 100644
 +            Array.Fill(layerFullySolid, true);  // Fill with true; later if any block in the layer is non-solid we will set it to false
 +            Array.Fill(layerFullyEmpty, true);  // Fill with true; later if any block in the layer is non-solid we will set it to false
 +            layerFullyEmpty[mapsizeY - 1] = false;  // The top block is always empty (air), leaving space for grass, snowlayer etc.
- 
+
 -                float distY = oceanicity + ComputeOceanAndUpheavalDistY(upHeavalStrength, worldX, worldZ, distGeo);
 +            object mergeLock = new object(); // to block threads
- 
+
 -                columnResults[chunkIndex2d].WaterBlockID = oceanicity > 1 ? gcfg.saltWaterBlockId : gcfg.waterBlockId;
 +            Parallel.For(0, chunksize * chunksize, new ParallelOptions() { MaxDegreeOfParallelism = maxThreads },
 +                // localInit: Initialize Thread-Local buffers once per thread, without allocations
@@ -482,18 +538,18 @@ index 5f759f1..b5956e7 100644
 +                    int lZ = chunkIndex2d / chunksize;
 +                    int worldX = chunkX * chunksize + lX;
 +                    int worldZ = chunkZ * chunksize + lZ;
- 
+
 -                // Prepare the noise for the entire column.
 -                NewNormalizedSimplexFractalNoise.ColumnNoise columnNoise = terrainNoise.ForColumn(verticalNoiseRelativeFrequency, lerpedAmps, lerpedTh, worldX + distTerrain.X, worldZ + distTerrain.Z);
 -                double noiseBoundMin = columnNoise.BoundMin;
 -                double noiseBoundMax = columnNoise.BoundMax;
 +                    float lxChunkBlockDelta = lX * chunkBlockDelta;
 +                    float lzChunkBlockDelta = lZ * chunkBlockDelta;
- 
+
 -                WeightedTaper wtaper = taperMap[chunkIndex2d];
 +                    BitArray columnBlockSolidities = columnResults[chunkIndex2d].ColumnBlockSolidities;
 +                    columnBlockSolidities.SetAll(false);
- 
+
 -                float distortedPosYSlide = distY - (int)Math.Floor(distY);    // This value will be unchanged throughout the posY loop
 -                for (int posY = 1; posY <= mapsizeYm2; posY++)
 -                {
@@ -501,7 +557,7 @@ index 5f759f1..b5956e7 100644
 -                    StartSampleDisplacedYThreshold(posY + distY, mapsizeYm2, out int distortedPosYBase);
 +                    double[] lerpedAmps = data.LerpedAmplitudes;
 +                    double[] lerpedTh = data.LerpedThresholds;
- 
+
 -                    // Value starts as the landform Y threshold.
 -                    double threshold = 0;
 -                    for (int i = 0; i < columnLandformIndexedWeights.Length; i++)
@@ -517,14 +573,14 @@ index 5f759f1..b5956e7 100644
 +                        lerpedAmps[i] = GameMath.BiLerp(octNoiseX0[i], octNoiseX1[i], octNoiseX2[i], octNoiseX3[i], lxChunkBlockDelta, lzChunkBlockDelta);
 +                        lerpedTh[i] = GameMath.BiLerp(octThX0[i], octThX1[i], octThX2[i], octThX3[i], lxChunkBlockDelta, lzChunkBlockDelta);
                      }
- 
+
 -                    // Geo Upheaval modifier for threshold
 -                    ComputeGeoUpheavalTaper(posY, distY, taperThreshold, geoUpheavalAmplitude, mapsizeY, ref threshold);
 +                    // Create that directional compression effect.
 +                    VectorXZ dist = NewDistortionNoise(worldX, worldZ);
 +                    VectorXZ distTerrain = ApplyIsotropicDistortionThreshold(dist * terrainDistortionMultiplier, terrainDistortionThreshold,
 +                        terrainDistortionMultiplier * maxDistortionAmount);
- 
+
 -                    if (requiresChunkBorderSmoothing)
 -                    {
 -                        double th = posY > wtaper.TerrainYPos ? 1 : -1;
@@ -532,21 +588,21 @@ index 5f759f1..b5956e7 100644
 +                    float upHeavalStrength = GameMath.BiLerp(upheavalMapUpLeft, upheavalMapUpRight, upheavalMapBotLeft, upheavalMapBotRight, lxChunkBlockDelta, lzChunkBlockDelta);
 +                    float oceanicity = GameMath.BiLerp(oceanUpLeft, oceanUpRight, oceanBotLeft, oceanBotRight, lxChunkBlockDelta, lzChunkBlockDelta) * oceanicityFac;
 +                    VectorXZ distGeo = ApplyIsotropicDistortionThreshold(dist * geoDistortionMultiplier, geoDistortionThreshold, geoDistortionMultiplier * maxDistortionAmount);
- 
+
 -                        var ydiff = Math.Abs(posY - wtaper.TerrainYPos);
 -                        var noise = ydiff > 10 ? 0 : distort2dx.Noise(-(chunkX * chunksize + lX) / 10.0, posY / 10.0, -(chunkZ * chunksize + lZ) / 10.0) / Math.Max(1, ydiff / 2.0);
 +                    float distY = oceanicity + ComputeOceanAndUpheavalDistY(upHeavalStrength, worldX, worldZ, distGeo);
- 
+
 -                        noise *= GameMath.Clamp(2*(1 - wtaper.Weight), 0, 1) * 0.1;
 +                    columnResults[chunkIndex2d].WaterBlockID = oceanicity > 1 ? gcfg.saltWaterBlockId : gcfg.waterBlockId;
- 
+
 -                        threshold = GameMath.Lerp(threshold, th + noise, wtaper.Weight);
 -                    }
 +                    // Prepare the noise for the entire column.
 +                    NewNormalizedSimplexFractalNoise.ColumnNoise columnNoise = terrainNoise.ForColumn(verticalNoiseRelativeFrequency, lerpedAmps, lerpedTh, worldX + distTerrain.X, worldZ + distTerrain.Z);
 +                    double noiseBoundMin = columnNoise.BoundMin;
 +                    double noiseBoundMax = columnNoise.BoundMax;
- 
+
 -                    // Often we don't need to calculate the noise.
 -                    if (threshold <= noiseBoundMin)
 -                    {
@@ -557,7 +613,7 @@ index 5f759f1..b5956e7 100644
 -                    {
 -                        layerFullySolid[posY] = false;  // No terrain block  (thread safe even when this is parallel)
 +                    WeightedTaper wtaper = taperMap[chunkIndex2d];
- 
+
 -                        //We can now exit the loop early, because empirical testing shows that once the threshold has exceeded the max noise bound, it never returns to a negative noise value at any higher y value in the same blocks column.  This represents air well above the "interesting" part of the terrain.  Tested for all world heights in the range 256-1536, tested with arches, overhangs etc.
 -                        for (int yAbove = posY + 1; yAbove <= mapsizeYm2; yAbove++) layerFullySolid[yAbove] = false;
 -                        break;
@@ -571,10 +627,7 @@ index 5f759f1..b5956e7 100644
 -                        noiseSign = columnNoise.NoiseSign(posY, noiseSign);
 +                        // Setup a lerp between threshold values, so that distortY can be applied continuously there.
 +                        StartSampleDisplacedYThreshold(posY + distY, mapsizeYm2, out int distortedPosYBase);
- 
--                        // If it ever comes up to change the noise formula to one that's less trivial to layer-skip-optimize,
--                        // Replace the above-two lines with the one below.
--                        //noiseSign = columnNoise.Noise(posY) - threshold;
++
 +                        // Value starts as the landform Y threshold.
 +                        double threshold = 0;
 +                        for (int i = 0; i < columnLandformIndexedWeights.Length; i++)
@@ -585,7 +638,10 @@ index 5f759f1..b5956e7 100644
 +                            // Underflow and overflow of distortedPosY result in linear extrapolation.
 +                            threshold += weight * ContinueSampleDisplacedYThreshold(distortedPosYBase, distortedPosYSlide, terrainYThresholds[i]);
 +                        }
-+
+
+-                        // If it ever comes up to change the noise formula to one that's less trivial to layer-skip-optimize,
+-                        // Replace the above-two lines with the one below.
+-                        //noiseSign = columnNoise.Noise(posY) - threshold;
 +                        // Geo Upheaval modifier for threshold
 +                        ComputeGeoUpheavalTaper(posY, distY, taperThreshold, geoUpheavalAmplitude, mapsizeY, ref threshold);
 +                        // Create that directional compression effect.
@@ -597,23 +653,23 @@ index 5f759f1..b5956e7 100644
 +                            noise *= GameMath.Clamp(2 * (1 - wtaper.Weight), 0, 1) * 0.1;
 +                            threshold = GameMath.Lerp(threshold, th + noise, wtaper.Weight);
 +                        }
- 
+
 -                        if (noiseSign > 0)  // solid
 +                        // Often we don't need to calculate the noise.
 +                        if (threshold <= noiseBoundMin)
++                        {
++                            columnBlockSolidities[posY] = true; // Yes terrain block
++                            data.LocalLayerFullyEmpty[posY] = false; // Without False Sharing
++                        }
++                        else if (!(threshold < noiseBoundMax))  // Second case also catches NaN if it were to ever happen.
                          {
 -                            columnBlockSolidities[posY] = true;    // Yes terrain block
 -                            layerFullyEmpty[posY] = false;          //   (thread safe even when this is parallel)
-+                            columnBlockSolidities[posY] = true; // Yes terrain block
-+                            data.LocalLayerFullyEmpty[posY] = false; // Without False Sharing
-                         }
-+                        else if (!(threshold < noiseBoundMax))  // Second case also catches NaN if it were to ever happen.
-+                        {
 +                            data.LocalLayerFullySolid[posY] = false; // No terrain block. Without False Sharing
 +                            //We can now exit the loop early, because empirical testing shows that once the threshold has exceeded the max noise bound, it never returns to a negative noise value at any higher y value in the same blocks column.  This represents air well above the "interesting" part of the terrain.  Tested for all world heights in the range 256-1536, tested with arches, overhangs etc.
 +                            for (int yAbove = posY + 1; yAbove <= mapsizeYm2; yAbove++) data.LocalLayerFullySolid[yAbove] = false;
 +                            break;
-+                        }
+                         }
 +                        // But sometimes we do.
                          else
                          {
@@ -651,37 +707,53 @@ index 5f759f1..b5956e7 100644
 +            );
 +
 +            // Stratum end
- 
+
              IChunkBlocks chunkBlockData = chunks[0].Data;
- 
+
              // First set all the fully solid layers in bulk, as much as possible
              chunkBlockData.SetBlockBulk(0, chunksize, chunksize, gcfg.mantleBlockId);
-@@ -566,20 +711,21 @@ namespace Vintagestory.ServerMods
+             int yBase = 1;
+             for (; yBase < mapsizeY - 1; yBase++)
+@@ -564,22 +755,36 @@ namespace Vintagestory.ServerMods
+
+             chunks[0].MapChunk.YMax = ymax;
          }
- 
- 
+
+
          LerpedWeightedIndex2DMap GetOrLoadLerpedLandformMap(IMapChunk mapchunk, int regionX, int regionZ)
          {
-+            int index2d = regionZ * regionMapSize + regionX;
-+
-             // 1. Load?
+-            // 1. Load?
 -            LandformMapByRegion.TryGetValue(regionZ * regionMapSize + regionX, out LerpedWeightedIndex2DMap map);
 -            if (map != null) return map;
-+            if (LandformMapByRegion.TryGetValue(index2d, out LerpedWeightedIndex2DMap map)) return map;
- 
--            IntDataMap2D lmap = mapchunk.MapRegion.LandformMap;
-             // 2. Create
++            int index2d = regionZ * regionMapSize + regionX;
++
++            // Stratum: the concurrent owner is the lock-free hot path for parallel Terrain columns.
++            if (stratumLandformMapsByRegion.TryGetValue(index2d, out LerpedWeightedIndex2DMap map)) return map;
++
++            // Stratum: honor maps a mod placed into the exact vanilla field before generation.
++            lock (LandformMapByRegion)
++            {
++                if (LandformMapByRegion.TryGetValue(index2d, out map))
++                {
++                    stratumLandformMapsByRegion.TryAdd(index2d, map);
++                    return map;
++                }
++            }
+
+             IntDataMap2D lmap = mapchunk.MapRegion.LandformMap;
+-            // 2. Create
 -            map = LandformMapByRegion[regionZ * regionMapSize + regionX]
 -                = new LerpedWeightedIndex2DMap(lmap.Data, lmap.Size, TerraGenConfig.landFormSmoothingRadius, lmap.TopLeftPadding, lmap.BottomRightPadding);
--
--            return map;
-+            // Stratum: GetOrAdd instead of a plain indexer write, so two threads racing
-+            // on the same not-yet-cached region under Terrain concurrency settle on one
-+            // shared instance instead of one silently overwriting the other's.
-+            IntDataMap2D lmap = mapchunk.MapRegion.LandformMap;
-+            return LandformMapByRegion.GetOrAdd(index2d, _ => new LerpedWeightedIndex2DMap(lmap.Data, lmap.Size, TerraGenConfig.landFormSmoothingRadius, lmap.TopLeftPadding, lmap.BottomRightPadding));
++            map = stratumLandformMapsByRegion.GetOrAdd(index2d, _ => new LerpedWeightedIndex2DMap(lmap.Data, lmap.Size, TerraGenConfig.landFormSmoothingRadius, lmap.TopLeftPadding, lmap.BottomRightPadding));
++
++            lock (LandformMapByRegion)
++            {
++                LandformMapByRegion[index2d] = map;
++            }
+
+             return map;
          }
- 
- 
+
+
          private void GetInterpolatedOctaves(float[] indices, out double[] amps, out double[] thresholds)
          {

--- a/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/1.GenTerra/GenTerraPostProcess.cs.patch
+++ b/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/1.GenTerra/GenTerraPostProcess.cs.patch
@@ -1,66 +1,98 @@
 diff --git a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/1.GenTerra/GenTerraPostProcess.cs b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/1.GenTerra/GenTerraPostProcess.cs
-index 79c481d..c7a1523 100644
+index 79c481d..02503c7 100644
 --- a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/1.GenTerra/GenTerraPostProcess.cs
 +++ b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/1.GenTerra/GenTerraPostProcess.cs
-@@ -13,12 +13,25 @@ namespace Vintagestory.ServerMods
-     public class GenTerraPostProcess : ModStdWorldGen
+@@ -14,14 +14,45 @@ namespace Vintagestory.ServerMods
      {
          ICoreServerAPI api;
          IWorldGenBlockAccessor blockAccessor;
- 
--        HashSet<int> chunkVisitedNodes = new HashSet<int>();
--        List<int> solidNodes = new List<int>(40);
-+        // Stratum: every field below used to be a plain instance field, written
-+        // and read within the processing of a single column (OnChunkColumnGen ->
-+        // deletePotentialFloatingBlocks -> AddToChunkVisitedNodesIfSameChunk),
-+        // unsafe once TerrainFeatures' same-stage cap moved off 1, which it since has
-+        // (see ServerSystemSupplyChunks.stratumStageMaxConcurrent). Matches the
-+        // InvalidOperationException: Collection was modified crash reported
-+        // against this class: two columns concurrently mutating the same shared
-+        // HashSet/List. [ThreadStatic] since GenTerraPostProcess is a singleton
-+        // ModSystem with no second live instance anywhere in the codebase
-+        // (confirmed by search).
+
+         HashSet<int> chunkVisitedNodes = new HashSet<int>();
+         List<int> solidNodes = new List<int>(40);
+
++        // Stratum: isolate scratch collections while the stock handler processes columns concurrently.
 +        [ThreadStatic] private static HashSet<int> stratumChunkVisitedNodes;
 +        [ThreadStatic] private static List<int> stratumSolidNodes;
 +        [ThreadStatic] private static QueueOfInt stratumBfsQueue;
 +        [ThreadStatic] private static int[] stratumCurrentVisited;
 +        [ThreadStatic] private static int stratumIteration;
- 
++        [ThreadStatic] private static GenTerraPostProcess stratumStateOwner;
++        [ThreadStatic] private static GenTerraPostProcess stratumActiveOwner;
++        [ThreadStatic] private static int stratumActiveDepth;
++
++        // Stratum: clear active TLS state on every handler exit without allocating on the hot path.
++        private readonly struct StratumPostProcessCallScope : IDisposable
++        {
++            private readonly GenTerraPostProcess previousOwner;
++            private readonly int previousDepth;
++
++            public StratumPostProcessCallScope(GenTerraPostProcess owner)
++            {
++                previousOwner = stratumActiveOwner;
++                previousDepth = stratumActiveDepth;
++                stratumActiveOwner = owner;
++                stratumActiveDepth = previousDepth + 1;
++            }
++
++            public void Dispose()
++            {
++                stratumActiveOwner = previousOwner;
++                stratumActiveDepth = previousDepth;
++            }
++        }
++
          public override bool ShouldLoad(EnumAppSide side)
          {
              return side == EnumAppSide.Server;
          }
-@@ -56,10 +69,11 @@ namespace Vintagestory.ServerMods
+
+
+         public override double ExecuteOrder()
+@@ -54,14 +85,27 @@ namespace Vintagestory.ServerMods
+             blockAccessor.BeginColumn();
+             int seaLevel = TerraGenConfig.seaLevel - 1;
              const int chunksize = GlobalConstants.ChunkSize;
              const int chunksizeSquared = chunksize * chunksize;
              int chunkY = seaLevel / chunksize;
              int yMax = chunks[0].MapChunk.YMax;
              int cyMax = Math.Min(yMax / chunksize + 1, api.World.BlockAccessor.MapSizeY / chunksize);
-+            HashSet<int> chunkVisitedNodes = stratumChunkVisitedNodes ??= new HashSet<int>();
++            if (stratumStateOwner != this)
++            {
++                stratumStateOwner = this;
++                stratumChunkVisitedNodes = new HashSet<int>();
++                stratumSolidNodes = new List<int>(40);
++                stratumBfsQueue = new QueueOfInt();
++                stratumCurrentVisited = new int[ARRAYSIZE * ARRAYSIZE * ARRAYSIZE];
++                stratumIteration = 0;
++            }
++
++            using StratumPostProcessCallScope stratumCallScope = new StratumPostProcessCallScope(this);
++            HashSet<int> chunkVisitedNodes = stratumChunkVisitedNodes;
++            this.chunkVisitedNodes = chunkVisitedNodes; // Stratum: publish the active set through the vanilla field.
              chunkVisitedNodes.Clear();
- 
+
              for (int cy = chunkY; cy < cyMax; cy++)
              {
                  IChunkBlocks chunkdata = chunks[cy].Data;
-@@ -106,28 +120,29 @@ namespace Vintagestory.ServerMods
-             }
-         }
- 
- 
- 
--        QueueOfInt bfsQueue = new QueueOfInt();
-         const int ARRAYSIZE = 41;  // Note if this constant is increased beyond 64, the bitshifts for compressedPos in the bfsQueue.Enqueue() and .Dequeue() calls may need updating
--        readonly int[] currentVisited = new int[ARRAYSIZE * ARRAYSIZE * ARRAYSIZE];
--        int iteration = 0;
- 
+
+                 int yStart = cy == 0 ? 1 : 0;  // Prevents attempts to get a blockbelow with y == -1 - impossible unless seaLeavel is set to 0
+@@ -114,22 +158,33 @@ namespace Vintagestory.ServerMods
+         int iteration = 0;
+
          /// <summary>
          /// Very similar to RoomRegistry room search code: we will search for contiguous islands of blocks, surrounded by air on all sides
          /// </summary>
          private void deletePotentialFloatingBlocks(int X, int Y, int Z)
          {
-+            List<int> solidNodes = stratumSolidNodes ??= new List<int>(40);
-+            QueueOfInt bfsQueue = stratumBfsQueue ??= new QueueOfInt();
-+            int[] currentVisited = stratumCurrentVisited ??= new int[ARRAYSIZE * ARRAYSIZE * ARRAYSIZE];
++            bool useStratumState = stratumActiveOwner == this && stratumActiveDepth > 0 && stratumStateOwner == this;
++            List<int> solidNodes = useStratumState ? stratumSolidNodes : this.solidNodes;
++            QueueOfInt bfsQueue = useStratumState ? stratumBfsQueue : this.bfsQueue;
++            int[] currentVisited = useStratumState ? stratumCurrentVisited : this.currentVisited;
++            if (useStratumState)
++            {
++                this.solidNodes = solidNodes;
++                this.bfsQueue = bfsQueue;
++            }
 +
              int halfSize = (ARRAYSIZE - 1) / 2;
              solidNodes.Clear();
@@ -68,24 +100,38 @@ index 79c481d..c7a1523 100644
              int compressedPos = halfSize << 12 | halfSize << 6 | halfSize;
              bfsQueue.Enqueue(compressedPos);
              solidNodes.Add(compressedPos);
- 
+
 -            int iteration = ++this.iteration;
-+            int iteration = ++stratumIteration;
++            int iteration = useStratumState ? ++stratumIteration : ++this.iteration;
++            if (useStratumState) this.iteration = iteration; // Stratum: publish the current counter through the vanilla field.
              int visitedIndex = (halfSize * ARRAYSIZE + halfSize) * ARRAYSIZE + halfSize; // Center node
              currentVisited[visitedIndex] = iteration;
- 
+
              int baseX = X - halfSize;
              int baseY = Y - halfSize;
-@@ -225,11 +240,11 @@ namespace Vintagestory.ServerMods
+             int baseZ = Z - halfSize;
+             BlockPos npos = new BlockPos(Dimensions.NormalWorld);
+@@ -223,15 +278,22 @@ namespace Vintagestory.ServerMods
+             const int chunkMask = ~(chunksize - 1);
+             if (((nposX ^ origX) & chunkMask) != 0) return;
              if (((nposZ ^ origZ) & chunkMask) != 0) return;
              if (((nposY ^ origY) & chunkMask) != 0) return;
- 
+
              const int inChunkMask = chunksize - 1;
              int index3d = ((nposY & inChunkMask) * chunksize + (nposZ & inChunkMask)) * chunksize + (nposX & inChunkMask);
 -            chunkVisitedNodes.Add(index3d);
-+            stratumChunkVisitedNodes.Add(index3d);
++            if (stratumActiveOwner == this && stratumActiveDepth > 0 && stratumStateOwner == this)
++            {
++                stratumChunkVisitedNodes.Add(index3d);
++            }
++            else
++            {
++                chunkVisitedNodes.Add(index3d);
++            }
          }
- 
+
          //struct VisitNode : IEquatable<VisitNode>
          //{
          //    public int X, Y, Z;
+
+         //    public VisitNode(int x, int y, int z)

--- a/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/2.GenRockStrata/GenRockStrata.cs.patch
+++ b/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/2.GenRockStrata/GenRockStrata.cs.patch
@@ -1,249 +1,165 @@
 diff --git a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/2.GenRockStrata/GenRockStrata.cs b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/2.GenRockStrata/GenRockStrata.cs
-index cb9eefa..cb95600 100644
+index cb9eefa..3a5476e 100644
 --- a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/2.GenRockStrata/GenRockStrata.cs
 +++ b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/2.GenRockStrata/GenRockStrata.cs
-@@ -1,7 +1,9 @@
+@@ -1,8 +1,9 @@
  using System;
 +using System.Collections.Concurrent;
  using System.Collections.Generic;
-+using System.Threading;
  using Vintagestory.API.Common;
  using Vintagestory.API.Datastructures;
  using Vintagestory.API.MathTools;
  using Vintagestory.API.Server;
  using Vintagestory.ServerMods.NoObf;
-@@ -24,11 +26,14 @@ namespace Vintagestory.ServerMods
+
+@@ -24,14 +25,20 @@ namespace Vintagestory.ServerMods
          internal SimplexNoise distort2dx;
          internal SimplexNoise distort2dz;
          internal MapLayerCustomPerlin[] strataNoises;
- 
+
          int regionMapSize;
--        Dictionary<int, LerpedWeightedIndex2DMap> ProvinceMapByRegion = new Dictionary<int, LerpedWeightedIndex2DMap>(10);
-+        // Stratum: ConcurrentDictionary since TerrainLate can now run concurrently for
-+        // distant columns (see StratumWorldGenStages), and two columns from different,
-+        // not-yet-cached regions could otherwise race on the same bucket at once.
-+        ConcurrentDictionary<int, LerpedWeightedIndex2DMap> ProvinceMapByRegion = new ConcurrentDictionary<int, LerpedWeightedIndex2DMap>();
- 
+         Dictionary<int, LerpedWeightedIndex2DMap> ProvinceMapByRegion = new Dictionary<int, LerpedWeightedIndex2DMap>(10);
+
++        // Stratum: each worldgen thread gets a complete generator so vanilla fields stay intact.
++        StratumWorkerInstances<GenRockStrataNew> stratumWorkers;
++
++        // Stratum: workers keep vanilla dictionaries while sharing the expensive cached maps.
++        ConcurrentDictionary<int, LerpedWeightedIndex2DMap> stratumProvinceMapsByRegion = new ConcurrentDictionary<int, LerpedWeightedIndex2DMap>();
++
          public override bool ShouldLoad(EnumAppSide side)
          {
              return side == EnumAppSide.Server;
          }
-@@ -46,11 +51,11 @@ namespace Vintagestory.ServerMods
+
+         public override double ExecuteOrder()
+         {
+@@ -42,17 +49,18 @@ namespace Vintagestory.ServerMods
+         {
+             this.api = api;
+         }
+
          public override void StartServerSide(ICoreServerAPI api)
          {
              this.api = api;
- 
++            stratumWorkers = new StratumWorkerInstances<GenRockStrataNew>(StratumCreateWorker); // Stratum: isolate mutable fields without changing their shape
+
              api.Event.InitWorldGenerator(initWorldGen, "standard");
 -            api.Event.ChunkColumnGeneration(GenChunkColumn, EnumWorldGenPass.Terrain, "standard");
-+            StratumTerrainSplit.Register(api, GenChunkColumn, "standard"); // Stratum: late half of the split Terrain pass
- 
++            StratumTerrainSplit.Register(api, GenChunkColumn, StratumGenChunkColumn, "standard"); // Stratum: expose vanilla topology until the worker path is safe
+
              api.Event.MapRegionGeneration(OnMapRegionGen, "standard");
          }
- 
- 
-@@ -134,24 +139,54 @@ namespace Vintagestory.ServerMods
-         }
- 
- 
-         // Cheap ugly code for better performance :<
-         #region
-+        // Stratum start: TerrainLate can now run concurrently for distant columns
-+        // (see StratumWorldGenStages). preLoad/genBlockColumn always run back-to-back
-+        // on the same worker thread for a given column (no internal Parallel.For
-+        // here, unlike GenTerra), so per-thread scratch is sufficient. ThreadLocal
-+        // instead of [ThreadStatic] because this class has a second instance used by
-+        // ProPickWorkSpace for prospecting-pick probing (see that file), and a
-+        // [ThreadStatic] static field would be shared between both instances on
-+        // whatever thread happens to run them, not scoped to this instance.
-+        class ThreadLocalScratch
-+        {
-+            public float[] rockGroupMaxThickness = new float[4];
-+            public int[] rockGroupCurrentThickness = new int[4];
-+            public float[] indicesBuf; // resized lazily once province count is known
-+
-+            public IMapChunk mapChunk;
-+            public ushort[] heightMap;
-+            public int rdx;
-+            public int rdz;
-+
-+            public LerpedWeightedIndex2DMap map;
-+            public float lerpMapInv;
-+            public float chunkInRegionX;
-+            public float chunkInRegionZ;
-+
-+            public GeologicProvinces provinces;
-+        }
-+        readonly ThreadLocal<ThreadLocalScratch> scratchThreadLocal = new ThreadLocal<ThreadLocalScratch>(() => new ThreadLocalScratch());
-+
-+        // Stratum start: compatibility shims for third-party Harmony patches that
-+        // inject or reflect on these fields (e.g. Rock Strata Variety). Values are
-+        // written from the per-thread scratch at method entry, valid only within
-+        // that call's scope on the current thread. Fixes #201.
-         float[] rockGroupMaxThickness = new float[4];
-         int[] rockGroupCurrentThickness = new int[4];
--
-         IMapChunk mapChunk;
-         ushort[] heightMap;
-         int rdx;
-         int rdz;
--
+
+
+         public void initWorldGen()
+         {
+@@ -146,16 +154,59 @@ namespace Vintagestory.ServerMods
+
          LerpedWeightedIndex2DMap map;
          float lerpMapInv;
          float chunkInRegionX;
          float chunkInRegionZ;
--
--        GeologicProvinces provinces = NoiseGeoProvince.provinces;
-+        GeologicProvinces provinces;
-+        // Stratum end
+
+         GeologicProvinces provinces = NoiseGeoProvince.provinces;
++
++        // Stratum: reuse province weights to avoid one allocation per block column.
++        float[] stratumIndicesBuf;
          #endregion
- 
+
++        private void StratumGenChunkColumn(IChunkColumnGenerateRequest request)
++        {
++            stratumWorkers.Current.GenChunkColumn(request);
++        }
++
++        private GenRockStrataNew StratumCreateWorker()
++        {
++            GenRockStrataNew worker = new GenRockStrataNew();
++            worker.StratumCopyStateFrom(this);
++            return worker;
++        }
++
++        // Stratum: copy configured state and give mutable fields to one worldgen thread.
++        private void StratumCopyStateFrom(GenRockStrataNew source)
++        {
++            api = source.api;
++            LoadGlobalConfig(api);
++            regionSize = source.regionSize;
++            regionChunkSize = source.regionChunkSize;
++            rockBlockId = source.rockBlockId;
++            strata = source.strata;
++            distort2dx = source.distort2dx;
++            distort2dz = source.distort2dz;
++            strataNoises = source.strataNoises;
++            regionMapSize = source.regionMapSize;
++            ProvinceMapByRegion = new Dictionary<int, LerpedWeightedIndex2DMap>(source.ProvinceMapByRegion);
++            stratumProvinceMapsByRegion = source.stratumProvinceMapsByRegion;
++            rockGroupMaxThickness = (float[])source.rockGroupMaxThickness.Clone();
++            rockGroupCurrentThickness = (int[])source.rockGroupCurrentThickness.Clone();
++            mapChunk = source.mapChunk;
++            heightMap = source.heightMap;
++            rdx = source.rdx;
++            rdz = source.rdz;
++            map = source.map;
++            lerpMapInv = source.lerpMapInv;
++            chunkInRegionX = source.chunkInRegionX;
++            chunkInRegionZ = source.chunkInRegionZ;
++            provinces = source.provinces;
++        }
++
          internal void GenChunkColumn(IChunkColumnGenerateRequest request)
          {
              var chunks = request.Chunks;
-@@ -169,42 +204,71 @@ namespace Vintagestory.ServerMods
-             }
-         }
- 
-         public void preLoad(IServerChunk[] chunks, int chunkX, int chunkZ)
-         {
--            mapChunk = chunks[0].MapChunk;
--            heightMap = mapChunk.WorldGenTerrainHeightMap;
--            rdx = chunkX % regionChunkSize;
--            rdz = chunkZ % regionChunkSize;
--
--            map = GetOrLoadLerpedProvinceMap(chunks[0].MapChunk, chunkX, chunkZ);
--            lerpMapInv = 1f / TerraGenConfig.geoProvMapScale;
--            chunkInRegionX = (chunkX % regionChunkSize) * lerpMapInv * chunksize;
--            chunkInRegionZ = (chunkZ % regionChunkSize) * lerpMapInv * chunksize;
--
--            provinces = NoiseGeoProvince.provinces;
-+            var s = scratchThreadLocal.Value; // Stratum: per-thread scratch, see the field declaration
-+            s.mapChunk = chunks[0].MapChunk;
-+            s.heightMap = s.mapChunk.WorldGenTerrainHeightMap;
-+            s.rdx = chunkX % regionChunkSize;
-+            s.rdz = chunkZ % regionChunkSize;
-+
-+            s.map = GetOrLoadLerpedProvinceMap(chunks[0].MapChunk, chunkX, chunkZ);
-+            s.lerpMapInv = 1f / TerraGenConfig.geoProvMapScale;
-+            s.chunkInRegionX = (chunkX % regionChunkSize) * s.lerpMapInv * chunksize;
-+            s.chunkInRegionZ = (chunkZ % regionChunkSize) * s.lerpMapInv * chunksize;
-+
-+            s.provinces = NoiseGeoProvince.provinces;
-+
-+            // Stratum: populate compat shim fields for third-party Harmony patches (#201)
-+            mapChunk = s.mapChunk;
-+            heightMap = s.heightMap;
-+            rdx = s.rdx;
-+            rdz = s.rdz;
-+            map = s.map;
-+            lerpMapInv = s.lerpMapInv;
-+            chunkInRegionX = s.chunkInRegionX;
-+            chunkInRegionZ = s.chunkInRegionZ;
-+            provinces = s.provinces;
-         }
- 
-         public void genBlockColumn(IServerChunk[] chunks, int chunkX, int chunkZ, int lx, int lz)
-         {
--            int surfaceY = heightMap[lz * chunksize + lx];
-+            var s = scratchThreadLocal.Value; // Stratum: per-thread scratch, see the field declaration
-+            int surfaceY = s.heightMap[lz * chunksize + lx];
+             int chunkX = request.ChunkX;
+             int chunkZ = request.ChunkZ;
+
+             preLoad(chunks, chunkX, chunkZ);
+@@ -190,23 +241,29 @@ namespace Vintagestory.ServerMods
              int ylower = 1;
              int yupper = surfaceY;
              int rockBlockId = this.rockBlockId;
- 
-+            float[] rockGroupMaxThickness = s.rockGroupMaxThickness;
-+            int[] rockGroupCurrentThickness = s.rockGroupCurrentThickness;
+
              rockGroupMaxThickness[0] = rockGroupMaxThickness[1] = rockGroupMaxThickness[2] = rockGroupMaxThickness[3] = 0;
              rockGroupCurrentThickness[0] = rockGroupCurrentThickness[1] = rockGroupCurrentThickness[2] = rockGroupCurrentThickness[3] = 0;
- 
+
 -            float[] indices = new float[provinces.Variants.Length];
--            map.WeightsAt(
--                chunkInRegionX + lx * lerpMapInv,
--                chunkInRegionZ + lz * lerpMapInv,
++            // Stratum: keep the measured allocation reduction while each worker owns its buffer.
++            if (stratumIndicesBuf == null || stratumIndicesBuf.Length != provinces.Variants.Length)
++            {
++                stratumIndicesBuf = new float[provinces.Variants.Length];
++            }
++
+             map.WeightsAt(
+                 chunkInRegionX + lx * lerpMapInv,
+                 chunkInRegionZ + lz * lerpMapInv,
 -                indices
-+            // Stratum start:
-+            // use a buffer to reduce allocations
-+            // Just in case, check the dimensions
-+            //
-+            // Tested on the generation of 10200 chunk columns:
-+            // - method execution time: reduced from 16152 ms to 14678 ms;
-+            // - GC memory allocations: reduced from 646 MB to 90 MB.
-+
-+            GeologicProvinces provinces = s.provinces;
-+            if (s.indicesBuf == null || s.indicesBuf.Length != provinces.Variants.Length)
-+                s.indicesBuf = new float[provinces.Variants.Length];
-+            float[] indicesBuf = s.indicesBuf;
-+
-+            s.map.WeightsAt(
-+                s.chunkInRegionX + lx * s.lerpMapInv,
-+                s.chunkInRegionZ + lz * s.lerpMapInv,
-+                indicesBuf
++                stratumIndicesBuf
              );
 -            for (int i = 0; i < indices.Length; i++)
 +
-+            for (int i = 0; i < indicesBuf.Length; i++)
++            for (int i = 0; i < stratumIndicesBuf.Length; i++)
              {
 -                float w = indices[i];
-+                float w = indicesBuf[i];
-+                // Stratum end
++                float w = stratumIndicesBuf[i];
                  if (w == 0) continue;
- 
+
                  GeologicProvinceRockStrata[] localstrata = provinces.Variants[i].RockStrataIndexed;
- 
+
                  rockGroupMaxThickness[0] += localstrata[0].ScaledMaxThickness * w;
-@@ -227,24 +291,24 @@ namespace Vintagestory.ServerMods
-             while (ylower <= yupper)
-             {
-                 if (--strataThickness <= 0f)
-                 {
-                     rockStrataId++;
--                    if (rockStrataId >= strata.Variants.Length || rockStrataId >= mapChunk.MapRegion.RockStrata.Length)
-+                    if (rockStrataId >= strata.Variants.Length || rockStrataId >= s.mapChunk.MapRegion.RockStrata.Length)
-                     {
-                         break;
-                     }
-                     stratum = strata.Variants[rockStrataId];
--                    rockMap = mapChunk.MapRegion.RockStrata[rockStrataId];
-+                    rockMap = s.mapChunk.MapRegion.RockStrata[rockStrataId];
-                     step = (float)rockMap.InnerSize / regionChunkSize;
- 
-                     grp = (int)stratum.RockGroup;
- 
-                     float allowedThickness = rockGroupMaxThickness[grp] * thicknessDistort - rockGroupCurrentThickness[grp];
- 
--                    var nx = rdx * step + step * (float)(lx + distx) / chunksize;
--                    var nz = rdz * step + step * (float)(lz + distz) / chunksize;
-+                    var nx = s.rdx * step + step * (float)(lx + distx) / chunksize;
-+                    var nz = s.rdz * step + step * (float)(lz + distz) / chunksize;
- 
-                     // 1.20 fix, only clamp the values, to prevent chunk borders
-                     // In 1.21 we ought to simply use normalized noise * rockmapsize
-                     nx = Math.Max(nx, -1.499f);
-                     nz = Math.Max(nz, -1.499f);
-@@ -312,21 +376,23 @@ namespace Vintagestory.ServerMods
- 
-         LerpedWeightedIndex2DMap GetOrLoadLerpedProvinceMap(IMapChunk mapchunk, int chunkX, int chunkZ)
-         {
-             int index2d = chunkZ / regionChunkSize * regionMapSize + chunkX / regionChunkSize;
- 
--            ProvinceMapByRegion.TryGetValue(index2d, out LerpedWeightedIndex2DMap map);
--            if (map != null) return map;
-+            if (ProvinceMapByRegion.TryGetValue(index2d, out LerpedWeightedIndex2DMap map)) return map;
- 
+                 rockGroupMaxThickness[1] += localstrata[1].ScaledMaxThickness * w;
+                 rockGroupMaxThickness[2] += localstrata[2].ScaledMaxThickness * w;
+@@ -320,13 +377,14 @@ namespace Vintagestory.ServerMods
              return CreateLerpedProvinceMap(mapchunk.MapRegion.GeologicProvinceMap, chunkX / regionChunkSize, chunkZ / regionChunkSize);
          }
- 
+
          LerpedWeightedIndex2DMap CreateLerpedProvinceMap(IntDataMap2D geoMap, int regionX, int regionZ)
          {
              int index2d = regionZ * regionMapSize + regionX;
- 
+
 -            return ProvinceMapByRegion[index2d] = new LerpedWeightedIndex2DMap(geoMap.Data, geoMap.Size, TerraGenConfig.geoProvSmoothingRadius, geoMap.TopLeftPadding, geoMap.BottomRightPadding);
-+            // Stratum: GetOrAdd instead of a plain indexer write, so two threads racing
-+            // on the same not-yet-cached region under TerrainLate concurrency settle on
-+            // one shared instance instead of one silently overwriting the other's.
-+            return ProvinceMapByRegion.GetOrAdd(index2d, _ => new LerpedWeightedIndex2DMap(geoMap.Data, geoMap.Size, TerraGenConfig.geoProvSmoothingRadius, geoMap.TopLeftPadding, geoMap.BottomRightPadding));
++            // Stratum: keep one expensive map across workers while preserving their vanilla cache field.
++            return ProvinceMapByRegion[index2d] = stratumProvinceMapsByRegion.GetOrAdd(index2d, _ => new LerpedWeightedIndex2DMap(geoMap.Data, geoMap.Size, TerraGenConfig.geoProvSmoothingRadius, geoMap.TopLeftPadding, geoMap.BottomRightPadding));
          }
- 
- 
+
+
      }
  }

--- a/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves.cs.patch
+++ b/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves.cs.patch
@@ -1,38 +1,22 @@
 diff --git a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves.cs b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves.cs
-index 30f034d..6c87d18 100644
 --- a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves.cs
 +++ b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves.cs
-@@ -1,7 +1,8 @@
- using System;
- using System.Collections.Generic;
-+using System.Threading;
- using Vintagestory.API.Common;
- using Vintagestory.API.MathTools;
- using Vintagestory.API.Server;
- 
- #nullable disable
-@@ -12,11 +13,17 @@ namespace Vintagestory.ServerMods
-     {
-         protected override int chunkRange { get { return 5; } }
+@@ -14,9 +14,14 @@
  
          public override double ExecuteOrder() { return 0.3; }
  
--        internal LCGRandom caveRand;
-+        // Stratum: ThreadLocal, not a plain field. GeneratePartial reseeds caveRand per
-+        // (chunkX+cdx, chunkZ+cdz) then hands it into CarveTunnel/CarveShaft's recursive
-+        // NextInt() sequence; if TerrainLate ever runs two columns at once, a shared
-+        // field lets one thread's reseed land mid-sequence of another thread's carve,
-+        // splicing two columns' cave shapes together.
-+        ThreadLocal<LCGRandom> caveRandThreadLocal;
-+        internal LCGRandom caveRand => caveRandThreadLocal.Value;
++        // Stratum: plain field, vanilla shape, because mods look it up by name.
++        // Each worldgen thread gets its own GenCaves, so two columns never share it.
+         internal LCGRandom caveRand;
          IWorldGenBlockAccessor worldgenBlockAccessor;
  
++        // Stratum: one GenCaves per worldgen thread, made on first use.
++        StratumWorkerInstances<GenCaves> stratumWorkers;
++
          NormalizedSimplexNoise basaltNoise;
          NormalizedSimplexNoise heightvarNoise;
          int regionsize;
-@@ -30,27 +37,28 @@ namespace Vintagestory.ServerMods
-                 api.Event.GetWorldgenBlockAccessor(OnWorldGenBlockAccessor);
- 
+@@ -32,14 +37,14 @@
                  api.ChatCommands.GetOrCreate("dev")
                      .BeginSubCommand("gencaves")
                      .WithDescription(
@@ -45,32 +29,52 @@ index 30f034d..6c87d18 100644
                  api.Event.MapChunkGeneration(OnMapChunkGen, "standard");
                  api.Event.MapChunkGeneration(OnMapChunkGen, "superflat");
 -                api.Event.ChunkColumnGeneration(GenChunkColumn, EnumWorldGenPass.Terrain, "standard");
-+                StratumTerrainSplit.Register(api, GenChunkColumn, "standard"); // Stratum: late half of the split Terrain pass
++                StratumTerrainSplit.Register(api, StratumGenChunkColumnOnWorker, "standard"); // Stratum: late half of the split Terrain pass, run on this thread's worker
                  api.Event.InitWorldGenerator(initWorldGen, "superflat");
              }
          }
- 
- 
-         public override void initWorldGen()
-         {
-             base.initWorldGen();
--            caveRand = new LCGRandom(api.WorldManager.Seed + 123128);
-+            int caveSeed = api.WorldManager.Seed + 123128;
-+            caveRandThreadLocal = new ThreadLocal<LCGRandom>(() => new LCGRandom(caveSeed));
-             basaltNoise = NormalizedSimplexNoise.FromDefaultOctaves(2, 1f / 3.5f, 0.9f, api.World.Seed + 12);
+@@ -53,6 +58,34 @@
              heightvarNoise = NormalizedSimplexNoise.FromDefaultOctaves(3, 1f / 20f, 0.9f, api.World.Seed + 12);
  
              regionsize = api.World.BlockAccessor.RegionSize;
++            stratumWorkers = new StratumWorkerInstances<GenCaves>(StratumCreateWorker); // Stratum
++        }
++
++        // Stratum: the registered handler. Runs on this thread's copy, never the shared one.
++        private void StratumGenChunkColumnOnWorker(IChunkColumnGenerateRequest request)
++        {
++            stratumWorkers.Current.GenChunkColumn(request);
++        }
++
++        private GenCaves StratumCreateWorker()
++        {
++            GenCaves worker = new GenCaves();
++            worker.StratumCopyStateFrom(this);
++            return worker;
++        }
++
++        // Stratum: the noise fields and the block accessor are set once and never written again, so workers share them.
++        // caveRand is per-column scratch, so each worker gets its own on the same seed.
++        protected override void StratumCopyStateFrom(GenPartial source)
++        {
++            base.StratumCopyStateFrom(source);
++
++            GenCaves origin = (GenCaves)source;
++            worldgenBlockAccessor = origin.worldgenBlockAccessor;
++            basaltNoise = origin.basaltNoise;
++            heightvarNoise = origin.heightvarNoise;
++            regionsize = origin.regionsize;
++            caveRand = new LCGRandom(api.WorldManager.Seed + 123128);
          }
-@@ -74,19 +82,25 @@ namespace Vintagestory.ServerMods
-             }
-         }
+ 
+ 
+@@ -76,15 +109,21 @@
  
          private TextCommandResult CmdCaveGenTest(TextCommandCallingArgs args)
          {
 -            caveRand = new LCGRandom(api.WorldManager.Seed + 123128);
 -            initWorldGen();
-+            initWorldGen(); // Stratum: this already reseeds caveRandThreadLocal with the same formula, no need to do it twice
++            initWorldGen(); // Stratum: this already reseeds caveRand with the same formula, no need to do it twice
  
 +            // Stratum start:
 +            // Adding light recalculation for caves
@@ -90,11 +94,7 @@ index 30f034d..6c87d18 100644
              for (int dx = -5; dx <= 5; dx++)
              {
                  for (int dz = -5; dz <= 5; dz++)
-                 {
-                     int chunkX = baseChunkX + dx;
-@@ -96,19 +110,19 @@ namespace Vintagestory.ServerMods
- 
-                     for (int i = 0; i < chunks.Length; i++)
+@@ -98,7 +137,7 @@
                      {
                          if (chunks[i] == null)
                          {
@@ -103,7 +103,7 @@ index 30f034d..6c87d18 100644
                          }
                      }
  
-                     OnMapChunkGen(chunks[0].MapChunk, chunkX, chunkZ);
+@@ -106,7 +145,7 @@
                  }
              }
  
@@ -112,11 +112,7 @@ index 30f034d..6c87d18 100644
              for (int dx = -5; dx <= 5; dx++)
              {
                  for (int dz = -5; dz <= 5; dz++)
-                 {
-                     int chunkX = baseChunkX + dx;
-@@ -125,15 +139,24 @@ namespace Vintagestory.ServerMods
-                             chunkRand.InitPositionSeed(chunkX + gdx, chunkZ + gdz);
-                             GeneratePartial(chunks, chunkX, chunkZ, gdx, gdz);
+@@ -127,11 +166,20 @@
                          }
                      }
  
@@ -137,11 +133,7 @@ index 30f034d..6c87d18 100644
  
              return TextCommandResult.Success("Generated and chunks force resend flags set");
          }
- 
-         private IServerChunk[] GetChunkColumn(int chunkX, int chunkZ)
-@@ -506,160 +529,225 @@ namespace Vintagestory.ServerMods
- 
- 
+@@ -508,69 +556,41 @@
  
          private bool SetBlocks(IServerChunk[] chunks, float horRadius, float vertRadius, double centerX, double centerY, double centerZ, ushort[] terrainheightmap, ushort[] rainheightmap, int chunkX, int chunkZ, bool genHotSpring)
          {
@@ -162,11 +154,7 @@ index 30f034d..6c87d18 100644
 -            double hRadiusSq = horRadius * horRadius;
 -            double vRadiusSq = vertRadius * vertRadius;
 -            double distortStrength = GameMath.Clamp(vertRadius / 4.0, 0, 0.1);
-+            // Stratum start:
-+            // Fixing incorrect cave generation in the /dev gencaves command mode
-+            // We sped up the algorithm, filtered out blocks that weren't within the ellipsoid's dimensions,
-+            // and checked for liquid in the same cycle as everything else.
- 
+-
 -            for (int lx = mindx; lx <= maxdx; lx++)
 -            {
 -                xdistRel = (lx - centerX) * (lx - centerX) / hRadiusSq;
@@ -195,39 +183,47 @@ index 30f034d..6c87d18 100644
 -                    }
 -                }
 -            }
-+            // Testing on 10,200 generation chunks:
-+            // Total method execution time: decreased from 9.2 s to 6.3 s;
- 
-+            IMapChunk mapchunk = chunks[0].MapChunk;
- 
+-
+-
 -            horRadius--;
 -            vertRadius-=2;
-+            // Regular generation radius
-+            float genHorRadius = horRadius;
-+            float genVertRadius = vertRadius;
++            // Stratum start:
++            // Fixing incorrect cave generation in the /dev gencaves command mode
++            // We sped up the algorithm, filtered out blocks that weren't within the ellipsoid's dimensions,
++            // and checked for liquid in the same cycle as everything else.
  
 -            mindx = (int)GameMath.Clamp(centerX - horRadius, 0, chunksize - 1);
 -            maxdx = (int)GameMath.Clamp(centerX + horRadius + 1, 0, chunksize - 1);
 -            mindz = (int)GameMath.Clamp(centerZ - horRadius, 0, chunksize - 1);
 -            maxdz = (int)GameMath.Clamp(centerZ + horRadius + 1, 0, chunksize - 1);
-+            // Increased radius for fluid checks
-+            float checkHorRadius = horRadius + 1;
-+            float checkVertRadius = vertRadius + 2;
++            // Testing on 10,200 generation chunks:
++            // Total method execution time: decreased from 9.2 s to 6.3 s;
  
 -            mindy = (int)GameMath.Clamp(centerY - vertRadius * 0.7f, 1, worldheight - 1);
 -            maxdy = (int)GameMath.Clamp(centerY + vertRadius + 1, 1, worldheight - 1);
+-
+-            hRadiusSq = horRadius * horRadius;
+-            vRadiusSq = vertRadius * vertRadius;
++            IMapChunk mapchunk = chunks[0].MapChunk;
+ 
++            // Regular generation radius
++            float genHorRadius = horRadius;
++            float genVertRadius = vertRadius;
++
++            // Increased radius for fluid checks
++            float checkHorRadius = horRadius + 1;
++            float checkVertRadius = vertRadius + 2;
++
 +            // Compute common bounds for both radii
 +            int mindx = (int)GameMath.Clamp(centerX - checkHorRadius, 0, chunksize - 1);
 +            int maxdx = (int)GameMath.Clamp(centerX + checkHorRadius + 1, 0, chunksize - 1);
 +            int mindz = (int)GameMath.Clamp(centerZ - checkHorRadius, 0, chunksize - 1);
 +            int maxdz = (int)GameMath.Clamp(centerZ + checkHorRadius + 1, 0, chunksize - 1);
- 
--            hRadiusSq = horRadius * horRadius;
--            vRadiusSq = vertRadius * vertRadius;
++
 +            // For Y use the check radius because it is larger
 +            int mindy = (int)GameMath.Clamp(centerY - checkVertRadius * 0.7f, 1, worldheight - 1);
 +            int maxdy = (int)GameMath.Clamp(centerY + checkVertRadius + 1, 1, worldheight - 1);
- 
++
 +            // Precompute squared radii for fast comparisons
 +            double genHorRadiusSq = genHorRadius * genHorRadius;
 +            double genVertRadiusSq = genVertRadius * genVertRadius;
@@ -238,7 +234,7 @@ index 30f034d..6c87d18 100644
              int geoActivity = getGeologicActivity(chunkX * chunksize + (int)centerX, chunkZ * chunksize + (int)centerZ);
              genHotSpring &= geoActivity > 128;
  
-             if (genHotSpring && centerX >= 0 && centerX < 32 && centerZ >= 0 && centerZ < 32)
+@@ -578,86 +598,179 @@
              {
                  var data = mapchunk.GetModdata<Dictionary<Vec3i, HotSpringGenData>>("hotspringlocations");
                  if (data == null) data = new Dictionary<Vec3i, HotSpringGenData>();
@@ -276,73 +272,53 @@ index 30f034d..6c87d18 100644
 +                    double distortStrength = GameMath.Clamp(genVertRadius / 4.0, 0, 0.1);
 +                    double heightrnd = (mapchunk.CaveHeightDistort[idx2d] - 127) * distortStrength;
 +                    int surfaceY = terrainheightmap[idx2d];
- 
--                        ydistRel = yDist * yDist / (vRadiusSq + heightOffFac);
++
 +                    // Compute maximum XZ distance for the check radius
 +                    double checkXZDist = dxSq / checkHorRadiusSq + dzSq / checkHorRadiusSq;
 +                    if (checkXZDist > 1.0) continue;
- 
--                        if (y > worldheight - 1 || xdistRel + ydistRel + zdistRel > 1.0) continue;
++
 +                    // Compute Y range for the check radius
 +                    double maxCheckDist = 1.0 - checkXZDist;
 +                    double maxCheckYDist = Math.Sqrt(maxCheckDist * checkVertRadiusSq);
 +                    int checkMindy = (int)Math.Max(mindy, centerY - maxCheckYDist);
 +                    int checkMaxdy = (int)Math.Min(maxdy, centerY + maxCheckYDist);
- 
--                        if (terrainheightmap[lz * chunksize + lx] == y)
--                        {
--                            terrainheightmap[lz * chunksize + lx] = (ushort)(y - 1);
--                            rainheightmap[lz * chunksize + lx]--;
--                        }
++
 +                    // Variables for tracking state
 +                    bool hasLiquidInCheckRadius = false;
 +                    bool needsGenInGenRadius = false;
 +                    int firstGenY = -1;
  
--                        IChunkBlocks chunkBlockData = chunks[y / chunksize].Data;
--                        int index3d = ((y % chunksize) * chunksize + lz) * chunksize + lx;
+-                        ydistRel = yDist * yDist / (vRadiusSq + heightOffFac);
 +                    // Walk Y once from top down
 +                    for (int y = checkMaxdy; y >= checkMindy; y--)
 +                    {
 +                        double dy = y - centerY;
 +                        double dySq = dy * dy;
  
--                        if (y == 11)
+-                        if (y > worldheight - 1 || xdistRel + ydistRel + zdistRel > 1.0) continue;
 +                        // Check inclusion in check radius (for fluids)
 +                        double checkYDistSq = dySq / checkVertRadiusSq;
 +                        if (dxSq / checkHorRadiusSq + checkYDistSq + dzSq / checkHorRadiusSq <= 1.0)
-                         {
--                            if (basaltNoise.Noise(chunkX * chunksize + lx, chunkZ * chunksize + lz) > 0.65)
++                        {
 +                            // Fluid check
 +                            if (!hasLiquidInCheckRadius && y >= 1 && y < worldheight)
-                             {
--                                chunkBlockData[index3d] = gcfg.basaltBlockId;
--                                terrainheightmap[lz * chunksize + lx] = Math.Max(terrainheightmap[lz * chunksize + lx], (ushort)11);
--                                rainheightmap[lz * chunksize + lx] = Math.Max(rainheightmap[lz * chunksize + lx], (ushort)11);
--                            }
--                            else
--                            {
--                                chunkBlockData[index3d] = 0;
--                                if (y > yLavaStart)
--                                {
--                                    chunkBlockData[index3d] = gcfg.basaltBlockId;
--                                } else
++                            {
 +                                int chunkY = y / chunksize;
 +                                int localY = y % chunksize;
 +                                var block = api.World.Blocks[chunks[chunkY].Data.GetFluid((localY * chunksize + lz) * chunksize + lx)];
 +                                if (block.LiquidCode != null)
-                                 {
--                                    chunkBlockData.SetFluid(index3d, gcfg.lavaBlockId);
++                                {
 +                                    return false; // Found fluid - exit immediately
-                                 }
--
--                                if (y <= yLavaStart) worldgenBlockAccessor.ScheduleBlockLightUpdate(new BlockPos(chunkX * chunksize + lx, y, chunkZ * chunksize + lz), airBlockId, gcfg.lavaBlockId);
-                             }
++                                }
++                            }
 +                        }
  
+-                        if (terrainheightmap[lz * chunksize + lx] == y)
 +                        // Check inclusion in generation radius (for setting blocks)
 +                        if (!needsGenInGenRadius)
-+                        {
+                         {
+-                            terrainheightmap[lz * chunksize + lx] = (ushort)(y - 1);
+-                            rainheightmap[lz * chunksize + lx]--;
 +                            double heightOffFac = dy > 0 ? heightrnd * heightrnd * Math.Min(1, Math.Abs(y - surfaceY) / 10.0) : 0;
 +                            double genYDistSq = dySq / (genVertRadiusSq + heightOffFac);
 +
@@ -352,25 +328,28 @@ index 30f034d..6c87d18 100644
 +                                firstGenY = y;
 +                            }
                          }
--                        else if (y < 12)
 +                    }
-+
+ 
+-                        IChunkBlocks chunkBlockData = chunks[y / chunksize].Data;
+-                        int index3d = ((y % chunksize) * chunksize + lz) * chunksize + lx;
 +                    // If we need to generate in this column
 +                    if (needsGenInGenRadius)
 +                    {
 +                        // Compute precise range for generation
 +                        double genXZDist = dxSq / genHorRadiusSq + dzSq / genHorRadiusSq;
 +                        double maxGenDist = 1.0 - genXZDist;
-+
+ 
+-                        if (y == 11)
 +                        if (maxGenDist > 0)
                          {
--                            chunkBlockData[index3d] = 0;
--                            if (y > yLavaStart)
+-                            if (basaltNoise.Noise(chunkX * chunksize + lx, chunkZ * chunksize + lz) > 0.65)
 +                            // For positive Y account for distortion
 +                            double vertRadiusSqWithDistort = genVertRadiusSq;
 +                            if (firstGenY > centerY)
                              {
 -                                chunkBlockData[index3d] = gcfg.basaltBlockId;
+-                                terrainheightmap[lz * chunksize + lx] = Math.Max(terrainheightmap[lz * chunksize + lx], (ushort)11);
+-                                rainheightmap[lz * chunksize + lx] = Math.Max(rainheightmap[lz * chunksize + lx], (ushort)11);
 +                                double heightOffFac = heightrnd * heightrnd * Math.Min(1, Math.Abs(firstGenY - surfaceY) / 10.0);
 +                                vertRadiusSqWithDistort += heightOffFac;
                              }
@@ -383,7 +362,11 @@ index 30f034d..6c87d18 100644
 +                            // Generate blocks in the column
 +                            for (int y = genMaxdy; y >= genMindy; y--)
                              {
--                                chunkBlockData.SetFluid(index3d, gcfg.lavaBlockId);
+-                                chunkBlockData[index3d] = 0;
+-                                if (y > yLavaStart)
+-                                {
+-                                    chunkBlockData[index3d] = gcfg.basaltBlockId;
+-                                } else
 +                                double dy = y - centerY;
 +                                double dySq = dy * dy;
 +
@@ -396,16 +379,30 @@ index 30f034d..6c87d18 100644
 +
 +                                // Update heightmaps
 +                                if (surfaceY == y)
-+                                {
+                                 {
+-                                    chunkBlockData.SetFluid(index3d, gcfg.lavaBlockId);
 +                                    terrainheightmap[idx2d] = (ushort)(y - 1);
 +                                    rainheightmap[idx2d]--;
-+                                }
-+
+                                 }
+ 
+-                                if (y <= yLavaStart) worldgenBlockAccessor.ScheduleBlockLightUpdate(new BlockPos(chunkX * chunksize + lx, y, chunkZ * chunksize + lz), airBlockId, gcfg.lavaBlockId);
+-                            }
 +                                int chunkY = y / chunksize;
 +                                int localY = y % chunksize;
 +                                IChunkBlocks chunkBlockData = chunks[chunkY].Data;
 +                                int index3d = localY * chunksizeSq + idx2d;
-+
+ 
+-                        }
+-                        else if (y < 12)
+-                        {
+-                            chunkBlockData[index3d] = 0;
+-                            if (y > yLavaStart)
+-                            {
+-                                chunkBlockData[index3d] = gcfg.basaltBlockId;
+-                            }
+-                            else
+-                            {
+-                                chunkBlockData.SetFluid(index3d, gcfg.lavaBlockId);
 +                                // Set block
 +                                if (y == 11)
 +                                {
@@ -463,5 +460,3 @@ index 30f034d..6c87d18 100644
          }
  
          private int getGeologicActivity(int posx, int posz)
-         {
-             var climateMap = worldgenBlockAccessor.GetMapRegion(posx / regionsize, posz / regionsize)?.ClimateMap;

--- a/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves.cs.patch
+++ b/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves.cs.patch
@@ -1,22 +1,35 @@
 diff --git a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves.cs b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves.cs
+index 30f034d..827cc28 100644
 --- a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves.cs
 +++ b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves.cs
-@@ -14,9 +14,14 @@
- 
+@@ -10,17 +10,22 @@ namespace Vintagestory.ServerMods
+ {
+     public class GenCaves : GenPartial
+     {
+         protected override int chunkRange { get { return 5; } }
+
          public override double ExecuteOrder() { return 0.3; }
- 
+
 +        // Stratum: plain field, vanilla shape, because mods look it up by name.
 +        // Each worldgen thread gets its own GenCaves, so two columns never share it.
          internal LCGRandom caveRand;
          IWorldGenBlockAccessor worldgenBlockAccessor;
- 
+
 +        // Stratum: one GenCaves per worldgen thread, made on first use.
 +        StratumWorkerInstances<GenCaves> stratumWorkers;
 +
          NormalizedSimplexNoise basaltNoise;
          NormalizedSimplexNoise heightvarNoise;
          int regionsize;
-@@ -32,14 +37,14 @@
+
+         public override void StartServerSide(ICoreServerAPI api)
+         {
+             base.StartServerSide(api);
+@@ -28,35 +33,63 @@ namespace Vintagestory.ServerMods
+             if (TerraGenConfig.DoDecorationPass)
+             {
+                 api.Event.GetWorldgenBlockAccessor(OnWorldGenBlockAccessor);
+
                  api.ChatCommands.GetOrCreate("dev")
                      .BeginSubCommand("gencaves")
                      .WithDescription(
@@ -25,17 +38,23 @@ diff --git a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves
                      .RequiresPrivilege(Privilege.controlserver)
                      .HandleWith(CmdCaveGenTest)
                      .EndSubCommand();
- 
+
                  api.Event.MapChunkGeneration(OnMapChunkGen, "standard");
                  api.Event.MapChunkGeneration(OnMapChunkGen, "superflat");
 -                api.Event.ChunkColumnGeneration(GenChunkColumn, EnumWorldGenPass.Terrain, "standard");
-+                StratumTerrainSplit.Register(api, StratumGenChunkColumnOnWorker, "standard"); // Stratum: late half of the split Terrain pass, run on this thread's worker
++                StratumTerrainSplit.Register(api, GenChunkColumn, StratumGenChunkColumnOnWorker, "standard"); // Stratum: expose vanilla topology until the worker path is safe
                  api.Event.InitWorldGenerator(initWorldGen, "superflat");
              }
          }
-@@ -53,6 +58,34 @@
+
+
+         public override void initWorldGen()
+         {
+             base.initWorldGen();
+             caveRand = new LCGRandom(api.WorldManager.Seed + 123128);
+             basaltNoise = NormalizedSimplexNoise.FromDefaultOctaves(2, 1f / 3.5f, 0.9f, api.World.Seed + 12);
              heightvarNoise = NormalizedSimplexNoise.FromDefaultOctaves(3, 1f / 20f, 0.9f, api.World.Seed + 12);
- 
+
              regionsize = api.World.BlockAccessor.RegionSize;
 +            stratumWorkers = new StratumWorkerInstances<GenCaves>(StratumCreateWorker); // Stratum
 +        }
@@ -66,35 +85,49 @@ diff --git a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves
 +            regionsize = origin.regionsize;
 +            caveRand = new LCGRandom(api.WorldManager.Seed + 123128);
          }
- 
- 
-@@ -76,15 +109,21 @@
- 
+
+
+         private void OnMapChunkGen(IMapChunk mapChunk, int chunkX, int chunkZ)
+         {
+             if (heightvarNoise == null) return;
+
+@@ -72,45 +105,51 @@ namespace Vintagestory.ServerMods
+                     mapChunk.CaveHeightDistort[dz * chunksize + dx] = (byte)(128 * val + 127);
+                 }
+             }
+         }
+
          private TextCommandResult CmdCaveGenTest(TextCommandCallingArgs args)
          {
 -            caveRand = new LCGRandom(api.WorldManager.Seed + 123128);
 -            initWorldGen();
 +            initWorldGen(); // Stratum: this already reseeds caveRand with the same formula, no need to do it twice
- 
+
 +            // Stratum start:
 +            // Adding light recalculation for caves
 +            // The cave generation command now works based on the player's coordinates.
- 
+
 +            // replace the air block with granite to generate inverted caves
              airBlockId = api.World.GetBlock(new AssetLocation("rock-granite")).BlockId;
- 
+
 -            int baseChunkX = api.World.BlockAccessor.MapSizeX / 2 / chunksize;
 -            int baseChunkZ = api.World.BlockAccessor.MapSizeZ / 2 / chunksize;
 +            // take the player as the center
 +            var player = args.Caller.Player as IServerPlayer;
 +            int baseChunkX = (int)player.Entity.Pos.X / chunksize;
 +            int baseChunkZ = (int)player.Entity.Pos.Z / chunksize;
- 
+
 +            // first check that all chunks are loaded
              for (int dx = -5; dx <= 5; dx++)
              {
                  for (int dz = -5; dz <= 5; dz++)
-@@ -98,7 +137,7 @@
+                 {
+                     int chunkX = baseChunkX + dx;
+                     int chunkZ = baseChunkZ + dz;
+
+                     IServerChunk[] chunks = GetChunkColumn(chunkX, chunkZ);
+
+                     for (int i = 0; i < chunks.Length; i++)
                      {
                          if (chunks[i] == null)
                          {
@@ -102,20 +135,28 @@ diff --git a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves
 +                            return TextCommandResult.Success("Cannot generate 10x10 area of caves, chunks are not loaded that far yet.");
                          }
                      }
- 
-@@ -106,7 +145,7 @@
+
+                     OnMapChunkGen(chunks[0].MapChunk, chunkX, chunkZ);
                  }
              }
- 
+
 -
 +            // clear all chunks and start cave generation
              for (int dx = -5; dx <= 5; dx++)
              {
                  for (int dz = -5; dz <= 5; dz++)
-@@ -127,11 +166,20 @@
+                 {
+                     int chunkX = baseChunkX + dx;
+                     int chunkZ = baseChunkZ + dz;
+
+@@ -123,19 +162,28 @@ namespace Vintagestory.ServerMods
+                         for (int gdz = -chunkRange; gdz <= chunkRange; gdz++)
+                         {
+                             chunkRand.InitPositionSeed(chunkX + gdx, chunkZ + gdz);
+                             GeneratePartial(chunks, chunkX, chunkZ, gdx, gdz);
                          }
                      }
- 
+
 +                    // Run lighting recalculation (like in GenLightSurvival)
 +                    worldgenBlockAccessor.BeginColumn();
 +                    api.WorldManager.SunFloodChunkColumnForWorldGen(chunks, chunkX, chunkZ);
@@ -125,16 +166,24 @@ diff --git a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves
                      MarkDirty(chunkX, chunkZ, chunks);
                  }
              }
- 
+
 +
 +            // restore the air block id back
              airBlockId = 0;
 +            // Stratum end
- 
+
              return TextCommandResult.Success("Generated and chunks force resend flags set");
          }
-@@ -508,69 +556,41 @@
- 
+
+         private IServerChunk[] GetChunkColumn(int chunkX, int chunkZ)
+         {
+             int size = api.World.BlockAccessor.MapSizeY / chunksize;
+@@ -504,164 +552,229 @@ namespace Vintagestory.ServerMods
+         }
+
+
+
+
          private bool SetBlocks(IServerChunk[] chunks, float horRadius, float vertRadius, double centerX, double centerY, double centerZ, ushort[] terrainheightmap, ushort[] rainheightmap, int chunkX, int chunkZ, bool genHotSpring)
          {
 -            IMapChunk mapchunk = chunks[0].MapChunk;
@@ -142,7 +191,11 @@ diff --git a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves
 -            // One extra size for checking if we run into water
 -            horRadius++;
 -            vertRadius+=2;
--
++            // Stratum start:
++            // Fixing incorrect cave generation in the /dev gencaves command mode
++            // We sped up the algorithm, filtered out blocks that weren't within the ellipsoid's dimensions,
++            // and checked for liquid in the same cycle as everything else.
+
 -            int mindx = (int)GameMath.Clamp(centerX - horRadius, 0, chunksize - 1);
 -            int maxdx = (int)GameMath.Clamp(centerX + horRadius + 1, 0, chunksize - 1);
 -            int mindy = (int)GameMath.Clamp(centerY - vertRadius * 0.7f, 1, worldheight - 1);
@@ -183,58 +236,50 @@ diff --git a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves
 -                    }
 -                }
 -            }
--
--
++            // Testing on 10,200 generation chunks:
++            // Total method execution time: decreased from 9.2 s to 6.3 s;
+
++            IMapChunk mapchunk = chunks[0].MapChunk;
+
 -            horRadius--;
 -            vertRadius-=2;
-+            // Stratum start:
-+            // Fixing incorrect cave generation in the /dev gencaves command mode
-+            // We sped up the algorithm, filtered out blocks that weren't within the ellipsoid's dimensions,
-+            // and checked for liquid in the same cycle as everything else.
- 
++            // Regular generation radius
++            float genHorRadius = horRadius;
++            float genVertRadius = vertRadius;
+
 -            mindx = (int)GameMath.Clamp(centerX - horRadius, 0, chunksize - 1);
 -            maxdx = (int)GameMath.Clamp(centerX + horRadius + 1, 0, chunksize - 1);
 -            mindz = (int)GameMath.Clamp(centerZ - horRadius, 0, chunksize - 1);
 -            maxdz = (int)GameMath.Clamp(centerZ + horRadius + 1, 0, chunksize - 1);
-+            // Testing on 10,200 generation chunks:
-+            // Total method execution time: decreased from 9.2 s to 6.3 s;
- 
--            mindy = (int)GameMath.Clamp(centerY - vertRadius * 0.7f, 1, worldheight - 1);
--            maxdy = (int)GameMath.Clamp(centerY + vertRadius + 1, 1, worldheight - 1);
--
--            hRadiusSq = horRadius * horRadius;
--            vRadiusSq = vertRadius * vertRadius;
-+            IMapChunk mapchunk = chunks[0].MapChunk;
- 
-+            // Regular generation radius
-+            float genHorRadius = horRadius;
-+            float genVertRadius = vertRadius;
-+
 +            // Increased radius for fluid checks
 +            float checkHorRadius = horRadius + 1;
 +            float checkVertRadius = vertRadius + 2;
-+
+
+-            mindy = (int)GameMath.Clamp(centerY - vertRadius * 0.7f, 1, worldheight - 1);
+-            maxdy = (int)GameMath.Clamp(centerY + vertRadius + 1, 1, worldheight - 1);
 +            // Compute common bounds for both radii
 +            int mindx = (int)GameMath.Clamp(centerX - checkHorRadius, 0, chunksize - 1);
 +            int maxdx = (int)GameMath.Clamp(centerX + checkHorRadius + 1, 0, chunksize - 1);
 +            int mindz = (int)GameMath.Clamp(centerZ - checkHorRadius, 0, chunksize - 1);
 +            int maxdz = (int)GameMath.Clamp(centerZ + checkHorRadius + 1, 0, chunksize - 1);
-+
+
+-            hRadiusSq = horRadius * horRadius;
+-            vRadiusSq = vertRadius * vertRadius;
 +            // For Y use the check radius because it is larger
 +            int mindy = (int)GameMath.Clamp(centerY - checkVertRadius * 0.7f, 1, worldheight - 1);
 +            int maxdy = (int)GameMath.Clamp(centerY + checkVertRadius + 1, 1, worldheight - 1);
-+
+
 +            // Precompute squared radii for fast comparisons
 +            double genHorRadiusSq = genHorRadius * genHorRadius;
 +            double genVertRadiusSq = genVertRadius * genVertRadius;
 +            double checkHorRadiusSq = checkHorRadius * checkHorRadius;
 +            double checkVertRadiusSq = checkVertRadius * checkVertRadius;
- 
+
 +            // Get geologic activity once
              int geoActivity = getGeologicActivity(chunkX * chunksize + (int)centerX, chunkZ * chunksize + (int)centerZ);
              genHotSpring &= geoActivity > 128;
- 
-@@ -578,86 +598,179 @@
+
+             if (genHotSpring && centerX >= 0 && centerX < 32 && centerZ >= 0 && centerZ < 32)
              {
                  var data = mapchunk.GetModdata<Dictionary<Vec3i, HotSpringGenData>>("hotspringlocations");
                  if (data == null) data = new Dictionary<Vec3i, HotSpringGenData>();
@@ -242,10 +287,10 @@ diff --git a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves
 +                data[new Vec3i((int)centerX, (int)centerY, (int)centerZ)] = new HotSpringGenData() { horRadius = genHorRadius };
                  mapchunk.SetModdata("hotspringlocations", data);
              }
- 
+
              int yLavaStart = (geoActivity * 16) / 128;
 +            int chunksizeSq = chunksize * chunksize;
- 
+
 -
 +            // Main loop - single pass
              for (int lx = mindx; lx <= maxdx; lx++)
@@ -253,17 +298,17 @@ diff --git a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves
 -                xdistRel = (lx - centerX) * (lx - centerX) / hRadiusSq;
 +                double dx = lx - centerX;
 +                double dxSq = dx * dx;
- 
+
                  for (int lz = mindz; lz <= maxdz; lz++)
                  {
 -                    zdistRel = (lz - centerZ) * (lz - centerZ) / hRadiusSq;
 +                    double dz = lz - centerZ;
 +                    double dzSq = dz * dz;
- 
+
 -                    double heightrnd = (mapchunk.CaveHeightDistort[lz * chunksize + lx] - 127) * distortStrength;
 -                    int surfaceY = terrainheightmap[lz * chunksize + lx];
 +                    int idx2d = lz * chunksize + lx;
- 
+
 -                    for (int y = maxdy + 10; y >= mindy; y--)
 -                    {
 -                        double yDist = y - centerY;
@@ -272,84 +317,101 @@ diff --git a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves
 +                    double distortStrength = GameMath.Clamp(genVertRadius / 4.0, 0, 0.1);
 +                    double heightrnd = (mapchunk.CaveHeightDistort[idx2d] - 127) * distortStrength;
 +                    int surfaceY = terrainheightmap[idx2d];
-+
+
+-                        ydistRel = yDist * yDist / (vRadiusSq + heightOffFac);
 +                    // Compute maximum XZ distance for the check radius
 +                    double checkXZDist = dxSq / checkHorRadiusSq + dzSq / checkHorRadiusSq;
 +                    if (checkXZDist > 1.0) continue;
-+
+
+-                        if (y > worldheight - 1 || xdistRel + ydistRel + zdistRel > 1.0) continue;
 +                    // Compute Y range for the check radius
 +                    double maxCheckDist = 1.0 - checkXZDist;
 +                    double maxCheckYDist = Math.Sqrt(maxCheckDist * checkVertRadiusSq);
 +                    int checkMindy = (int)Math.Max(mindy, centerY - maxCheckYDist);
 +                    int checkMaxdy = (int)Math.Min(maxdy, centerY + maxCheckYDist);
-+
+
+-                        if (terrainheightmap[lz * chunksize + lx] == y)
+-                        {
+-                            terrainheightmap[lz * chunksize + lx] = (ushort)(y - 1);
+-                            rainheightmap[lz * chunksize + lx]--;
+-                        }
 +                    // Variables for tracking state
 +                    bool hasLiquidInCheckRadius = false;
 +                    bool needsGenInGenRadius = false;
 +                    int firstGenY = -1;
- 
--                        ydistRel = yDist * yDist / (vRadiusSq + heightOffFac);
+
+-                        IChunkBlocks chunkBlockData = chunks[y / chunksize].Data;
+-                        int index3d = ((y % chunksize) * chunksize + lz) * chunksize + lx;
 +                    // Walk Y once from top down
 +                    for (int y = checkMaxdy; y >= checkMindy; y--)
 +                    {
 +                        double dy = y - centerY;
 +                        double dySq = dy * dy;
- 
--                        if (y > worldheight - 1 || xdistRel + ydistRel + zdistRel > 1.0) continue;
+
+-                        if (y == 11)
 +                        // Check inclusion in check radius (for fluids)
 +                        double checkYDistSq = dySq / checkVertRadiusSq;
 +                        if (dxSq / checkHorRadiusSq + checkYDistSq + dzSq / checkHorRadiusSq <= 1.0)
-+                        {
+                         {
+-                            if (basaltNoise.Noise(chunkX * chunksize + lx, chunkZ * chunksize + lz) > 0.65)
+-                            {
+-                                chunkBlockData[index3d] = gcfg.basaltBlockId;
+-                                terrainheightmap[lz * chunksize + lx] = Math.Max(terrainheightmap[lz * chunksize + lx], (ushort)11);
+-                                rainheightmap[lz * chunksize + lx] = Math.Max(rainheightmap[lz * chunksize + lx], (ushort)11);
+-                            }
+-                            else
 +                            // Fluid check
 +                            if (!hasLiquidInCheckRadius && y >= 1 && y < worldheight)
-+                            {
+                             {
+-                                chunkBlockData[index3d] = 0;
+-                                if (y > yLavaStart)
 +                                int chunkY = y / chunksize;
 +                                int localY = y % chunksize;
 +                                var block = api.World.Blocks[chunks[chunkY].Data.GetFluid((localY * chunksize + lz) * chunksize + lx)];
 +                                if (block.LiquidCode != null)
-+                                {
+                                 {
+-                                    chunkBlockData[index3d] = gcfg.basaltBlockId;
+-                                } else
+-                                {
+-                                    chunkBlockData.SetFluid(index3d, gcfg.lavaBlockId);
 +                                    return false; // Found fluid - exit immediately
-+                                }
-+                            }
+                                 }
+-
+-                                if (y <= yLavaStart) worldgenBlockAccessor.ScheduleBlockLightUpdate(new BlockPos(chunkX * chunksize + lx, y, chunkZ * chunksize + lz), airBlockId, gcfg.lavaBlockId);
+                             }
 +                        }
- 
--                        if (terrainheightmap[lz * chunksize + lx] == y)
++
 +                        // Check inclusion in generation radius (for setting blocks)
 +                        if (!needsGenInGenRadius)
-                         {
--                            terrainheightmap[lz * chunksize + lx] = (ushort)(y - 1);
--                            rainheightmap[lz * chunksize + lx]--;
++                        {
 +                            double heightOffFac = dy > 0 ? heightrnd * heightrnd * Math.Min(1, Math.Abs(y - surfaceY) / 10.0) : 0;
 +                            double genYDistSq = dySq / (genVertRadiusSq + heightOffFac);
-+
+
 +                            if (dxSq / genHorRadiusSq + genYDistSq + dzSq / genHorRadiusSq <= 1.0 && y < worldheight)
 +                            {
 +                                needsGenInGenRadius = true;
 +                                firstGenY = y;
 +                            }
                          }
+-                        else if (y < 12)
 +                    }
- 
--                        IChunkBlocks chunkBlockData = chunks[y / chunksize].Data;
--                        int index3d = ((y % chunksize) * chunksize + lz) * chunksize + lx;
++
 +                    // If we need to generate in this column
 +                    if (needsGenInGenRadius)
 +                    {
 +                        // Compute precise range for generation
 +                        double genXZDist = dxSq / genHorRadiusSq + dzSq / genHorRadiusSq;
 +                        double maxGenDist = 1.0 - genXZDist;
- 
--                        if (y == 11)
++
 +                        if (maxGenDist > 0)
                          {
--                            if (basaltNoise.Noise(chunkX * chunksize + lx, chunkZ * chunksize + lz) > 0.65)
+-                            chunkBlockData[index3d] = 0;
+-                            if (y > yLavaStart)
 +                            // For positive Y account for distortion
 +                            double vertRadiusSqWithDistort = genVertRadiusSq;
 +                            if (firstGenY > centerY)
                              {
 -                                chunkBlockData[index3d] = gcfg.basaltBlockId;
--                                terrainheightmap[lz * chunksize + lx] = Math.Max(terrainheightmap[lz * chunksize + lx], (ushort)11);
--                                rainheightmap[lz * chunksize + lx] = Math.Max(rainheightmap[lz * chunksize + lx], (ushort)11);
 +                                double heightOffFac = heightrnd * heightrnd * Math.Min(1, Math.Abs(firstGenY - surfaceY) / 10.0);
 +                                vertRadiusSqWithDistort += heightOffFac;
                              }
@@ -362,11 +424,7 @@ diff --git a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves
 +                            // Generate blocks in the column
 +                            for (int y = genMaxdy; y >= genMindy; y--)
                              {
--                                chunkBlockData[index3d] = 0;
--                                if (y > yLavaStart)
--                                {
--                                    chunkBlockData[index3d] = gcfg.basaltBlockId;
--                                } else
+-                                chunkBlockData.SetFluid(index3d, gcfg.lavaBlockId);
 +                                double dy = y - centerY;
 +                                double dySq = dy * dy;
 +
@@ -379,30 +437,16 @@ diff --git a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves
 +
 +                                // Update heightmaps
 +                                if (surfaceY == y)
-                                 {
--                                    chunkBlockData.SetFluid(index3d, gcfg.lavaBlockId);
++                                {
 +                                    terrainheightmap[idx2d] = (ushort)(y - 1);
 +                                    rainheightmap[idx2d]--;
-                                 }
- 
--                                if (y <= yLavaStart) worldgenBlockAccessor.ScheduleBlockLightUpdate(new BlockPos(chunkX * chunksize + lx, y, chunkZ * chunksize + lz), airBlockId, gcfg.lavaBlockId);
--                            }
++                                }
++
 +                                int chunkY = y / chunksize;
 +                                int localY = y % chunksize;
 +                                IChunkBlocks chunkBlockData = chunks[chunkY].Data;
 +                                int index3d = localY * chunksizeSq + idx2d;
- 
--                        }
--                        else if (y < 12)
--                        {
--                            chunkBlockData[index3d] = 0;
--                            if (y > yLavaStart)
--                            {
--                                chunkBlockData[index3d] = gcfg.basaltBlockId;
--                            }
--                            else
--                            {
--                                chunkBlockData.SetFluid(index3d, gcfg.lavaBlockId);
++
 +                                // Set block
 +                                if (y == 11)
 +                                {
@@ -453,10 +497,14 @@ diff --git a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves
                      }
                  }
              }
- 
+
              return true;
 +
 +            // Stratum end
          }
- 
+
          private int getGeologicActivity(int posx, int posz)
+         {
+             var climateMap = worldgenBlockAccessor.GetMapRegion(posx / regionsize, posz / regionsize)?.ClimateMap;
+             if (climateMap == null) return 0;
+             int regionChunkSize = regionsize / chunksize;

--- a/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/4.GenBlockLayers/GenBlockLayers.cs.patch
+++ b/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/4.GenBlockLayers/GenBlockLayers.cs.patch
@@ -1,231 +1,116 @@
 diff --git a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/4.GenBlockLayers/GenBlockLayers.cs b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/4.GenBlockLayers/GenBlockLayers.cs
+index 55b134c..28229c8 100644
 --- a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/4.GenBlockLayers/GenBlockLayers.cs
 +++ b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/4.GenBlockLayers/GenBlockLayers.cs
-@@ -1,5 +1,6 @@
- using System;
- using System.Collections.Generic;
-+using System.Threading;
- using Vintagestory.API.Common;
- using Vintagestory.API.Datastructures;
- using Vintagestory.API.MathTools;
-@@ -14,15 +15,35 @@
+@@ -12,14 +12,18 @@ namespace Vintagestory.ServerMods
+
+     public class GenBlockLayers : ModStdWorldGen
      {
          private ICoreServerAPI api;
- 
--        List<int> BlockLayersIds = new List<int>();
-+        // Stratum: TerrainLate can now run concurrently for distant columns. rnd gets
-+        // reseeded per column at the top of OnChunkColumnGeneration, then LoadBlockLayers
-+        // writes BlockLayersIds/layersUnderWater and PutLayers reads them back a few
-+        // calls later, all within the processing of one column, the same shared-scratch
-+        // shape GenCreatures had. ThreadLocal instead of [ThreadStatic] static since
-+        // this class is a plain instance field owner with no other instances today, but
-+        // matches the idiom used across the rest of this pass rather than relying on
-+        // "only one instance exists right now" staying true.
-+        class ThreadLocalScratch
-+        {
-+            public LCGRandom rnd;
-+            public List<int> BlockLayersIds = new List<int>();
-+            public int[] layersUnderWaterTmp = new int[1];
-+            public int[] layersUnderWater = Array.Empty<int>();
-+        }
-+        ThreadLocal<ThreadLocalScratch> scratchThreadLocal;
-+
-+        // Stratum start: compat shim for mods that reflect on this field, such as Watersheds.
-+        // Seeded at setup so it stays valid when a mod prefix replaces OnChunkColumnGeneration.
-+        // Refreshed from the per-thread scratch on entry to that method when it does run.
+
+         List<int> BlockLayersIds = new List<int>();
          LCGRandom rnd;
-+        // Stratum end
++
++        // Stratum: each worldgen thread gets a complete generator so vanilla fields stay intact.
++        StratumWorkerInstances<GenBlockLayers> stratumWorkers;
 +
          int mapheight;
          ClampedSimplexNoise grassDensity;
          ClampedSimplexNoise grassHeight;
          int boilingWaterBlockId;
- 
--        public int[] layersUnderWaterTmp = new int[1];
--        public int[] layersUnderWater = Array.Empty<int>();
-         public BlockLayerConfig blockLayerConfig;
-         public SimplexNoise distort2dx;
-         public SimplexNoise distort2dz;
-@@ -48,7 +69,7 @@
- 
+
+         public int[] layersUnderWaterTmp = new int[1];
+         public int[] layersUnderWater = Array.Empty<int>();
+@@ -36,23 +40,24 @@ namespace Vintagestory.ServerMods
+         {
+             return 0.4;
+         }
+
+         public override void StartServerSide(ICoreServerAPI api)
+         {
+             this.api = api;
++            stratumWorkers = new StratumWorkerInstances<GenBlockLayers>(StratumCreateWorker); // Stratum: isolate mutable fields without changing their shape
+
+             this.api.Event.InitWorldGenerator(InitWorldGen, "standard");
+             this.api.Event.InitWorldGenerator(InitWorldGen, "superflat"); // Just the Init so that BlockSoil can grow grass; and both these are needed even if DecoPass is off
+             //this.api.Event.MapRegionGeneration(OnMapRegionGen, "standard");   // 8.2.24 commented out because the method has no code
+
+
              if (TerraGenConfig.DoDecorationPass)
              {
 -                this.api.Event.ChunkColumnGeneration(OnChunkColumnGeneration, EnumWorldGenPass.Terrain, "standard");
-+                StratumTerrainSplit.Register(this.api, OnChunkColumnGeneration, "standard"); // Stratum: late half of the split Terrain pass
++                StratumTerrainSplit.Register(this.api, OnChunkColumnGeneration, StratumOnChunkColumnGeneration, "standard"); // Stratum: expose vanilla topology until the worker path is safe
              }
              distort2dx = new SimplexNoise(new double[] { 14, 9, 6, 3 }, new double[] { 1 / 100.0, 1 / 50.0, 1 / 25.0, 1 / 12.5 }, api.World.SeaLevel + 20980);
              distort2dz = new SimplexNoise(new double[] { 14, 9, 6, 3 }, new double[] { 1 / 100.0, 1 / 50.0, 1 / 25.0, 1 / 12.5 }, api.World.SeaLevel + 20981);
-@@ -83,9 +104,11 @@
-             api.ObjectCache.Remove(BlockLayerConfig.cacheKey);
-             blockLayerConfig = BlockLayerConfig.GetInstance(api);
- 
--            rnd = new LCGRandom(api.WorldManager.Seed);
-+            int seed = api.WorldManager.Seed;
-+            rnd = new LCGRandom(seed); // Stratum: a field, not a local, so the shim survives a mod prefix skipping the method below.
-             grassDensity = new ClampedSimplexNoise(new double[] { 4 }, new double[] { 0.5 }, rnd.NextInt());
+         }
+
+         private void OnMapRegionGen(IMapRegion mapRegion, int regionX, int regionZ, ITreeAttribute chunkGenParams = null)
+         {
+@@ -88,14 +93,44 @@ namespace Vintagestory.ServerMods
              grassHeight = new ClampedSimplexNoise(new double[] { 1.5 }, new double[] { 0.5 }, rnd.NextInt());
-+            scratchThreadLocal = new ThreadLocal<ThreadLocalScratch>(() => new ThreadLocalScratch { rnd = new LCGRandom(seed) });
- 
+
              mapheight = api.WorldManager.MapSizeY;
- 
-@@ -98,7 +121,9 @@
+
+             boilingWaterBlockId = gcfg.boilingWaterBlockId;
+         }
+
++        private void StratumOnChunkColumnGeneration(IChunkColumnGenerateRequest request)
++        {
++            stratumWorkers.Current.OnChunkColumnGeneration(request);
++        }
++
++        private GenBlockLayers StratumCreateWorker()
++        {
++            GenBlockLayers worker = new GenBlockLayers();
++            worker.StratumCopyStateFrom(this);
++            return worker;
++        }
++
++        // Stratum: copy configured state and give mutable scratch to one worldgen thread.
++        private void StratumCopyStateFrom(GenBlockLayers source)
++        {
++            api = source.api;
++            LoadGlobalConfig(api);
++            BlockLayersIds = new List<int>(source.BlockLayersIds);
++            rnd = new LCGRandom(api.WorldManager.Seed);
++            mapheight = source.mapheight;
++            grassDensity = source.grassDensity;
++            grassHeight = source.grassHeight;
++            boilingWaterBlockId = source.boilingWaterBlockId;
++            layersUnderWaterTmp = (int[])source.layersUnderWaterTmp.Clone();
++            layersUnderWater = source.layersUnderWater == source.layersUnderWaterTmp ? layersUnderWaterTmp : (int[])source.layersUnderWater.Clone();
++            blockLayerConfig = source.blockLayerConfig;
++            distort2dx = source.distort2dx;
++            distort2dz = source.distort2dz;
++        }
++
+         private void OnChunkColumnGeneration(IChunkColumnGenerateRequest request)
+         {
+             var chunks = request.Chunks;
              int chunkX = request.ChunkX;
              int chunkZ = request.ChunkZ;
- 
--            rnd.InitPositionSeed(chunkX, chunkZ);
-+            ThreadLocalScratch s = scratchThreadLocal.Value; // Stratum: per-thread scratch, fetched once and threaded through for this column
-+            s.rnd.InitPositionSeed(chunkX, chunkZ);
-+            rnd = s.rnd; // Stratum: populate compat shim for third-party reflection (#201)
- 
-             IntDataMap2D forestMap = chunks[0].MapChunk.MapRegion.ForestMap;
-             IntDataMap2D climateMap = chunks[0].MapChunk.MapRegion.ClimateMap;
-@@ -203,7 +228,7 @@
- 
-                     herePos.Y = posY;
-                     int disty = (int)(distort2dx.Noise(-herePos.X, -herePos.Z) / 4.0);
--                    posY = PutLayers(transitionRand, x, z, disty, herePos, chunks, rainRel, temp, tempUnscaled, heightMap, biome);
-+                    posY = StratumPutLayersInner(s, transitionRand, x, z, disty, herePos, chunks, rainRel, temp, tempUnscaled, heightMap, biome);
- 
-                     if (prevY == TerraGenConfig.seaLevel - 1)
-                     {
-@@ -211,7 +236,7 @@
-                         GenBeach(x, prevY, z, chunks, rainRel, temp, beachRel, rockblockID);
+
+             rnd.InitPositionSeed(chunkX, chunkZ);
+@@ -357,14 +392,21 @@ namespace Vintagestory.ServerMods
                      }
- 
--                    PlaceTallGrass(x, prevY, z, chunks, rainRel, tempRel, temp, forestRel, biome);
-+                    PlaceTallGrass(s, x, prevY, z, chunks, rainRel, tempRel, temp, forestRel, biome);
- 
- 
-                     // Try again to put layers if above sealevel and we found over 10 air blocks
-@@ -257,8 +282,17 @@
-             return (int)(distx / 5);
-         }
- 
-+        // Stratum start: compatibility overload for third-party Harmony patches that
-+        // bind PutLayers via GetMethod with the original parameter list (e.g. Watersheds).
-+        // Resolves per-thread scratch internally, same pattern as the public PlaceTallGrass. Fixes #201.
-         private int PutLayers(double posRand, int lx, int lz, int posyoffs, BlockPos pos, IServerChunk[] chunks, float rainRel, float temp, int unscaledTemp, ushort[] heightMap, int biome)
-         {
-+            return StratumPutLayersInner(scratchThreadLocal.Value, posRand, lx, lz, posyoffs, pos, chunks, rainRel, temp, unscaledTemp, heightMap, biome);
-+        }
-+        // Stratum end
-+
-+        private int StratumPutLayersInner(ThreadLocalScratch s, double posRand, int lx, int lz, int posyoffs, BlockPos pos, IServerChunk[] chunks, float rainRel, float temp, int unscaledTemp, ushort[] heightMap, int biome)
-+        {
-             int i = 0;
-             int j = 0;
-             bool underWater = false;
-@@ -304,20 +338,20 @@
-                         chunks[0].MapChunk.TopRockIdMap[lz * chunksize + lx] = blockId;
-                         if (underIce) break;   // radfast 30.1.24: Note, under ice we do not set the sea/lake floor layers (gravel etc), for consistency with legacy worldgen prior to 1.19.4
- 
--                        LoadBlockLayers(posRand, rainRel, temp, unscaledTemp, startPosY + posyoffs, pos, blockId, isOcean, biome);
-+                        LoadBlockLayers(s, posRand, rainRel, temp, unscaledTemp, startPosY + posyoffs, pos, blockId, isOcean, biome);
-                         first = false;
- 
-                         if (!underWater) heightMap[lz * chunksize + lx] = (ushort)(pos.Y + 1);
-                     }
- 
--                    if (i >= BlockLayersIds.Count || (underWater && j >= layersUnderWater.Length))
-+                    if (i >= s.BlockLayersIds.Count || (underWater && j >= s.layersUnderWater.Length))
-                     {
-                         return pos.Y;
-                     }
- 
- 
-                     IChunkBlocks chunkdata = chunks[chunkY].Data;
--                    chunkdata.SetBlockUnsafe(index3d, underWater ? layersUnderWater[j++] : BlockLayersIds[i++]);
-+                    chunkdata.SetBlockUnsafe(index3d, underWater ? s.layersUnderWater[j++] : s.BlockLayersIds[i++]);
-                     chunkdata.SetFluid(index3d, 0);
                  }
-                 else
-@@ -359,9 +393,18 @@
              }
          }
- 
-+        // Stratum: kept for external callers (ModStdWorldGen.GenerateGrass calls this on
-+        // whatever generator invoked it, which may not have a ThreadLocalScratch handle
-+        // of its own) that can't see the private ThreadLocalScratch type. Resolves the
-+        // per-thread scratch itself, same as the internal call sites do explicitly.
+
          public void PlaceTallGrass(int x, int posY, int z, IServerChunk[] chunks, float rainRel, float tempRel, float temp, float forestRel, int biome)
          {
--            double rndVal = blockLayerConfig.Tallgrass.RndWeight * rnd.NextDouble() + blockLayerConfig.Tallgrass.PerlinWeight * grassDensity.Noise(x, z, -0.5f);
-+            PlaceTallGrass(scratchThreadLocal.Value, x, posY, z, chunks, rainRel, tempRel, temp, forestRel, biome);
-+        }
++            // Stratum: external callers use the same per-thread generator as the registered handler.
++            if (stratumWorkers != null)
++            {
++                stratumWorkers.Current.PlaceTallGrass(x, posY, z, chunks, rainRel, tempRel, temp, forestRel, biome);
++                return;
++            }
 +
-+        private void PlaceTallGrass(ThreadLocalScratch s, int x, int posY, int z, IServerChunk[] chunks, float rainRel, float tempRel, float temp, float forestRel, int biome)
-+        {
-+            double rndVal = blockLayerConfig.Tallgrass.RndWeight * s.rnd.NextDouble() + blockLayerConfig.Tallgrass.PerlinWeight * grassDensity.Noise(x, z, -0.5f);
- 
+             double rndVal = blockLayerConfig.Tallgrass.RndWeight * rnd.NextDouble() + blockLayerConfig.Tallgrass.PerlinWeight * grassDensity.Noise(x, z, -0.5f);
+
              double extraGrass = Math.Max(0, rainRel * tempRel - 0.25);
- 
-@@ -369,13 +412,13 @@
- 
+
+             if (rndVal <= GameMath.Clamp(forestRel - extraGrass, 0.05, 0.99) || posY >= mapheight - 1 || posY < 1) return;
+
              int blockId = chunks[posY / chunksize].Data[(chunksize * (posY % chunksize) + z) * chunksize + x];
- 
--            if (api.World.Blocks[blockId].Fertility <= rnd.NextInt(100)) return;
-+            if (api.World.Blocks[blockId].Fertility <= s.rnd.NextInt(100)) return;
- 
-             if (blockLayerConfig.Tallgrass.BlockCodeByBiome != null)
-             {
-                 var layers = blockLayerConfig.Tallgrass.BlockCodeByBiome;
-                 double gh = Math.Max(0, grassHeight.Noise(x, z) * layers.Length - 1);
--                int st = (int)gh + (rnd.NextDouble() < gh ? 1 : 0);
-+                int st = (int)gh + (s.rnd.NextDouble() < gh ? 1 : 0);
-                 for (int i = st; i < layers.Length; i++)
-                 {
-                     if (layers[i].Biome == -1 || layers[i].Biome == biome)
-@@ -389,7 +432,7 @@
-             if (blockLayerConfig.Tallgrass.BlockCodeByMin != null)
-             {
-                 double gheight = Math.Max(0, grassHeight.Noise(x, z) * blockLayerConfig.Tallgrass.BlockCodeByMin.Length - 1);
--                int start = (int)gheight + (rnd.NextDouble() < gheight ? 1 : 0);
-+                int start = (int)gheight + (s.rnd.NextDouble() < gheight ? 1 : 0);
- 
-                 for (int i = start; i < blockLayerConfig.Tallgrass.BlockCodeByMin.Length; i++)
-                 {
-@@ -406,18 +449,19 @@
-         }
- 
- 
--        private void LoadBlockLayers(double posRand, float rainRel, float temperature, int unscaledTemp, int posY, BlockPos pos, int firstBlockId, bool isOcean, int biome)
-+        private void LoadBlockLayers(ThreadLocalScratch s, double posRand, float rainRel, float temperature, int unscaledTemp, int posY, BlockPos pos, int firstBlockId, bool isOcean, int biome)
-         {
-             float heightRel = ((float)posY - TerraGenConfig.seaLevel) / ((float)mapheight - TerraGenConfig.seaLevel);
-             float fertilityRel = Climate.GetFertilityFromUnscaledTemp((int)(rainRel * 255), unscaledTemp, heightRel) / 255f;
- 
-             float depthf = TerraGenConfig.SoilThickness(rainRel, temperature, posY - TerraGenConfig.seaLevel, 1f);
-             int depth = (int)depthf;
--            if (depthf - depth > rnd.NextFloat()) depth++;
-+            if (depthf - depth > s.rnd.NextFloat()) depth++;
- 
-             // Hardcoding crime here. Please don't look. Makes deep layers of ice work
-             if (temperature < -16) depth += 10;
- 
-+            List<int> BlockLayersIds = s.BlockLayersIds;
-             BlockLayersIds.Clear();
-             for (int j = 0; j < blockLayerConfig.Blocklayers.Length; j++)
-             {
-@@ -462,17 +506,17 @@
-             int lakeBedId;
-             if (isOcean)
-             {
--                lakeBedId = blockLayerConfig.OceanBedLayer.GetSuitable(temperature, rainRel, (float)pos.Y / api.WorldManager.MapSizeY, rnd, firstBlockId);
-+                lakeBedId = blockLayerConfig.OceanBedLayer.GetSuitable(temperature, rainRel, (float)pos.Y / api.WorldManager.MapSizeY, s.rnd, firstBlockId);
-             }
-             else
-             {
--                lakeBedId = blockLayerConfig.LakeBedLayer.GetSuitable(temperature, rainRel, (float)pos.Y / api.WorldManager.MapSizeY, rnd, firstBlockId);
-+                lakeBedId = blockLayerConfig.LakeBedLayer.GetSuitable(temperature, rainRel, (float)pos.Y / api.WorldManager.MapSizeY, s.rnd, firstBlockId);
-             }
--            if (lakeBedId == 0) layersUnderWater = Array.Empty<int>();
-+            if (lakeBedId == 0) s.layersUnderWater = Array.Empty<int>();
-             else
-             {
--                layersUnderWaterTmp[0] = lakeBedId;
--                layersUnderWater = layersUnderWaterTmp;
-+                s.layersUnderWaterTmp[0] = lakeBedId;
-+                s.layersUnderWater = s.layersUnderWaterTmp;
-             }
-         }
-     }

--- a/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/4.GenBlockLayers/GenBlockLayers.cs.patch
+++ b/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/4.GenBlockLayers/GenBlockLayers.cs.patch
@@ -1,19 +1,14 @@
 diff --git a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/4.GenBlockLayers/GenBlockLayers.cs b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/4.GenBlockLayers/GenBlockLayers.cs
-index 55b134c..220eed6 100644
 --- a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/4.GenBlockLayers/GenBlockLayers.cs
 +++ b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/4.GenBlockLayers/GenBlockLayers.cs
-@@ -1,7 +1,8 @@
+@@ -1,5 +1,6 @@
  using System;
  using System.Collections.Generic;
 +using System.Threading;
  using Vintagestory.API.Common;
  using Vintagestory.API.Datastructures;
  using Vintagestory.API.MathTools;
- using Vintagestory.API.Server;
- 
-@@ -12,19 +13,39 @@ namespace Vintagestory.ServerMods
- 
-     public class GenBlockLayers : ModStdWorldGen
+@@ -14,15 +15,35 @@
      {
          private ICoreServerAPI api;
  
@@ -35,10 +30,9 @@ index 55b134c..220eed6 100644
 +        }
 +        ThreadLocal<ThreadLocalScratch> scratchThreadLocal;
 +
-+        // Stratum start: compatibility shim for third-party Harmony patches that
-+        // reflect on this field (e.g. Watersheds uses GetField("rnd")). Value is
-+        // written from the per-thread scratch at OnChunkColumnGeneration entry,
-+        // valid only within that call's scope on the current thread. Fixes #201.
++        // Stratum start: compat shim for mods that reflect on this field, such as Watersheds.
++        // Seeded at setup so it stays valid when a mod prefix replaces OnChunkColumnGeneration.
++        // Refreshed from the per-thread scratch on entry to that method when it does run.
          LCGRandom rnd;
 +        // Stratum end
 +
@@ -52,11 +46,7 @@ index 55b134c..220eed6 100644
          public BlockLayerConfig blockLayerConfig;
          public SimplexNoise distort2dx;
          public SimplexNoise distort2dz;
- 
-         public override bool ShouldLoad(EnumAppSide side)
-@@ -46,11 +67,11 @@ namespace Vintagestory.ServerMods
-             //this.api.Event.MapRegionGeneration(OnMapRegionGen, "standard");   // 8.2.24 commented out because the method has no code
- 
+@@ -48,7 +69,7 @@
  
              if (TerraGenConfig.DoDecorationPass)
              {
@@ -65,30 +55,20 @@ index 55b134c..220eed6 100644
              }
              distort2dx = new SimplexNoise(new double[] { 14, 9, 6, 3 }, new double[] { 1 / 100.0, 1 / 50.0, 1 / 25.0, 1 / 12.5 }, api.World.SeaLevel + 20980);
              distort2dz = new SimplexNoise(new double[] { 14, 9, 6, 3 }, new double[] { 1 / 100.0, 1 / 50.0, 1 / 25.0, 1 / 12.5 }, api.World.SeaLevel + 20981);
-         }
- 
-@@ -81,13 +102,15 @@ namespace Vintagestory.ServerMods
-             LoadGlobalConfig(api);
- 
+@@ -83,9 +104,11 @@
              api.ObjectCache.Remove(BlockLayerConfig.cacheKey);
              blockLayerConfig = BlockLayerConfig.GetInstance(api);
  
 -            rnd = new LCGRandom(api.WorldManager.Seed);
--            grassDensity = new ClampedSimplexNoise(new double[] { 4 }, new double[] { 0.5 }, rnd.NextInt());
--            grassHeight = new ClampedSimplexNoise(new double[] { 1.5 }, new double[] { 0.5 }, rnd.NextInt());
 +            int seed = api.WorldManager.Seed;
-+            LCGRandom setupRnd = new LCGRandom(seed); // one-time draw for the two noise fields below, not the per-column scratch
-+            grassDensity = new ClampedSimplexNoise(new double[] { 4 }, new double[] { 0.5 }, setupRnd.NextInt());
-+            grassHeight = new ClampedSimplexNoise(new double[] { 1.5 }, new double[] { 0.5 }, setupRnd.NextInt());
++            rnd = new LCGRandom(seed); // Stratum: a field, not a local, so the shim survives a mod prefix skipping the method below.
+             grassDensity = new ClampedSimplexNoise(new double[] { 4 }, new double[] { 0.5 }, rnd.NextInt());
+             grassHeight = new ClampedSimplexNoise(new double[] { 1.5 }, new double[] { 0.5 }, rnd.NextInt());
 +            scratchThreadLocal = new ThreadLocal<ThreadLocalScratch>(() => new ThreadLocalScratch { rnd = new LCGRandom(seed) });
  
              mapheight = api.WorldManager.MapSizeY;
  
-             boilingWaterBlockId = gcfg.boilingWaterBlockId;
-         }
-@@ -96,11 +119,13 @@ namespace Vintagestory.ServerMods
-         {
-             var chunks = request.Chunks;
+@@ -98,7 +121,9 @@
              int chunkX = request.ChunkX;
              int chunkZ = request.ChunkZ;
  
@@ -99,11 +79,7 @@ index 55b134c..220eed6 100644
  
              IntDataMap2D forestMap = chunks[0].MapChunk.MapRegion.ForestMap;
              IntDataMap2D climateMap = chunks[0].MapChunk.MapRegion.ClimateMap;
-             IntDataMap2D beachMap = chunks[0].MapChunk.MapRegion.BeachMap;
-             IntDataMap2D biomeMap = chunks[0].MapChunk.MapRegion.BiomeMap;
-@@ -201,19 +226,19 @@ namespace Vintagestory.ServerMods
-                         }
-                     }
+@@ -203,7 +228,7 @@
  
                      herePos.Y = posY;
                      int disty = (int)(distort2dx.Noise(-herePos.X, -herePos.Z) / 4.0);
@@ -112,7 +88,7 @@ index 55b134c..220eed6 100644
  
                      if (prevY == TerraGenConfig.seaLevel - 1)
                      {
-                         float beachRel = GameMath.BiLerp(beachUpLeft, beachUpRight, beachBotLeft, beachBotRight, (float)x / chunksize, (float)z / chunksize) / 255f;
+@@ -211,7 +236,7 @@
                          GenBeach(x, prevY, z, chunks, rainRel, temp, beachRel, rockblockID);
                      }
  
@@ -121,11 +97,7 @@ index 55b134c..220eed6 100644
  
  
                      // Try again to put layers if above sealevel and we found over 10 air blocks
-                     int foundAir = 0;
-                     while (posY >= TerraGenConfig.seaLevel - 1)
-@@ -255,11 +280,20 @@ namespace Vintagestory.ServerMods
-             distx = distort2dx.Noise(herePos.X, herePos.Z);
-             distz = distort2dz.Noise(herePos.X, herePos.Z);
+@@ -257,8 +282,17 @@
              return (int)(distx / 5);
          }
  
@@ -133,20 +105,17 @@ index 55b134c..220eed6 100644
 +        // bind PutLayers via GetMethod with the original parameter list (e.g. Watersheds).
 +        // Resolves per-thread scratch internally, same pattern as the public PlaceTallGrass. Fixes #201.
          private int PutLayers(double posRand, int lx, int lz, int posyoffs, BlockPos pos, IServerChunk[] chunks, float rainRel, float temp, int unscaledTemp, ushort[] heightMap, int biome)
-+        {
+         {
 +            return StratumPutLayersInner(scratchThreadLocal.Value, posRand, lx, lz, posyoffs, pos, chunks, rainRel, temp, unscaledTemp, heightMap, biome);
 +        }
 +        // Stratum end
 +
 +        private int StratumPutLayersInner(ThreadLocalScratch s, double posRand, int lx, int lz, int posyoffs, BlockPos pos, IServerChunk[] chunks, float rainRel, float temp, int unscaledTemp, ushort[] heightMap, int biome)
-         {
++        {
              int i = 0;
              int j = 0;
              bool underWater = false;
-             bool isOcean = false;
-@@ -302,24 +336,24 @@ namespace Vintagestory.ServerMods
-                     if (heightMap != null && first)
-                     {
+@@ -304,20 +338,20 @@
                          chunks[0].MapChunk.TopRockIdMap[lz * chunksize + lx] = blockId;
                          if (underIce) break;   // radfast 30.1.24: Note, under ice we do not set the sea/lake floor layers (gravel etc), for consistency with legacy worldgen prior to 1.19.4
  
@@ -170,11 +139,7 @@ index 55b134c..220eed6 100644
                      chunkdata.SetFluid(index3d, 0);
                  }
                  else
-                 {
-                     if ((i > 0 && temp > -18) || j > 0) return pos.Y;
-@@ -357,27 +391,36 @@ namespace Vintagestory.ServerMods
-                     }
-                 }
+@@ -359,9 +393,18 @@
              }
          }
  
@@ -194,7 +159,7 @@ index 55b134c..220eed6 100644
  
              double extraGrass = Math.Max(0, rainRel * tempRel - 0.25);
  
-             if (rndVal <= GameMath.Clamp(forestRel - extraGrass, 0.05, 0.99) || posY >= mapheight - 1 || posY < 1) return;
+@@ -369,13 +412,13 @@
  
              int blockId = chunks[posY / chunksize].Data[(chunksize * (posY % chunksize) + z) * chunksize + x];
  
@@ -210,11 +175,7 @@ index 55b134c..220eed6 100644
                  for (int i = st; i < layers.Length; i++)
                  {
                      if (layers[i].Biome == -1 || layers[i].Biome == biome)
-                     {
-                         chunks[(posY + 1) / chunksize].Data[(chunksize * ((posY + 1) % chunksize) + z) * chunksize + x] = layers[i].BlockId;
-@@ -387,11 +430,11 @@ namespace Vintagestory.ServerMods
-             }
- 
+@@ -389,7 +432,7 @@
              if (blockLayerConfig.Tallgrass.BlockCodeByMin != null)
              {
                  double gheight = Math.Max(0, grassHeight.Noise(x, z) * blockLayerConfig.Tallgrass.BlockCodeByMin.Length - 1);
@@ -223,11 +184,7 @@ index 55b134c..220eed6 100644
  
                  for (int i = start; i < blockLayerConfig.Tallgrass.BlockCodeByMin.Length; i++)
                  {
-                     TallGrassBlockCodeByMin bcbymin = blockLayerConfig.Tallgrass.BlockCodeByMin[i];
- 
-@@ -404,22 +447,23 @@ namespace Vintagestory.ServerMods
-                 }
-             }
+@@ -406,18 +449,19 @@
          }
  
  
@@ -249,11 +206,7 @@ index 55b134c..220eed6 100644
              BlockLayersIds.Clear();
              for (int j = 0; j < blockLayerConfig.Blocklayers.Length; j++)
              {
-                 BlockLayer bl = blockLayerConfig.Blocklayers[j];
-                 float yDist = bl.CalcYDistance(posY, mapheight);
-@@ -460,20 +504,20 @@ namespace Vintagestory.ServerMods
-             }
- 
+@@ -462,17 +506,17 @@
              int lakeBedId;
              if (isOcean)
              {
@@ -276,4 +229,3 @@ index 55b134c..220eed6 100644
              }
          }
      }
- }

--- a/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/5.GenDeposits/GenDeposits.cs.patch
+++ b/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/5.GenDeposits/GenDeposits.cs.patch
@@ -1,39 +1,44 @@
 diff --git a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/5.GenDeposits/GenDeposits.cs b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/5.GenDeposits/GenDeposits.cs
-index b6ab588..aaa2055 100644
+index b6ab588..4348e32 100644
 --- a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/5.GenDeposits/GenDeposits.cs
 +++ b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/5.GenDeposits/GenDeposits.cs
-@@ -26,10 +26,27 @@ namespace Vintagestory.ServerMods
- 
+@@ -24,14 +24,18 @@ namespace Vintagestory.ServerMods
+
+         float chanceMultiplier;
+
          IBlockAccessor blockAccessor;
- 
+
          public LCGRandom depositRand;
- 
-+        // Stratum: an instance lock, not [ThreadStatic]/ThreadLocal. GeneratePartial
-+        // reseeds depositRand then immediately generates with it, the same shape as the
-+        // other landmines this session found, but depositRand's actual value gets
-+        // captured by reference into every DepositGeneratorBase this class's variants
-+        // create (DepositVariant.Init -> DepositGeneratorBase.DepositRand = depositRand,
-+        // done once at load time). Swapping depositRand itself to a per-thread instance
-+        // would not isolate anything: every generator would still read whatever
-+        // depositRand reference existed on whichever thread ran initAssets, not the one
-+        // reseeded on the thread actually generating. A lock preserves the existing
-+        // object-identity relationship exactly, at the cost of serializing GeneratePartial
-+        // calls under TerrainFeatures' same-stage cap, which has since risen off 1 (see
-+        // ServerSystemSupplyChunks.stratumStageMaxConcurrent); this closed the landmine
-+        // before that happened. Also covers subDepositsToPlace and tmpPos below,
-+        // cleared/set at the top of every GeneratePartial call and safe to keep as
-+        // plain fields under the same lock.
+
++        // Stratum: DepositGeneratorBase instances capture depositRand by reference.
++        // Serialize its RNG and scratch fields so concurrent columns cannot corrupt them.
 +        private readonly object stratumGenDepositsLock = new object();
 +
          BlockPos tmpPos = new BlockPos(API.Config.Dimensions.NormalWorld);
- 
+
          NormalizedSimplexNoise depositShapeDistortNoise;
          Dictionary<BlockPos, DepositVariant> subDepositsToPlace = new Dictionary<BlockPos, DepositVariant>();
          MapLayerBase verticalDistortTop;
-@@ -207,48 +224,51 @@ namespace Vintagestory.ServerMods
-             base.GenChunkColumn(request);
+         MapLayerBase verticalDistortBottom;
+         public bool addHandbookAttributes = true;
+@@ -199,58 +203,65 @@ namespace Vintagestory.ServerMods
+                 variant.OnMapRegionGen(mapRegion, regionX, regionZ);
+             }
          }
- 
+
+
+         protected override void GenChunkColumn(IChunkColumnGenerateRequest request)
+         {
+-            if (blockAccessor is IWorldGenBlockAccessor wgba) wgba.BeginColumn();
+-            base.GenChunkColumn(request);
++            // Stratum: include GenPartial's shared chunkRand reseed in the existing generator lock.
++            lock (stratumGenDepositsLock)
++            {
++                if (blockAccessor is IWorldGenBlockAccessor wgba) wgba.BeginColumn();
++                base.GenChunkColumn(request);
++            }
+         }
+
          public override void GeneratePartial(IServerChunk[] chunks, int chunkX, int chunkZ, int chunkdX, int chunkdZ)
          {
 -            LCGRandom chunkRand = this.chunkRand;
@@ -44,18 +49,18 @@ index b6ab588..aaa2055 100644
 +                LCGRandom chunkRand = this.chunkRand;
 +                int fromChunkx = chunkX + chunkdX;
 +                int fromChunkz = chunkZ + chunkdZ;
- 
+
 -            int fromBaseX = fromChunkx * chunksize;
 -            int fromBaseZ = fromChunkz * chunksize;
 +                int fromBaseX = fromChunkx * chunksize;
 +                int fromBaseZ = fromChunkz * chunksize;
- 
+
 -            subDepositsToPlace.Clear();
 +                subDepositsToPlace.Clear();
- 
+
 -            float scaleAdjustMul = (float)api.WorldManager.MapSizeY / 256;
 +                float scaleAdjustMul = (float)api.WorldManager.MapSizeY / 256;
- 
+
 -            for (int i = 0; i < Deposits.Length; i++)
 -            {
 -                DepositVariant variant = Deposits[i];
@@ -64,12 +69,12 @@ index b6ab588..aaa2055 100644
 +                for (int i = 0; i < Deposits.Length; i++)
 +                {
 +                    DepositVariant variant = Deposits[i];
- 
+
 -                float qModified = variant.TriesPerChunk * quantityFactor * chanceMultiplier * (variant.ScaleWithWorldheight ? scaleAdjustMul : 1);
 -                int quantity = (int)qModified;
 -                quantity += chunkRand.NextInt(100) < 100 * (qModified - quantity) ? 1 : 0;
 +                    float quantityFactor = variant.WithOreMap ? variant.GetOreMapFactor(fromChunkx, fromChunkz) : 1;
- 
+
 -                while (quantity-- > 0)
 -                {
 -                    tmpPos.Set(fromBaseX + chunkRand.NextInt(chunksize), -99, fromBaseZ + chunkRand.NextInt(chunksize));
@@ -79,20 +84,20 @@ index b6ab588..aaa2055 100644
 +                    float qModified = variant.TriesPerChunk * quantityFactor * chanceMultiplier * (variant.ScaleWithWorldheight ? scaleAdjustMul : 1);
 +                    int quantity = (int)qModified;
 +                    quantity += chunkRand.NextInt(100) < 100 * (qModified - quantity) ? 1 : 0;
- 
--                    GenDeposit(chunks, chunkX, chunkZ, tmpPos, variant);
++
 +                    while (quantity-- > 0)
 +                    {
 +                        tmpPos.Set(fromBaseX + chunkRand.NextInt(chunksize), -99, fromBaseZ + chunkRand.NextInt(chunksize));
 +                        long crseed = chunkRand.NextInt(10000000);
 +                        depositRand.SetWorldSeed(crseed);
 +                        depositRand.InitPositionSeed(fromChunkx, fromChunkz);
-+
+
+-                    GenDeposit(chunks, chunkX, chunkZ, tmpPos, variant);
 +                        GenDeposit(chunks, chunkX, chunkZ, tmpPos, variant);
 +                    }
                  }
 -            }
- 
+
 -            foreach (var val in subDepositsToPlace)
 -            {
 -                depositRand.SetWorldSeed(chunkRand.NextInt(10000000));
@@ -101,12 +106,14 @@ index b6ab588..aaa2055 100644
 +                {
 +                    depositRand.SetWorldSeed(chunkRand.NextInt(10000000));
 +                    depositRand.InitPositionSeed(fromChunkx, fromChunkz);
- 
+
 -                val.Value.GeneratorInst.GenDeposit(blockAccessor, chunks, chunkX, chunkZ, val.Key, ref subDepositsToPlace);
 +                    val.Value.GeneratorInst.GenDeposit(blockAccessor, chunks, chunkX, chunkZ, val.Key, ref subDepositsToPlace);
 +                }
              }
          }
- 
- 
- 
+
+
+
+         public virtual void GenDeposit(IServerChunk[] chunks, int chunkX, int chunkZ, BlockPos depoCenterPos, DepositVariant variant)
+         {

--- a/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/6.GenStructures/GenStructures.cs.patch
+++ b/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/6.GenStructures/GenStructures.cs.patch
@@ -1,42 +1,23 @@
 diff --git a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/6.GenStructures/GenStructures.cs b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/6.GenStructures/GenStructures.cs
-index 95025db..e14044e 100644
+index 95025db..7c475dd 100644
 --- a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/6.GenStructures/GenStructures.cs
 +++ b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/6.GenStructures/GenStructures.cs
-@@ -35,33 +35,55 @@ namespace Vintagestory.ServerMods
-         ICoreServerAPI api;
- 
-         int worldheight;
-         int regionChunkSize;
- 
--        ushort[] heightmap;
--        int climateUpLeft;
--        int climateUpRight;
--        int climateBotLeft;
--        int climateBotRight;
--
--        int forestUpLeft;
--        int forestUpRight;
--        int forestBotLeft;
--        int forestBotRight;
-+        // Stratum: every field below used to be a plain instance field, written by
-+        // OnChunkColumnGen/DoGenStructures and read a few calls later in the same
-+        // column's processing (TryGenerate, TryGenVillages), the same shape of bug as
-+        // GenVegetationAndPatches' equivalent fields and GenCreatures' original one for
-+        // PreDone. This landmine went off: TerrainFeatures (this class's stage) got
-+        // raised off same-stage cap 1 (see ServerSystemSupplyChunks.stratumStageMaxConcurrent),
-+        // same framing as treeAndShrubSupressingStructures below. [ThreadStatic] keeps
-+        // every field private to whichever thread is currently inside OnChunkColumnGen
-+        // for a given column, at zero cost while only one thread at a time is in here.
-+        // strucRand needed the same reasoning as GenVegetationAndPatches' rnd: it is
-+        // reseeded per column via InitPositionSeed alone (no SetWorldSeed), which does
-+        // not depend on strucRand's own prior state, so lazy-constructing a fresh
-+        // instance per thread with the same world-seed argument reproduces today's
-+        // single-shared-instance behavior exactly, just isolated per thread.
+@@ -44,23 +44,48 @@ namespace Vintagestory.ServerMods
+         int climateBotRight;
+
+         int forestUpLeft;
+         int forestUpRight;
+         int forestBotLeft;
+         int forestBotRight;
+
++        // Stratum: concurrent TerrainFeatures columns keep an isolated owner behind the vanilla fields.
 +        [ThreadStatic] private static ushort[] stratumHeightmap;
 +        [ThreadStatic] private static int stratumClimateUpLeft, stratumClimateUpRight, stratumClimateBotLeft, stratumClimateBotRight;
 +        [ThreadStatic] private static int stratumForestUpLeft, stratumForestUpRight, stratumForestBotLeft, stratumForestBotRight;
 +        [ThreadStatic] private static LCGRandom stratumStrucRand;
-+        [ThreadStatic] private static WorldGenStructure[] stratumShuffledStructures;
++        [ThreadStatic] private static GenStructures stratumStateOwner;
++        [ThreadStatic] private static int stratumStateChunkX;
++        [ThreadStatic] private static int stratumStateChunkZ;
 +
 +        // Stratum: struc.TryGenerate (both the ruins loop below and GenVillage) does
 +        // three things that were never safe to run on two columns at once: it reads
@@ -54,94 +35,131 @@ index 95025db..e14044e 100644
 +        // serialize the whole decide-place-register sequence, which is also the fix for
 +        // WorldGenStructure's un-[ThreadStatic]'d static tmpLoc scratch field.
 +        readonly object stratumStructurePlacementLock = new object();
- 
++
          public event PeventSchematicAtDelegate OnPreventSchematicPlaceAt;
- 
+
          internal WorldGenStructuresConfig scfg;
- 
+
          public WorldGenVillageConfig vcfg;
- 
--        LCGRandom strucRand; // Deterministic random
--
+
+         LCGRandom strucRand; // Deterministic random
+
 -
          IWorldGenBlockAccessor worldgenBlockAccessor;
- 
--        WorldGenStructure[] shuffledStructures;
+
+         WorldGenStructure[] shuffledStructures;
          private Dictionary<string, WorldGenStructure[]> StoryStructures;
- 
+
          public override double ExecuteOrder() { return 0.3; }
- 
-         public override void StartServerSide(ICoreServerAPI api)
-@@ -111,12 +133,10 @@ namespace Vintagestory.ServerMods
- 
-             worldheight = api.WorldManager.MapSizeY;
-             regionChunkSize = api.WorldManager.RegionSize / chunksize;
-             chunkMapSizeY = api.WorldManager.MapSizeY / chunksize;
- 
--            strucRand = new LCGRandom(api.WorldManager.Seed + 1090);
--
-             LoadStructures();
-             LoadVillages();
- 
-             var genStoryStructures = api.World.Config.GetAsString("loreContent", "true").ToBool(true);
-             if (!genStoryStructures) return;
-@@ -202,11 +222,11 @@ namespace Vintagestory.ServerMods
-                 structures.AddRange(conf.Structures);
-             }
- 
-             scfg.Structures = structures.ToArray();
- 
--            shuffledStructures = new WorldGenStructure[scfg.Structures.Length];
-+            stratumShuffledStructures = new WorldGenStructure[scfg.Structures.Length];
- 
-             scfg.Init(api);
+
+@@ -236,14 +261,51 @@ namespace Vintagestory.ServerMods
+             var chunks = request.Chunks;
+             int chunkX = request.ChunkX;
+             int chunkZ = request.ChunkZ;
+
+             worldgenBlockAccessor.BeginColumn();
+
+             IMapRegion region = chunks[0].MapChunk.MapRegion;
++            if (stratumHasColumnState(chunkX, chunkZ))
++            {
++                heightmap = stratumHeightmap;
++                climateUpLeft = stratumClimateUpLeft;
++                climateUpRight = stratumClimateUpRight;
++                climateBotLeft = stratumClimateBotLeft;
++                climateBotRight = stratumClimateBotRight;
++                forestUpLeft = stratumForestUpLeft;
++                forestUpRight = stratumForestUpRight;
++                forestBotLeft = stratumForestBotLeft;
++                forestBotRight = stratumForestBotRight;
++            }
++            else
++            {
++                // Stratum: direct postpass calls may not have the main handler's thread state.
++                IntDataMap2D climateMap = region.ClimateMap;
++                IntDataMap2D forestMap = region.ForestMap;
++                int rlX = chunkX % regionChunkSize;
++                int rlZ = chunkZ % regionChunkSize;
++                float facC = (float)climateMap.InnerSize / regionChunkSize;
++
++                stratumClimateUpLeft = climateUpLeft = climateMap.GetUnpaddedInt((int)(rlX * facC), (int)(rlZ * facC));
++                stratumClimateUpRight = climateUpRight = climateMap.GetUnpaddedInt((int)(rlX * facC + facC), (int)(rlZ * facC));
++                stratumClimateBotLeft = climateBotLeft = climateMap.GetUnpaddedInt((int)(rlX * facC), (int)(rlZ * facC + facC));
++                stratumClimateBotRight = climateBotRight = climateMap.GetUnpaddedInt((int)(rlX * facC + facC), (int)(rlZ * facC + facC));
++
++                stratumForestUpLeft = forestUpLeft = forestMap.GetUnpaddedInt((int)(rlX * facC), (int)(rlZ * facC));
++                stratumForestUpRight = forestUpRight = forestMap.GetUnpaddedInt((int)(rlX * facC + facC), (int)(rlZ * facC));
++                stratumForestBotLeft = forestBotLeft = forestMap.GetUnpaddedInt((int)(rlX * facC), (int)(rlZ * facC + facC));
++                stratumForestBotRight = forestBotRight = forestMap.GetUnpaddedInt((int)(rlX * facC + facC), (int)(rlZ * facC + facC));
++
++                stratumHeightmap = heightmap = chunks[0].MapChunk.WorldGenTerrainHeightMap;
++                if (stratumStateOwner != this) stratumStrucRand = null; // Stratum: a reused thread may now belong to another world
++                stratumStateOwner = this;
++                stratumStateChunkX = chunkX;
++                stratumStateChunkZ = chunkZ;
++            }
+
+             DoGenStructures(region, chunkX, chunkZ, true, structure?.Code, request.ChunkGenParams);
+             TryGenVillages(region, chunkX, chunkZ, true, request.ChunkGenParams);
          }
- 
-         private void LoadVillages()
-@@ -268,24 +288,24 @@ namespace Vintagestory.ServerMods
+
+         private void OnChunkColumnGen(IChunkColumnGenerateRequest request)
+         {
+@@ -266,57 +328,63 @@ namespace Vintagestory.ServerMods
+             // A region has 16 chunks
+             // Size of the forest map is RegionSize / TerraGenConfig.forestMapScale  => 32*16 / 32  = 16 pixel
              // rlX, rlZ goes from 0..16 pixel
              // facF = 16/16 = 1
              // Get 4 pixels for chunkx, chunkz, chunkx+1 and chunkz+1 inside the map
- 
+
              float facC = (float)climateMap.InnerSize / regionChunkSize;
 -            climateUpLeft = climateMap.GetUnpaddedInt((int)(rlX * facC), (int)(rlZ * facC));
 -            climateUpRight = climateMap.GetUnpaddedInt((int)(rlX * facC + facC), (int)(rlZ * facC));
 -            climateBotLeft = climateMap.GetUnpaddedInt((int)(rlX * facC), (int)(rlZ * facC + facC));
 -            climateBotRight = climateMap.GetUnpaddedInt((int)(rlX * facC + facC), (int)(rlZ * facC + facC));
-+            stratumClimateUpLeft = climateMap.GetUnpaddedInt((int)(rlX * facC), (int)(rlZ * facC));
-+            stratumClimateUpRight = climateMap.GetUnpaddedInt((int)(rlX * facC + facC), (int)(rlZ * facC));
-+            stratumClimateBotLeft = climateMap.GetUnpaddedInt((int)(rlX * facC), (int)(rlZ * facC + facC));
-+            stratumClimateBotRight = climateMap.GetUnpaddedInt((int)(rlX * facC + facC), (int)(rlZ * facC + facC));
- 
- 
++            stratumClimateUpLeft = climateUpLeft = climateMap.GetUnpaddedInt((int)(rlX * facC), (int)(rlZ * facC));
++            stratumClimateUpRight = climateUpRight = climateMap.GetUnpaddedInt((int)(rlX * facC + facC), (int)(rlZ * facC));
++            stratumClimateBotLeft = climateBotLeft = climateMap.GetUnpaddedInt((int)(rlX * facC), (int)(rlZ * facC + facC));
++            stratumClimateBotRight = climateBotRight = climateMap.GetUnpaddedInt((int)(rlX * facC + facC), (int)(rlZ * facC + facC));
+
+
              float facf = (float)forestMap.InnerSize / regionChunkSize;
 -            forestUpLeft = forestMap.GetUnpaddedInt((int)(rlX * facC), (int)(rlZ * facC));
 -            forestUpRight = forestMap.GetUnpaddedInt((int)(rlX * facC + facC), (int)(rlZ * facC));
 -            forestBotLeft = forestMap.GetUnpaddedInt((int)(rlX * facC), (int)(rlZ * facC + facC));
 -            forestBotRight = forestMap.GetUnpaddedInt((int)(rlX * facC + facC), (int)(rlZ * facC + facC));
-+            stratumForestUpLeft = forestMap.GetUnpaddedInt((int)(rlX * facC), (int)(rlZ * facC));
-+            stratumForestUpRight = forestMap.GetUnpaddedInt((int)(rlX * facC + facC), (int)(rlZ * facC));
-+            stratumForestBotLeft = forestMap.GetUnpaddedInt((int)(rlX * facC), (int)(rlZ * facC + facC));
-+            stratumForestBotRight = forestMap.GetUnpaddedInt((int)(rlX * facC + facC), (int)(rlZ * facC + facC));
- 
- 
++            stratumForestUpLeft = forestUpLeft = forestMap.GetUnpaddedInt((int)(rlX * facC), (int)(rlZ * facC));
++            stratumForestUpRight = forestUpRight = forestMap.GetUnpaddedInt((int)(rlX * facC + facC), (int)(rlZ * facC));
++            stratumForestBotLeft = forestBotLeft = forestMap.GetUnpaddedInt((int)(rlX * facC), (int)(rlZ * facC + facC));
++            stratumForestBotRight = forestBotRight = forestMap.GetUnpaddedInt((int)(rlX * facC + facC), (int)(rlZ * facC + facC));
+
+
 -            heightmap = chunks[0].MapChunk.WorldGenTerrainHeightMap;
-+            stratumHeightmap = chunks[0].MapChunk.WorldGenTerrainHeightMap;
- 
++            stratumHeightmap = heightmap = chunks[0].MapChunk.WorldGenTerrainHeightMap;
++            if (stratumStateOwner != this) stratumStrucRand = null; // Stratum: a reused thread may now belong to another world
++            stratumStateOwner = this;
++            stratumStateChunkX = chunkX;
++            stratumStateChunkZ = chunkZ;
+
              DoGenStructures(region, chunkX, chunkZ, false, structure?.Code, request.ChunkGenParams);
              if (structure == null)
              {
                  TryGenVillages(region, chunkX, chunkZ, false, request.ChunkGenParams);
-@@ -298,22 +318,22 @@ namespace Vintagestory.ServerMods
+             }
+         }
+
+         private void DoGenStructures(IMapRegion region, int chunkX, int chunkZ, bool postPass, string locationCode, ITreeAttribute chunkGenParams = null)
+         {
+             // We need to make a copy each time to preserve determinism
              // which is crucial for the translocator to find an exit point
++            WorldGenStructure[] activeShuffledStructures;
              if (locationCode != null)
              {
                  if (StoryStructures.TryGetValue(locationCode, out var storyStructures))
                  {
 -                    shuffledStructures = new WorldGenStructure[storyStructures.Length];
 -                    for (int i = 0; i < storyStructures.Length; i++) shuffledStructures[i] = storyStructures[i];
-+                    stratumShuffledStructures = new WorldGenStructure[storyStructures.Length];
-+                    for (int i = 0; i < storyStructures.Length; i++) stratumShuffledStructures[i] = storyStructures[i];
++                    activeShuffledStructures = new WorldGenStructure[storyStructures.Length];
++                    for (int i = 0; i < storyStructures.Length; i++) activeShuffledStructures[i] = storyStructures[i];
                  }
                  else
                  {
@@ -152,88 +170,139 @@ index 95025db..e14044e 100644
              {
 -                shuffledStructures = new WorldGenStructure[scfg.Structures.Length];
 -                for (int i = 0; i < shuffledStructures.Length; i++) shuffledStructures[i] = scfg.Structures[i];
-+                stratumShuffledStructures = new WorldGenStructure[scfg.Structures.Length];
-+                for (int i = 0; i < stratumShuffledStructures.Length; i++) stratumShuffledStructures[i] = scfg.Structures[i];
++                activeShuffledStructures = new WorldGenStructure[scfg.Structures.Length];
++                for (int i = 0; i < activeShuffledStructures.Length; i++) activeShuffledStructures[i] = scfg.Structures[i];
              }
++            shuffledStructures = activeShuffledStructures; // Stratum: publish the active vanilla field for mod code
              BlockPos startPos = new BlockPos(Dimensions.NormalWorld);
- 
+
              ITreeAttribute chanceModTree = null;
              ITreeAttribute maxQuantityModTree = null;
-@@ -326,17 +346,17 @@ namespace Vintagestory.ServerMods
+             StoryStructureLocation location = null;
+             if (chunkGenParams?["structureChanceModifier"] != null)
+             {
+@@ -324,21 +392,35 @@ namespace Vintagestory.ServerMods
+             }
+             if (chunkGenParams?["structureMaxCount"] != null)
              {
                  maxQuantityModTree = chunkGenParams["structureMaxCount"] as TreeAttribute;
              }
- 
- 
+
+
 -            strucRand.InitPositionSeed(chunkX, chunkZ);
-+            (stratumStrucRand ??= new LCGRandom(api.WorldManager.Seed + 1090)).InitPositionSeed(chunkX, chunkZ);
- 
+-
 -            shuffledStructures.Shuffle(strucRand);
-+            stratumShuffledStructures.Shuffle(stratumStrucRand);
- 
+-
 -            for (int i = 0; i < shuffledStructures.Length; i++)
-+            for (int i = 0; i < stratumShuffledStructures.Length; i++)
++            bool hasColumnState = stratumHasColumnState(chunkX, chunkZ);
++            LCGRandom activeRand = hasColumnState
++                ? (stratumStrucRand ??= new LCGRandom(api.WorldManager.Seed + 1090))
++                : strucRand;
++            ushort[] activeHeightmap = hasColumnState ? stratumHeightmap : heightmap;
++            int activeClimateUpLeft = hasColumnState ? stratumClimateUpLeft : climateUpLeft;
++            int activeClimateUpRight = hasColumnState ? stratumClimateUpRight : climateUpRight;
++            int activeClimateBotLeft = hasColumnState ? stratumClimateBotLeft : climateBotLeft;
++            int activeClimateBotRight = hasColumnState ? stratumClimateBotRight : climateBotRight;
++            int activeForestUpLeft = hasColumnState ? stratumForestUpLeft : forestUpLeft;
++            int activeForestUpRight = hasColumnState ? stratumForestUpRight : forestUpRight;
++            int activeForestBotLeft = hasColumnState ? stratumForestBotLeft : forestBotLeft;
++            int activeForestBotRight = hasColumnState ? stratumForestBotRight : forestBotRight;
++            activeRand.InitPositionSeed(chunkX, chunkZ);
++            strucRand = activeRand; // Stratum: keep the vanilla field current before downstream calls
++
++            activeShuffledStructures.Shuffle(activeRand);
++
++            for (int i = 0; i < activeShuffledStructures.Length; i++)
              {
 -                WorldGenStructure struc = shuffledStructures[i];
-+                WorldGenStructure struc = stratumShuffledStructures[i];
++                WorldGenStructure struc = activeShuffledStructures[i];
                  if (struc.PostPass != postPass) continue;
- 
+
                  float chance = struc.Chance * scfg.ChanceMultiplier;
                  int toGenerate = 9999;
                  if (chanceModTree != null)
-@@ -348,26 +368,26 @@ namespace Vintagestory.ServerMods
+                 {
+                     chance *= chanceModTree.GetFloat(struc.Code, 0);
+@@ -346,30 +428,30 @@ namespace Vintagestory.ServerMods
+
+                 if (maxQuantityModTree != null)
                  {
                      toGenerate = maxQuantityModTree.GetInt(struc.Code, 9999);
                  }
- 
- 
+
+
 -                while (chance-- > strucRand.NextFloat() && toGenerate > 0)
-+                while (chance-- > stratumStrucRand.NextFloat() && toGenerate > 0)
++                while (chance-- > activeRand.NextFloat() && toGenerate > 0)
                  {
 -                    int dx = strucRand.NextInt(chunksize);
 -                    int dz = strucRand.NextInt(chunksize);
 -                    int ySurface = heightmap[dz * chunksize + dx];
-+                    int dx = stratumStrucRand.NextInt(chunksize);
-+                    int dz = stratumStrucRand.NextInt(chunksize);
-+                    int ySurface = stratumHeightmap[dz * chunksize + dx];
++                    int dx = activeRand.NextInt(chunksize);
++                    int dz = activeRand.NextInt(chunksize);
++                    int ySurface = activeHeightmap[dz * chunksize + dx];
                      if (ySurface <= 0 || ySurface >= worldheight - 15) continue;
- 
+
                      if (struc.Placement == EnumStructurePlacement.Underground)
                      {
                          if (struc.Depth != null)
                          {
 -                            startPos.Set(chunkX * chunksize + dx, ySurface - (int)struc.Depth.nextFloat(1, strucRand), chunkZ * chunksize + dz);
-+                            startPos.Set(chunkX * chunksize + dx, ySurface - (int)struc.Depth.nextFloat(1, stratumStrucRand), chunkZ * chunksize + dz);
++                            startPos.Set(chunkX * chunksize + dx, ySurface - (int)struc.Depth.nextFloat(1, activeRand), chunkZ * chunksize + dz);
                          }
                          else
                          {
 -                            startPos.Set(chunkX * chunksize + dx, 8 + strucRand.NextInt(Math.Max(1, ySurface - 8 - 5)), chunkZ * chunksize + dz);
-+                            startPos.Set(chunkX * chunksize + dx, 8 + stratumStrucRand.NextInt(Math.Max(1, ySurface - 8 - 5)), chunkZ * chunksize + dz);
++                            startPos.Set(chunkX * chunksize + dx, 8 + activeRand.NextInt(Math.Max(1, ySurface - 8 - 5)), chunkZ * chunksize + dz);
                          }
                      }
                      else
                      {
                          startPos.Set(chunkX * chunksize + dx, ySurface, chunkZ * chunksize + dz);
-@@ -393,50 +413,57 @@ namespace Vintagestory.ServerMods
+                     }
+
+@@ -380,155 +462,193 @@ namespace Vintagestory.ServerMods
+                         continue;
+                     }
+
+                     // check if in storylocation and if we can still generate this structure
+                     if (locationCode != null)
+                     {
+                         location = GetIntersectingStructure(chunkX * chunksize + chunksize / 2, chunkZ * chunksize + chunksize / 2) as StoryStructureLocation;
+-                        if (location.SchematicsSpawned?.TryGetValue(struc.Group, out var spawnedSchematics) == true && spawnedSchematics >= struc.StoryLocationMaxAmount)
++                        if (struc.StoryMaxFromCenter != 0 &&  !startPos.InRangeHorizontally(location.CenterPos.X, location.CenterPos.Z, struc.StoryMaxFromCenter))
                          {
                              continue;
                          }
-                     }
- 
--                    int forest = GameMath.BiLerpRgbColor((float)(startPos.X % chunksize) / chunksize, (float)(startPos.Z % chunksize) / chunksize, forestUpLeft, forestUpRight, forestBotLeft, forestBotRight);
--                    if (struc.TryGenerate(worldgenBlockAccessor, api.World, startPos, climateUpLeft, climateUpRight, climateBotLeft, climateBotRight, forest, locationCode))
-+                    int forest = GameMath.BiLerpRgbColor((float)(startPos.X % chunksize) / chunksize, (float)(startPos.Z % chunksize) / chunksize, stratumForestUpLeft, stratumForestUpRight, stratumForestBotLeft, stratumForestBotRight);
++                    }
+
+-                        if (struc.StoryMaxFromCenter != 0 &&  !startPos.InRangeHorizontally(location.CenterPos.X, location.CenterPos.Z, struc.StoryMaxFromCenter))
++                    int forest = GameMath.BiLerpRgbColor((float)(startPos.X % chunksize) / chunksize, (float)(startPos.Z % chunksize) / chunksize, activeForestUpLeft, activeForestUpRight, activeForestBotLeft, activeForestBotRight);
 +                    bool didGenerate;
 +                    lock (stratumStructurePlacementLock)
-                     {
++                    {
++                        // Stratum: keep the story quota check atomic with placement and registration.
++                        if (locationCode != null && location.SchematicsSpawned?.TryGetValue(struc.Group, out var existingSpawnCount) == true && existingSpawnCount >= struc.StoryLocationMaxAmount)
+                         {
+                             continue;
+                         }
+-                    }
+
+-                    int forest = GameMath.BiLerpRgbColor((float)(startPos.X % chunksize) / chunksize, (float)(startPos.Z % chunksize) / chunksize, forestUpLeft, forestUpRight, forestBotLeft, forestBotRight);
+-                    if (struc.TryGenerate(worldgenBlockAccessor, api.World, startPos, climateUpLeft, climateUpRight, climateBotLeft, climateBotRight, forest, locationCode))
+-                    {
 -                        if(locationCode != null && location != null)
-+                        didGenerate = struc.TryGenerate(worldgenBlockAccessor, api.World, startPos, stratumClimateUpLeft, stratumClimateUpRight, stratumClimateBotLeft, stratumClimateBotRight, forest, locationCode);
++                        didGenerate = struc.TryGenerate(worldgenBlockAccessor, api.World, startPos, activeClimateUpLeft, activeClimateUpRight, activeClimateBotLeft, activeClimateBotRight, forest, locationCode);
 +                        if (didGenerate)
                          {
 -                            if (location.SchematicsSpawned?.TryGetValue(struc.Group, out var spawnedSchematics) == true)
+-                            {
+-                                location.SchematicsSpawned[struc.Group] = spawnedSchematics + 1;
+-                            }
+-                            else
 +                            if(locationCode != null && location != null)
                              {
--                                location.SchematicsSpawned[struc.Group] = spawnedSchematics + 1;
+-                                location.SchematicsSpawned ??= new Dictionary<string, int>();
+-                                location.SchematicsSpawned[struc.Group] = 1;
 +                                if (location.SchematicsSpawned?.TryGetValue(struc.Group, out var spawnedSchematics) == true)
 +                                {
 +                                    location.SchematicsSpawned[struc.Group] = spawnedSchematics + 1;
@@ -244,18 +313,13 @@ index 95025db..e14044e 100644
 +                                    location.SchematicsSpawned[struc.Group] = 1;
 +                                }
                              }
--                            else
--                            {
--                                location.SchematicsSpawned ??= new Dictionary<string, int>();
--                                location.SchematicsSpawned[struc.Group] = 1;
--                            }
 -                        }
 -                        Cuboidi loc = struc.LastPlacedSchematicLocation;
 +                            Cuboidi loc = struc.LastPlacedSchematicLocation;
- 
+
 -                        string code = (struc.LastPlacedSchematic == null ? "" : struc.LastPlacedSchematic.FromFile.GetNameWithDomain()) + "/" + struc.Code;
 +                            string code = (struc.LastPlacedSchematic == null ? "" : struc.LastPlacedSchematic.FromFile.GetNameWithDomain()) + "/" + struc.Code;
- 
+
 -                        region.AddGeneratedStructure(new GeneratedStructure() {
 -                            Code = code,
 -                            Group = struc.Group,
@@ -270,7 +334,7 @@ index 95025db..e14044e 100644
 +                                SuppressTreesAndShrubs = struc.SuppressTrees,
 +                                SuppressRivulets = struc.SuppressWaterfalls
 +                            });
- 
+
 -                        if (struc.BuildProtected)
 -                        {
 -                            api.World.Claims.Add(new LandClaim()
@@ -303,39 +367,57 @@ index 95025db..e14044e 100644
                  }
              }
          }
-@@ -446,18 +473,18 @@ namespace Vintagestory.ServerMods
- 
- 
- 
+
+
+
+
+
+
++        private bool stratumHasColumnState(int chunkX, int chunkZ)
++        {
++            return stratumStateOwner == this && stratumStateChunkX == chunkX && stratumStateChunkZ == chunkZ;
++        }
++
          public void TryGenVillages(IMapRegion region, int chunkX, int chunkZ, bool postPass, ITreeAttribute chunkGenParams = null)
          {
 -            strucRand.InitPositionSeed(chunkX, chunkZ);
-+            (stratumStrucRand ??= new LCGRandom(api.WorldManager.Seed + 1090)).InitPositionSeed(chunkX, chunkZ);
- 
++            LCGRandom activeRand = stratumHasColumnState(chunkX, chunkZ)
++                ? (stratumStrucRand ??= new LCGRandom(api.WorldManager.Seed + 1090))
++                : strucRand;
++            activeRand.InitPositionSeed(chunkX, chunkZ);
++            strucRand = activeRand; // Stratum: keep the exact field current even when ruins returned early
+
              for (int i = 0; i < vcfg.VillageTypes.Length; i++)
              {
                  WorldGenVillage struc = vcfg.VillageTypes[i];
                  if (struc.PostPass != postPass) continue;
                  float chance = struc.Chance * vcfg.ChanceMultiplier;
 -                while (chance-- > strucRand.NextFloat())
-+                while (chance-- > stratumStrucRand.NextFloat())
++                while (chance-- > activeRand.NextFloat())
                  {
                      GenVillage(worldgenBlockAccessor, region, struc, chunkX, chunkZ);
                  }
              }
          }
-@@ -466,67 +493,89 @@ namespace Vintagestory.ServerMods
+
+         public bool GenVillage(IBlockAccessor blockAccessor, IMapRegion region, WorldGenVillage struc, int chunkX, int chunkZ)
          {
++            bool hasColumnState = stratumHasColumnState(chunkX, chunkZ);
++            ushort[] activeHeightmap = hasColumnState ? stratumHeightmap : heightmap;
++            int activeClimateUpLeft = hasColumnState ? stratumClimateUpLeft : climateUpLeft;
++            int activeClimateUpRight = hasColumnState ? stratumClimateUpRight : climateUpRight;
++            int activeClimateBotLeft = hasColumnState ? stratumClimateBotLeft : climateBotLeft;
++            int activeClimateBotRight = hasColumnState ? stratumClimateBotRight : climateBotRight;
              BlockPos pos = new BlockPos(Dimensions.NormalWorld);
- 
+
              int dx = chunksize / 2;
              int dz = chunksize / 2;
 -            int ySurface = heightmap[dz * chunksize + dx];
-+            int ySurface = stratumHeightmap[dz * chunksize + dx];
++            int ySurface = activeHeightmap[dz * chunksize + dx];
              if (ySurface <= 0 || ySurface >= worldheight - 15) return false;
- 
+
              pos.Set(chunkX * chunksize + dx, ySurface, chunkZ * chunksize + dz);
- 
+
 -            return struc.TryGenerate(blockAccessor, api.World, pos, climateUpLeft, climateUpRight, climateBotLeft, climateBotRight, (loc, schematic) =>
 +            // Stratum: same lock as the ruins loop in DoGenStructures. Villages and
 +            // ruins share the same region.GeneratedStructures overlap check, so they
@@ -343,13 +425,13 @@ index 95025db..e14044e 100644
 +            lock (stratumStructurePlacementLock)
              {
 -                string code = (schematic == null ? "" : schematic.FromFile.GetNameWithDomain()) + "/" + struc.Code;
-+                return struc.TryGenerate(blockAccessor, api.World, pos, stratumClimateUpLeft, stratumClimateUpRight, stratumClimateBotLeft, stratumClimateBotRight, (loc, schematic) =>
++                return struc.TryGenerate(blockAccessor, api.World, pos, activeClimateUpLeft, activeClimateUpRight, activeClimateBotLeft, activeClimateBotRight, (loc, schematic) =>
 +                {
 +                    string code = (schematic == null ? "" : schematic.FromFile.GetNameWithDomain()) + "/" + struc.Code;
- 
+
 -                region.AddGeneratedStructure(new GeneratedStructure() { Code = code, Group = struc.Group, Location = loc.Clone() });
 +                    region.AddGeneratedStructure(new GeneratedStructure() { Code = code, Group = struc.Group, Location = loc.Clone() });
- 
+
 -                if (struc.BuildProtected)
 -                {
 -                    api.World.Claims.Add(new LandClaim()
@@ -377,25 +459,18 @@ index 95025db..e14044e 100644
 +                }, spawnPos);
 +            }
          }
- 
- 
-+        // Stratum: treeAndShrubSupressingStructures is a single instance field, one
-+        // GenStructures per world, that PreventPlacementBroadlyAt clears and rebuilds
-+        // per column and PreventPlacementAt reads a bit later for the same column's
-+        // Vegetation-stage processing. Both currently only run from within Vegetation,
-+        // which stays at same-stage cap 1, so today's callers never overlap. The moment
-+        // anyone raises Vegetation's cap the way PreDone/TerrainLate/Terrain already
-+        // got raised, two columns' clear-then-read sequences would interleave on the
-+        // same shared list. Locked now, while the cost is zero (Vegetation is already
-+        // serialized), instead of leaving it as a landmine for whoever raises that cap.
+
+
++        // Stratum: protect the shared suppression list while serial Vegetation rebuilds and reads it.
++        // A future concurrent Vegetation pass will need per-column suppression state as well.
 +        readonly object stratumTreeShrubSuppressLock = new object();
          List<Cuboidi> treeAndShrubSupressingStructures = new List<Cuboidi>();
          int chunkMapSizeY;
- 
+
          public bool PreventPlacementAt(int x, int z, int category)
          {
              if (category != ShrubsHashCode && category != TreesHashCode) return false;
- 
+
 -            for (int i = 0; i < treeAndShrubSupressingStructures.Count; i++)
 +            lock (stratumTreeShrubSuppressLock)
              {
@@ -405,15 +480,15 @@ index 95025db..e14044e 100644
 +                    if (treeAndShrubSupressingStructures[i].Contains(x, z)) return true;
 +                }
              }
- 
+
              return false;
          }
- 
+
          public bool PreventPlacementBroadlyAt(int chunkX, int chunkZ)
          {
              BlockPos chunkStart = new BlockPos(Dimensions.NormalWorld);
              BlockPos chunkEnd = new BlockPos(Dimensions.NormalWorld);
- 
+
 -            treeAndShrubSupressingStructures.Clear();
 -            api.World.BlockAccessor.WalkStructures(
 -                chunkStart.Set(chunkX * chunksize, 0, chunkZ * chunksize),
@@ -435,8 +510,10 @@ index 95025db..e14044e 100644
 +                    }
 +                });
 +            }
- 
+
              return false;
          }
- 
+
          public BlockPatchConfig GetPatchProviderAt(int chunkX, int chunkZ, ref EnumHandling handling)
+         {
+             return null;

--- a/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/7.GenPonds/GenPonds.cs.patch
+++ b/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/7.GenPonds/GenPonds.cs.patch
@@ -1,207 +1,247 @@
 diff --git a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/7.GenPonds/GenPonds.cs b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/7.GenPonds/GenPonds.cs
-index acfac74..44cd890 100644
+index acfac74..fb99e05 100644
 --- a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/7.GenPonds/GenPonds.cs
 +++ b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/7.GenPonds/GenPonds.cs
-@@ -9,27 +9,38 @@ using Vintagestory.API.Server;
- namespace Vintagestory.ServerMods
- {
-     public class GenPonds : ModStdWorldGen
-     {
-         ICoreServerAPI api;
--        LCGRandom rand;
-+        // Stratum: every field below used to be a plain instance field, written by
-+        // OnChunkColumnGen/TryPlacePondAt for one column and read a few calls later
-+        // in the same call chain, unsafe once TerrainFeatures' same-stage cap moved
-+        // off 1, which it since has (see ServerSystemSupplyChunks.stratumStageMaxConcurrent).
-+        // [ThreadStatic] since GenPonds is a singleton ModSystem with no
-+        // second live instance anywhere in the codebase (confirmed by search).
-+        // rand needs lazy per-thread construction with the same world-seed offset
-+        // the old shared instance used (see stratumWorldSeed below), since it's
-+        // reseeded via InitPositionSeed alone per column, never from prior state.
-+        // Wrapped in a StratumWorldgenThreadGuard (opt-in, off by default, see that
-+        // class) instead of stored bare: this field's whole value is that no other
-+        // thread should ever read it, so it is exactly the kind of resource the
-+        // guard is meant to catch a violation of, if one exists.
+@@ -24,16 +24,48 @@ namespace Vintagestory.ServerMods
+         int climateUpLeft;
+         int climateUpRight;
+         int climateBotLeft;
+         int climateBotRight;
+         int[] didCheckPosition;
+         int iteration;
+
++        // Stratum: isolate the original scratch fields while the stock handler runs concurrently.
 +        [ThreadStatic] private static StratumWorldgenThreadGuard<LCGRandom> stratumRandGuard;
 +        [ThreadStatic] private static QueueOfInt stratumSearchPositionsDeltas;
 +        [ThreadStatic] private static QueueOfInt stratumPondPositions;
 +        [ThreadStatic] private static int[] stratumDidCheckPosition;
 +        [ThreadStatic] private static int stratumIteration;
 +        [ThreadStatic] private static int stratumClimateUpLeft, stratumClimateUpRight, stratumClimateBotLeft, stratumClimateBotRight;
++        [ThreadStatic] private static GenPonds stratumStateOwner;
++        [ThreadStatic] private static GenPonds stratumActiveOwner;
++        [ThreadStatic] private static int stratumActiveDepth;
 +
-+        long worldSeed;
-         int mapheight;
-         IWorldGenBlockAccessor blockAccessor;
--        readonly QueueOfInt searchPositionsDeltas = new QueueOfInt();
--        readonly QueueOfInt pondPositions = new QueueOfInt();
-         int searchSize;
-         int mapOffset;
-         int minBoundary;
-         int maxBoundary;
- 
--        int climateUpLeft;
--        int climateUpRight;
--        int climateBotLeft;
--        int climateBotRight;
--        int[] didCheckPosition;
--        int iteration;
--
          LakeBedLayerProperties lakebedLayerConfig;
- 
- 
+
++        // Stratum: clear active TLS state on every handler exit without allocating on the hot path.
++        private readonly struct StratumPondCallScope : IDisposable
++        {
++            private readonly GenPonds previousOwner;
++            private readonly int previousDepth;
++
++            public StratumPondCallScope(GenPonds owner)
++            {
++                previousOwner = stratumActiveOwner;
++                previousDepth = stratumActiveDepth;
++                stratumActiveOwner = owner;
++                stratumActiveDepth = previousDepth + 1;
++            }
++
++            public void Dispose()
++            {
++                stratumActiveOwner = previousOwner;
++                stratumActiveDepth = previousDepth;
++            }
++        }
++
+
          public override double ExecuteOrder()
          {
-@@ -65,17 +76,16 @@ namespace Vintagestory.ServerMods
- 
-         public void initWorldGen()
-         {
-             LoadGlobalConfig(api);
- 
--            rand = new LCGRandom(api.WorldManager.Seed - 12);
-+            worldSeed = api.WorldManager.Seed - 12;
-             searchSize = 3 * chunksize;
-             mapOffset = chunksize;
-             minBoundary = -chunksize + 1;
-             maxBoundary = 2 * chunksize - 1;
-             mapheight = api.WorldManager.MapSizeY;
--            didCheckPosition = new int[searchSize * searchSize];
- 
-             var blockLayerConfig = BlockLayerConfig.GetInstance(api);
- 
-             lakebedLayerConfig = blockLayerConfig.LakeBedLayer;
+             return 0.4;
          }
-@@ -88,11 +98,11 @@ namespace Vintagestory.ServerMods
+
+         public override bool ShouldLoad(EnumAppSide side)
+@@ -85,35 +117,48 @@ namespace Vintagestory.ServerMods
+             var chunks = request.Chunks;
+             int chunkX = request.ChunkX;
+             int chunkZ = request.ChunkZ;
              if (GetIntersectingStructure(chunkX * chunksize + chunksize / 2, chunkZ * chunksize + chunksize / 2, PondsHashCode) != null)
              {
                  return;
              }
++            if (stratumStateOwner != this)
++            {
++                stratumStateOwner = this;
++                stratumRandGuard = new StratumWorldgenThreadGuard<LCGRandom>("GenPonds.rand", new LCGRandom(api.WorldManager.Seed - 12));
++                stratumSearchPositionsDeltas = new QueueOfInt();
++                stratumPondPositions = new QueueOfInt();
++                stratumDidCheckPosition = new int[searchSize * searchSize];
++                stratumIteration = 0;
++            }
++
++            didCheckPosition = stratumDidCheckPosition; // Stratum: publish the active visited map through the vanilla field.
++            using StratumPondCallScope stratumCallScope = new StratumPondCallScope(this);
              blockAccessor.BeginColumn();
 -            LCGRandom rand = this.rand;
-+            LCGRandom rand = (stratumRandGuard ??= new StratumWorldgenThreadGuard<LCGRandom>("GenPonds.rand", new LCGRandom(worldSeed))).Get();
++            LCGRandom rand = stratumRandGuard.Get();
++            this.rand = rand; // Stratum: keep the vanilla field current for reflection and Harmony state access.
              rand.InitPositionSeed(chunkX, chunkZ);
              int maxHeight = mapheight - 1;
              int pondYPos;
- 
+
              ushort[] heightmap = chunks[0].MapChunk.RainHeightMap;
-@@ -102,16 +112,16 @@ namespace Vintagestory.ServerMods
+             var mc = chunks[0].MapChunk;
+
+             IntDataMap2D climateMap = chunks[0].MapChunk.MapRegion.ClimateMap;
              int regionChunkSize = api.WorldManager.RegionSize / chunksize;
              float fac = (float)climateMap.InnerSize / regionChunkSize;
              int rlX = chunkX % regionChunkSize;
              int rlZ = chunkZ % regionChunkSize;
- 
+
 -            climateUpLeft = climateMap.GetUnpaddedInt((int)(rlX * fac), (int)(rlZ * fac));
 -            climateUpRight = climateMap.GetUnpaddedInt((int)(rlX * fac + fac), (int)(rlZ * fac));
 -            climateBotLeft = climateMap.GetUnpaddedInt((int)(rlX * fac), (int)(rlZ * fac + fac));
 -            climateBotRight = climateMap.GetUnpaddedInt((int)(rlX * fac + fac), (int)(rlZ * fac + fac));
-+            stratumClimateUpLeft = climateMap.GetUnpaddedInt((int)(rlX * fac), (int)(rlZ * fac));
-+            stratumClimateUpRight = climateMap.GetUnpaddedInt((int)(rlX * fac + fac), (int)(rlZ * fac));
-+            stratumClimateBotLeft = climateMap.GetUnpaddedInt((int)(rlX * fac), (int)(rlZ * fac + fac));
-+            stratumClimateBotRight = climateMap.GetUnpaddedInt((int)(rlX * fac + fac), (int)(rlZ * fac + fac));
- 
++            climateUpLeft = stratumClimateUpLeft = climateMap.GetUnpaddedInt((int)(rlX * fac), (int)(rlZ * fac));
++            climateUpRight = stratumClimateUpRight = climateMap.GetUnpaddedInt((int)(rlX * fac + fac), (int)(rlZ * fac));
++            climateBotLeft = stratumClimateBotLeft = climateMap.GetUnpaddedInt((int)(rlX * fac), (int)(rlZ * fac + fac));
++            climateBotRight = stratumClimateBotRight = climateMap.GetUnpaddedInt((int)(rlX * fac + fac), (int)(rlZ * fac + fac));
+
 -            int climateMid = GameMath.BiLerpRgbColor(0.5f, 0.5f, climateUpLeft, climateUpRight, climateBotLeft, climateBotRight);
 +            int climateMid = GameMath.BiLerpRgbColor(0.5f, 0.5f, stratumClimateUpLeft, stratumClimateUpRight, stratumClimateBotLeft, stratumClimateBotRight);
- 
+
              // 16-23 bits = Red = temperature
              // 8-15 bits = Green = rain
              // 0-7 bits = Blue = humidity
- 
-@@ -184,10 +194,13 @@ namespace Vintagestory.ServerMods
+
+             int rain = (climateMid >> 8) & 0xff;
+             int temp = (climateMid >> 16) & 0xff;
+@@ -182,26 +227,36 @@ namespace Vintagestory.ServerMods
+         {
+             int mapOffset = this.mapOffset;
              int searchSize = this.searchSize;
              int minBoundary = this.minBoundary;
              int maxBoundary = this.maxBoundary;
              int waterID = gcfg.waterBlockId;
              int ndx, ndz;
-+            QueueOfInt searchPositionsDeltas = stratumSearchPositionsDeltas ??= new QueueOfInt();
-+            QueueOfInt pondPositions = stratumPondPositions ??= new QueueOfInt();
-+            int[] didCheckPosition = stratumDidCheckPosition ??= new int[searchSize * searchSize];
++            bool useStratumState = stratumActiveOwner == this && stratumActiveDepth > 0 && stratumStateOwner == this;
++            QueueOfInt searchPositionsDeltas = useStratumState ? stratumSearchPositionsDeltas : this.searchPositionsDeltas;
++            QueueOfInt pondPositions = useStratumState ? stratumPondPositions : this.pondPositions;
++            int[] didCheckPosition = useStratumState ? stratumDidCheckPosition : this.didCheckPosition;
++            LCGRandom activeRand = useStratumState ? stratumRandGuard.Get() : rand;
++            int activeClimateUpLeft = useStratumState ? stratumClimateUpLeft : climateUpLeft;
++            int activeClimateUpRight = useStratumState ? stratumClimateUpRight : climateUpRight;
++            int activeClimateBotLeft = useStratumState ? stratumClimateBotLeft : climateBotLeft;
++            int activeClimateBotRight = useStratumState ? stratumClimateBotRight : climateBotRight;
              searchPositionsDeltas.Clear();
              pondPositions.Clear();
- 
+
              int basePosX = chunkX * chunksize;
              int basePosZ = chunkZ * chunksize;
-@@ -195,11 +208,11 @@ namespace Vintagestory.ServerMods
- 
+             Vec2i tmp = new Vec2i();
+
              // The starting block is an air block
              int arrayIndex = (dz + mapOffset) * searchSize + dx + mapOffset;
              searchPositionsDeltas.Enqueue(arrayIndex);
              pondPositions.Enqueue(arrayIndex);
 -            int iteration = ++this.iteration;
-+            int iteration = ++stratumIteration;
++            int iteration = useStratumState ? ++stratumIteration : ++this.iteration;
++            if (useStratumState) this.iteration = iteration; // Stratum: publish the current counter through the vanilla field.
              didCheckPosition[arrayIndex] = iteration;
- 
+
              BlockPos tmpPos = new BlockPos(API.Config.Dimensions.NormalWorld);
- 
+
              while (searchPositionsDeltas.Count > 0)
-@@ -262,11 +275,11 @@ namespace Vintagestory.ServerMods
+             {
+                 int p = searchPositionsDeltas.Dequeue();
+@@ -260,15 +315,15 @@ namespace Vintagestory.ServerMods
+             int regionChunkSize = api.WorldManager.RegionSize / chunksize;
+             IMapChunk mapchunk=null;
              IServerChunk chunk = null;
              IServerChunk chunkOneBlockBelow = null;
- 
+
              int ly = GameMath.Mod(pondYPos, chunksize);
- 
+
 -            bool extraPondDepth = rand.NextFloat() > 0.5f;
-+            bool extraPondDepth = stratumRandGuard.Get().NextFloat() > 0.5f;
++            bool extraPondDepth = activeRand.NextFloat() > 0.5f;
              bool withSeabed = extraPondDepth || pondPositions.Count > 16;
- 
+
              while (pondPositions.Count > 0)
              {
                  int p = pondPositions.Dequeue();
-@@ -281,10 +294,14 @@ namespace Vintagestory.ServerMods
+                 int px = p % searchSize - mapOffset + basePosX;
+                 int pz = p / searchSize - mapOffset + basePosZ;
+@@ -279,14 +334,16 @@ namespace Vintagestory.ServerMods
+                 int lz = GameMath.Mod(pz, chunksize);
+
                  // Get correct chunk and correct climate data if we don't have it already
                  if (curChunkX != prevChunkX || curChunkZ != prevChunkZ)
                  {
                      chunk = (IServerChunk)blockAccessor.GetChunk(curChunkX, pondYPos / chunksize, curChunkZ);
                      if (chunk == null) chunk = api.WorldManager.GetChunk(curChunkX, pondYPos / chunksize, curChunkZ);
-+                    // Stratum: the fallback lookup can still return null (e.g. a neighbour column that's absent or mid-unload
-+                    // while multiple columns run TerrainFeatures concurrently); the sibling chunkOneBlockBelow lookup just
-+                    // below already guards this way, so bail out here too instead of NRE'ing on Unpack().
++                    // Stratum: concurrent generation can observe an absent neighbour.
 +                    if (chunk == null) return;
                      chunk.Unpack();
- 
+
                      if (ly == 0)
                      {
                          chunkOneBlockBelow = ((IServerChunk)blockAccessor.GetChunk(curChunkX, (pondYPos - 1) / chunksize, curChunkZ));
-@@ -300,14 +317,14 @@ namespace Vintagestory.ServerMods
- 
+                         if (chunkOneBlockBelow == null) return;
+                         chunkOneBlockBelow.Unpack();
+@@ -298,32 +355,44 @@ namespace Vintagestory.ServerMods
+                     mapchunk = chunk.MapChunk;
+                     IntDataMap2D climateMap = mapchunk.MapRegion.ClimateMap;
+
                      float fac = (float)climateMap.InnerSize / regionChunkSize;
                      int rlX = curChunkX % regionChunkSize;
                      int rlZ = curChunkZ % regionChunkSize;
- 
+
 -                    climateUpLeft = climateMap.GetUnpaddedInt((int)(rlX * fac), (int)(rlZ * fac));
 -                    climateUpRight = climateMap.GetUnpaddedInt((int)(rlX * fac + fac), (int)(rlZ * fac));
 -                    climateBotLeft = climateMap.GetUnpaddedInt((int)(rlX * fac), (int)(rlZ * fac + fac));
 -                    climateBotRight = climateMap.GetUnpaddedInt((int)(rlX * fac + fac), (int)(rlZ * fac + fac));
-+                    stratumClimateUpLeft = climateMap.GetUnpaddedInt((int)(rlX * fac), (int)(rlZ * fac));
-+                    stratumClimateUpRight = climateMap.GetUnpaddedInt((int)(rlX * fac + fac), (int)(rlZ * fac));
-+                    stratumClimateBotLeft = climateMap.GetUnpaddedInt((int)(rlX * fac), (int)(rlZ * fac + fac));
-+                    stratumClimateBotRight = climateMap.GetUnpaddedInt((int)(rlX * fac + fac), (int)(rlZ * fac + fac));
- 
++                    activeClimateUpLeft = climateMap.GetUnpaddedInt((int)(rlX * fac), (int)(rlZ * fac));
++                    activeClimateUpRight = climateMap.GetUnpaddedInt((int)(rlX * fac + fac), (int)(rlZ * fac));
++                    activeClimateBotLeft = climateMap.GetUnpaddedInt((int)(rlX * fac), (int)(rlZ * fac + fac));
++                    activeClimateBotRight = climateMap.GetUnpaddedInt((int)(rlX * fac + fac), (int)(rlZ * fac + fac));
++
++                    if (useStratumState)
++                    {
++                        stratumClimateUpLeft = activeClimateUpLeft;
++                        stratumClimateUpRight = activeClimateUpRight;
++                        stratumClimateBotLeft = activeClimateBotLeft;
++                        stratumClimateBotRight = activeClimateBotRight;
++                    }
++                    climateUpLeft = activeClimateUpLeft;
++                    climateUpRight = activeClimateUpRight;
++                    climateBotLeft = activeClimateBotLeft;
++                    climateBotRight = activeClimateBotRight;
+
                      prevChunkX = curChunkX;
                      prevChunkZ = curChunkZ;
- 
+
                      chunkOneBlockBelow.MarkModified();
-@@ -317,11 +334,11 @@ namespace Vintagestory.ServerMods
- 
+                     chunk.MarkModified();
+                 }
+
+
                  // Raise heightmap by 1 (only relevant for above-ground ponds)
                  if (mapchunk.RainHeightMap[lz * chunksize + lx] < pondYPos) mapchunk.RainHeightMap[lz * chunksize + lx] = (ushort)pondYPos;
- 
+
                  // Identify correct climate at this position - could be optimised if we place water into ponds in columns instead of layers
 -                int climate = GameMath.BiLerpRgbColor((float)lx / chunksize, (float)lz / chunksize, climateUpLeft, climateUpRight, climateBotLeft, climateBotRight);
-+                int climate = GameMath.BiLerpRgbColor((float)lx / chunksize, (float)lz / chunksize, stratumClimateUpLeft, stratumClimateUpRight, stratumClimateBotLeft, stratumClimateBotRight);
++                int climate = GameMath.BiLerpRgbColor((float)lx / chunksize, (float)lz / chunksize, activeClimateUpLeft, activeClimateUpRight, activeClimateBotLeft, activeClimateBotRight);
                  float temp = Climate.GetScaledAdjustedTemperatureFloat((climate >> 16) & 0xff, pondYPos - TerraGenConfig.seaLevel);
- 
- 
+
+
                  // 1. Place water or ice block
                  int index3d = (ly * chunksize + lz) * chunksize + lx;
-@@ -355,11 +372,11 @@ namespace Vintagestory.ServerMods
- 
+                 Block existing = api.World.GetBlock(chunk.Data.GetBlockId(index3d, BlockLayersAccess.Solid));
+                 if (existing.BlockMaterial == EnumBlockMaterial.Plant)
+@@ -353,15 +422,15 @@ namespace Vintagestory.ServerMods
+                 // Water below? Seabed already placed
+                 if (belowBlock.IsLiquid()) continue;
+
                  float rainRel = Climate.GetRainFall((climate >> 8) & 0xff, pondYPos) / 255f;
                  int rockBlockId = mapchunk.TopRockIdMap[lz * chunksize + lx];
                  if (rockBlockId == 0) continue;
- 
+
 -                int lakebedId = lakebedLayerConfig.GetSuitable(temp, rainRel, (float)pondYPos / mapheight, rand, rockBlockId);
-+                int lakebedId = lakebedLayerConfig.GetSuitable(temp, rainRel, (float)pondYPos / mapheight, stratumRandGuard.Get(), rockBlockId);
++                int lakebedId = lakebedLayerConfig.GetSuitable(temp, rainRel, (float)pondYPos / mapheight, activeRand, rockBlockId);
                  if (lakebedId != 0) chunkOneBlockBelow.Data[index] = lakebedId;
              }
- 
- 
+
+
              if (extraPondDepth)
+             {
+                 TryPlacePondAt(dx, pondYPos+1, dz, chunkX, chunkZ, depth + 1);

--- a/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/8.GenVegetationAndPatches/GenVegetationAndPatches.cs.patch
+++ b/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/8.GenVegetationAndPatches/GenVegetationAndPatches.cs.patch
@@ -1,425 +1,55 @@
 diff --git a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/8.GenVegetationAndPatches/GenVegetationAndPatches.cs b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/8.GenVegetationAndPatches/GenVegetationAndPatches.cs
-index aadf540..ffa4195 100644
+index aadf540..6f1c45c 100644
 --- a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/8.GenVegetationAndPatches/GenVegetationAndPatches.cs
 +++ b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/8.GenVegetationAndPatches/GenVegetationAndPatches.cs
-@@ -29,11 +29,10 @@ namespace Vintagestory.ServerMods
-     }
- 
-     public class GenVegetationAndPatches : ModStdWorldGen
-     {
-         protected ICoreServerAPI sapi;
--        protected LCGRandom rnd;
-         protected IWorldGenBlockAccessor blockAccessor;
-         protected WgenTreeSupplier treeSupplier;
-         protected int worldheight;
-         protected int regionChunkSize;
-         protected IBlockPatchModifier[] patchMod = new IBlockPatchModifier[0];
-@@ -47,10 +46,25 @@ namespace Vintagestory.ServerMods
- 
+@@ -48,8 +48,15 @@ namespace Vintagestory.ServerMods
          /// <summary>
          /// Vegetation and BlockPatch sub seed
          /// </summary>
          protected const int subSeed = 87698;
 +
-+        // Stratum: genPatches/genShrubs/genTrees each allocated a fresh LCGRandom every
-+        // column, six per column between them (genPatches runs twice, pre-pass and
-+        // post-pass). LCGRandom.SetWorldSeed() overwrites every field the class has
-+        // (worldSeed, mapGenSeed, currentSeed) before InitPositionSeed() runs, so a
-+        // reused instance behaves identically to a fresh one, nothing carries over
-+        // between calls. [ThreadStatic] instead of a shared field: this class also has
-+        // an actual shared LCGRandom (rnd, above), reseeded the same way per column,
-+        // which stays a real cross-column race risk the moment Vegetation's same-stage
-+        // cap moves off 1, flagged separately, not touched by this change.
-+        [ThreadStatic] private static LCGRandom stratumPatchIterRandom;
-+        [ThreadStatic] private static LCGRandom stratumBlockPatchRandom;
-+        [ThreadStatic] private static LCGRandom stratumShrubTryRandom;
-+        [ThreadStatic] private static LCGRandom stratumTreeTryRandom;
++        // Stratum: Vegetation stays serial, so reuse its temporary random generators per instance.
++        private LCGRandom stratumPatchIterRandom;
++        private LCGRandom stratumBlockPatchRandom;
++        private LCGRandom stratumShrubTryRandom;
++        private LCGRandom stratumTreeTryRandom;
 +
          public override bool ShouldLoad(EnumAppSide side)
          {
              return side == EnumAppSide.Server;
          }
- 
-@@ -112,12 +126,10 @@ namespace Vintagestory.ServerMods
-             regionSize = sapi.WorldManager.RegionSize;
-             noiseSizeDensityMap = regionSize / TerraGenConfig.blockPatchesMapScale;
- 
-             LoadGlobalConfig(sapi);
- 
--            rnd = new LCGRandom(sapi.WorldManager.Seed - subSeed);
--
-             treeSupplier.LoadTrees();
- 
-             worldheight = sapi.WorldManager.MapSizeY;
-             regionChunkSize = sapi.WorldManager.RegionSize / chunksize;
- 
-@@ -139,11 +151,11 @@ namespace Vintagestory.ServerMods
-             {
-                 allPatches.AddRange(patches.Value);
-             }
-             bpc.Patches = allPatches.ToArray();
- 
--            bpc.ResolveBlockIds(sapi, rockstrata, rnd);
-+            bpc.ResolveBlockIds(sapi, rockstrata, stratumRnd ??= new LCGRandom(sapi.WorldManager.Seed - subSeed));
-             treeSupplier.treeGenerators.forestFloorSystem.SetBlockPatches(bpc);
- 
- 
-             ITreeAttribute worldConfig = sapi.WorldManager.SaveGame.WorldConfiguration;
-             forestMod = worldConfig.GetString("globalForestation").ToFloat(0);
-@@ -157,80 +169,88 @@ namespace Vintagestory.ServerMods
-                 int seed = sapi.World.Seed + 112897 + hs;
-                 blockPatchMapGens[patch.MapCode] = new MapLayerWobbled(seed, 2, 0.9f, TerraGenConfig.forestMapScale, 4000, -2500);
-             }
-         }
- 
--        ushort[] heightmap;
--        int forestUpLeft;
--        int forestUpRight;
--        int forestBotLeft;
--        int forestBotRight;
--
--        int shrubUpLeft;
--        int shrubUpRight;
--        int shrubBotLeft;
--        int shrubBotRight;
--
--        int climateUpLeft;
--        int climateUpRight;
--        int climateBotLeft;
--        int climateBotRight;
--
--        BlockPos tmpPos = new BlockPos(API.Config.Dimensions.NormalWorld);
-+        // Stratum: every field below used to be a plain instance field, written by
-+        // OnChunkColumnGen and read a few calls later by genPatches/genShrubs/genTrees/
-+        // canGenerateAt, all within the processing of ONE column, the same shape of bug
-+        // GenCreatures had for PreDone (see the comment on that class's own [ThreadStatic]
-+        // block). Vegetation's own same-stage cap stays at 1 today, so this was not a live
-+        // race yet, but two columns' write-then-read sequences would clobber each other
-+        // the moment anyone raises that cap, the same way rnd (below) and
-+        // treeAndShrubSupressingStructures in GenStructures already did. [ThreadStatic]
-+        // keeps every field private to whichever thread is currently inside
-+        // OnChunkColumnGen for a given column, at zero cost while only one thread at a
-+        // time is ever in here.
-+        [ThreadStatic] private static ushort[] stratumHeightmap;
-+        [ThreadStatic] private static int stratumForestUpLeft, stratumForestUpRight, stratumForestBotLeft, stratumForestBotRight;
-+        [ThreadStatic] private static int stratumShrubUpLeft, stratumShrubUpRight, stratumShrubBotLeft, stratumShrubBotRight;
-+        [ThreadStatic] private static int stratumClimateUpLeft, stratumClimateUpRight, stratumClimateBotLeft, stratumClimateBotRight;
-+        [ThreadStatic] private static BlockPos stratumTmpPos;
- 
-         /// <summary>
-         /// Structures generally are sparsely placed in the world, so 99% of the time we can generate block patches unimpeded.
-         /// So for performance reasons, lets do a single broad test first, which allows us to skip detail testing later
-         /// </summary>
--        bool preventBroadly;
-+        [ThreadStatic] private static bool stratumPreventBroadly;
-+
-+        // Stratum: rnd used to be seeded once for the whole world in initWorldGen and
-+        // reseeded per column via InitPositionSeed alone, no SetWorldSeed. That reseed
-+        // does not depend on rnd's own prior state (InitPositionSeed derives currentSeed
-+        // from mapGenSeed, xPos, and zPos only, and mapGenSeed itself never changes after
-+        // the one-time SetWorldSeed call in the constructor), so this needed isolation,
-+        // not GenCreatures' extra fix of removing a dispatch-order dependency: two
-+        // different columns already got two different, order-independent seeds here.
-+        [ThreadStatic] private static LCGRandom stratumRnd;
- 
-         private void OnChunkColumnGen(IChunkColumnGenerateRequest request)
-         {
-             var chunks = request.Chunks;
-             int chunkX = request.ChunkX;
-             int chunkZ = request.ChunkZ;
- 
-             blockAccessor.BeginColumn();
--            rnd.InitPositionSeed(chunkX, chunkZ);
-+            (stratumRnd ??= new LCGRandom(sapi.WorldManager.Seed - subSeed)).InitPositionSeed(chunkX, chunkZ);
- 
-             IMapChunk mapChunk = chunks[0].MapChunk;
- 
-             IntDataMap2D forestMap = mapChunk.MapRegion.ForestMap;
-             IntDataMap2D shrubMap = mapChunk.MapRegion.ShrubMap;
-             IntDataMap2D climateMap = mapChunk.MapRegion.ClimateMap;
-             int rlX = chunkX % regionChunkSize;
-             int rlZ = chunkZ % regionChunkSize;
- 
-             float facS = (float)shrubMap.InnerSize / regionChunkSize;
--            shrubUpLeft = shrubMap.GetUnpaddedInt((int)(rlX * facS), (int)(rlZ * facS));
--            shrubUpRight = shrubMap.GetUnpaddedInt((int)(rlX * facS + facS), (int)(rlZ * facS));
--            shrubBotLeft = shrubMap.GetUnpaddedInt((int)(rlX * facS), (int)(rlZ * facS + facS));
--            shrubBotRight = shrubMap.GetUnpaddedInt((int)(rlX * facS + facS), (int)(rlZ * facS + facS));
-+            stratumShrubUpLeft = shrubMap.GetUnpaddedInt((int)(rlX * facS), (int)(rlZ * facS));
-+            stratumShrubUpRight = shrubMap.GetUnpaddedInt((int)(rlX * facS + facS), (int)(rlZ * facS));
-+            stratumShrubBotLeft = shrubMap.GetUnpaddedInt((int)(rlX * facS), (int)(rlZ * facS + facS));
-+            stratumShrubBotRight = shrubMap.GetUnpaddedInt((int)(rlX * facS + facS), (int)(rlZ * facS + facS));
- 
-             // A region has 16 chunks
-             // Size of the forest map is RegionSize / TerraGenConfig.forestMapScale  => 32*16 / 32  = 16 pixel
-             // rlX, rlZ goes from 0..16 pixel
-             // facF = 16/16 = 1
-             // Get 4 pixels for chunkx, chunkz, chunkx+1 and chunkz+1 inside the map
-             float facF = (float)forestMap.InnerSize / regionChunkSize;
--            forestUpLeft = forestMap.GetUnpaddedInt((int)(rlX * facF), (int)(rlZ * facF));
--            forestUpRight = forestMap.GetUnpaddedInt((int)(rlX * facF + facF), (int)(rlZ * facF));
--            forestBotLeft = forestMap.GetUnpaddedInt((int)(rlX * facF), (int)(rlZ * facF + facF));
--            forestBotRight = forestMap.GetUnpaddedInt((int)(rlX * facF + facF), (int)(rlZ * facF + facF));
-+            stratumForestUpLeft = forestMap.GetUnpaddedInt((int)(rlX * facF), (int)(rlZ * facF));
-+            stratumForestUpRight = forestMap.GetUnpaddedInt((int)(rlX * facF + facF), (int)(rlZ * facF));
-+            stratumForestBotLeft = forestMap.GetUnpaddedInt((int)(rlX * facF), (int)(rlZ * facF + facF));
-+            stratumForestBotRight = forestMap.GetUnpaddedInt((int)(rlX * facF + facF), (int)(rlZ * facF + facF));
- 
-             float facC = (float)climateMap.InnerSize / regionChunkSize;
--            climateUpLeft = climateMap.GetUnpaddedInt((int)(rlX * facC), (int)(rlZ * facC));
--            climateUpRight = climateMap.GetUnpaddedInt((int)(rlX * facC + facC), (int)(rlZ * facC));
--            climateBotLeft = climateMap.GetUnpaddedInt((int)(rlX * facC), (int)(rlZ * facC + facC));
--            climateBotRight = climateMap.GetUnpaddedInt((int)(rlX * facC + facC), (int)(rlZ * facC + facC));
-+            stratumClimateUpLeft = climateMap.GetUnpaddedInt((int)(rlX * facC), (int)(rlZ * facC));
-+            stratumClimateUpRight = climateMap.GetUnpaddedInt((int)(rlX * facC + facC), (int)(rlZ * facC));
-+            stratumClimateBotLeft = climateMap.GetUnpaddedInt((int)(rlX * facC), (int)(rlZ * facC + facC));
-+            stratumClimateBotRight = climateMap.GetUnpaddedInt((int)(rlX * facC + facC), (int)(rlZ * facC + facC));
- 
--            heightmap = chunks[0].MapChunk.RainHeightMap;
--            preventBroadly = false;
-+            stratumHeightmap = chunks[0].MapChunk.RainHeightMap;
-+            stratumPreventBroadly = false;
- 
-             foreach (var provider in patchMod)
-             {
--                preventBroadly |= provider.PreventPlacementBroadlyAt(chunkX, chunkZ);
-+                stratumPreventBroadly |= provider.PreventPlacementBroadlyAt(chunkX, chunkZ);
-             }
- 
- 
-             if (TerraGenConfig.GenerateVegetation)
-             {
-@@ -245,12 +265,12 @@ namespace Vintagestory.ServerMods
-         {
+@@ -246,10 +253,10 @@ namespace Vintagestory.ServerMods
              int dx, dz, x, z;
              Block liquidBlock;
              int mapsizeY = blockAccessor.MapSizeY;
- 
+
 -            var patchIterRandom = new LCGRandom();
 -            var blockPatchRandom = new LCGRandom();
 +            var patchIterRandom = stratumPatchIterRandom ??= new LCGRandom();
 +            var blockPatchRandom = stratumBlockPatchRandom ??= new LCGRandom();
- 
+
              // get temp pos to check if we need a story location patch or a regular one
              patchIterRandom.SetWorldSeed(sapi.WorldManager.Seed - subSeed);
              patchIterRandom.InitPositionSeed(chunkX, chunkZ);
- 
-@@ -272,29 +292,29 @@ namespace Vintagestory.ServerMods
-                     dx = patchIterRandom.NextInt(chunksize);
-                     dz = patchIterRandom.NextInt(chunksize);
-                     x = dx + chunkX * chunksize;
-                     z = dz + chunkZ * chunksize;
- 
--                    int y = heightmap[dz * chunksize + dx];
-+                    int y = stratumHeightmap[dz * chunksize + dx];
-                     if (y <= 0 || y >= worldheight - 15) continue;
- 
--                    tmpPos.Set(x, y, z);
-+                    (stratumTmpPos ??= new BlockPos(API.Config.Dimensions.NormalWorld)).Set(x, y, z);
- 
--                    liquidBlock = blockAccessor.GetBlock(tmpPos, BlockLayersAccess.Fluid);
-+                    liquidBlock = blockAccessor.GetBlock(stratumTmpPos, BlockLayersAccess.Fluid);
- 
-                     // Place according to forest value
--                    float forestRel = GameMath.BiLerp(forestUpLeft, forestUpRight, forestBotLeft, forestBotRight, (float)dx / chunksize, (float)dz / chunksize) / 255f;
-+                    float forestRel = GameMath.BiLerp(stratumForestUpLeft, stratumForestUpRight, stratumForestBotLeft, stratumForestBotRight, (float)dx / chunksize, (float)dz / chunksize) / 255f;
-                     forestRel = GameMath.Clamp(forestRel + forestMod, 0, 1);
- 
--                    float shrubRel = GameMath.BiLerp(shrubUpLeft, shrubUpRight, shrubBotLeft, shrubBotRight, (float)dx / chunksize, (float)dz / chunksize) / 255f;
-+                    float shrubRel = GameMath.BiLerp(stratumShrubUpLeft, stratumShrubUpRight, stratumShrubBotLeft, stratumShrubBotRight, (float)dx / chunksize, (float)dz / chunksize) / 255f;
-                     shrubRel = GameMath.Clamp(shrubRel + shrubMod, 0, 1);
- 
--                    int climate = GameMath.BiLerpRgbColor((float)dx / chunksize, (float)dz / chunksize, climateUpLeft, climateUpRight, climateBotLeft, climateBotRight);
-+                    int climate = GameMath.BiLerpRgbColor((float)dx / chunksize, (float)dz / chunksize, stratumClimateUpLeft, stratumClimateUpRight, stratumClimateBotLeft, stratumClimateBotRight);
- 
-                     if (bpc.IsPatchSuitableAt(blockPatch, liquidBlock, mapsizeY, climate, y, forestRel, shrubRel))
-                     {
--                        if (!preventBroadly && !canGenerateAt(tmpPos.X, tmpPos.Z, blockPatch.CategoryHashCode)) continue;
-+                        if (!stratumPreventBroadly && !canGenerateAt(stratumTmpPos.X, stratumTmpPos.Z, blockPatch.CategoryHashCode)) continue;
- 
-                         if (blockPatch.MapCode != null && patchIterRandom.NextInt(255) > GetPatchDensity(blockPatch.MapCode, x, z, mapregion))
-                         {
-                             continue;
-                         }
-@@ -306,11 +326,11 @@ namespace Vintagestory.ServerMods
-                         {
-                             found = false;
-                             int dy = 1;
-                             while (dy < 5 && y - dy > 0)
-                             {
--                                string lastCodePart = blockAccessor.GetBlockBelow(tmpPos, dy, BlockLayersAccess.Solid).LastCodePart();
-+                                string lastCodePart = blockAccessor.GetBlockBelow(stratumTmpPos, dy, BlockLayersAccess.Solid).LastCodePart();
-                                 if (RockBlockIdsByType.TryGetValue(lastCodePart, out firstBlockId)) { found = true; break; }
-                                 dy++;
-                             }
-                         }
- 
-@@ -318,11 +338,11 @@ namespace Vintagestory.ServerMods
-                         {
-                             blockPatchRandom.SetWorldSeed(sapi.WorldManager.Seed - subSeed + i);
-                             blockPatchRandom.InitPositionSeed(x, z);
-                             blockPatch.Generate(
-                                 blockAccessor, patchIterRandom, x, y, z, firstBlockId,
--                                !preventBroadly ? null : (tx, tz) => canGenerateAt(tx, tz, PatchesHashCode)
-+                                !stratumPreventBroadly ? null : (tx, tz) => canGenerateAt(tx, tz, PatchesHashCode)
-                             );
-                         }
-                     }
-                 }
-             }
-@@ -362,15 +382,15 @@ namespace Vintagestory.ServerMods
-             return bpcPatchesNonTree;
-         }
- 
-         void genShrubs(int chunkX, int chunkZ)
-         {
--            rnd.InitPositionSeed(chunkX, chunkZ);
--            int triesShrubs = (int)treeSupplier.treeGenProps.shrubsPerChunk.nextFloat(1f, rnd);
-+            (stratumRnd ??= new LCGRandom(sapi.WorldManager.Seed - subSeed)).InitPositionSeed(chunkX, chunkZ);
-+            int triesShrubs = (int)treeSupplier.treeGenProps.shrubsPerChunk.nextFloat(1f, stratumRnd);
+@@ -367,9 +374,9 @@ namespace Vintagestory.ServerMods
+             rnd.InitPositionSeed(chunkX, chunkZ);
+             int triesShrubs = (int)treeSupplier.treeGenProps.shrubsPerChunk.nextFloat(1f, rnd);
              int dx, dz, x, z;
              Block block;
 -            var shrubTryRandom = new LCGRandom();
 +            var shrubTryRandom = stratumShrubTryRandom ??= new LCGRandom();
- 
+
              while (triesShrubs > 0)
              {
                  shrubTryRandom.SetWorldSeed(sapi.World.Seed - subSeed + triesShrubs);
-                 shrubTryRandom.InitPositionSeed(chunkX, chunkZ);
-@@ -379,61 +399,61 @@ namespace Vintagestory.ServerMods
-                 dx = shrubTryRandom.NextInt(chunksize);
-                 dz = shrubTryRandom.NextInt(chunksize);
-                 x = dx + chunkX * chunksize;
-                 z = dz + chunkZ * chunksize;
- 
--                int y = heightmap[dz * chunksize + dx];
-+                int y = stratumHeightmap[dz * chunksize + dx];
-                 if (y <= 0 || y >= worldheight - 15) continue;
- 
--                tmpPos.Set(x, y, z);
-+                (stratumTmpPos ??= new BlockPos(API.Config.Dimensions.NormalWorld)).Set(x, y, z);
- 
--                block = blockAccessor.GetBlock(tmpPos);
-+                block = blockAccessor.GetBlock(stratumTmpPos);
-                 if (block.Fertility == 0) continue;
- 
-                 // Place according to forest value
--                int climate = GameMath.BiLerpRgbColor((float)dx / chunksize, (float)dz / chunksize, climateUpLeft, climateUpRight, climateBotLeft, climateBotRight);
--                float shrubChance = GameMath.BiLerp(shrubUpLeft, shrubUpRight, shrubBotLeft, shrubBotRight, (float)dx / chunksize, (float)dz / chunksize);
-+                int climate = GameMath.BiLerpRgbColor((float)dx / chunksize, (float)dz / chunksize, stratumClimateUpLeft, stratumClimateUpRight, stratumClimateBotLeft, stratumClimateBotRight);
-+                float shrubChance = GameMath.BiLerp(stratumShrubUpLeft, stratumShrubUpRight, stratumShrubBotLeft, stratumShrubBotRight, (float)dx / chunksize, (float)dz / chunksize);
-                 shrubChance = GameMath.Clamp(shrubChance + 255*forestMod, 0, 255);
- 
-                 if (shrubTryRandom.NextFloat() > (shrubChance / 255f) * (shrubChance / 255f)) continue;
-                 TreeGenInstance treegenParams = treeSupplier.GetRandomShrubGenForClimate(shrubTryRandom, climate, (int)shrubChance, y);
- 
-                 if (treegenParams != null)
-                 {
--                    if (preventBroadly && !canGenerateAt(tmpPos.X, tmpPos.Z, ShrubsHashCode)) continue;
-+                    if (stratumPreventBroadly && !canGenerateAt(stratumTmpPos.X, stratumTmpPos.Z, ShrubsHashCode)) continue;
- 
--                    if (blockAccessor.GetBlock(tmpPos).Replaceable >= 6000)
-+                    if (blockAccessor.GetBlock(stratumTmpPos).Replaceable >= 6000)
-                     {
--                        tmpPos.Y--;
-+                        stratumTmpPos.Y--;
-                     }
- 
-                     treegenParams.skipForestFloor = true;
- 
--                    treegenParams.GrowTree(blockAccessor, tmpPos, shrubTryRandom);
-+                    treegenParams.GrowTree(blockAccessor, stratumTmpPos, shrubTryRandom);
-                 }
-             }
-         }
- 
-         void genTrees(int chunkX, int chunkZ)
-         {
--            rnd.InitPositionSeed(chunkX, chunkZ);
--            int climate = GameMath.BiLerpRgbColor((float)0.5f, (float)0.5f, climateUpLeft, climateUpRight, climateBotLeft, climateBotRight);
--            float wetrel = Climate.GetRainFall((climate >> 8) & 0xff, heightmap[(chunksize / 2) * chunksize + chunksize/2]) / 255f;
-+            (stratumRnd ??= new LCGRandom(sapi.WorldManager.Seed - subSeed)).InitPositionSeed(chunkX, chunkZ);
-+            int climate = GameMath.BiLerpRgbColor((float)0.5f, (float)0.5f, stratumClimateUpLeft, stratumClimateUpRight, stratumClimateBotLeft, stratumClimateBotRight);
-+            float wetrel = Climate.GetRainFall((climate >> 8) & 0xff, stratumHeightmap[(chunksize / 2) * chunksize + chunksize/2]) / 255f;
-             float temprel = ((climate>>16) & 0xff) / 255f;
-             float dryrel = 1 - wetrel;
- 
-             float drypenalty = 1 - GameMath.Clamp(2f * (dryrel - 0.5f + 1.5f*Math.Max(temprel - 0.6f, 0)), 0, 0.8f); // Reduce tree generation by up to 70% in low rain places
-             float wetboost = 1 + 3 * Math.Max(0, wetrel - 0.75f);
- 
--            int triesTrees = (int)(treeSupplier.treeGenProps.treesPerChunk.nextFloat(1f, rnd) * drypenalty * wetboost);
-+            int triesTrees = (int)(treeSupplier.treeGenProps.treesPerChunk.nextFloat(1f, stratumRnd) * drypenalty * wetboost);
-             int dx, dz, x, z;
-             Block block;
+@@ -430,9 +437,9 @@ namespace Vintagestory.ServerMods
              int treesGenerated = 0;
- 
+
              EnumHemisphere hemisphere = sapi.World.Calendar.GetHemisphere(new BlockPos(chunkX * chunksize + chunksize / 2, 0, chunkZ * chunksize + chunksize / 2));
- 
+
 -            var treeTryRandom = new LCGRandom();
 +            var treeTryRandom = stratumTreeTryRandom ??= new LCGRandom();
              while (triesTrees > 0)
              {
                  treeTryRandom.SetWorldSeed(sapi.World.Seed - subSeed + triesTrees);
                  treeTryRandom.InitPositionSeed(chunkX, chunkZ);
-                 triesTrees--;
-@@ -441,26 +461,26 @@ namespace Vintagestory.ServerMods
-                 dx = treeTryRandom.NextInt(chunksize);
-                 dz = treeTryRandom.NextInt(chunksize);
-                 x = dx + chunkX * chunksize;
-                 z = dz + chunkZ * chunksize;
- 
--                int y = heightmap[dz * chunksize + dx];
-+                int y = stratumHeightmap[dz * chunksize + dx];
-                 if (y <= 0 || y >= worldheight - 15) continue;
- 
-                 bool underwater = false;
- 
--                tmpPos.Set(x, y, z);
--                block = blockAccessor.GetBlock(tmpPos, BlockLayersAccess.Fluid);
-+                (stratumTmpPos ??= new BlockPos(API.Config.Dimensions.NormalWorld)).Set(x, y, z);
-+                block = blockAccessor.GetBlock(stratumTmpPos, BlockLayersAccess.Fluid);
- 
--                if (block.IsLiquid()) { underwater = true; tmpPos.Y--; block = blockAccessor.GetBlock(tmpPos, BlockLayersAccess.Fluid); if (block.IsLiquid()) tmpPos.Y--; }
-+                if (block.IsLiquid()) { underwater = true; stratumTmpPos.Y--; block = blockAccessor.GetBlock(stratumTmpPos, BlockLayersAccess.Fluid); if (block.IsLiquid()) stratumTmpPos.Y--; }
- 
--                block = blockAccessor.GetBlock(tmpPos);
-+                block = blockAccessor.GetBlock(stratumTmpPos);
-                 if (block.Fertility == 0) continue;
- 
-                 // Place according to forest value
--                float treeDensity = GameMath.BiLerp(forestUpLeft, forestUpRight, forestBotLeft, forestBotRight, (float)dx / chunksize, (float)dz / chunksize);
--                climate = GameMath.BiLerpRgbColor((float)dx / chunksize, (float)dz / chunksize, climateUpLeft, climateUpRight, climateBotLeft, climateBotRight);
-+                float treeDensity = GameMath.BiLerp(stratumForestUpLeft, stratumForestUpRight, stratumForestBotLeft, stratumForestBotRight, (float)dx / chunksize, (float)dz / chunksize);
-+                climate = GameMath.BiLerpRgbColor((float)dx / chunksize, (float)dz / chunksize, stratumClimateUpLeft, stratumClimateUpRight, stratumClimateBotLeft, stratumClimateBotRight);
- 
-                 treeDensity = GameMath.Clamp(treeDensity + forestMod*255, 0, 255);
- 
-                 float treeDensityNormalized = treeDensity / 255f;
- 
-@@ -471,22 +491,22 @@ namespace Vintagestory.ServerMods
-                 if (treeTryRandom.NextFloat() > Math.Max(0.0025f, treeDensityNormalized * treeDensityNormalized) || forestMod <= -1) continue;
-                 TreeGenInstance treegenParams = treeSupplier.GetRandomTreeGenForClimate(treeTryRandom, climate, (int)treeDensity, y, underwater);
- 
-                 if (treegenParams != null)
-                 {
--                    if (preventBroadly && !canGenerateAt(tmpPos.X, tmpPos.Z, TreesHashCode)) continue;
-+                    if (stratumPreventBroadly && !canGenerateAt(stratumTmpPos.X, stratumTmpPos.Z, TreesHashCode)) continue;
- 
--                    if (blockAccessor.GetBlock(tmpPos).Replaceable >= 6000)
-+                    if (blockAccessor.GetBlock(stratumTmpPos).Replaceable >= 6000)
-                     {
--                        tmpPos.Y--;
-+                        stratumTmpPos.Y--;
-                     }
- 
-                     treegenParams.skipForestFloor = false;
-                     treegenParams.hemisphere = hemisphere;
-                     treegenParams.treesInChunkGenerated = treesGenerated;
- 
--                    treegenParams.GrowTree(blockAccessor, tmpPos, treeTryRandom);
-+                    treegenParams.GrowTree(blockAccessor, stratumTmpPos, treeTryRandom);
- 
-                     treesGenerated++;
-                 }
-             }
-         }

--- a/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/93.GenCreatures.cs.patch
+++ b/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/93.GenCreatures.cs.patch
@@ -1,252 +1,69 @@
 diff --git a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/93.GenCreatures.cs b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/93.GenCreatures.cs
-index 647310c..8df05ba 100644
+index 647310c..0eb2ea3 100644
 --- a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/93.GenCreatures.cs
 +++ b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/93.GenCreatures.cs
-@@ -20,35 +20,42 @@ namespace Vintagestory.ServerMods
-     }
+@@ -48,6 +48,9 @@ namespace Vintagestory.ServerMods
+         protected int shrubsBotRight;
+         protected List<SpawnOppurtunity> spawnPositions = new List<SpawnOppurtunity>();
  
-     public class GenCreatures : ModStdWorldGen
-     {
-         protected ICoreServerAPI api;
--        protected Random rnd;
-         protected int worldheight;
-         protected IWorldGenBlockAccessor wgenBlockAccessor;
-         protected Dictionary<EntityProperties, EntityProperties[]> entityTypeGroups = new Dictionary<EntityProperties, EntityProperties[]>();
- 
-         public Dictionary<string, MapLayerBase> animalMapGens = new Dictionary<string, MapLayerBase>();
-         protected int noiseSizeDensityMap;
-         protected int regionSize;
- 
--
--        protected int climateUpLeft;
--        protected int climateUpRight;
--        protected int climateBotLeft;
--        protected int climateBotRight;
--
--        protected int forestUpLeft;
--        protected int forestUpRight;
--        protected int forestBotLeft;
--        protected int forestBotRight;
--
--        protected int shrubsUpLeft;
--        protected int shrubsUpRight;
--        protected int shrubsBotLeft;
--        protected int shrubsBotRight;
--        protected List<SpawnOppurtunity> spawnPositions = new List<SpawnOppurtunity>();
-+        // Stratum start: this generator can now run concurrently for distant columns
-+        // on different worker threads (see StratumWorldGenStages / PreDone concurrency
-+        // cap). Everything that used to be a plain instance field here was written by
-+        // OnChunkColumnGen and read a few calls later by TrySpawnGroupAt/CreateEntity,
-+        // all within the processing of ONE column; sharing the field across threads
-+        // let two concurrently-processed columns clobber each other's climate/forest/
-+        // shrub readings and creature-position scratch list. [ThreadStatic] keeps each
-+        // field private to the thread that is currently inside OnChunkColumnGen for a
-+        // given column, at zero cost for the still-common case of one thread at a time.
-+        //
-+        // rnd needed a different fix, not just isolation: the old field was a single
-+        // Random seeded once for the whole world and advanced across every column in
-+        // whatever order the dispatcher happened to hand them out, so two runs of the
-+        // same seed could already spawn different creatures depending on processing
-+        // order, with or without concurrency. Seeding a fresh Random per column from a
-+        // hash of (world seed, chunkX, chunkZ) removes that order dependency and is
-+        // safe under concurrency for the same reason it is safe today: two different
-+        // columns always get two different seeds.
-+        [ThreadStatic] private static Random stratumRnd;
-+        [ThreadStatic] private static int stratumClimateUpLeft, stratumClimateUpRight, stratumClimateBotLeft, stratumClimateBotRight;
-+        [ThreadStatic] private static int stratumForestUpLeft, stratumForestUpRight, stratumForestBotLeft, stratumForestBotRight;
-+        [ThreadStatic] private static int stratumShrubsUpLeft, stratumShrubsUpRight, stratumShrubsBotLeft, stratumShrubsBotRight;
-+        [ThreadStatic] private static List<SpawnOppurtunity> stratumSpawnPositions;
-+        // Stratum end
- 
++        // Stratum: each worldgen thread gets a complete generator so protected fields stay mod-visible.
++        StratumWorkerInstances<GenCreatures> stratumWorkers;
++
  
          public override bool ShouldLoad(EnumAppSide side) => side == EnumAppSide.Server;
          public override double ExecuteOrder() => 0.1;
+@@ -58,8 +61,9 @@ namespace Vintagestory.ServerMods
  
-@@ -96,12 +103,11 @@ namespace Vintagestory.ServerMods
- 
- 
-         protected void initWorldGen()
-         {
-             LoadGlobalConfig(api);
--            rnd = new Random(api.WorldManager.Seed - 18722);
--            worldheight = api.WorldManager.MapSizeY;
-+            worldheight = api.WorldManager.MapSizeY; // Stratum: stratumRnd is now seeded per column in OnChunkColumnGen, not once here
- 
-             Dictionary<AssetLocation, EntityProperties> entityTypesByCode = new Dictionary<AssetLocation, EntityProperties>();
- 
-             for (int i = 0; i < api.World.EntityTypes.Count; i++)
+             if (TerraGenConfig.DoDecorationPass)
              {
-@@ -180,61 +186,68 @@ namespace Vintagestory.ServerMods
++                stratumWorkers = new StratumWorkerInstances<GenCreatures>(StratumCreateWorker); // Stratum: isolate per-column state without changing vanilla fields
+                 api.Event.InitWorldGenerator(initWorldGen, "standard");
+-                api.Event.ChunkColumnGeneration(OnChunkColumnGen, EnumWorldGenPass.PreDone, "standard");
++                api.Event.ChunkColumnGeneration(StratumOnChunkColumnGen, EnumWorldGenPass.PreDone, "standard"); // Stratum: run the handler on this thread's worker
+
+                 api.Event.MapRegionGeneration(OnMapRegionGen, "standard");
+                 api.Event.MapRegionGeneration(OnMapRegionGen, "superflat");
+@@ -141,6 +145,33 @@ namespace Vintagestory.ServerMods
+             loadAnimalMaps();
+         }
  
-             if (GetIntersectingStructure(chunkX * chunksize + chunksize / 2, chunkZ * chunksize + chunksize / 2, CreaturesHashCode) != null)
++        private void StratumOnChunkColumnGen(IChunkColumnGenerateRequest request)
++        {
++            stratumWorkers.Current.OnChunkColumnGen(request);
++        }
++
++        private GenCreatures StratumCreateWorker()
++        {
++            GenCreatures worker = new GenCreatures();
++            worker.StratumCopyStateFrom(this);
++            return worker;
++        }
++
++        // Stratum: copy configured state and give mutable fields to one worldgen thread.
++        private void StratumCopyStateFrom(GenCreatures source)
++        {
++            api = source.api;
++            LoadGlobalConfig(api);
++            rnd = new Random(api.WorldManager.Seed - 18722);
++            worldheight = source.worldheight;
++            wgenBlockAccessor = source.wgenBlockAccessor;
++            entityTypeGroups = source.entityTypeGroups;
++            animalMapGens = source.animalMapGens;
++            noiseSizeDensityMap = source.noiseSizeDensityMap;
++            regionSize = source.regionSize;
++            spawnPositions = new List<SpawnOppurtunity>(source.spawnPositions);
++        }
++
+         protected void loadAnimalMaps()
+         {
+             regionSize = api.WorldManager.RegionSize;
+@@ -182,6 +213,9 @@ namespace Vintagestory.ServerMods
              {
                  return;
              }
 +
-+            // Stratum: reseed per column instead of reading a shared, world-lifetime
-+            // Random. Two different columns always get two different seeds, so this
-+            // stays correct whether this stage runs one column at a time or several
-+            // concurrently, and it removes the old dependency on processing order.
-+            stratumRnd = new Random(GameMath.MurmurHash3(api.WorldManager.Seed, chunkX, chunkZ) - 18722);
++            rnd = new Random(GameMath.MurmurHash3(api.WorldManager.Seed, chunkX, chunkZ) - 18722); // Stratum: make creature placement independent of column dispatch order
 +
              wgenBlockAccessor.BeginColumn();
              IntDataMap2D climateMap = chunks[0].MapChunk.MapRegion.ClimateMap;
              ushort[] heightMap = chunks[0].MapChunk.WorldGenTerrainHeightMap;
- 
-             int regionChunkSize = api.WorldManager.RegionSize / chunksize;
-             int rlX = chunkX % regionChunkSize;
-             int rlZ = chunkZ % regionChunkSize;
- 
-             float facC = (float)climateMap.InnerSize / regionChunkSize;
--            climateUpLeft = climateMap.GetUnpaddedInt((int)(rlX * facC), (int)(rlZ * facC));
--            climateUpRight = climateMap.GetUnpaddedInt((int)(rlX * facC + facC), (int)(rlZ * facC));
--            climateBotLeft = climateMap.GetUnpaddedInt((int)(rlX * facC), (int)(rlZ * facC + facC));
--            climateBotRight = climateMap.GetUnpaddedInt((int)(rlX * facC + facC), (int)(rlZ * facC + facC));
-+            stratumClimateUpLeft = climateMap.GetUnpaddedInt((int)(rlX * facC), (int)(rlZ * facC));
-+            stratumClimateUpRight = climateMap.GetUnpaddedInt((int)(rlX * facC + facC), (int)(rlZ * facC));
-+            stratumClimateBotLeft = climateMap.GetUnpaddedInt((int)(rlX * facC), (int)(rlZ * facC + facC));
-+            stratumClimateBotRight = climateMap.GetUnpaddedInt((int)(rlX * facC + facC), (int)(rlZ * facC + facC));
- 
-             IntDataMap2D forestMap = chunks[0].MapChunk.MapRegion.ForestMap;
-             float facF = (float)forestMap.InnerSize / regionChunkSize;
--            forestUpLeft = forestMap.GetUnpaddedInt((int)(rlX * facF), (int)(rlZ * facF));
--            forestUpRight = forestMap.GetUnpaddedInt((int)(rlX * facF + facF), (int)(rlZ * facF));
--            forestBotLeft = forestMap.GetUnpaddedInt((int)(rlX * facF), (int)(rlZ * facF + facF));
--            forestBotRight = forestMap.GetUnpaddedInt((int)(rlX * facF + facF), (int)(rlZ * facF + facF));
-+            stratumForestUpLeft = forestMap.GetUnpaddedInt((int)(rlX * facF), (int)(rlZ * facF));
-+            stratumForestUpRight = forestMap.GetUnpaddedInt((int)(rlX * facF + facF), (int)(rlZ * facF));
-+            stratumForestBotLeft = forestMap.GetUnpaddedInt((int)(rlX * facF), (int)(rlZ * facF + facF));
-+            stratumForestBotRight = forestMap.GetUnpaddedInt((int)(rlX * facF + facF), (int)(rlZ * facF + facF));
- 
-             IntDataMap2D shrubMap = chunks[0].MapChunk.MapRegion.ShrubMap;
-             float facS = (float)shrubMap.InnerSize / regionChunkSize;
--            shrubsUpLeft = shrubMap.GetUnpaddedInt((int)(rlX * facS), (int)(rlZ * facS));
--            shrubsUpRight = shrubMap.GetUnpaddedInt((int)(rlX * facS + facS), (int)(rlZ * facS));
--            shrubsBotLeft = shrubMap.GetUnpaddedInt((int)(rlX * facS), (int)(rlZ * facS + facS));
--            shrubsBotRight = shrubMap.GetUnpaddedInt((int)(rlX * facS + facS), (int)(rlZ * facS + facS));
-+            stratumShrubsUpLeft = shrubMap.GetUnpaddedInt((int)(rlX * facS), (int)(rlZ * facS));
-+            stratumShrubsUpRight = shrubMap.GetUnpaddedInt((int)(rlX * facS + facS), (int)(rlZ * facS));
-+            stratumShrubsBotLeft = shrubMap.GetUnpaddedInt((int)(rlX * facS), (int)(rlZ * facS + facS));
-+            stratumShrubsBotRight = shrubMap.GetUnpaddedInt((int)(rlX * facS + facS), (int)(rlZ * facS + facS));
- 
-             Vec3d posAsVec = new Vec3d();
-             BlockPos pos = new BlockPos(Dimensions.NormalWorld);
- 
-             foreach (var val in entityTypeGroups)
-             {
-                 EntityProperties entitytype = val.Key;
--                float tries = entitytype.Server.SpawnConditions.Worldgen.TriesPerChunk.nextFloat(1, rnd);
-+                float tries = entitytype.Server.SpawnConditions.Worldgen.TriesPerChunk.nextFloat(1, stratumRnd);
-                 if (tries == 0f) continue;
- 
-                 var scRuntime = entitytype.Server.SpawnConditions.Runtime;   // the Group ("hostile"/"neutral"/"passive") is only held in the Runtime spawn conditions
-                 if (scRuntime == null || scRuntime.Group != "hostile") tries *= gcfg.neutralCreatureSpawnMultiplier;
- 
--                while (tries-- > rnd.NextDouble())
-+                while (tries-- > stratumRnd.NextDouble())
-                 {
--                    int dx = rnd.Next(chunksize);
--                    int dz = rnd.Next(chunksize);
-+                    int dx = stratumRnd.Next(chunksize);
-+                    int dz = stratumRnd.Next(chunksize);
- 
-                     pos.Set(chunkX * chunksize + dx, 0, chunkZ * chunksize + dz);
- 
-                     pos.Y =
-                         entitytype.Server.SpawnConditions.Worldgen.TryOnlySurface ?
-                         heightMap[dz * chunksize + dx] + 1 :
--                        rnd.Next(worldheight)
-+                        stratumRnd.Next(worldheight)
-                     ;
-                     posAsVec.Set(pos.X + 0.5, pos.Y + 0.005, pos.Z + 0.5);
- 
-                     TrySpawnGroupAt(request.Chunks[0].MapChunk.MapRegion, pos, posAsVec, entitytype, val.Value);
-                 }
-@@ -244,10 +257,11 @@ namespace Vintagestory.ServerMods
- 
- 
- 
-         protected void TrySpawnGroupAt(IMapRegion mr, BlockPos origin, Vec3d posAsVec, EntityProperties entityType, EntityProperties[] grouptypes)
-         {
-+            List<SpawnOppurtunity> spawnPositions = stratumSpawnPositions ??= new List<SpawnOppurtunity>(); // Stratum: per-thread, see the field declaration
-             BlockPos pos = origin.Copy();
-             int climate;
-             float temp;
-             float rain;
-             float forestDensity;
-@@ -268,11 +282,11 @@ namespace Vintagestory.ServerMods
-             {
-                 float val = sc.HerdSize.nextFloat();
- #if PERFTEST
-                 val *= 40;
- #endif
--                nextGroupSize = (int)val + ((val - (int)val) > rnd.NextDouble() ? 1 : 0);
-+                nextGroupSize = (int)val + ((val - (int)val) > stratumRnd.NextDouble() ? 1 : 0);
-             }
- 
- 
-             for (int i = 0; i < nextGroupSize * 4 + 5; i++)
-             {
-@@ -281,13 +295,13 @@ namespace Vintagestory.ServerMods
-                 EntityProperties typeToSpawn = entityType;
- 
-                 // First entity with valid spawnpos (typically the male) must be the dominant creature, every subsequent only 20% chance for males (or even lower if more than 5 companion types)
-                 double dominantChance = spawned == 0 ? 1 : Math.Min(0.2, 1f / grouptypes.Length);
- 
--                if (grouptypes.Length > 1 && rnd.NextDouble() > dominantChance)
-+                if (grouptypes.Length > 1 && stratumRnd.NextDouble() > dominantChance)
-                 {
--                    typeToSpawn = grouptypes[1 + rnd.Next(grouptypes.Length - 1)];
-+                    typeToSpawn = grouptypes[1 + stratumRnd.Next(grouptypes.Length - 1)];
-                 }
- 
-                 IBlockAccessor blockAccessor = wgenBlockAccessor.GetChunkAtBlockPos(pos) == null ? api.World.BlockAccessor : wgenBlockAccessor;
- 
-                 IMapChunk mapchunk = blockAccessor.GetMapChunkAtBlockPos(pos);
-@@ -305,15 +319,15 @@ namespace Vintagestory.ServerMods
- 
-                         xRel = (float)(posAsVec.X % chunksize) / chunksize;
-                         zRel = (float)(posAsVec.Z % chunksize) / chunksize;
- 
-                         // We check temperature at 109% of sea level for the sake of consistency (no polar bears on tall mountains)
--                        climate = GameMath.BiLerpRgbColor(xRel, zRel, climateUpLeft, climateUpRight, climateBotLeft, climateBotRight);
-+                        climate = GameMath.BiLerpRgbColor(xRel, zRel, stratumClimateUpLeft, stratumClimateUpRight, stratumClimateBotLeft, stratumClimateBotRight);
-                         temp = Climate.GetScaledAdjustedTemperatureFloat((climate >> 16) & 0xff, (int)(TerraGenConfig.seaLevel * 0.09));
-                         rain = ((climate >> 8) & 0xff) / 255f;
--                        forestDensity = GameMath.BiLerp(forestUpLeft, forestUpRight, forestBotLeft, forestBotRight, xRel, zRel) / 255f;
--                        shrubDensity = GameMath.BiLerp(shrubsUpLeft, shrubsUpRight, shrubsBotLeft, shrubsBotRight, xRel, zRel) / 255f;
-+                        forestDensity = GameMath.BiLerp(stratumForestUpLeft, stratumForestUpRight, stratumForestBotLeft, stratumForestBotRight, xRel, zRel) / 255f;
-+                        shrubDensity = GameMath.BiLerp(stratumShrubsUpLeft, stratumShrubsUpRight, stratumShrubsBotLeft, stratumShrubsBotRight, xRel, zRel) / 255f;
- 
- 
-                         if (CanSpawnAtConditions(blockAccessor, typeToSpawn, pos, posAsVec, sc, rain, temp, forestDensity, shrubDensity))
-                         {
-                             spawnPositions.Add(new SpawnOppurtunity() { ForType = typeToSpawn, Pos = posAsVec.Clone() });
-@@ -321,12 +335,12 @@ namespace Vintagestory.ServerMods
-                         }
- 
-                     }
-                 }
- 
--                pos.X = origin.X + ((rnd.Next(11) - 5) + (rnd.Next(11) - 5)) / 2;
--                pos.Z = origin.Z + ((rnd.Next(11) - 5) + (rnd.Next(11) - 5)) / 2;
-+                pos.X = origin.X + ((stratumRnd.Next(11) - 5) + (stratumRnd.Next(11) - 5)) / 2;
-+                pos.Z = origin.Z + ((stratumRnd.Next(11) - 5) + (stratumRnd.Next(11) - 5)) / 2;
-             }
- 
- 
-             // Only spawn if the group reached the minimum group size
-             if (spawnPositions.Count >= nextGroupSize)
-@@ -362,11 +376,11 @@ namespace Vintagestory.ServerMods
- 
-         protected Entity CreateEntity(EntityProperties entityType, Vec3d spawnPosition)
-         {
-             Entity entity = api.ClassRegistry.CreateEntity(entityType);
-             entity.Pos.SetPosWithDimension(spawnPosition);
--            entity.Pos.SetYaw((float)rnd.NextDouble() * GameMath.TWOPI);
-+            entity.Pos.SetYaw((float)stratumRnd.NextDouble() * GameMath.TWOPI);
-             entity.PositionBeforeFalling.Set(entity.Pos.X, entity.Pos.Y, entity.Pos.Z);
-             entity.Attributes.SetString("origin", "worldgen");
-             return entity;
-         }
- 

--- a/patches/VSEssentials/Systems/WorldGen/Standard/Datastructures/BlockSchematicStructure.cs.patch
+++ b/patches/VSEssentials/Systems/WorldGen/Standard/Datastructures/BlockSchematicStructure.cs.patch
@@ -1,75 +1,55 @@
 diff --git a/VSEssentials/Systems/WorldGen/Standard/Datastructures/BlockSchematicStructure.cs b/VSEssentials/Systems/WorldGen/Standard/Datastructures/BlockSchematicStructure.cs
-index 7573f32..d75ab17 100644
+index 7573f32..7b9e3e9 100644
 --- a/VSEssentials/Systems/WorldGen/Standard/Datastructures/BlockSchematicStructure.cs
 +++ b/VSEssentials/Systems/WorldGen/Standard/Datastructures/BlockSchematicStructure.cs
-@@ -12,11 +12,30 @@ using Vintagestory.ServerMods.NoObf;
- 
- namespace Vintagestory.ServerMods
- {
+@@ -15,8 +15,15 @@ namespace Vintagestory.ServerMods
      public class BlockSchematicStructure : BlockSchematic
      {
--        public Dictionary<int, AssetLocation> BlockCodesTmpForRemap = new();
-+        // Stratum: scratch storage for the remapped block-code map built below, used only
-+        // when replaceBlocks is non-null. It must never be handed a reference to BlockCodes.
-+        //
-+        // This field used to hold either the scratch dictionary OR BlockCodes itself, and
-+        // being [ThreadStatic] on a static it is shared by every BlockSchematicStructure on
-+        // the thread, not one per schematic the way the original instance field was. So a
-+        // placement with replaceBlocks == null pointed it at that schematic's permanent
-+        // BlockCodes, and the next placement on the same thread with replaceBlocks != null
-+        // saw a non-null value that did not match ITS OWN BlockCodes and called Clear() on
-+        // it, wiping a different schematic's permanent id-to-code map for the rest of the
-+        // process. Downstream that surfaces as "block id N not found in block registry"
-+        // warnings and a KeyNotFoundException from BlockSchematic.PlaceOneDecor, which
-+        // indexes BlockCodes directly, and the wrong blocks it places are persisted.
-+        //
-+        // Now the resolve method returns the map instead of publishing it here, and the
-+        // null-replaceBlocks path returns BlockCodes untouched, matching what vanilla
-+        // BlockSchematic does. This field can therefore only ever hold its own scratch
-+        // dictionary, which makes clearing and reusing it safe.
+         public Dictionary<int, AssetLocation> BlockCodesTmpForRemap = new();
+
++        // Stratum: reuse remap storage without clearing any schematic's permanent BlockCodes.
 +        [ThreadStatic]
 +        private static Dictionary<int, AssetLocation> stratumBlockCodesRemapScratch;
- 
++
++        // Stratum: capture the public remap result before another placement can replace it.
++        private readonly object stratumRemapLock = new object();
++
          public AssetLocation FromFile;
- 
+
          public Block[,,] blocksByPos;
          public Dictionary<int, Block> FluidBlocksByPos;
-@@ -125,11 +144,11 @@ namespace Vintagestory.ServerMods
-             IMapChunk mapchunk = blockAccessor.GetMapChunkAtBlockPos(curPos);
+@@ -126,9 +133,14 @@ namespace Vintagestory.ServerMods
              int centerrockblockid = mapchunk.TopRockIdMap[(curPos.Z % chunksize) * chunksize + curPos.X % chunksize];
- 
+
              IWorldAccessor worldgenWorldAccessor = blockAccessor is IWorldGenBlockAccessor wgba ? wgba.WorldgenWorldAccessor : worldForCollectibleResolve;
- 
+
 -            resolveReplaceRemapsForBlockEntities(blockAccessor, worldForCollectibleResolve, replaceBlocks, centerrockblockid);
-+            Dictionary<int, AssetLocation> blockCodesForRemap = resolveReplaceRemapsForBlockEntities(blockAccessor, worldForCollectibleResolve, replaceBlocks, centerrockblockid);
- 
++            Dictionary<int, AssetLocation> blockCodesForRemap;
++            lock (stratumRemapLock)
++            {
++                resolveReplaceRemapsForBlockEntities(blockAccessor, worldForCollectibleResolve, replaceBlocks, centerrockblockid);
++                blockCodesForRemap = BlockCodesTmpForRemap;
++            }
+
              Dictionary<BlockPos, Block> layerBlockForBlockEntities = new Dictionary<BlockPos, Block>();
- 
+
              for (int x = 0; x < SizeX; x++)
-             {
-@@ -306,38 +325,43 @@ namespace Vintagestory.ServerMods
-                     }
+@@ -307,9 +319,9 @@ namespace Vintagestory.ServerMods
                  }
              }
- 
+
              PlaceDecors(blockAccessor, startPos);
 -            PlaceEntitiesAndBlockEntities(blockAccessor, worldForCollectibleResolve, startPos, BlockCodesTmpForRemap, ItemCodes, replaceBlockEntities, replaceBlocks, centerrockblockid, layerBlockForBlockEntities, replaceMetaBlocks);
 +            PlaceEntitiesAndBlockEntities(blockAccessor, worldForCollectibleResolve, startPos, blockCodesForRemap, ItemCodes, replaceBlockEntities, replaceBlocks, centerrockblockid, layerBlockForBlockEntities, replaceMetaBlocks);
- 
+
              return placed;
          }
- 
--        private void resolveReplaceRemapsForBlockEntities(IBlockAccessor blockAccessor, IWorldAccessor worldForCollectibleResolve, Dictionary<int, Dictionary<int, int>> replaceBlocks, int centerrockblockid)
-+        private Dictionary<int, AssetLocation> resolveReplaceRemapsForBlockEntities(IBlockAccessor blockAccessor, IWorldAccessor worldForCollectibleResolve, Dictionary<int, Dictionary<int, int>> replaceBlocks, int centerrockblockid)
-         {
-             if (replaceBlocks == null)
-             {
--                BlockCodesTmpForRemap = BlockCodes;
--                return;
-+                // Stratum: hand BlockCodes back directly and never store or mutate it, same as vanilla.
-+                return BlockCodes;
+
+@@ -320,23 +332,28 @@ namespace Vintagestory.ServerMods
+                 BlockCodesTmpForRemap = BlockCodes;
+                 return;
              }
- 
+
 +            if (stratumBlockCodesRemapScratch == null) stratumBlockCodesRemapScratch = new Dictionary<int, AssetLocation>();
 +            else stratumBlockCodesRemapScratch.Clear();
 +
@@ -77,10 +57,10 @@ index 7573f32..d75ab17 100644
              {
                  Block origBlock = worldForCollectibleResolve.GetBlock(val.Value);
                  if (origBlock == null) continue; // Invalid blocks
- 
+
 -                BlockCodesTmpForRemap[val.Key] = val.Value;
 +                stratumBlockCodesRemapScratch[val.Key] = val.Value;
- 
+
                  if (replaceBlocks.TryGetValue(origBlock.Id, out var replaceByBlock))
                  {
                      if (replaceByBlock.TryGetValue(centerrockblockid, out int newBlockId))
@@ -91,44 +71,43 @@ index 7573f32..d75ab17 100644
                  }
              }
 +
-+            return stratumBlockCodesRemapScratch;
++            BlockCodesTmpForRemap = stratumBlockCodesRemapScratch;
          }
- 
- 
- 
- 
-@@ -358,11 +382,11 @@ namespace Vintagestory.ServerMods
- 
+
+
+
+@@ -359,9 +376,14 @@ namespace Vintagestory.ServerMods
              const int chunksize = GlobalConstants.ChunkSize;
              curPos.Set(SizeX / 2 + startPos.X, startPos.Y, SizeZ / 2 + startPos.Z);
              IMapChunk mapchunk = blockAccessor.GetMapChunkAtBlockPos(curPos);
              int centerrockblockid = rockBlockId ?? mapchunk.TopRockIdMap[(curPos.Z % chunksize) * chunksize + curPos.X % chunksize];
 -            resolveReplaceRemapsForBlockEntities(blockAccessor, worldForCollectibleResolve, replaceBlocks, centerrockblockid);
-+            Dictionary<int, AssetLocation> blockCodesForRemap = resolveReplaceRemapsForBlockEntities(blockAccessor, worldForCollectibleResolve, replaceBlocks, centerrockblockid);
- 
- 
++            Dictionary<int, AssetLocation> blockCodesForRemap;
++            lock (stratumRemapLock)
++            {
++                resolveReplaceRemapsForBlockEntities(blockAccessor, worldForCollectibleResolve, replaceBlocks, centerrockblockid);
++                blockCodesForRemap = BlockCodesTmpForRemap;
++            }
+
+
              PlaceBlockDelegate handler = null;
              switch (ReplaceMode)
-             {
-@@ -426,11 +450,11 @@ namespace Vintagestory.ServerMods
-             }
- 
+@@ -427,9 +449,9 @@ namespace Vintagestory.ServerMods
+
              if (!(blockAccessor is IBlockAccessorRevertable))
              {
                  PlaceDecors(blockAccessor, startPos);
 -                PlaceEntitiesAndBlockEntities(blockAccessor, worldForCollectibleResolve, startPos, BlockCodesTmpForRemap, ItemCodes, false, null, centerrockblockid, null, GlobalConfig.ReplaceMetaBlocks);
 +                PlaceEntitiesAndBlockEntities(blockAccessor, worldForCollectibleResolve, startPos, blockCodesForRemap, ItemCodes, false, null, centerrockblockid, null, GlobalConfig.ReplaceMetaBlocks);
              }
- 
+
              return placed;
          }
- 
-@@ -512,29 +536,52 @@ namespace Vintagestory.ServerMods
-             cloned.OriginalPos = OriginalPos;
- 
+@@ -513,27 +535,50 @@ namespace Vintagestory.ServerMods
+
              return cloned;
          }
- 
+
 +        // Stratum: guards the lazy unpack below. schematicDatas entries (see WorldGenStructure)
 +        // are cached objects reused by every column that draws this schematic, and worldgen has
 +        // always let different columns run in different pipeline stages at the same time,
@@ -162,7 +141,7 @@ index 7573f32..d75ab17 100644
 +                }
              }
          }
- 
+
          public void Unpack(ICoreAPI api, int orientation)
          {
 -            if (orientation > 0 && blocksByPos == null)
@@ -180,4 +159,3 @@ index 7573f32..d75ab17 100644
              Unpack(api);
          }
      }
- }

--- a/patches/VSEssentials/Systems/WorldGen/Standard/GenPartial.cs.patch
+++ b/patches/VSEssentials/Systems/WorldGen/Standard/GenPartial.cs.patch
@@ -1,57 +1,27 @@
 diff --git a/VSEssentials/Systems/WorldGen/Standard/GenPartial.cs b/VSEssentials/Systems/WorldGen/Standard/GenPartial.cs
-index 58aa710..43ec0ad 100644
 --- a/VSEssentials/Systems/WorldGen/Standard/GenPartial.cs
 +++ b/VSEssentials/Systems/WorldGen/Standard/GenPartial.cs
-@@ -1,5 +1,6 @@
-+using System.Threading;
- using Vintagestory.API.MathTools;
- using Vintagestory.API.Server;
- 
- #nullable disable
- 
-@@ -11,11 +12,21 @@ namespace Vintagestory.ServerMods
-         protected int worldheight;
-         public int airBlockId = 0;
- 
-         protected abstract int chunkRange { get; }
- 
--        protected LCGRandom chunkRand;
-+        // Stratum: ThreadLocal instance field, not a plain LCGRandom field. GenChunkColumn
-+        // reseeds chunkRand per (chunkX+dx, chunkZ+dz) right before each GeneratePartial
-+        // call, which only stays correct if one column's reseed-then-use sequence can't
-+        // interleave with another's; a plain shared field breaks that the moment a stage
-+        // runs more than one column at a time (see GenCaves, the current TerrainLate
-+        // occupant that reaches this class). ThreadLocal, not [ThreadStatic] static,
-+        // because GenPartial has more than one live subclass instance (GenCaves,
-+        // GenDeposits, GenHugePatches), and a static field would be shared by all of
-+        // them on whatever thread happens to run them.
-+        protected ThreadLocal<LCGRandom> chunkRandThreadLocal;
-+        protected LCGRandom chunkRand => chunkRandThreadLocal.Value;
- 
-         public override void StartServerSide(ICoreServerAPI api)
-         {
-             this.api = api;
- 
-@@ -25,19 +36,21 @@ namespace Vintagestory.ServerMods
-         public virtual void initWorldGen()
-         {
-             LoadGlobalConfig(api);
- 
-             worldheight = api.WorldManager.MapSizeY;
--            chunkRand = new LCGRandom(api.WorldManager.Seed);
-+            int seed = api.WorldManager.Seed;
-+            chunkRandThreadLocal = new ThreadLocal<LCGRandom>(() => new LCGRandom(seed));
+@@ -30,6 +30,23 @@
+             chunkRand = new LCGRandom(api.WorldManager.Seed);
          }
  
++        // Stratum: makes a worker copy for one worldgen thread.
++        // Shared state is copied by reference, per-column scratch is made fresh.
++        // Does not call initWorldGen, so a mod's patch on that still runs once.
++        protected virtual void StratumCopyStateFrom(GenPartial source)
++        {
++            api = source.api;
++
++            // Sets gcfg and the structure provider, both plain lookups of shared objects.
++            // The provider field is private to ModStdWorldGen, so copying gcfg alone would leave
++            // it null and GetIntersectingStructure would quietly stop seeing story structures.
++            LoadGlobalConfig(api);
++
++            worldheight = source.worldheight;
++            airBlockId = source.airBlockId;
++            chunkRand = new LCGRandom(api.WorldManager.Seed);
++        }
++
  
          protected virtual void GenChunkColumn(IChunkColumnGenerateRequest request)
          {
-             var chunks = request.Chunks;
-             int chunkX = request.ChunkX;
-             int chunkZ = request.ChunkZ;
-+            LCGRandom chunkRand = this.chunkRand;
- 
-             for (int dx = -chunkRange; dx <= chunkRange; dx++)
-             {
-                 for (int dz = -chunkRange; dz <= chunkRange; dz++)
-                 {

--- a/patches/VSEssentials/Systems/WorldGen/Standard/ModStdWorldGen.cs.patch
+++ b/patches/VSEssentials/Systems/WorldGen/Standard/ModStdWorldGen.cs.patch
@@ -1,0 +1,47 @@
+diff --git a/VSEssentials/Systems/WorldGen/Standard/ModStdWorldGen.cs b/VSEssentials/Systems/WorldGen/Standard/ModStdWorldGen.cs
+index 1bd4340..3d6d3f6 100644
+--- a/VSEssentials/Systems/WorldGen/Standard/ModStdWorldGen.cs
++++ b/VSEssentials/Systems/WorldGen/Standard/ModStdWorldGen.cs
+@@ -44,6 +44,8 @@ namespace Vintagestory.ServerMods
+ 
+         public void TriggerRegenFinalized(int chunkX, int chunkZ) => OnRegenFinalized?.Invoke(chunkX, chunkZ);
+         protected IStructureProvider[] providers;
++        // Stratum: Keep mod structure-provider callbacks under their vanilla serial execution assumption.
++        private readonly object stratumProvidersLock = new();
+         public override bool ShouldLoad(EnumAppSide forSide) => true;
+ 
+ 
+@@ -54,7 +56,10 @@ namespace Vintagestory.ServerMods
+ 
+         public void RegisterProvider(IStructureProvider provider)
+         {
+-            providers = providers.Append(provider);
++            lock (stratumProvidersLock)
++            {
++                providers = providers.Append(provider);
++            }
+         }
+ 
+         /// <summary>
+@@ -68,13 +73,16 @@ namespace Vintagestory.ServerMods
+         /// <returns></returns>
+         public IStructureLocation GetIntersectingStructure(int x, int z, int category)
+         {
+-            for (int i = 0; i < providers.Length; i++)
++            lock (stratumProvidersLock)
+             {
+-                var structure = providers[i].GetBlockingStructureAt(x, z, category);
+-                if (structure != null) return structure;
+-            }
++                for (int i = 0; i < providers.Length; i++)
++                {
++                    var structure = providers[i].GetBlockingStructureAt(x, z, category);
++                    if (structure != null) return structure;
++                }
+ 
+-            return null;
++                return null;
++            }
+         }
+ 
+     }

--- a/patches/VSSurvivalMod/Systems/WorldGen/Standard/ChunkGen/6.GenStructures/GenDungeons.cs.patch
+++ b/patches/VSSurvivalMod/Systems/WorldGen/Standard/ChunkGen/6.GenStructures/GenDungeons.cs.patch
@@ -1,94 +1,60 @@
 diff --git a/VSSurvivalMod/Systems/WorldGen/Standard/ChunkGen/6.GenStructures/GenDungeons.cs b/VSSurvivalMod/Systems/WorldGen/Standard/ChunkGen/6.GenStructures/GenDungeons.cs
-index dfdae53..9c8c660 100644
+index dfdae53..7ddb048 100644
 --- a/VSSurvivalMod/Systems/WorldGen/Standard/ChunkGen/6.GenStructures/GenDungeons.cs
 +++ b/VSSurvivalMod/Systems/WorldGen/Standard/ChunkGen/6.GenStructures/GenDungeons.cs
-@@ -1,5 +1,7 @@
-+using System;
-+using System.Collections.Concurrent;
- using System.Collections.Generic;
- using System.Diagnostics.CodeAnalysis;
- using System.Linq;
- using ProtoBuf;
- using Vintagestory.API.Common;
-@@ -48,19 +50,41 @@ namespace Vintagestory.ServerMods
+@@ -48,14 +48,16 @@ namespace Vintagestory.ServerMods
      public class GenDungeons : ModStdWorldGen
      {
          private ModSystemTiledDungeons tiledDungeonsSys = null!;
          private IWorldGenBlockAccessor worldgenBlockAccessor = null!;
          private ICoreServerAPI sapi = null!;
--        private LCGRandom rand = null!;
- 
--        private Dictionary<long, List<DungeonPlaceTask>> dungeonPlaceTasksByRegion = new Dictionary<long, List<DungeonPlaceTask>>();
-+        // Stratum: rand and grassRand used to be plain instance fields, reseeded
-+        // via InitPositionSeed per column/connector and read a few calls later in
-+        // the same call chain, unsafe once TerrainFeatures' same-stage cap moved
-+        // off 1, which it since has (see ServerSystemSupplyChunks.stratumStageMaxConcurrent).
-+        // [ThreadStatic] since GenDungeons is a singleton ModSystem with no
-+        // second live instance anywhere in the codebase (confirmed by search), and
-+        // both need lazy per-thread construction with the same seed formula the
-+        // old shared instances used, since both are reseeded via InitPositionSeed
-+        // alone, never from prior state.
-+        [ThreadStatic] private static LCGRandom stratumRand;
-+        [ThreadStatic] private static LCGRandom stratumGrassRand;
-+
-+        // Stratum: dungeonPlaceTasksByRegion and Dungeons are not per-column
-+        // scratch, they are persistent, cross-column, cross-region shared state
-+        // by design (region generation removes/adds entries a chunk-column call
-+        // three regions over can be reading or mutating at the same time), so
-+        // [ThreadStatic] would be wrong here, this needs to stay one shared,
-+        // consistent structure. ConcurrentDictionary covers the dictionary's own
-+        // structure; stratumDungeonStateLock covers the compound read-modify-write
-+        // sequences (region generation's clear-then-repopulate of Dungeons, and a
-+        // chunk column's read-then-mutate of a shared DungeonPlaceTask's fields)
-+        // that neither a concurrent collection nor per-field atomicity would make
-+        // safe on their own.
+         private LCGRandom rand = null!;
+
++        // Stratum: protect persistent dungeon tasks and locations while TerrainFeatures runs concurrently.
 +        private readonly object stratumDungeonStateLock = new object();
-+        private ConcurrentDictionary<long, List<DungeonPlaceTask>> dungeonPlaceTasksByRegion = new ConcurrentDictionary<long, List<DungeonPlaceTask>>();
- 
+         private Dictionary<long, List<DungeonPlaceTask>> dungeonPlaceTasksByRegion = new Dictionary<long, List<DungeonPlaceTask>>();
+
          private int regionSize;
          private BlockPos spawnPos = null!;
          private GenStoryStructures storyStructSys = null!;
          private GenBlockLayers genBlockLayers = null!;
--        private LCGRandom grassRand = null!;
-         public List<DungeonLocation> Dungeons = new List<DungeonLocation>();
-         public bool DungeonsDirty = false;
- 
-         public override double ExecuteOrder() { return 0.12; }
- 
-@@ -101,17 +125,15 @@ namespace Vintagestory.ServerMods
-             {
-                 spawnPos = sapi.World.BlockAccessor.MapSize.AsBlockPos / 2;
-             }
- 
-             storyStructSys = sapi.ModLoader.GetModSystem<GenStoryStructures>();
--            grassRand = new LCGRandom(sapi.WorldManager.Seed);
-         }
- 
-         private void OnWorldGenBlockAccessor(IChunkProviderThread chunkProvider)
-         {
-             worldgenBlockAccessor = chunkProvider.GetBlockAccessor(false);
--            rand = new LCGRandom(sapi.WorldManager.Seed ^ 8991827198);
-             regionSize = sapi.World.BlockAccessor.RegionSize;
-         }
- 
+         private LCGRandom grassRand = null!;
+@@ -116,110 +118,126 @@ namespace Vintagestory.ServerMods
          private void Event_MapRegionLoaded(Vec2i mapCoord, IMapRegion region)
          {
-@@ -131,21 +153,27 @@ namespace Vintagestory.ServerMods
- 
+             try
+             {
+                 var tasks = region.GetModdata<List<DungeonPlaceTask>>("dungeonPlaceTasks");
+                 if (tasks != null)
+                 {
+-                    dungeonPlaceTasksByRegion[MapRegionIndex2D(mapCoord.X, mapCoord.Y)] = tasks;
++                    lock (stratumDungeonStateLock)
++                    {
++                        dungeonPlaceTasksByRegion[MapRegionIndex2D(mapCoord.X, mapCoord.Y)] = tasks;
++                    }
+                 }
+             }
+             catch
+             {
+
+             }
+         }
+
          private void Event_GameWorldSave()
          {
-             if (DungeonsDirty)
+-            if (DungeonsDirty)
++            lock (stratumDungeonStateLock)
              {
 -                sapi.WorldManager.SaveGame.StoreData("dungeonLocations", SerializerUtil.Serialize(Dungeons));
 -                DungeonsDirty = false;
-+                lock (stratumDungeonStateLock)
++                if (DungeonsDirty)
 +                {
 +                    sapi.WorldManager.SaveGame.StoreData("dungeonLocations", SerializerUtil.Serialize(Dungeons));
 +                    DungeonsDirty = false;
 +                }
              }
          }
- 
+
          private void Event_SaveGameLoaded()
          {
              var strucs = sapi.WorldManager.SaveGame.GetData<List<DungeonLocation>>("dungeonLocations");
@@ -101,78 +67,89 @@ index dfdae53..9c8c660 100644
 +                }
              }
          }
- 
+
          private void Event_MapRegionUnloaded(Vec2i mapCoord, IMapRegion region)
          {
-@@ -161,63 +189,69 @@ namespace Vintagestory.ServerMods
+-            if (dungeonPlaceTasksByRegion.TryGetValue(MapRegionIndex2D(mapCoord.X, mapCoord.Y), out var list) && list.Any(d => d.IsDirty))
++            lock (stratumDungeonStateLock)
+             {
+-                region.SetModdata("dungeonPlaceTasks", list);
++                if (dungeonPlaceTasksByRegion.TryGetValue(MapRegionIndex2D(mapCoord.X, mapCoord.Y), out var list) && list.Any(d => d.IsDirty))
++                {
++                    region.SetModdata("dungeonPlaceTasks", list);
++                }
+             }
+         }
+
+         private void onMapRegionGen(IMapRegion mapRegion, int regionX, int regionZ, ITreeAttribute? chunkGenParams = null)
+         {
+             int size = sapi.WorldManager.RegionSize;
              var mapRand = new LCGRandom(sapi.WorldManager.Seed ^ 8991827198);
              mapRand.InitPositionSeed(regionX * size, regionZ * size);
- 
+
              long mapRegionIndex = MapRegionIndex2D(regionX, regionZ);
- 
+
 -            if (dungeonPlaceTasksByRegion.ContainsKey(mapRegionIndex))
-+            // Stratum: locked for the whole method, see stratumDungeonStateLock's
-+            // own comment. This is per-region, not per-column, so contention stays
-+            // low even once same-stage concurrency reaches this far.
++            // Stratum: region generation replaces shared dungeon state as one operation.
 +            lock (stratumDungeonStateLock)
              {
 -                Dungeons.RemoveAll(d => d.Position.X / regionSize == regionX && d.Position.Z / regionSize == regionZ);
 -            }
+-
+-            dungeonPlaceTasksByRegion[mapRegionIndex] = new List<DungeonPlaceTask>();
 +                if (dungeonPlaceTasksByRegion.ContainsKey(mapRegionIndex))
 +                {
 +                    Dungeons.RemoveAll(d => d.Position.X / regionSize == regionX && d.Position.Z / regionSize == regionZ);
 +                }
- 
--            dungeonPlaceTasksByRegion[mapRegionIndex] = new List<DungeonPlaceTask>();
-+                dungeonPlaceTasksByRegion[mapRegionIndex] = new List<DungeonPlaceTask>();
- 
+
 -            var dungeons = tiledDungeonsSys.Tcfg.Dungeons.Where(d => d.Worldgen).ToList();
-+                var dungeons = tiledDungeonsSys.Tcfg.Dungeons.Where(d => d.Worldgen).ToList();
- 
++                dungeonPlaceTasksByRegion[mapRegionIndex] = new List<DungeonPlaceTask>();
+
 -            var dungeIndices = new int[dungeons.Count];
 -            for (int l = 0; l < dungeIndices.Length; l++) dungeIndices[l] = l;
-+                var dungeIndices = new int[dungeons.Count];
-+                for (int l = 0; l < dungeIndices.Length; l++) dungeIndices[l] = l;
- 
++                var dungeons = tiledDungeonsSys.Tcfg.Dungeons.Where(d => d.Worldgen).ToList();
+
 -            var seaLevel = sapi.World.SeaLevel;
 -            for (int i = 0; i < 12; i++)
 -            {
 -                int posx = regionX * size + mapRand.NextInt(size);
 -                int posz = regionZ * size + mapRand.NextInt(size);
--
++                var dungeIndices = new int[dungeons.Count];
++                for (int l = 0; l < dungeIndices.Length; l++) dungeIndices[l] = l;
+
 -                if(!SatisfiesMinDistance(posx, seaLevel, posz)) continue;
 +                var seaLevel = sapi.World.SeaLevel;
 +                for (int i = 0; i < 12; i++)
 +                {
 +                    int posx = regionX * size + mapRand.NextInt(size);
 +                    int posz = regionZ * size + mapRand.NextInt(size);
- 
+
 -                if(storyStructSys.Structures.values.Values.Any(storyLoc =>
 -                       storyLoc.CenterPos.HorDistanceSqTo(posx, posz) < tiledDungeonsSys.Tcfg.StoryStructMinDistanceSq)) continue;
 +                    if(!SatisfiesMinDistance(posx, seaLevel, posz)) continue;
- 
+
 -                var dungeon = pickDungeon(dungeIndices, mapRand, dungeons);
 +                    if(storyStructSys.Structures.values.Values.Any(storyLoc =>
 +                           storyLoc.CenterPos.HorDistanceSqTo(posx, posz) < tiledDungeonsSys.Tcfg.StoryStructMinDistanceSq)) continue;
- 
+
 -                if (spawnPos.HorDistanceSqTo(posx, posz) < dungeon.MinSpawnDistance * dungeon.MinSpawnDistance) continue;
 +                    var dungeon = pickDungeon(dungeIndices, mapRand, dungeons);
- 
+
 -                if (IsInOcean(mapRegion, posx, posz)) continue;
 +                    if (spawnPos.HorDistanceSqTo(posx, posz) < dungeon.MinSpawnDistance * dungeon.MinSpawnDistance) continue;
- 
+
 -                if (!HasSuitableLandforms(dungeon, mapRegion, posx, posz)) continue;
 +                    if (IsInOcean(mapRegion, posx, posz)) continue;
- 
+
 +                    if (!HasSuitableLandforms(dungeon, mapRegion, posx, posz)) continue;
- 
+
 -                int posy = seaLevel-dungeon.MaxDepth + mapRand.NextInt(dungeon.MaxDepth-dungeon.MinDepth);
 -                var dungeonStartPos = new BlockPos(posx, posy, posz);
 -                var didGen = false;
 -                for (int j = 0; j < 5; j++)
 -                {
 -                    var placeTask = tiledDungeonsSys.TryPregenerateTiledDungeon(mapRand, dungeon, mapRegion.GeneratedStructures, dungeonStartPos, dungeon.MinTiles, dungeon.MaxTiles);
- 
+
 -                    if (placeTask != null)
 +                    int posy = seaLevel-dungeon.MaxDepth + mapRand.NextInt(dungeon.MaxDepth-dungeon.MinDepth);
 +                    var dungeonStartPos = new BlockPos(posx, posy, posz);
@@ -202,49 +179,51 @@ index dfdae53..9c8c660 100644
 +                        }
                      }
 -                }
- 
+
 -                if (didGen) break;
 +                    if (didGen) break;
 +                }
              }
          }
- 
+
          private static TiledDungeon pickDungeon(int[] dungeIndices, LCGRandom mapRand, List<TiledDungeon> dungeons)
          {
-@@ -363,10 +397,19 @@ namespace Vintagestory.ServerMods
-                     if (!dungeonPlaceTasksByRegion.TryGetValue(mapRegionIndex2D, out var dungePlaceTasks)) continue;
- 
+             TiledDungeon dungeon = null!;
+             dungeIndices.Shuffle(mapRand);
+@@ -356,19 +374,28 @@ namespace Vintagestory.ServerMods
+             IMapRegion region = request.Chunks[0].MapChunk.MapRegion;
+
+             for (int dx = -1; dx <= 1; dx++)
+             {
+                 for (int dz = -1; dz <= 1; dz++)
+                 {
+                     var mapRegionIndex2D = MapRegionIndex2D(regionx + dx, regionz + dz);
+-                    if (!dungeonPlaceTasksByRegion.TryGetValue(mapRegionIndex2D, out var dungePlaceTasks)) continue;
++                    List<DungeonPlaceTask> dungePlaceTasks;
++                    lock (stratumDungeonStateLock)
++                    {
++                        if (!dungeonPlaceTasksByRegion.TryGetValue(mapRegionIndex2D, out dungePlaceTasks)) continue;
++                    }
+
                      foreach (var placeTask in dungePlaceTasks)
                      {
                          if (!placeTask.DungeonBoundaries.Intersects(cuboid)) continue;
-+                        // Stratum: locked from here to the end of this placeTask's
-+                        // processing, see stratumDungeonStateLock's own comment.
-+                        // placeTask.RockBlockCode and .SurfacePlaceTasks are both
-+                        // check-then-compute-then-assign sequences on an object
-+                        // shared with every other column touching this dungeon;
-+                        // two columns racing here could both compute and one
-+                        // assignment would silently overwrite the other's.
++                        // Stratum: keep each shared task's placement and cached surface state atomic.
 +                        lock (stratumDungeonStateLock)
 +                        {
++                            // Stratum: do not place tasks from a list replaced by region regeneration.
++                            if (!dungeonPlaceTasksByRegion.TryGetValue(mapRegionIndex2D, out var activeTasks) || activeTasks != dungePlaceTasks) break;
                          if (!tiledDungeonsSys.Tcfg.DungeonsByCode.TryGetValue(placeTask.Code, out var dungeon)) return; // Ignore dungeons that no longer exist in assets
- 
+
                          Block? rockBlock = null;
                          // get the rockblock for the first generating chunk and reuse that for each room
                          if (placeTask.RockBlockCode == null)
-@@ -408,10 +451,11 @@ namespace Vintagestory.ServerMods
-                             var height = sapi.World.BlockAccessor.GetTerrainMapheightAt(pos);
-                             if (height == 0) continue;
-                             // skip if we get our of range where we can generate, should not happen if the stairs and surface rooms are not larger than 2 chunks
-                             height += dungeon.surfaceYOffset;
- 
-+                            LCGRandom rand = stratumRand ??= new LCGRandom(sapi.WorldManager.Seed ^ 8991827198);
-                             rand.InitPositionSeed(connector.Position.X, connector.Position.Y, connector.Position.Z);
-                             var tileIndices = new int[dungeon.StairCase.Tiles.Count];
-                             for (int i = 0; i < tileIndices.Length; i++) tileIndices[i] = i;
- 
-                             DungeonGenWorkspace dgd = new DungeonGenWorkspace(dungeon.StairCase, 0, 0, [], [], [], [], null);
-@@ -500,31 +544,32 @@ namespace Vintagestory.ServerMods
- 
+                         {
+                             var posY = placeTask.TilePlaceTasks[0].Pos.Y;
+@@ -498,14 +525,15 @@ namespace Vintagestory.ServerMods
+                             placeTask.IsDirty = true;
+                         }
+
                          if (placeTask.SurfacePlaceTasks != null)
                          {
                              generateDungeonSurfacePartial(request ,region, dungeon, placeTask.SurfacePlaceTasks, request.Chunks, request.ChunkX, request.ChunkZ, rockBlock);
@@ -254,41 +233,6 @@ index dfdae53..9c8c660 100644
                  }
              }
          }
- 
- 
+
+
          private bool pickStairTile(DungeonGenWorkspace dgd, ConnectorMetaData connector, int[] tileIndices, [NotNullWhen(true)] ref BlockSchematicPartial? schematic, [NotNullWhen(true)] ref DungeonTile? tile, [NotNullWhen(true)] ref FastVec3i? offsetPos)
-         {
--            tile = tiledDungeonsSys.dungeonGen.pickTile(dgd, tileIndices, rand, connector);
-+            tile = tiledDungeonsSys.dungeonGen.pickTile(dgd, tileIndices, stratumRand, connector);
-             if (tile != null)
-             {
--                tile.FreshShuffleIndices(rand);
-+                tile.FreshShuffleIndices(stratumRand);
-                 int len = tile.ResolvedSchematics.Length;
-                 for (var k = 0; k < len; k++)
-                 {
-                     var schematicByRot = tile.ResolvedSchematics[tile.ShuffledIndices[k]];
- 
-                     int startRot = connector.Rotation;
-                     if (connector.Facing.IsHorizontal)
-                     {
--                        startRot = rand.NextInt(4);
-+                        startRot = stratumRand.NextInt(4);
-                     }
- 
-                     // Try any of the 4 sides and see which one can connect
-                     for (var i = 0; i < 4; i++)
-                     {
-@@ -579,11 +624,11 @@ namespace Vintagestory.ServerMods
-                 if (schematic == null) continue;
-                 var placed = schematic.PlacePartial(chunks, worldgenBlockAccessor, sapi.World, chunkX, chunkZ, placeTask.Pos, EnumReplaceMode.ReplaceAll, null, GlobalConfig.ReplaceMetaBlocks, true, dungeon.resolvedRockTypeRemaps, dungeon.replacewithblocklayersBlockids, rockBlock);
-                 if (placed > 0)
-                 {
-                     UpdateHeightmap(request, worldgenBlockAccessor);
--                    GenerateGrass(sapi, request, grassRand, genBlockLayers);
-+                    GenerateGrass(sapi, request, stratumGrassRand ??= new LCGRandom(sapi.WorldManager.Seed), genBlockLayers);
-                 }
- 
-                 if (request.ChunkX == placeTask.Pos.X / chunksize && request.ChunkZ == placeTask.Pos.Z / chunksize)
-                 {
-                     var location = new Cuboidi(placeTask.Pos, placeTask.Pos.AddCopy(schematic.SizeX, schematic.SizeY, schematic.SizeZ));

--- a/patches/VintagestoryApi/Server/PathfinderTask.cs.patch
+++ b/patches/VintagestoryApi/Server/PathfinderTask.cs.patch
@@ -1,10 +1,8 @@
 diff --git a/VintagestoryApi/Server/PathfinderTask.cs b/VintagestoryApi/Server/PathfinderTask.cs
-index cc21075..5c84f72 100644
+index cc21075..6051161 100644
 --- a/VintagestoryApi/Server/PathfinderTask.cs
 +++ b/VintagestoryApi/Server/PathfinderTask.cs
-@@ -16,22 +16,27 @@ namespace Vintagestory.API.Server
-         public int searchDepth;
-         public int mhdistanceTolerance = 0;
+@@ -18,10 +18,20 @@ namespace Vintagestory.API.Server
          public List<Vec3d> waypoints;
          public EnumAICreatureType CreatureType;
          public float modeMinFleeDistance;
@@ -15,19 +13,22 @@ index cc21075..5c84f72 100644
  
          public bool Finished;
  
--        public PathfinderTask(BlockPos startBlockPos, BlockPos targetBlockPos, float modeMinFleeDistance, int maxFallHeight, float stepHeight, Cuboidf collisionBox, int searchDepth, int mhdistanceTolerance = 0, EnumAICreatureType creatureType = EnumAICreatureType.Default)
-+        public PathfinderTask(BlockPos startBlockPos, BlockPos targetBlockPos, float modeMinFleeDistance, int maxFallHeight, float stepHeight, Cuboidf collisionBox, int searchDepth, int mhdistanceTolerance = 0, EnumAICreatureType creatureType = EnumAICreatureType.Default, long sourceEntityId = 0)
++        // Stratum start: preserve the vanilla constructor signature for compiled mods.
+         public PathfinderTask(BlockPos startBlockPos, BlockPos targetBlockPos, float modeMinFleeDistance, int maxFallHeight, float stepHeight, Cuboidf collisionBox, int searchDepth, int mhdistanceTolerance = 0, EnumAICreatureType creatureType = EnumAICreatureType.Default)
++            : this(startBlockPos, targetBlockPos, modeMinFleeDistance, maxFallHeight, stepHeight, collisionBox, searchDepth, mhdistanceTolerance, creatureType, 0)
++        {
++        }
++
++        public PathfinderTask(BlockPos startBlockPos, BlockPos targetBlockPos, float modeMinFleeDistance, int maxFallHeight, float stepHeight, Cuboidf collisionBox, int searchDepth, int mhdistanceTolerance, EnumAICreatureType creatureType, long sourceEntityId)
          {
              this.startBlockPos = startBlockPos;
              this.targetBlockPos = targetBlockPos;
-             this.maxFallHeight = maxFallHeight;
-             this.stepHeight = stepHeight;
-             this.collisionBox = collisionBox;
-             this.searchDepth = searchDepth;
+@@ -32,6 +42,8 @@ namespace Vintagestory.API.Server
              this.mhdistanceTolerance = mhdistanceTolerance;
              this.modeMinFleeDistance = modeMinFleeDistance;
              this.CreatureType = creatureType;
 +            this.SourceEntityId = sourceEntityId;
          }
++        // Stratum end
      }
  }

--- a/patches/VintagestoryLib/Vintagestory.Server/ServerEventAPI.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/ServerEventAPI.cs.patch
@@ -8,9 +8,9 @@ index fba8acc..c9c311a 100644
  	public ServerEventAPI(ServerMain server)
  		: base(server)
  	{
-+		// Stratum: mod assemblies reference VintagestoryAPI, not VintagestoryLib, so the late
-+		// Terrain sub-stage is reached through this hook. StratumWorldgenCompat picks the shape.
++		// Stratum: route API registrations into the server's compatibility-aware Terrain split.
 +		StratumTerrainSplit.RegisterLate = (handler, worldType) => StratumWorldgenCompat.RegisterTerrainLate(server, handler, worldType);
++		StratumTerrainSplit.RegisterLateOptimized = (vanillaHandler, optimizedHandler, worldType) => StratumWorldgenCompat.RegisterTerrainLate(server, vanillaHandler, optimizedHandler, worldType);
  	}
  
  	public void Trigger<T>(Delegate[] delegates, string eventName, Action<T> onDele, Action onException = null) where T : Delegate

--- a/patches/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs.patch
@@ -1,15 +1,13 @@
 diff --git a/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs b/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs
-index f644852..9bb2256 100644
+index 707d78e..534b43d 100644
 --- a/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs
 +++ b/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs
-@@ -1,139 +1,1125 @@
+@@ -1,195 +1,1170 @@
  using System;
  using System.Collections.Generic;
  using System.Linq;
 +using System.Reflection;
-+using System.Text;
  using System.Threading;
-+using HarmonyLib;
  using Vintagestory.API.Common;
  using Vintagestory.API.Common.Entities;
  using Vintagestory.API.Config;
@@ -24,30 +22,30 @@ index f644852..9bb2256 100644
 +using System.Diagnostics;
 +using System.Collections.Concurrent;
  namespace Vintagestory.Server;
- 
+
 +
  internal class ServerSystemSupplyChunks : ServerSystem
  {
 +	// World generation handler (generation pass callbacks)
  	private WorldGenHandler worldgenHandler;
- 
+
 +	// Chunk load/save thread
  	private ChunkServerThread chunkthread;
- 
+
 +	// Flag: 8+ CPU cores — enable multithreaded generation
  	private bool is8Core = Environment.ProcessorCount >= 8;
- 
+
 +	// Whether chunk border smoothing is required (for worlds created before version 3)
  	private bool requiresChunkBorderSmoothing;
- 
+
 +	// Whether the "empty chunk" flag needs to be set (for worlds before 1.12-dev.1)
  	private bool requiresSetEmptyFlag;
- 
+
 +	// Pause request flag for all worldgen threads (0 = run, 1 = pause requested).
 +	// Acknowledgements live in pauseAckState, so a late or raced acknowledgement
 +	// can never leave this flag above zero with no pauser active.
  	private volatile int pauseAllWorldgenThreads;
- 
+
 +	// Packed pause acknowledgement state: the upper bits carry the pause epoch,
 +	// the low 16 bits count workers parked for that epoch. The epoch moves on
 +	// every pause start, cancel, and resume, so an acknowledgement from a worker
@@ -61,19 +59,19 @@ index f644852..9bb2256 100644
 +	// Thread-local stream for chunk serialization during saving
  	[ThreadStatic]
  	private static FastMemoryStream saveChunksStream;
- 
+
 +	// List of entity IDs to remove when unloading a chunk
  	private List<long> entitiesToRemove = new List<long>();
- 
+
 +	// Counter of "story" messages printed during spawn loading
  	private int storyEventPrints;
- 
+
 +	// Array of "story" messages displayed during spawn loading
  	private string[] storyChunkSpawnEvents;
- 
+
 +	// Number of remaining blocking requests (for loadChunkAreaBlocking)
  	private int blockingRequestsRemaining;
- 
+
 +	// Stratum start:
 +
 +
@@ -163,8 +161,8 @@ index f644852..9bb2256 100644
 +	/// research/gap-mod-patch-conflict-visibility.md gave up on: that doc needed
 +	/// a build-time manifest of every method Stratum source-patches, which needs
 +	/// real Roslyn tooling. This needs no manifest, because the only methods that
-+	/// matter for a cap raise are the handlers for the raised stage, and those
-+	/// are already in hand as live MethodInfo.
++	/// matter for a cap raise are the registered handler types, and those are
++	/// already in hand without a build-time manifest.
 +	///
 +	/// Deliberately does not make the transpiler-vs-prefix/postfix distinction
 +	/// StratumHarmonyVisibility makes. That distinction is about whether a
@@ -179,10 +177,11 @@ index f644852..9bb2256 100644
 +	/// Two honest limits, neither of which the fallback direction makes unsafe:
 +	/// this only sees patches applied by the time worldgen starts (a mod that
 +	/// defers PatchAll past that is invisible, same caveat as
-+	/// StratumHarmonyVisibility), and it only inspects the handler methods
-+	/// themselves, not everything they call. Both mean it can miss, never that it
-+	/// wrongly clears. A false positive costs throughput on one pass; a false
-+	/// negative corrupts world generation, so erring toward capping is deliberate.
++	/// StratumHarmonyVisibility), and it only inspects methods declared on the
++	/// handler type and its in-assembly base types, not everything they call. Both
++	/// mean it can miss, never that it wrongly clears. A false positive costs
++	/// throughput on one pass; a false negative corrupts world generation, so
++	/// erring toward capping is deliberate.
 +	///
 +	/// Called once per raised stage from InitWorldgenAndSpawnChunks, right after
 +	/// worldgenHandler is populated, which is the first point every mod has
@@ -192,6 +191,12 @@ index f644852..9bb2256 100644
 +	{
 +		int desiredCap = stratumStageMaxConcurrent[internalStage];
 +		if (desiredCap <= 1) return;
++		if (internalStage == StratumWorldGenStages.Terrain && StratumWorldgenCompat.TerrainRequiresSerialFallback)
++		{
++			FallBackStageToSerial(internalStage, stageName,
++				"the Terrain split stayed in vanilla topology, so its shared generator instances must remain serial");
++			return;
++		}
 +
 +		List<ChunkColumnGenerationDelegate> handlers = internalStage == StratumWorldGenStages.TerrainLate
 +			? worldgenHandler.OnChunkColumnGenTerrainLate
@@ -211,11 +216,11 @@ index f644852..9bb2256 100644
 +				return;
 +			}
 +
-+			string modPatches = DescribeModPatches(method);
-+			if (modPatches != null)
++			string patchedMethod = StratumModCompat.FindPatchedMethodOn(method.DeclaringType);
++			if (patchedMethod != null)
 +			{
 +				FallBackStageToSerial(internalStage, stageName,
-+					"Stratum's own worldgen handler " + DescribeMethod(method) + " is Harmony-patched (" + modPatches + "), "
++					"Stratum's own worldgen handler type includes a mod-patched method " + patchedMethod + ", "
 +					+ "so that mod's code would run inside a generator Stratum audited only in its own form, "
 +					+ "on several columns at once. Stratum cannot verify third-party code is safe under that");
 +				return;
@@ -236,42 +241,6 @@ index f644852..9bb2256 100644
 +			+ "World generation stays correct, it just gives up this pass's speedup. "
 +			+ "If you are the author of that mod and have verified it is safe to run concurrently across "
 +			+ "columns, get in touch so it can be allowlisted.");
-+	}
-+
-+	/// <summary>
-+	/// Stratum: lists every mod-owned Harmony patch on one method, or null when
-+	/// there are none. Stratum applies no Harmony patches of its own (its changes
-+	/// are compiled in, see StratumHarmonyVisibility), so anything found here is
-+	/// third-party by construction.
-+	/// </summary>
-+	private static string DescribeModPatches(MethodBase method)
-+	{
-+		if (method == null) return null;
-+
-+		Patches info = Harmony.GetPatchInfo(method);
-+		if (info == null) return null;
-+
-+		StringBuilder sb = null;
-+		AppendPatchOwners(ref sb, info.Transpilers, "transpiler");
-+		AppendPatchOwners(ref sb, info.Prefixes, "prefix");
-+		AppendPatchOwners(ref sb, info.Postfixes, "postfix");
-+		AppendPatchOwners(ref sb, info.Finalizers, "finalizer");
-+		return sb?.ToString();
-+	}
-+
-+	private static void AppendPatchOwners(ref StringBuilder sb, IReadOnlyCollection<Patch> patches, string kind)
-+	{
-+		if (patches == null) return;
-+
-+		foreach (Patch patch in patches)
-+		{
-+			if (sb == null) sb = new StringBuilder();
-+			else sb.Append(", ");
-+
-+			sb.Append(kind).Append(" from '")
-+				.Append(string.IsNullOrWhiteSpace(patch.owner) ? "(unknown mod)" : patch.owner)
-+				.Append('\'');
-+		}
 +	}
 +
 +	private static string DescribeMethod(MethodBase method)
@@ -360,7 +329,7 @@ index f644852..9bb2256 100644
 +		stratumStageMaxConcurrent[StratumWorldGenStages.Terrain] = Math.Max(1, chunkthread.additionalWorldGenThreadsCount);
 +		stratumStageMaxConcurrent[StratumWorldGenStages.TerrainFeatures] = Math.Max(1, chunkthread.additionalWorldGenThreadsCount);
  	}
- 
+
 +	/// <summary>
 +	/// Returns the system update interval (in ms).
 +	/// When requests exist and 8+ cores are available — minimal interval for maximum throughput.
@@ -374,7 +343,7 @@ index f644852..9bb2256 100644
 -		return chunkthread.additionalWorldGenThreadsCount - 1;
 +		return Math.Max(1, chunkthread.additionalWorldGenThreadsCount - 1); // protection against negative and zero values
  	}
- 
+
 +	/// <summary>
 +	/// Called when the game is ready. Initializes version flags and starts generation threads.
 +	/// </summary>
@@ -907,13 +876,13 @@ index f644852..9bb2256 100644
 +					Volatile.Write(ref request.dispatchClaimed, 0);
 +					SignalDispatcher(); // wake the dispatcher
 +				}
- 			}
- 		}
++			}
++		}
 +
 +		// Release thread-local generation resources
 +		BlockAccessorWorldGen.ThreadDispose();
- 	}
- 
++	}
++
 +
 +	/// <summary>
 +	/// Stratum: Builds a priority list of chunks sorted by proximity to players.
@@ -992,8 +961,8 @@ index f644852..9bb2256 100644
 +				// Closer than the farthest in top-K — replace
 +				stratumTopKHeap.Dequeue();
 +				stratumTopKHeap.Enqueue(r, -distSq);
-+			}
-+		}
+ 			}
+ 		}
 +
 +		// Extract from heap (farthest to nearest) and reverse
 +		while (stratumTopKHeap.Count > 0)
@@ -1014,8 +983,8 @@ index f644852..9bb2256 100644
 +	{
 +		Volatile.Write(ref stratumPriorityListPublished, list);
 +		return list;
-+	}
-+
+ 	}
+
 +
 +
 +	/// <summary>
@@ -1150,12 +1119,14 @@ index f644852..9bb2256 100644
  			if (!tryLoadOrGenerateChunkColumnsInQueue())
  			{
  				break;
-@@ -143,39 +1129,59 @@ internal class ServerSystemSupplyChunks : ServerSystem
+ 			}
+ 			if (server.Suspended)
+ 			{
  				break;
  			}
  		}
  	}
- 
+
 +
 +
 +
@@ -1212,7 +1183,7 @@ index f644852..9bb2256 100644
  				ServerChunk serverChunk = (ServerChunk)server.WorldMap.GetChunk(x, i, z);
  				if (serverChunk != null)
  				{
-@@ -183,11 +1189,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
+ 					Entity[] entities = serverChunk.Entities;
  					for (int j = 0; j < entities.Length; j++)
  					{
  						Entity entity = entities[j];
@@ -1225,7 +1196,11 @@ index f644852..9bb2256 100644
  						{
  							if (j >= serverChunk.EntitiesCount)
  							{
-@@ -211,19 +1217,23 @@ internal class ServerSystemSupplyChunks : ServerSystem
+ 								break;
+ 							}
+@@ -209,23 +1184,27 @@ internal class ServerSystemSupplyChunks : ServerSystem
+ 					Y = i,
+ 					Z = z
  				});
  			}
  			list2.Add(item);
@@ -1250,12 +1225,16 @@ index f644852..9bb2256 100644
  		{
  			ChunkPos item2 = server.WorldMap.MapRegionPosFromIndex2D(result2);
  			if (hashSet == null)
-@@ -237,28 +1247,46 @@ internal class ServerSystemSupplyChunks : ServerSystem
+ 			{
+ 				hashSet = new HashSet<ChunkPos>();
+@@ -235,162 +1214,300 @@ internal class ServerSystemSupplyChunks : ServerSystem
+ 		}
+ 		if (hashSet != null && hashSet.Count > 0)
  		{
  			chunkthread.gameDatabase.DeleteMapRegions(hashSet);
  		}
  	}
- 
+
 +	/// <summary>
 +	/// Moves requests from the main queue (server.requestedChunkColumns)
 +	/// to the generation queue (chunkthread.requestedChunkColumns) with capacity limiting.
@@ -1292,7 +1271,7 @@ index f644852..9bb2256 100644
 +		}
 +		// Stratum end
  	}
- 
+
 +	/// <summary>
 +	/// Simple load of a chunk column from the database (without generation).
 +	/// Returns true on successful load.
@@ -1302,7 +1281,8 @@ index f644852..9bb2256 100644
  		ServerMapChunk orCreateMapChunk = chunkthread.loadsavechunks.GetOrCreateMapChunk(request);
  		if (orCreateMapChunk == null)
  		{
-@@ -267,94 +1295,203 @@ internal class ServerSystemSupplyChunks : ServerSystem
+ 			return false;
+ 		}
  		ServerChunk[] array = chunkthread.loadsavechunks.TryLoadChunkColumn(request);
  		if (array == null)
  		{
@@ -1325,7 +1305,7 @@ index f644852..9bb2256 100644
  		});
  		return true;
  	}
- 
+
 +	/// <summary>
 +	/// Attempts to load or generate chunks from the queue.
 +	/// Uses the priority list (Stratum) or FIFO as a fallback.
@@ -1452,7 +1432,7 @@ index f644852..9bb2256 100644
  		}
  		return false;
  	}
- 
+
 +
 +
 +	/// <summary>
@@ -1486,7 +1466,7 @@ index f644852..9bb2256 100644
  		}
  		return num;
  	}
- 
+
 +	/// <summary>
 +	/// Loads or generates a chunk column on the chunk thread.
 +	/// Handles loading from DB, generation, finalization (Done), and stage transitions.
@@ -1512,7 +1492,9 @@ index f644852..9bb2256 100644
  				chunkRequest.Chunks = TryLoadChunkColumn(chunkRequest);
  				if (chunkRequest.Chunks != null)
  				{
-@@ -364,31 +1501,42 @@ internal class ServerSystemSupplyChunks : ServerSystem
+ 					for (int i = 0; i < chunkRequest.Chunks.Length; i++)
+ 					{
+ 						ServerChunk obj = chunkRequest.Chunks[i];
  						obj.serverMapChunk = orCreateMapChunk;
  						obj.MarkFresh();
  					}
@@ -1555,7 +1537,11 @@ index f644852..9bb2256 100644
  				ServerEventAPI eventapi = server.api.eventapi;
  				ServerMapChunk mapChunk = orCreateMapChunk;
  				int chunkX = chunkRequest.chunkX;
-@@ -404,117 +1552,105 @@ internal class ServerSystemSupplyChunks : ServerSystem
+ 				int chunkZ = chunkRequest.chunkZ;
+ 				IWorldChunk[] chunks = chunkRequest.Chunks;
+@@ -402,121 +1519,109 @@ internal class ServerSystemSupplyChunks : ServerSystem
+ 				if (server.Config.RepairMode)
+ 				{
  					ServerMain.Logger.Error("Repair mode is enabled so will delete the entire chunk column.");
  					GenerateNewChunkColumn(orCreateMapChunk, chunkRequest);
  					return false;
@@ -1596,7 +1582,7 @@ index f644852..9bb2256 100644
  		}
  		return num;
  	}
- 
+
 -	public int GenerateChunkColumns_OnSeparateThread(int stageStart, int stageEnd)
 -	{
 -		ChunkColumnLoadRequest chunkColumnLoadRequest = null;
@@ -1636,7 +1622,7 @@ index f644852..9bb2256 100644
 -		}
 -		return 0;
 -	}
- 
+
 +
 +
 +	/// <summary>
@@ -1651,7 +1637,7 @@ index f644852..9bb2256 100644
  		}
  		return true;
  	}
- 
+
 +	/// <summary>
 +	/// Finalizes chunk column loading on the main thread.
 +	/// Registers chunks, loads entities, initializes BlockEntities, triggers events.
@@ -1703,7 +1689,11 @@ index f644852..9bb2256 100644
  				try
  				{
  					serverChunk.Unpack();
-@@ -529,10 +1665,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
+ 				}
+ 				catch (Exception ex)
+@@ -527,14 +1632,16 @@ internal class ServerSystemSupplyChunks : ServerSystem
+ 						ServerMain.Logger.Error("Repair mode is enabled so will delete the entire chunk column.");
+ 						server.api.worldapi.DeleteChunkColumn(chunkRequest.chunkX, chunkRequest.chunkZ);
  						ServerMain.FrameProfiler.Leave();
  						return;
  					}
@@ -1716,7 +1706,11 @@ index f644852..9bb2256 100644
  			{
  				for (int j = 0; j < serverChunk.Entities.Length; j++)
  				{
-@@ -548,10 +1686,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
+ 					Entity entity = serverChunk.Entities[j];
+ 					if (entity == null)
+@@ -546,14 +1653,15 @@ internal class ServerSystemSupplyChunks : ServerSystem
+ 					}
+ 					else
  					{
  						if (server.LoadEntity(entity, num2))
  						{
@@ -1728,7 +1722,11 @@ index f644852..9bb2256 100644
  						{
  							string text = "-";
  							try
-@@ -564,14 +1703,18 @@ internal class ServerSystemSupplyChunks : ServerSystem
+ 							{
+ 								text = entity.WatchedAttributes.GetTreeAttribute("nametag")?.GetString("name") ?? "-";
+@@ -562,57 +1670,81 @@ internal class ServerSystemSupplyChunks : ServerSystem
+ 							{
+ 							}
  							ServerMain.Logger.Log(EnumLogType.Worldgen, "In " + server.WorldName + ", villager " + text + " removed at " + entity.Pos.AsBlockPos?.ToString() + " due to an exception on loading");
  						}
  					}
@@ -1747,7 +1745,8 @@ index f644852..9bb2256 100644
  			{
  				BlockEntity value = blockEntity.Value;
  				if (value == null)
-@@ -580,13 +1723,23 @@ internal class ServerSystemSupplyChunks : ServerSystem
+ 				{
+ 					continue;
  				}
  				try
  				{
@@ -1773,7 +1772,7 @@ index f644852..9bb2256 100644
  					ServerMain.FrameProfiler.Leave();
  				}
  				catch (Exception ex3)
-@@ -594,23 +1747,33 @@ internal class ServerSystemSupplyChunks : ServerSystem
+ 				{
  					ServerMain.Logger.Notification("Exception thrown when trying to initialize a block entity @{0}: {1}", value.Pos, ex3);
  					value.UnregisterAllTickListeners();
  				}
@@ -1798,7 +1797,7 @@ index f644852..9bb2256 100644
  		ServerMain.FrameProfiler.Mark("MTT-ChunkLoaded-Pack");
  		ServerMain.FrameProfiler.Leave();
  	}
- 
+
 +	/// <summary>
 +	/// Updates neighbour loaded flags for the given MapChunk.
 +	/// </summary>
@@ -1807,12 +1806,16 @@ index f644852..9bb2256 100644
  		mapChunk.NeighboursLoaded = default(SmallBoolArray);
  		mapChunk.SelfLoaded = true;
  		for (int i = 0; i < Cardinal.ALL.Length; i++)
-@@ -623,20 +1786,26 @@ internal class ServerSystemSupplyChunks : ServerSystem
+ 		{
+ 			Cardinal cardinal = Cardinal.ALL[i];
+@@ -621,24 +1753,30 @@ internal class ServerSystemSupplyChunks : ServerSystem
+ 			{
+ 				mapChunk.NeighboursLoaded[i] = serverMapChunk.SelfLoaded;
  				serverMapChunk.NeighboursLoaded[cardinal.Opposite.Index] = true;
  			}
  		}
  	}
- 
+
 +	/// <summary>
 +	/// Resets neighbour loaded flags when a chunk is deleted.
 +	/// Iterates 8 neighbouring positions and clears the corresponding flags.
@@ -1834,12 +1837,16 @@ index f644852..9bb2256 100644
  			serverMapChunk.NeighboursLoaded[4] = false;
  		}
  		if (serverMapChunk2 != null)
-@@ -667,12 +1836,17 @@ internal class ServerSystemSupplyChunks : ServerSystem
+ 		{
+ 			serverMapChunk2.NeighboursLoaded[5] = false;
+@@ -665,38 +1803,48 @@ internal class ServerSystemSupplyChunks : ServerSystem
+ 		}
+ 		if (serverMapChunk8 != null)
  		{
  			serverMapChunk8.NeighboursLoaded[3] = false;
  		}
  	}
- 
+
 +	/// <summary>
 +	/// Executes deferred block updates for a chunk and its neighbours
 +	/// if all neighbours are loaded and generation is complete.
@@ -1852,7 +1859,9 @@ index f644852..9bb2256 100644
  			for (int j = -1; j <= 1; j++)
  			{
  				bool flag = false;
-@@ -682,19 +1856,24 @@ internal class ServerSystemSupplyChunks : ServerSystem
+ 				if (server.loadedMapChunks.TryGetValue(server.WorldMap.MapChunkIndex2D(chunkRequest.chunkX + j, chunkRequest.chunkZ + i), out var value) && value.CurrentIncompletePass == EnumWorldGenPass.Done && value.ScheduledBlockUpdates.Count > 0 && areAllChunkNeighboursLoaded(value, chunkRequest.chunkX + j, chunkRequest.chunkZ + i))
+ 				{
+ 					flag = true;
  				}
  				if (!flag)
  				{
@@ -1868,7 +1877,7 @@ index f644852..9bb2256 100644
  			}
  		}
  	}
- 
+
 +	/// <summary>
 +	/// Checks whether all 8 neighbours of a chunk are loaded (generation complete).
 +	/// </summary>
@@ -1877,12 +1886,16 @@ index f644852..9bb2256 100644
  		int num = 0;
  		for (int i = -1; i <= 1; i++)
  		{
-@@ -707,60 +1886,78 @@ internal class ServerSystemSupplyChunks : ServerSystem
+ 			for (int j = -1; j <= 1; j++)
+ 			{
+@@ -705,79 +1853,99 @@ internal class ServerSystemSupplyChunks : ServerSystem
+ 					num++;
+ 				}
  			}
  		}
  		return num == 8;
  	}
- 
+
 +	/// <summary>
 +	/// Gets or creates a map region, ensuring neighbouring regions are loaded.
 +	/// On first neighbour load, triggers OnMapRegionNeighborsLoaded callbacks.
@@ -1917,7 +1930,7 @@ index f644852..9bb2256 100644
  		}
  		return orCreateMapRegion;
  	}
- 
+
 +	/// <summary>
 +	/// Gets or creates a map region without storing it in the global registry.
 +	/// Updates outdated generation version if necessary, preserving existing data.
@@ -1957,7 +1970,9 @@ index f644852..9bb2256 100644
  				dictionary = value.ModData;
  				dictionary2 = value.OreMaps;
  				intDataMap2D = value.GeologicProvinceMap;
-@@ -770,12 +1967,14 @@ internal class ServerSystemSupplyChunks : ServerSystem
+ 				array = value.RockStrata;
+ 			}
+ 			else
  			{
  				flag = false;
  				value.loadedTotalMs = server.ElapsedMilliseconds;
@@ -1972,12 +1987,16 @@ index f644852..9bb2256 100644
  			if (list != null)
  			{
  				value.GeneratedStructures = list;
-@@ -798,35 +1997,48 @@ internal class ServerSystemSupplyChunks : ServerSystem
+ 			}
+ 			if (dictionary != null)
+@@ -796,118 +1964,158 @@ internal class ServerSystemSupplyChunks : ServerSystem
+ 			{
+ 				value.RockStrata = array;
  			}
  		}
  		return value;
  	}
- 
+
 +	/// <summary>
 +	/// Gets or creates a map region with storage in the global registry.
 +	/// Triggers the MapRegionLoaded event on the main thread.
@@ -1998,7 +2017,7 @@ index f644852..9bb2256 100644
  		});
  		return mapRegion;
  	}
- 
+
 +	/// <summary>
 +	/// Creates a new map region, invoking all region generation callbacks.
 +	/// </summary>
@@ -2011,7 +2030,7 @@ index f644852..9bb2256 100644
  		}
  		return serverMapRegion;
  	}
- 
+
 +	/// <summary>
 +	/// Restores generated structures from chunk generation parameters.
 +	/// Stratum: uses HashSet for O(N+M) instead of O(N*M) nested scanning.
@@ -2021,7 +2040,9 @@ index f644852..9bb2256 100644
  		byte[] array = chunkGenParams?.GetBytes("GeneratedStructures");
  		if (array == null)
  		{
-@@ -836,44 +2048,60 @@ internal class ServerSystemSupplyChunks : ServerSystem
+ 			return;
+ 		}
+ 		Dictionary<long, List<GeneratedStructure>> dictionary = SerializerUtil.Deserialize<Dictionary<long, List<GeneratedStructure>>>(array);
  		long key = server.api.WorldManager.MapRegionIndex2D(regionX, regionZ);
  		if (!dictionary.TryGetValue(key, out var value) || value == null)
  		{
@@ -2033,7 +2054,7 @@ index f644852..9bb2256 100644
 +		List<GeneratedStructure> generatedStructure = [.. value.Where(structure => !existingStarts.Contains(structure.Location.Start))];
  		mapRegion.AddGeneratedStructures(generatedStructure);
  	}
- 
+
 +	/// <summary>
 +	/// Gets or creates a MapChunk for the request. Searches memory first,
 +	/// then the database, creates a new one if necessary.
@@ -2073,7 +2094,7 @@ index f644852..9bb2256 100644
  		server.loadedMapChunks[key] = value;
  		return value;
  	}
- 
+
 +	/// <summary>
 +	/// Quickly gets a MapChunk from memory or the database without creating a new one.
 +	/// </summary>
@@ -2083,12 +2104,12 @@ index f644852..9bb2256 100644
  		long key = server.WorldMap.MapChunkIndex2D(chunkX, chunkZ);
  		server.loadedMapChunks.TryGetValue(key, out var value);
  		if (value != null)
-@@ -881,31 +2109,42 @@ internal class ServerSystemSupplyChunks : ServerSystem
+ 		{
  			return value;
  		}
  		return TryLoadMapChunk(chunkX, chunkZ);
  	}
- 
+
 +	/// <summary>
 +	/// Creates a new MapChunk, invoking all MapChunk generation callbacks.
 +	/// </summary>
@@ -2101,7 +2122,7 @@ index f644852..9bb2256 100644
  		}
  		return serverMapChunk;
  	}
- 
+
 +	/// <summary>
 +	/// Creates a new chunk column for generation.
 +	/// Prepares border smoothing data if necessary.
@@ -2126,7 +2147,11 @@ index f644852..9bb2256 100644
  			for (int j = 0; j < Cardinal.ALL.Length; j++)
  			{
  				Cardinal cardinal = Cardinal.ALL[j];
-@@ -918,47 +2157,111 @@ internal class ServerSystemSupplyChunks : ServerSystem
+ 				ServerMapChunk serverMapChunk = PeekMapChunk(chunkRequest.chunkX + cardinal.Normali.X, chunkRequest.chunkZ + cardinal.Normali.Z);
+ 				if (serverMapChunk != null && serverMapChunk.CurrentIncompletePass >= EnumWorldGenPass.Done && serverMapChunk.WorldGenVersion != 3)
+@@ -916,83 +2124,153 @@ internal class ServerSystemSupplyChunks : ServerSystem
+ 					{
+ 						chunkRequest.NeighbourTerrainHeight = new ushort[8][];
  					}
  					chunkRequest.NeighbourTerrainHeight[j] = serverMapChunk.WorldGenTerrainHeightMap;
  				}
@@ -2143,7 +2168,7 @@ index f644852..9bb2256 100644
 +		// Set the initial generation stage
  		chunkRequest.CurrentIncompletePass = EnumWorldGenPass.Terrain;
  	}
- 
+
 +	/// <summary>
 +	/// Attempts to load a chunk column from the database.
 +	/// Supports parallel loading via StratumChunkReadPool.
@@ -2254,7 +2279,8 @@ index f644852..9bb2256 100644
  			foreach (ServerChunk serverChunk in array)
  			{
  				if (serverChunk != null)
-@@ -967,10 +2270,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
+ 				{
+ 					serverChunk.Unpack();
  					serverChunk.MarkModified();
  					serverChunk.TryPackAndCommit();
  				}
@@ -2267,12 +2293,13 @@ index f644852..9bb2256 100644
  			ServerMain.Logger.Error("Loaded some but not all chunks of a column? Discarding whole column.");
  			return null;
  		}
-@@ -979,18 +2284,22 @@ internal class ServerSystemSupplyChunks : ServerSystem
+ 		if (num != chunkMapSizeY)
+ 		{
  			return null;
  		}
  		return array;
  	}
- 
+
 +	/// <summary>
 +	/// Attempts to load a MapChunk from the database. Returns null if absent or on error.
 +	/// </summary>
@@ -2290,12 +2317,16 @@ index f644852..9bb2256 100644
  					serverMapChunk.YMax = (ushort)(server.SaveGameData.MapSizeY - 1);
  				}
  				return serverMapChunk;
-@@ -1011,10 +2320,13 @@ internal class ServerSystemSupplyChunks : ServerSystem
+ 			}
+ 			catch (Exception ex)
+@@ -1009,14 +2287,17 @@ internal class ServerSystemSupplyChunks : ServerSystem
+ 				ServerMain.Logger.Error("Failed deserializing a map chunk, we are in repair mode, so will initialize empty one. Exception: {0}", ex);
+ 				return null;
  			}
  		}
  		return null;
  	}
- 
+
 +	/// <summary>
 +	/// Attempts to load a map region from the database. Returns null if absent or on error.
 +	/// </summary>
@@ -2304,12 +2335,16 @@ index f644852..9bb2256 100644
  		byte[] mapRegion = chunkthread.gameDatabase.GetMapRegion(regionX, regionZ);
  		try
  		{
-@@ -1035,14 +2347,33 @@ internal class ServerSystemSupplyChunks : ServerSystem
+ 			if (mapRegion != null)
+ 			{
+@@ -1033,18 +2314,37 @@ internal class ServerSystemSupplyChunks : ServerSystem
+ 			}
+ 			ServerMain.Logger.Error("Failed deserializing a map region. Not in repair mode, will exit.");
  			throw;
  		}
  		return null;
  	}
- 
+
 +	/// <summary>
 +	/// Initializes world generation and loads spawn chunks.
 +	/// For old worlds, searches for a suitable spawn point; for new ones, loads the map center.
@@ -2338,7 +2373,11 @@ index f644852..9bb2256 100644
  			storyChunkSpawnEvents = new string[15]
  			{
  				Lang.Get("...the carved mountains"),
-@@ -1060,23 +2391,27 @@ internal class ServerSystemSupplyChunks : ServerSystem
+ 				Lang.Get("...the rolling hills"),
+ 				Lang.Get("...the vertical cliffs"),
+@@ -1058,27 +2358,31 @@ internal class ServerSystemSupplyChunks : ServerSystem
+ 				Lang.Get("...the roaming creatures"),
+ 				Lang.Get("with their offspring..."),
  				Lang.Get("...a misty sunrise"),
  				Lang.Get("...dew drops on a blade of grass"),
  				Lang.Get("...a soft breeze")
@@ -2366,7 +2405,11 @@ index f644852..9bb2256 100644
  					double value = random.NextDouble() * 6.2831854820251465;
  					double num7 = num6 * GameMath.Sin(value);
  					double num8 = num6 * GameMath.Cos(value);
-@@ -1096,10 +2431,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
+ 					num = (int)num7;
+ 					num2 = (int)num8;
+@@ -1094,114 +2398,139 @@ internal class ServerSystemSupplyChunks : ServerSystem
+ 				if (i + 1 < num3)
+ 				{
  					server.api.Logger.Notification("Trying another spawn location ({0}/{1})...", i + 2, num3);
  				}
  			}
@@ -2378,7 +2421,7 @@ index f644852..9bb2256 100644
  				if (!server.blockAccessor.GetBlock(blockPos).SideSolid[BlockFacing.UP.Index])
  				{
  					server.blockAccessor.SetBlock(server.blockAccessor.GetBlock(new AssetLocation("planks-oak-we")).Id, blockPos);
-@@ -1107,13 +2443,16 @@ internal class ServerSystemSupplyChunks : ServerSystem
+ 				}
  				blockPos.Y++;
  			}
  		}
@@ -2395,12 +2438,14 @@ index f644852..9bb2256 100644
  			x = blockPos.X,
  			y = blockPos.Y,
  			z = blockPos.Z
-@@ -1123,10 +2462,14 @@ internal class ServerSystemSupplyChunks : ServerSystem
+ 		};
+ 		if (blockPos.Y < 0)
+ 		{
  			server.mapMiddleSpawnPos.y = null;
  		}
  		server.api.Logger.VerboseDebug("Done spawn chunk");
  	}
- 
+
 +	/// <summary>
 +	/// Adjusts the spawn position: searches for a safe spot (not liquid, no solid block above,
 +	/// not blocked by a land claim). Up to 60 attempts with random offset.
@@ -2410,7 +2455,10 @@ index f644852..9bb2256 100644
  		int num = 60;
  		int num2 = 0;
  		int num3 = 0;
-@@ -1137,36 +2480,47 @@ internal class ServerSystemSupplyChunks : ServerSystem
+ 		int num4 = 0;
+ 		int num5 = 0;
+ 		int num6 = 0;
+ 		while (num-- > 0)
  		{
  			num4 = GameMath.Clamp(num2 + pos.X, 0, server.WorldMap.MapSizeX - 1);
  			num6 = GameMath.Clamp(num3 + pos.Z, 0, server.WorldMap.MapSizeZ - 1);
@@ -2437,7 +2485,7 @@ index f644852..9bb2256 100644
  		}
  		return false;
  	}
- 
+
 +	/// <summary>
 +	/// Generates a chunk area in "peek" mode without saving.
 +	/// Used for preview purposes (e.g., cartography).
@@ -2459,7 +2507,7 @@ index f644852..9bb2256 100644
  		{
  			for (int k = -num2; k <= num2; k++)
  			{
-@@ -1174,18 +2528,22 @@ internal class ServerSystemSupplyChunks : ServerSystem
+ 				if (server.WorldMap.IsValidChunkPos(x + j, 0, y + k))
  				{
  					long index2d = server.WorldMap.MapChunkIndex2D(x + j, y + k);
  					int regionX = (x + j) / MagicNum.ChunkRegionSizeInChunks;
@@ -2483,7 +2531,10 @@ index f644852..9bb2256 100644
  					};
  					chunkColumnLoadRequest.MapChunk = mapChunk;
  					GenerateNewChunkColumn(mapChunk, chunkColumnLoadRequest);
-@@ -1196,10 +2554,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
+ 					chunkColumnLoadRequest.Unpack();
+ 					array[j + num2, k + num2] = chunkColumnLoadRequest;
+ 					lock (chunkthread.peekingChunkColumns)
+ 					{
  						chunkthread.peekingChunkColumns.Enqueue(chunkColumnLoadRequest);
  					}
  				}
@@ -2496,7 +2547,11 @@ index f644852..9bb2256 100644
  		{
  			num4 = num - i;
  			for (int l = -num4; l <= num4; l++)
-@@ -1212,10 +2572,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
+ 			{
+ 				for (int m = -num4; m <= num4; m++)
+@@ -1210,14 +2539,16 @@ internal class ServerSystemSupplyChunks : ServerSystem
+ 					{
+ 						ChunkColumnLoadRequest chunkRequest = array[l + num2, m + num2];
  						runGenerators(chunkRequest, i);
  					}
  				}
@@ -2509,7 +2564,11 @@ index f644852..9bb2256 100644
  		{
  			for (int n = -num2; n <= num2; n++)
  			{
-@@ -1232,61 +2594,111 @@ internal class ServerSystemSupplyChunks : ServerSystem
+ 				for (int num5 = -num2; num5 <= num2; num5++)
+ 				{
+@@ -1230,65 +2561,115 @@ internal class ServerSystemSupplyChunks : ServerSystem
+ 						Vec2i key = new Vec2i(x + n, y + num5);
+ 						IServerChunk[] chunks = chunkColumnLoadRequest2.Chunks;
  						dictionary2[key] = chunks;
  					}
  				}
@@ -2530,7 +2589,7 @@ index f644852..9bb2256 100644
  			ServerMain.FrameProfiler.Mark("MTT-PeekChunk");
  		});
  	}
- 
+
 +	/// <summary>
 +	/// Blocking load/generation of a rectangular chunk area.
 +	/// Throttles request submission to avoid queue overflow.
@@ -2623,7 +2682,11 @@ index f644852..9bb2256 100644
  				millisecondsSinceStart = server.totalUnpausedTime.ElapsedMilliseconds;
  				float num4 = 100f * ((float)server.loadedChunks.Count / (float)server.WorldMap.ChunkMapSizeY - (float)num) / (float)num2;
  				ServerMain.Logger.Event(num4.ToString("0.#") + "% ({0} in queue)", chunkthread.requestedChunkColumns.Count);
-@@ -1298,37 +2710,84 @@ internal class ServerSystemSupplyChunks : ServerSystem
+ 				if (storyEventPrints < storyChunkSpawnEvents.Length)
+ 				{
+@@ -1296,41 +2677,88 @@ internal class ServerSystemSupplyChunks : ServerSystem
+ 				}
+ 				else
  				{
  					ServerMain.Logger.StoryEvent("...");
  				}
@@ -2711,12 +2774,16 @@ index f644852..9bb2256 100644
  				foreach (ChunkColumnLoadRequest requestedChunkColumn3 in chunkthread.requestedChunkColumns)
  				{
  					if (requestedChunkColumn3 != null)
-@@ -1340,16 +2799,25 @@ internal class ServerSystemSupplyChunks : ServerSystem
+ 					{
+ 						string text = ((requestedChunkColumn3.chunkX >= chunkX1 && requestedChunkColumn3.chunkX <= chunkX2 && requestedChunkColumn3.chunkZ >= chunkZ1 && requestedChunkColumn3.chunkZ <= chunkZ2) ? " (in original req)" : "");
+@@ -1338,55 +2766,94 @@ internal class ServerSystemSupplyChunks : ServerSystem
+ 					}
+ 				}
  				throw new Exception("Somehow worldgen has become stuck in an endless loop, please report this as a bug!  Additional data in the server-main log");
  			}
  		}
  	}
- 
+
 +	/// <summary>
 +	/// Executes one generation stage for a chunk (PopulateChunk).
 +	/// Invokes generators for the current pass, marks chunks as modified,
@@ -2737,7 +2804,9 @@ index f644852..9bb2256 100644
  				if (chunkRequest.CurrentIncompletePass == EnumWorldGenPass.Terrain)
  				{
  					ushort sunLight = (ushort)server.sunBrightness;
-@@ -1359,32 +2827,62 @@ internal class ServerSystemSupplyChunks : ServerSystem
+ 					for (int i = 0; i < chunkRequest.Chunks.Length; i++)
+ 					{
+ 						chunkRequest.Chunks[i].Lighting.ClearWithSunlight(sunLight);
  					}
  				}
  			}
@@ -2783,7 +2852,7 @@ index f644852..9bb2256 100644
  			chunkRequest.generatingLock.ReleaseWriteLock();
  		}
  	}
- 
+
 +	/// <summary>
 +	/// Runs all registered generators for the specified pass.
 +	/// On error at Terrain stage or below — aborts generation.
@@ -2802,7 +2871,11 @@ index f644852..9bb2256 100644
  			return;
  		}
  		for (int i = 0; i < list.Count; i++)
-@@ -1396,89 +2894,119 @@ internal class ServerSystemSupplyChunks : ServerSystem
+ 		{
+ 			try
+@@ -1394,93 +2861,123 @@ internal class ServerSystemSupplyChunks : ServerSystem
+ 				list[i](chunkRequest);
+ 			}
  			catch (Exception ex)
  			{
  				ServerMain.Logger.Worldgen("An error was thrown in pass {5} when generating chunk column X={0},Z={1} in world '{3}' with seed {4}\nException {2}\n\n", chunkRequest.chunkX, chunkRequest.chunkZ, ex, server.SaveGameData.WorldName, server.SaveGameData.Seed, chunkRequest.CurrentIncompletePass.ToString());
@@ -2814,7 +2887,7 @@ index f644852..9bb2256 100644
  			}
  		}
  	}
- 
+
 +	/// <summary>
 +	/// Checks that chunk neighbours are sufficiently generated for the current stage.
 +	/// For stages up to and including Terrain2, no check is required.
@@ -2883,7 +2956,7 @@ index f644852..9bb2256 100644
 +		if (!result) Interlocked.Increment(ref stratumGateBlockedCounts[currentIncompletePass_AsInt]);
  		return result;
  	}
- 
+
 -	private EnumWorldGenPass getLoadedOrQueuedChunkPass(long index2d)
 -	{
 -		server.loadedMapChunks.TryGetValue(index2d, out var value);
@@ -2893,7 +2966,7 @@ index f644852..9bb2256 100644
 -		}
 -		return EnumWorldGenPass.Done;
 -	}
- 
+
 +
 +	/// <summary>
 +	/// Checks if there is space in the request queue. On overflow:
@@ -2939,12 +3012,16 @@ index f644852..9bb2256 100644
  			chunkthread.requestedChunkColumns.Enqueue(curRequest);
  			return true;
  		}
-@@ -1490,13 +3018,19 @@ internal class ServerSystemSupplyChunks : ServerSystem
+ 		finally
+ 		{
+@@ -1488,121 +2985,204 @@ internal class ServerSystemSupplyChunks : ServerSystem
+ 			if (chunkthread.additionalWorldGenThreadsCount > 0)
+ 			{
  				ServerMain.Logger.VerboseDebug("Un-pausing all worldgen threads.");
  			}
  		}
  	}
- 
+
 +	/// <summary>
 +	/// Fully clears the generation queue, saving incomplete chunks beforehand.
 +	/// </summary>
@@ -2959,12 +3036,13 @@ index f644852..9bb2256 100644
  			if (requestedChunkColumn != null && !requestedChunkColumn.Disposed)
  			{
  				server.loadedMapChunks.Remove(requestedChunkColumn.mapIndex2d);
-@@ -1505,104 +3039,181 @@ internal class ServerSystemSupplyChunks : ServerSystem
+ 				server.ChunkColumnRequested.Remove(requestedChunkColumn.mapIndex2d);
+ 			}
  		}
  		chunkthread.requestedChunkColumns.Clear();
  		ServerMain.Logger.VerboseDebug("Incomplete chunks stored and wiped.");
  	}
- 
+
 -	private Thread CreateAdditionalWorldGenThread(int stageStart, int stageEnd, int threadnum)
 +
 +	/// <summary>
@@ -2980,7 +3058,7 @@ index f644852..9bb2256 100644
  		thread.Start();
  		return thread;
  	}
- 
+
 -	public void GeneratorThreadLoop(int stageStart, int stageEnd)
 +
 +
@@ -3026,7 +3104,7 @@ index f644852..9bb2256 100644
 +		readyTasksQueue.CompleteAdding(); // Stratum: Close the channel for workers
  		BlockAccessorWorldGen.ThreadDispose();
  	}
- 
+
 -	public override void OnSeperateThreadShutDown()
 +	/// <summary>
 +	/// Resource disposal. Duplicates shutdown logic to guarantee correct shutdown.
@@ -3045,7 +3123,7 @@ index f644852..9bb2256 100644
 +
  		BlockAccessorWorldGen.ThreadDispose();
  	}
- 
+
 -	public override void Dispose()
 +	/// <summary>
 +	/// Retires the current pause epoch: bumps the epoch bits and zeroes the
@@ -3064,7 +3142,7 @@ index f644852..9bb2256 100644
 +			}
 +		}
  	}
- 
+
 +	/// <summary>
 +	/// Pauses all worldgen threads. Waits until all workers acknowledge the pause.
 +	/// Returns false on timeout (cancels the request to prevent deadlock).
@@ -3106,7 +3184,7 @@ index f644852..9bb2256 100644
  		}
  		return true;
  	}
- 
+
 +	/// <summary>
 +	/// Resumes all worldgen threads and wakes the dispatcher.
 +	/// </summary>
@@ -3116,7 +3194,7 @@ index f644852..9bb2256 100644
  		pauseAllWorldgenThreads = 0;
 +		SignalDispatcher(); // Stratum: wake the dispatcher — time to work
  	}
- 
+
 +	/// <summary>
 +	/// Called by a worker to acknowledge the pause.
 +	/// Registers the acknowledgement against the current epoch and waits for
@@ -3178,6 +3256,4 @@ index f644852..9bb2256 100644
 +			}
 +		}
  	}
--}
-+}
-\ No newline at end of file
+ }

--- a/sources/VintagestoryApi/Server/StratumWorkerInstances.cs
+++ b/sources/VintagestoryApi/Server/StratumWorkerInstances.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace Vintagestory.API.Server
+{
+    /// <summary>
+    /// One copy of T per thread, instead of moving T's fields into ThreadLocal.
+    /// A generator is already safe on one thread, so giving each thread its own keeps vanilla's field shape.
+    /// That matters because a field turned into a property is invisible to mods that look it up by name.
+    /// Anything genuinely shared must be captured in the factory so every copy points at it.
+    /// </summary>
+    public sealed class StratumWorkerInstances<T> where T : class
+    {
+        private readonly Func<T> factory;
+        private readonly ThreadLocal<T> perThread;
+        private readonly ConcurrentBag<T> created = new ConcurrentBag<T>();
+
+        public StratumWorkerInstances(Func<T> factory)
+        {
+            this.factory = factory ?? throw new ArgumentNullException(nameof(factory));
+            perThread = new ThreadLocal<T>(Create, trackAllValues: false);
+        }
+
+        /// <summary>
+        /// The calling thread's instance, built on first use.
+        /// </summary>
+        public T Current => perThread.Value;
+
+        /// <summary>
+        /// Every instance handed out so far, for shutdown and diagnostics. Not for hot paths.
+        /// </summary>
+        public IReadOnlyCollection<T> Created => created;
+
+        private T Create()
+        {
+            T instance = factory();
+            created.Add(instance);
+            return instance;
+        }
+    }
+}

--- a/sources/VintagestoryApi/Server/Worldgen/StratumTerrainSplit.cs
+++ b/sources/VintagestoryApi/Server/Worldgen/StratumTerrainSplit.cs
@@ -3,13 +3,10 @@ using Vintagestory.API.Common;
 namespace Vintagestory.API.Server
 {
     /// <summary>
-    /// Stratum: registration point for the second half of the Terrain worldgen
-    /// pass. Stratum schedules Terrain as two internal sub-stages so two threads
-    /// can share the heaviest pass. Handlers registered here run after the 3d
-    /// terrain generators, in registration order, with the same guarantees the
-    /// vanilla Terrain pass gives (no neighbour chunks required). Registering
-    /// through the vanilla ChunkColumnGeneration API is unchanged and keeps
-    /// vanilla pass numbering.
+    /// Stratum: registration point for the second half of the Terrain worldgen pass.
+    /// Stratum schedules Terrain as two internal stages so two threads can share the heaviest pass.
+    /// Late handlers keep their registration order and require no neighbour chunks.
+    /// Vanilla registrations keep the original pass numbering.
     /// </summary>
     public static class StratumTerrainSplit
     {
@@ -19,9 +16,13 @@ namespace Vintagestory.API.Server
         public static System.Action<ChunkColumnGenerationDelegate, string> RegisterLate;
 
         /// <summary>
-        /// Registers a generator for the late Terrain sub-stage. Falls back to the
-        /// vanilla Terrain pass when no Stratum scheduler is present, so callers
-        /// behave like vanilla registrations outside Stratum.
+        /// Assigned by the server for generators whose clean-stock handler runs on a worker instance.
+        /// </summary>
+        public static System.Action<ChunkColumnGenerationDelegate, ChunkColumnGenerationDelegate, string> RegisterLateOptimized;
+
+        /// <summary>
+        /// Registers a generator for the late Terrain stage.
+        /// Outside Stratum, it registers through the vanilla Terrain pass.
         /// </summary>
         public static void Register(ICoreServerAPI api, ChunkColumnGenerationDelegate handler, string forWorldType)
         {
@@ -32,6 +33,21 @@ namespace Vintagestory.API.Server
             else
             {
                 api.Event.ChunkColumnGeneration(handler, EnumWorldGenPass.Terrain, forWorldType);
+            }
+        }
+
+        /// <summary>
+        /// Keeps the vanilla handler visible until the server confirms the optimized handler is compatible.
+        /// </summary>
+        public static void Register(ICoreServerAPI api, ChunkColumnGenerationDelegate vanillaHandler, ChunkColumnGenerationDelegate optimizedHandler, string forWorldType)
+        {
+            if (RegisterLateOptimized != null)
+            {
+                RegisterLateOptimized(vanillaHandler, optimizedHandler, forWorldType);
+            }
+            else
+            {
+                api.Event.ChunkColumnGeneration(vanillaHandler, EnumWorldGenPass.Terrain, forWorldType);
             }
         }
     }

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumModCompat.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumModCompat.cs
@@ -61,6 +61,28 @@ internal static class StratumModCompat
 		return null;
 	}
 
+	// First mod-patched method declared on this type or one of its base types.
+	// Worker wrappers use this so patches on the vanilla handler still disable unsafe concurrency.
+	public static string FindPatchedMethodOn(Type type)
+	{
+		if (type == null) return null;
+
+		for (Type current = type; current?.Assembly == type.Assembly; current = current.BaseType)
+		{
+			MethodInfo[] methods = current.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly);
+			foreach (MethodInfo method in methods)
+			{
+				string patches = DescribeModPatches(method);
+				if (patches != null)
+				{
+					return current.Name + "." + method.Name + " (" + patches + ")";
+				}
+			}
+		}
+
+		return null;
+	}
+
 	// Every mod-owned Harmony patch on one method, or null when there are none. Stratum compiles
 	// its own changes in and applies no Harmony patches, so anything here is third-party.
 	public static string DescribeModPatches(MethodBase method)

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumWorldgenCompat.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumWorldgenCompat.cs
@@ -4,41 +4,60 @@ using Vintagestory.API.Server;
 
 namespace Vintagestory.Server;
 
-// Keeps the Terrain pass in its vanilla shape whenever a mod is watching it.
-// The split moves rock strata, caves and block layers into a later stage, so mod handlers
-// at Terrain stop running after them, and anything walking OnChunkColumnGen[Terrain] to
-// replace one of them finds nothing and quietly does nothing while Stratum still runs it.
+// Keeps the Terrain pass in its vanilla shape whenever a mod may observe it.
+// The split moves rock strata, caves and block layers into a later stage.
+// Mods could otherwise fail to find or replace the vanilla handlers.
 internal static class StratumWorldgenCompat
 {
 	// Where the vanilla generators and the noise and map layers they call live.
 	private const string worldgenNamespace = "Vintagestory.ServerMods";
 
-	// Handlers bound for the late sub-stage, per world type, in registration order.
-	private static readonly Dictionary<string, List<ChunkColumnGenerationDelegate>> pendingLateHandlers = new Dictionary<string, List<ChunkColumnGenerationDelegate>>();
+	private readonly struct PendingLateHandler
+	{
+		public readonly ChunkColumnGenerationDelegate Vanilla;
+		public readonly ChunkColumnGenerationDelegate Optimized;
+
+		public PendingLateHandler(ChunkColumnGenerationDelegate vanilla, ChunkColumnGenerationDelegate optimized)
+		{
+			Vanilla = vanilla;
+			Optimized = optimized;
+		}
+	}
+
+	// Handler pairs bound for the late sub-stage, per world type, in registration order.
+	private static readonly Dictionary<string, List<PendingLateHandler>> pendingLateHandlers = new Dictionary<string, List<PendingLateHandler>>();
+
+	// Original shared generators need vanilla's serial scheduling when the worker swap is not applied.
+	public static bool TerrainRequiresSerialFallback { get; private set; }
 
 	public static void RegisterTerrainLate(ServerMain server, ChunkColumnGenerationDelegate handler, string worldType)
 	{
-		// Vanilla position for now. ApplyTerrainSplitIfSafe moves it later if that turns out safe.
-		server.ModEventManager.GetWorldGenHandler(worldType).OnChunkColumnGen[(int)EnumWorldGenPass.Terrain].Add(handler);
+		RegisterTerrainLate(server, handler, handler, worldType);
+	}
+
+	public static void RegisterTerrainLate(ServerMain server, ChunkColumnGenerationDelegate vanillaHandler, ChunkColumnGenerationDelegate optimizedHandler, string worldType)
+	{
+		// Keep the vanilla target visible until every mod has finished registering.
+		server.ModEventManager.GetWorldGenHandler(worldType).OnChunkColumnGen[(int)EnumWorldGenPass.Terrain].Add(vanillaHandler);
 
 		string key = worldType ?? string.Empty;
-		if (!pendingLateHandlers.TryGetValue(key, out List<ChunkColumnGenerationDelegate> late))
+		if (!pendingLateHandlers.TryGetValue(key, out List<PendingLateHandler> late))
 		{
-			late = new List<ChunkColumnGenerationDelegate>();
+			late = new List<PendingLateHandler>();
 			pendingLateHandlers[key] = late;
 		}
 
-		late.Add(handler);
+		late.Add(new PendingLateHandler(vanillaHandler, optimizedHandler));
 	}
 
-	// Called once every OnInitWorldGen handler has run, which is the first point where every
-	// mod has finished registering.
+	// Called after every mod has finished registering its worldgen handlers.
 	public static void ApplyTerrainSplitIfSafe(ServerMain server, WorldGenHandler worldgenHandler)
 	{
+		TerrainRequiresSerialFallback = false;
 		if (worldgenHandler == null) return;
 
 		string key = server?.SaveGameData?.WorldType ?? string.Empty;
-		if (!pendingLateHandlers.TryGetValue(key, out List<ChunkColumnGenerationDelegate> late) || late.Count == 0)
+		if (!pendingLateHandlers.TryGetValue(key, out List<PendingLateHandler> late) || late.Count == 0)
 		{
 			return;
 		}
@@ -47,28 +66,57 @@ internal static class StratumWorldgenCompat
 		string blocker = FindSplitBlocker(worldgenHandler, late, StratumRuntime.Config.Worldgen);
 		if (blocker != null)
 		{
+			TerrainRequiresSerialFallback = HasActiveWorkerBackedVanillaHandler(worldgenHandler, late);
 			StratumModCompat.ReportFallback("worldgen", "the Terrain pass split", blocker, "Worldgen.AutoDisableSplitForMods");
 			return;
 		}
 
 		List<ChunkColumnGenerationDelegate> terrain = worldgenHandler.OnChunkColumnGen[(int)EnumWorldGenPass.Terrain];
-		for (int i = 0; i < late.Count; i++)
+		int moved = 0;
+		for (int terrainIndex = 0; terrainIndex < terrain.Count;)
 		{
-			terrain.Remove(late[i]);
+			int pendingIndex = -1;
+			for (int i = 0; i < late.Count; i++)
+			{
+				if (terrain[terrainIndex] != late[i].Vanilla) continue;
+
+				pendingIndex = i;
+				break;
+			}
+
+			if (pendingIndex < 0)
+			{
+				terrainIndex++;
+				continue;
+			}
+
+			terrain.RemoveAt(terrainIndex);
+			worldgenHandler.OnChunkColumnGenTerrainLate.Add(late[pendingIndex].Optimized);
+			moved++;
 		}
 
-		worldgenHandler.OnChunkColumnGenTerrainLate.AddRange(late);
-		StratumRuntime.LogInfo($"worldgen: Terrain pass split in two, {late.Count} generator(s) moved to TerrainLate");
+		StratumRuntime.LogInfo($"worldgen: Terrain pass split in two, {moved} generator(s) moved to TerrainLate");
+	}
+
+	private static bool HasActiveWorkerBackedVanillaHandler(WorldGenHandler worldgenHandler, List<PendingLateHandler> late)
+	{
+		List<ChunkColumnGenerationDelegate> terrain = worldgenHandler.OnChunkColumnGen[(int)EnumWorldGenPass.Terrain];
+		for (int i = 0; i < late.Count; i++)
+		{
+			PendingLateHandler pending = late[i];
+			if (pending.Vanilla != pending.Optimized && terrain.Contains(pending.Vanilla)) return true;
+		}
+
+		return false;
 	}
 
 	// Null when the split is safe, otherwise the reason, phrased for whoever reads the log.
-	private static string FindSplitBlocker(WorldGenHandler worldgenHandler, List<ChunkColumnGenerationDelegate> late, StratumWorldgenConfig config)
+	private static string FindSplitBlocker(WorldGenHandler worldgenHandler, List<PendingLateHandler> late, StratumWorldgenConfig config)
 	{
 		if (!config.SplitTerrainPass) return "Worldgen.SplitTerrainPass is disabled in stratum.json";
 		if (!config.AutoDisableSplitForMods) return null;
 
-		// One foreign handler is enough. Even if it registered before every late generator and
-		// would keep its order, it can still be walking the list looking for them.
+		// One foreign handler is enough because it may inspect or replace the vanilla handlers.
 		string foreign = StratumModCompat.FindForeignHandler(worldgenHandler.OnChunkColumnGen[(int)EnumWorldGenPass.Terrain]);
 		if (foreign != null)
 		{
@@ -77,7 +125,7 @@ internal static class StratumWorldgenCompat
 
 		for (int i = 0; i < late.Count; i++)
 		{
-			string patches = StratumModCompat.DescribeModPatches(late[i]?.Method);
+			string patches = StratumModCompat.DescribeModPatches(late[i].Optimized?.Method);
 			if (patches != null)
 			{
 				return "a generator Stratum would move to the late sub-stage is Harmony patched (" + patches + ")";


### PR DESCRIPTION
Feature: give each worldgen thread its own generator instead of ThreadLocal fields

Feature: StratumWorkerInstances, one copy of a generator per worldgen thread

Fixed: caveRand and chunkRand are plain fields again, so mods that look them
up by name find them

Fixed: GenBlockLayers seeds its rnd shim at setup, so it survives a mod prefix
replacing OnChunkColumnGeneration

Tweak: GenCaves runs generation on the calling thread's worker

Fixed: preserve vanilla worldgen contracts for mods

Fixed: keep vanilla fields, methods, constructors, and handler identities visible

Feature: use per-thread generator instances on the optimized stock path

Fixed: restore vanilla topology and serial scheduling when foreign code is detected

Fixed: serialize mod structure-provider callbacks without disabling the whole stage

Fixed: initialize compatibility state before mod prefixes can replace generation

Tweak: retain existing worldgen pooling, parallelism, and generation optimizations

**Draft, not verified. Vanilla worldgen has not been confirmed clean and the
same-seed cave comparison has not been run.**

Only comitting as I won't be able to work on it again until later and want to share progress.

## Related issues

Will fix the issues below.
https://github.com/StratumServer/Stratum/issues/230
https://github.com/StratumServer/Stratum/issues/227
https://github.com/StratumServer/Stratum/issues/226
