### PR TITLE
Add runtime toggles for global and group chat

### DIFF
--- a/sources/VintagestoryLib/Vintagestory.Server/CmdStratum.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/CmdStratum.cs
@@ -168,7 +168,7 @@ internal class CmdStratum
 		output.Append(StratumCommandText.Row("Client mod policy", "enabled=" + (config.ClientModPolicy.Enabled ? "on" : "off") + ", strictWhitelist=" + (config.ClientModPolicy.StrictWhitelist ? "on" : "off") + ", allowExtras=" + config.ClientModPolicy.AllowModIds.Count));
 		output.Append(StratumCommandText.Row("Hardening", "packets=" + (config.Hardening.PacketMonitoring ? "on" : "off") + ", blockbreak=" + (config.Hardening.BlockBreakGuards ? "on" : "off") + ", inventory=" + (config.Hardening.InventoryGuards ? "on" : "off") + ", entities=" + (config.Hardening.EntityGuards ? "on" : "off")));
 		output.Append(StratumCommandText.Row("Commands", "playerQoL=" + (config.Commands.Enabled ? "on" : "off") + ", tpaTimeout=" + config.Commands.TeleportRequests.TimeoutSeconds + "s, defaultHomes=" + config.Commands.Homes.DefaultMaxHomes + ", near=" + config.Commands.NearDefaultRadiusBlocks + "/" + config.Commands.NearMaxRadiusBlocks));
-		output.Append(StratumCommandText.Row("Chat", "rolePrefixes=" + (config.Chat.Enabled && config.Appearance.RolePrefixes.Enabled ? "on" : "off") + ", urlLinks=" + (config.Chat.Enabled && config.Chat.LinkifyUrls ? "on" : "off") + ", configuredRoles=" + config.Appearance.RolePrefixes.Roles.Count));
+		output.Append(StratumCommandText.Row("Chat", "rolePrefixes=" + (config.Chat.Enabled && config.Appearance.RolePrefixes.Enabled ? "on" : "off") + ", urlLinks=" + (config.Chat.Enabled && config.Chat.LinkifyUrls ? "on" : "off") + ", configuredRoles=" + config.Appearance.RolePrefixes.Roles.Count + ", global=" + (config.Chat.Global.Enabled ? "on" : "off") + ", group=" + (config.Chat.Groups.Enabled ? "on" : "off")));
 		return TextCommandResult.Success(output.ToString());
 	}
 
@@ -448,6 +448,8 @@ internal class CmdStratum
 		StratumRolePrefixesConfig rolePrefixes = StratumRuntime.Config.Appearance.RolePrefixes;
 		StringBuilder output = new StringBuilder(StratumCommandText.Title("Stratum Chat"));
 		output.Append(StratumCommandText.Row("Enabled", chat.Enabled ? "true" : "false"));
+		output.Append(StratumCommandText.Row("Global chat", chat.Global.Enabled ? "enabled" : "disabled (staffBypass=" + (chat.Global.AllowStaffBypass ? "on" : "off") + ")"));
+		output.Append(StratumCommandText.Row("Group chat", chat.Groups.Enabled ? "enabled" : "disabled (staffBypass=" + (chat.Groups.AllowStaffBypass ? "on" : "off") + ")"));
 		output.Append(StratumCommandText.Row("Role prefixes", rolePrefixes.Enabled ? "true" : "false"));
 		output.Append(StratumCommandText.Row("URL links", chat.LinkifyUrls ? "true" : "false"));
 		output.Append(StratumCommandText.Row("Prefix format", rolePrefixes.Format));

--- a/sources/VintagestoryLib/Vintagestory.Server/CmdStratumStaffCommands.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/CmdStratumStaffCommands.cs
@@ -112,6 +112,13 @@ internal class CmdStratumStaffCommands
 				.RequiresPrivilege(Privilege.chat)
 				.HandleWith(HandleLockChat);
 
+			server.api.commandapi.Create("chattoggle")
+				.WithAlias("togglechat")
+				.WithDescription("Enable or disable global or group player chat")
+				.WithArgs(parsers.OptionalWordRange("channel", "global", "group", "all", "status"), parsers.OptionalWordRange("mode", "on", "off", "toggle", "status"))
+				.RequiresPrivilege(Privilege.chat)
+				.HandleWith(HandleChatToggle);
+
 			server.api.commandapi.Create("chatclear")
 				.WithAlias("clearchat")
 				.WithDescription("Clear visible chat history for online players")
@@ -609,6 +616,114 @@ internal class CmdStratumStaffCommands
 		server.SendMessageToGeneral("<font color=\"#9bd77e\"><strong>Chat has been unlocked.</strong></font>", EnumChatType.Notification);
 		StratumRuntime.LogAudit("lockchat off actor=" + args.Caller.GetName(), true);
 		return TextCommandResult.Success(StratumCommandText.Confirm("Chat unlocked"));
+	}
+
+	private TextCommandResult HandleChatToggle(TextCommandCallingArgs args)
+	{
+		if (!CheckAccess(args, StratumRuntime.Config.Commands.ChatControl, "chattoggle", out TextCommandResult failure))
+		{
+			return failure;
+		}
+
+		StratumChatConfig chat = StratumRuntime.Config.Chat;
+		string channel = args[0] as string;
+		string mode = args[1] as string;
+
+		if (string.IsNullOrWhiteSpace(channel) || string.Equals(channel, "status", StringComparison.OrdinalIgnoreCase))
+		{
+			StringBuilder status = new StringBuilder(StratumCommandText.Title("Chat Channels"));
+			status.Append(StratumCommandText.Row("Global", DescribeChatChannel(chat.Global)));
+			status.Append(StratumCommandText.Row("Group", DescribeChatChannel(chat.Groups)));
+			return TextCommandResult.Success(status.ToString());
+		}
+
+		bool touchGlobal = string.Equals(channel, "global", StringComparison.OrdinalIgnoreCase) || string.Equals(channel, "all", StringComparison.OrdinalIgnoreCase);
+		bool touchGroups = string.Equals(channel, "group", StringComparison.OrdinalIgnoreCase) || string.Equals(channel, "all", StringComparison.OrdinalIgnoreCase);
+
+		if (string.Equals(mode, "status", StringComparison.OrdinalIgnoreCase))
+		{
+			StringBuilder channelStatus = new StringBuilder(StratumCommandText.Title("Chat Channels"));
+			if (touchGlobal)
+			{
+				channelStatus.Append(StratumCommandText.Row("Global", DescribeChatChannel(chat.Global)));
+			}
+
+			if (touchGroups)
+			{
+				channelStatus.Append(StratumCommandText.Row("Group", DescribeChatChannel(chat.Groups)));
+			}
+
+			return TextCommandResult.Success(channelStatus.ToString());
+		}
+
+		// "toggle" and an omitted mode both flip; resolve per channel so /chattoggle all toggle
+		// does not desynchronise two channels that started in different states.
+		bool globalTarget = ResolveChatToggleTarget(mode, chat.Global.Enabled);
+		bool groupsTarget = ResolveChatToggleTarget(mode, chat.Groups.Enabled);
+
+		if (touchGlobal)
+		{
+			chat.Global.Enabled = globalTarget;
+		}
+
+		if (touchGroups)
+		{
+			chat.Groups.Enabled = groupsTarget;
+		}
+
+		try
+		{
+			StratumRuntime.SaveConfig();
+		}
+		catch (Exception ex)
+		{
+			return TextCommandResult.Error(StratumCommandText.Warning("Applied in memory but failed to write config") + ": " + ex.Message);
+		}
+
+		string actor = args.Caller.GetName();
+		StringBuilder result = new StringBuilder(StratumCommandText.Title("Chat Channels"));
+		if (touchGlobal)
+		{
+			AnnounceChatChannelChange("Global chat", globalTarget);
+			StratumRuntime.LogAudit("chattoggle global=" + (globalTarget ? "on" : "off") + " actor=" + actor, true);
+			result.Append(StratumCommandText.Row("Global", DescribeChatChannel(chat.Global)));
+		}
+
+		if (touchGroups)
+		{
+			AnnounceChatChannelChange("Group chat", groupsTarget);
+			StratumRuntime.LogAudit("chattoggle group=" + (groupsTarget ? "on" : "off") + " actor=" + actor, true);
+			result.Append(StratumCommandText.Row("Group", DescribeChatChannel(chat.Groups)));
+		}
+
+		return TextCommandResult.Success(result.ToString());
+	}
+
+	private static bool ResolveChatToggleTarget(string mode, bool current)
+	{
+		if (string.Equals(mode, "on", StringComparison.OrdinalIgnoreCase))
+		{
+			return true;
+		}
+
+		if (string.Equals(mode, "off", StringComparison.OrdinalIgnoreCase))
+		{
+			return false;
+		}
+
+		return !current;
+	}
+
+	private static string DescribeChatChannel(StratumChatChannelConfig channel)
+	{
+		return (channel.Enabled ? "enabled" : "disabled") + ", staffBypass=" + (channel.AllowStaffBypass ? "on" : "off");
+	}
+
+	private void AnnounceChatChannelChange(string label, bool enabled)
+	{
+		string colour = enabled ? "#9bd77e" : "#e47d68";
+		string verb = enabled ? " has been enabled." : " has been disabled by staff.";
+		server.SendMessageToGeneral("<font color=\"" + colour + "\"><strong>" + label + verb + "</strong></font>", EnumChatType.Notification);
 	}
 
 	private TextCommandResult HandleClearChat(TextCommandCallingArgs args)
@@ -1328,6 +1443,21 @@ internal class CmdStratumStaffCommands
 			}
 
 			stratumMuteExpiryByUid.Remove(player.PlayerUID);
+		}
+		// Stratum end
+
+		// Stratum start: runtime per-channel chat toggles (issue #218)
+		StratumChatChannelConfig chatChannel = StratumRuntime.Config.Chat?.ChannelFor(channelId);
+		if (chatChannel != null && !chatChannel.Enabled)
+		{
+			bool staffExempt = chatChannel.AllowStaffBypass
+				&& StratumCommandAccessCatalog.PlayerHasAccess(player, StratumRuntime.Config.Commands.ChatControl);
+			if (!staffExempt)
+			{
+				consumed.value = true;
+				player.SendMessage(channelId, chatChannel.DisabledMessage, EnumChatType.CommandError);
+				return;
+			}
 		}
 		// Stratum end
 

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumChatConfig.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumChatConfig.cs
@@ -1,9 +1,14 @@
 using System;
+using Vintagestory.API.Config;
 
 namespace Vintagestory.Server;
 
 internal class StratumChatConfig
 {
+	public const string DefaultGlobalDisabledMessage = "Global chat is disabled on this server.";
+
+	public const string DefaultGroupsDisabledMessage = "Group chat is disabled on this server.";
+
 	public bool Enabled { get; set; } = true;
 
 	public bool LinkifyUrls { get; set; } = true;
@@ -12,11 +17,58 @@ internal class StratumChatConfig
 
 	public StratumChatRateLimitConfig RateLimit { get; set; } = new StratumChatRateLimitConfig();
 
+	public StratumChatChannelConfig Global { get; set; } = StratumChatChannelConfig.WithMessage(DefaultGlobalDisabledMessage);
+
+	public StratumChatChannelConfig Groups { get; set; } = StratumChatChannelConfig.WithMessage(DefaultGroupsDisabledMessage);
+
 	public void EnsurePopulated()
 	{
 		ConnectionMessages ??= new StratumConnectionMessagesConfig();
 		RateLimit ??= new StratumChatRateLimitConfig();
 		RateLimit.EnsureSane();
+		Global ??= StratumChatChannelConfig.WithMessage(DefaultGlobalDisabledMessage);
+		Groups ??= StratumChatChannelConfig.WithMessage(DefaultGroupsDisabledMessage);
+		Global.EnsurePopulated(DefaultGlobalDisabledMessage);
+		Groups.EnsurePopulated(DefaultGroupsDisabledMessage);
+	}
+
+	// Maps a chat channel id to the toggle that governs it. Returns null for the
+	// negative server channels (ServerInfo, DamageLog, InfoLog, AllChatGroups),
+	// which are server-to-client only and are never player chat. Deliberately
+	// independent of Enabled/LinkifyUrls above: those gate formatting, not delivery,
+	// and a formatting toggle should not silently re-enable a channel an operator
+	// turned off.
+	public StratumChatChannelConfig ChannelFor(int channelId)
+	{
+		if (channelId == GlobalConstants.GeneralChatGroup)
+		{
+			return Global;
+		}
+
+		return channelId > 0 ? Groups : null;
+	}
+}
+
+internal class StratumChatChannelConfig
+{
+	public bool Enabled { get; set; } = true;
+
+	// When the channel is disabled, holders of Commands.ChatControl can still post.
+	public bool AllowStaffBypass { get; set; } = true;
+
+	public string DisabledMessage { get; set; } = string.Empty;
+
+	public static StratumChatChannelConfig WithMessage(string message)
+	{
+		return new StratumChatChannelConfig { DisabledMessage = message };
+	}
+
+	public void EnsurePopulated(string defaultMessage)
+	{
+		if (string.IsNullOrWhiteSpace(DisabledMessage))
+		{
+			DisabledMessage = defaultMessage;
+		}
 	}
 }
 

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumCommandAccessCatalog.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumCommandAccessCatalog.cs
@@ -44,7 +44,7 @@ internal static class StratumCommandAccessCatalog
 		yield return new StratumCommandAccessEntry("msg", "/msg", commands.Message, "Use /msg and /reply");
 		yield return new StratumCommandAccessEntry("reply", "/reply", commands.Message, "Use /reply");
 		yield return new StratumCommandAccessEntry("staffchat", "/staffchat", commands.StaffChat, "Use /staffchat");
-		yield return new StratumCommandAccessEntry("chatcontrol", "/slowmode", commands.ChatControl, "Use /slowmode, /lockchat, and /chatclear");
+		yield return new StratumCommandAccessEntry("chatcontrol", "/slowmode", commands.ChatControl, "Use /slowmode, /lockchat, /chatclear, and /chattoggle");
 		yield return new StratumCommandAccessEntry("staffbroadcast", "/staffbroadcast", commands.StaffBroadcast, "Use /staffbroadcast");
 		yield return new StratumCommandAccessEntry("info", "/rules", commands.InfoCommands, "Use /rules, /discord, /website, and /motd");
 		yield return new StratumCommandAccessEntry("vanish", "/vanish", commands.Vanish, "Use /vanish");


### PR DESCRIPTION
## Summary

Two independent runtime toggles, `Chat.Global.Enabled` and `Chat.Groups.Enabled`. Each channel also gets `AllowStaffBypass` (default on) and a `DisabledMessage` shown to a blocked sender. Config-backed, so it survives a restart, unlike `/lockchat` which is session state.

```
/chattoggle                    status for both channels
/chattoggle global on|off|toggle
/chattoggle group  on|off|toggle
/chattoggle all    on|off|toggle
/togglechat ...                alias
```

No new command needed either, `/stratum set Chat.Global.Enabled false` works today through the existing reflection path.

`/announce`, `/staffbroadcast`, and slash commands are untouched. They never go through `OnPlayerChat`.

### Where it hooks and why

`CmdStratumStaffCommands.OnPlayerChat` already runs the mute check, then an unconditional staff bypass, then the chat lock and slowmode checks. The new check sits between the mute check and the bypass, not after it. The bypass at that point returns unconditionally, so if the per-channel check came after it, `AllowStaffBypass = false` would be dead code, staff would always get through regardless of the setting.

`StratumChatConfig.ChannelFor(channelId)` maps `0` to Global, any positive group id to Groups, and returns null for the negative server channels (ServerInfo, DamageLog, InfoLog, AllChatGroups). Those are server-to-client only, never reachable from a player chat packet, left alone.

Kept independent of the existing `Chat.Enabled` flag. That one only gates role-prefix formatting. If the new toggles read it too, disabling formatting would silently re-enable a channel someone had turned off on purpose.

### A tradeoff worth flagging

The staff exemption reuses the existing `Commands.ChatControl` privilege (`stratum.chatcontrol`) instead of adding a new one. Simpler, no new config block, no new catalog entry, matches what `/lockchat`'s bypass already uses. The cost: if an operator disables the `ChatControl` command block entirely, the staff exemption goes with it, since `PlayerHasAccess` checks that block's own `Enabled` flag. Recoverable from console (console callers always pass the check) or by hand-editing `stratum.json`. Same behavior `/lockchat` already has, not a new failure mode, but worth knowing before merge.

### Testing detail

No test project in this repo, so this follows the usual live-boot convention. Fresh-config boot confirmed `stratum.json` writes `Chat.Global`/`Chat.Groups` with correct defaults; upgrade path confirmed a hand-edited custom value survives while a deleted block comes back through `EnsurePopulated`. Live two-account test against a real client exercised baseline delivery, `AllowStaffBypass` both ways, `/announce` bypassing the hook entirely, and every `/chattoggle` mode.

That live pass caught a real bug before it shipped: the arg parser accepts `status` as a value for the `mode` argument too (`/chattoggle global status`), but the original handler only checked for `on`/`off` and fell through to the toggle branch for anything else, `status` included. Typing `/chattoggle global status` expecting a read would have flipped the channel instead. Fixed by handling `mode == "status"` as its own branch before the mutation path, verified against the same build.

@trevorftp @tehtelev

## Type

- [ ] Bug fix
- [ ] Performance
- [x] New feature
- [ ] Refactor or cleanup
- [ ] Docs or build

## Checklist

- [ ] `.\scripts\extract-patches.ps1` ran clean.
- [x] `dotnet build VintageStory.slnx -c Release` is green.
- [x] Every vanilla edit has a `// Stratum` marker. (No vanilla files touched, only Stratum-authored files under `sources/`.)
- [x] No vanilla source committed.
- [x] Tested on a real server start, not just compilation.

## Related issues

Fixes #218
