### PR TITLE
Add mutual invisibility for vanished staff

### DIFF
--- a/sources/VintagestoryLib/Vintagestory.Server/CmdStratumStaffCommands.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/CmdStratumStaffCommands.cs
@@ -156,8 +156,10 @@ internal class CmdStratumStaffCommands
 		if (StratumCommandRegistration.ShouldRegister(commands.Vanish, "/vanish", "Commands.Vanish"))
 		{
 			server.api.commandapi.Create("vanish")
-				.WithDescription("Toggle staff vanish")
-				.WithArgs(parsers.OptionalWordRange("mode", "on", "off", "toggle"))
+				.WithDescription("Toggle staff vanish, or /vanish hideothers to hide other vanished staff from yourself")
+				.WithArgs(
+					parsers.OptionalWordRange("mode", "on", "off", "toggle", "hideothers", "status"),
+					parsers.OptionalWordRange("state", "on", "off", "toggle"))
 				.RequiresPrivilege(Privilege.chat)
 				.HandleWith(HandleVanish);
 		}
@@ -384,7 +386,12 @@ internal class CmdStratumStaffCommands
 		var nearby = server.Clients.Values
 			.Where(client => client.State.IsAdmitted() && client.Player?.Entity?.Pos != null && client.Player.PlayerUID != player.PlayerUID)
 			.Where(client => client.Player.Entity.Pos.Dimension == pos.Dimension)
-			.Where(client => !StratumStaffCommandState.IsVanished(client.Player.PlayerUID) || StratumCommandAccessCatalog.PlayerHasAccess(player, StratumRuntime.Config.Commands.Vanish))
+			// Stratum #213: mirror the entity-visibility rule exactly, including the
+			// per-viewer "hide other vanished" preference, so /near never lists someone
+			// the caller cannot see.
+			.Where(client => !StratumStaffCommandState.IsVanished(client.Player.PlayerUID)
+				|| (StratumCommandAccessCatalog.PlayerHasAccess(player, StratumRuntime.Config.Commands.Vanish)
+					&& !StratumStaffCommandState.HidesOtherVanished(player.PlayerUID)))
 			.Select(client => new
 			{
 				client.Player.PlayerName,
@@ -701,6 +708,22 @@ internal class CmdStratumStaffCommands
 		}
 
 		string mode = args[0] as string;
+
+		// Stratum #213: /vanish hideothers [on|off|toggle] is a per-viewer preference and
+		// does not touch the caller's own vanish state. Must be handled before the toggle
+		// fallthrough below, which treats any unrecognised mode word as "toggle vanish".
+		if (string.Equals(mode, "hideothers", StringComparison.OrdinalIgnoreCase))
+		{
+			return HandleVanishHideOthers(player, args[1] as string);
+		}
+
+		if (string.Equals(mode, "status", StringComparison.OrdinalIgnoreCase))
+		{
+			return TextCommandResult.Success(StratumCommandText.Title("Vanish")
+				+ StratumCommandText.Row("Vanished", StratumStaffCommandState.IsVanished(player.PlayerUID) ? "yes" : "no")
+				+ StratumCommandText.Row("Hide other vanished", StratumStaffCommandState.HidesOtherVanished(player.PlayerUID) ? "on" : "off"));
+		}
+
 		bool enable = string.Equals(mode, "on", StringComparison.OrdinalIgnoreCase) || (!string.Equals(mode, "off", StringComparison.OrdinalIgnoreCase) && !StratumStaffCommandState.IsVanished(player.PlayerUID));
 		StratumStaffCommandState.SetVanished(player, enable);
 		if (enable)
@@ -713,6 +736,32 @@ internal class CmdStratumStaffCommands
 		StratumStaffCommandState.RevealPlayerToOthers(server, player);
 		lastVanishIndicatorMsByUid.Remove(player.PlayerUID);
 		return TextCommandResult.Success(StratumCommandText.Confirm("Vanish disabled"));
+	}
+
+	private TextCommandResult HandleVanishHideOthers(IServerPlayer player, string state)
+	{
+		bool current = StratumStaffCommandState.HidesOtherVanished(player.PlayerUID);
+		bool target;
+		if (string.Equals(state, "on", StringComparison.OrdinalIgnoreCase))
+		{
+			target = true;
+		}
+		else if (string.Equals(state, "off", StringComparison.OrdinalIgnoreCase))
+		{
+			target = false;
+		}
+		else
+		{
+			target = !current;
+		}
+
+		StratumStaffCommandState.SetHidesOtherVanished(player.PlayerUID, target);
+		StratumStaffCommandState.RefreshVanishedVisibilityForViewer(server, player);
+		StratumRuntime.LogAudit("vanish hideothers=" + (target ? "on" : "off") + " actor=" + EscapeLog(player.PlayerName));
+
+		return TextCommandResult.Success(StratumCommandText.Confirm(target
+			? "Other vanished staff are now hidden from you"
+			: "Other vanished staff are now visible to you"));
 	}
 
 	private TextCommandResult HandlePvp(TextCommandCallingArgs args)

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumCommandAccessCatalog.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumCommandAccessCatalog.cs
@@ -47,7 +47,7 @@ internal static class StratumCommandAccessCatalog
 		yield return new StratumCommandAccessEntry("chatcontrol", "/slowmode", commands.ChatControl, "Use /slowmode, /lockchat, and /chatclear");
 		yield return new StratumCommandAccessEntry("staffbroadcast", "/staffbroadcast", commands.StaffBroadcast, "Use /staffbroadcast");
 		yield return new StratumCommandAccessEntry("info", "/rules", commands.InfoCommands, "Use /rules, /discord, /website, and /motd");
-		yield return new StratumCommandAccessEntry("vanish", "/vanish", commands.Vanish, "Use /vanish");
+		yield return new StratumCommandAccessEntry("vanish", "/vanish", commands.Vanish, "Use /vanish and /vanish hideothers");
 		yield return new StratumCommandAccessEntry("pvp", "/pvp", commands.Pvp, "Use /pvp");
 		yield return new StratumCommandAccessEntry("freeze", "/freeze", commands.Freeze, "Use /freeze");
 		yield return new StratumCommandAccessEntry("jail", "/jail", commands.Jail, "Use /setjail, /jail, /unjail, and /jailstatus");

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumConfig.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumConfig.cs
@@ -1544,6 +1544,11 @@ internal class StratumCommandsConfig
 
 	public int VanishReminderIntervalSeconds { get; set; } = 4;
 
+	// Stratum #213: default for the per-staff-member "hide other vanished staff from me"
+	// preference. Individual staff override it at runtime with /vanish hideothers on|off.
+	// Default false preserves today's behaviour: vanish holders see each other.
+	public bool VanishHideOtherVanishedDefault { get; set; } = false;
+
 	public StratumCommandAccessConfig Freeze { get; set; } = StratumCommandAccessConfig.ForPrivilege("stratum.freeze");
 
 	public StratumCommandAccessConfig Revive { get; set; } = StratumCommandAccessConfig.ForPrivilege("stratum.revive");

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumPlayerPrivacy.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumPlayerPrivacy.cs
@@ -5,9 +5,10 @@ namespace Vintagestory.Server;
 
 /// <summary>
 /// Stratum player privacy: hides player map pins by default, with staff override and group exception.
-/// Wires into the engine via <see cref="PlayerMapDisclosureHook"/> so VSEssentials' player-pin
-/// broadcaster (SystemRemotePlayerTracking) consults Stratum config without taking a hard reference
-/// back into VintagestoryLib.
+/// Also hides a vanished player's map pin unconditionally (see <see cref="VanishHidesSenderFromReceiver"/>),
+/// regardless of the opt-in config below. Wires into the engine via <see cref="PlayerMapDisclosureHook"/>
+/// so VSEssentials' player-pin broadcaster (SystemRemotePlayerTracking) consults Stratum state without
+/// taking a hard reference back into VintagestoryLib.
 /// </summary>
 internal static class StratumPlayerPrivacy
 {
@@ -49,6 +50,13 @@ internal static class StratumPlayerPrivacy
 
 	private static bool? AllowMapPinDisclosure(IServerPlayer sender, IServerPlayer receiver)
 	{
+		// Vanish hides the map pin too, independent of the Enabled/HideMapPins config below:
+		// a vanished player is meant to disappear entirely, not just off the entity tracker.
+		// Mirrors the /near and entity-visibility rule exactly (see StratumStaffCommandState),
+		// so staff who can still see a vanished player (and haven't opted into hideothers)
+		// keep seeing their pin too.
+		if (VanishHidesSenderFromReceiver(sender, receiver)) return false;
+
 		StratumPlayerPrivacyConfig cfg = Cfg;
 		if (cfg == null || !cfg.Enabled) return null;
 
@@ -75,6 +83,16 @@ internal static class StratumPlayerPrivacy
 		if (cfg.AllowGroupMapVisibility && SharesGroup(sender, receiver)) return 0;
 
 		return cfg.CoordinateSnapBlocks;
+	}
+
+	private static bool VanishHidesSenderFromReceiver(IServerPlayer sender, IServerPlayer receiver)
+	{
+		if (sender == null || receiver == null || sender.PlayerUID == receiver.PlayerUID) return false;
+		if (!StratumStaffCommandState.IsVanished(sender.PlayerUID)) return false;
+
+		bool receiverSeesVanished = StratumCommandAccessCatalog.PlayerHasAccess(receiver, StratumRuntime.Config.Commands.Vanish)
+			&& !StratumStaffCommandState.HidesOtherVanished(receiver.PlayerUID);
+		return !receiverSeesVanished;
 	}
 
 	private static bool SharesGroup(IServerPlayer a, IServerPlayer b)

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumStaffCommandState.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumStaffCommandState.cs
@@ -18,6 +18,11 @@ internal static class StratumStaffCommandState
 
 	private static readonly HashSet<string> VanishedPlayerUids = new HashSet<string>(StringComparer.Ordinal);
 
+	// Stratum #213: per-viewer override of "do I see other vanished players".
+	// Absent = follow Commands.VanishHideOtherVanishedDefault. Session state, same
+	// lifetime as VanishedPlayerUids, cleared in ClearSessionState.
+	private static readonly Dictionary<string, bool> HideOtherVanishedByUid = new Dictionary<string, bool>(StringComparer.Ordinal);
+
 	private static readonly Dictionary<string, FrozenPlayerState> FrozenPlayers = new Dictionary<string, FrozenPlayerState>(StringComparer.Ordinal);
 
 	private static readonly Dictionary<string, DateTime> LastSlowmodeChatUtcByUid = new Dictionary<string, DateTime>(StringComparer.Ordinal);
@@ -89,6 +94,29 @@ internal static class StratumStaffCommandState
 		return vanished ? VanishedPlayerUids.Add(player.PlayerUID) : VanishedPlayerUids.Remove(player.PlayerUID);
 	}
 
+	public static bool HidesOtherVanished(string viewerUid)
+	{
+		if (string.IsNullOrWhiteSpace(viewerUid))
+		{
+			return false;
+		}
+
+		if (HideOtherVanishedByUid.TryGetValue(viewerUid, out bool preference))
+		{
+			return preference;
+		}
+
+		return StratumRuntime.Config.Commands.VanishHideOtherVanishedDefault;
+	}
+
+	public static void SetHidesOtherVanished(string viewerUid, bool hide)
+	{
+		if (!string.IsNullOrWhiteSpace(viewerUid))
+		{
+			HideOtherVanishedByUid[viewerUid] = hide;
+		}
+	}
+
 	public static bool ShouldHideEntityFromClient(Entity entity, ConnectedClient client)
 	{
 		if (entity is not EntityPlayer entityPlayer || client?.Player == null || !IsVanished(entityPlayer.PlayerUID))
@@ -103,7 +131,15 @@ internal static class StratumStaffCommandState
 		}
 
 		StratumRuntime.Config.EnsurePopulated();
-		return !StratumCommandAccessCatalog.PlayerHasAccess(viewer, StratumRuntime.Config.Commands.Vanish);
+		if (!StratumCommandAccessCatalog.PlayerHasAccess(viewer, StratumRuntime.Config.Commands.Vanish))
+		{
+			// Non-staff never see a vanished player.
+			return true;
+		}
+
+		// Stratum #213: staff who opted in stop seeing other vanished staff.
+		// One-directional on purpose: this is the viewer's own preference.
+		return HidesOtherVanished(viewer.PlayerUID);
 	}
 
 	public static void HideVanishedPlayerFromOthers(ServerMain server, IServerPlayer player)
@@ -153,6 +189,75 @@ internal static class StratumStaffCommandState
 				client.TrackedEntities.Add(player.Entity.EntityId);
 				server.SendPacket(client.Id, packet);
 			}
+		}
+	}
+
+	// Stratum #213: the inverse of Hide/RevealPlayerToOthers. Those iterate every client
+	// for one subject; this iterates every vanished subject for one client, and is what
+	// makes the /vanish hideothers toggle take effect mid-session.
+	//
+	// The despawn half is mandatory, not cosmetic: PhysicsManager's tracking hysteresis
+	// (PhysicsManager.cs.patch:466) keeps an already-tracked entity tracked while it is
+	// inside 1.21x the tracking radius, so a newly hidden neighbour would otherwise stay
+	// visible indefinitely. The spawn half is a fast path; UpdateTrackedEntityLists would
+	// re-spawn it within a tick or two anyway.
+	public static void RefreshVanishedVisibilityForViewer(ServerMain server, IServerPlayer viewer)
+	{
+		if (server == null || viewer?.Entity == null || string.IsNullOrWhiteSpace(viewer.PlayerUID))
+		{
+			return;
+		}
+
+		if (!server.Clients.TryGetValue(viewer.ClientId, out ConnectedClient viewerClient)
+			|| viewerClient.Player == null || !viewerClient.State.IsAdmitted())
+		{
+			return;
+		}
+
+		List<EntityDespawn> despawns = null;
+		List<Entity> spawns = null;
+		int rangeSq = MagicNum.DefaultEntityTrackingRange * MagicNum.ServerChunkSize * MagicNum.DefaultEntityTrackingRange * MagicNum.ServerChunkSize;
+
+		foreach (string vanishedUid in VanishedPlayerUids)
+		{
+			if (string.Equals(vanishedUid, viewer.PlayerUID, StringComparison.Ordinal))
+			{
+				continue;
+			}
+
+			if (!server.PlayersByUid.TryGetValue(vanishedUid, out ServerPlayer subject) || subject?.Entity == null)
+			{
+				continue;
+			}
+
+			long entityId = subject.Entity.EntityId;
+			bool tracked = viewerClient.TrackedEntities.Contains(entityId);
+			bool hide = ShouldHideEntityFromClient(subject.Entity, viewerClient);
+
+			if (hide && tracked)
+			{
+				viewerClient.TrackedEntities.Remove(entityId);
+				(despawns ??= new List<EntityDespawn>()).Add(new EntityDespawn
+				{
+					EntityId = entityId,
+					DespawnData = new EntityDespawnData { Reason = EnumDespawnReason.Unload }
+				});
+			}
+			else if (!hide && !tracked && subject.Entity.Pos.InRangeOf(viewer.Entity.Pos, rangeSq))
+			{
+				viewerClient.TrackedEntities.Add(entityId);
+				(spawns ??= new List<Entity>()).Add(subject.Entity);
+			}
+		}
+
+		if (despawns != null)
+		{
+			server.SendPacket(viewerClient.Id, ServerPackets.GetEntityDespawnPacket(despawns));
+		}
+
+		if (spawns != null)
+		{
+			server.SendPacket(viewerClient.Id, ServerPackets.GetEntitySpawnPacket(spawns));
 		}
 	}
 
@@ -227,6 +332,7 @@ internal static class StratumStaffCommandState
 		}
 
 		VanishedPlayerUids.Remove(playerUid);
+		HideOtherVanishedByUid.Remove(playerUid);
 		FrozenPlayers.Remove(playerUid);
 		LastSlowmodeChatUtcByUid.Remove(playerUid);
 	}


### PR DESCRIPTION
## Summary

`/vanish hideothers on|off|toggle`, a per-viewer preference. When on, a staff member stops seeing other vanished staff, without touching what anyone else sees. Also `/vanish status`, prints your own vanish state and this preference, changes nothing.

```
/vanish                          unchanged, toggle own vanish
/vanish status                   new
/vanish hideothers on|off|toggle new
```

New config default, `Commands.VanishHideOtherVanishedDefault` (bool, default false), the starting value for a staff member who never touched the preference. Default keeps today's behavior, vanish holders still see each other unless someone opts in.

### Where it hooks and why

`ShouldHideEntityFromClient(entity, client)` already takes the viewer, not just the subject. The whole feature is one added branch there: non-staff still get an unconditional `true`, staff now return their own `HidesOtherVanished(viewer.PlayerUID)` instead of the old unconditional `false`. Nothing else calls this predicate directly, so no call site needed to change.

The tracking sweep in `PhysicsManager` won't despawn a hidden entity on its own at the range this issue is actually about. It has a hysteresis window, an already-tracked entity stays tracked as long as it's inside 1.21x the tracking radius, which is exactly two staff standing next to each other. So the toggle needs its own packet push or it silently does nothing at close range while appearing to work at long range. `RefreshVanishedVisibilityForViewer` is that push, the inverse of the existing `HideVanishedPlayerFromOthers`/`RevealPlayerToOthers`: those loop every client for one subject, this loops every vanished subject for one client.

`HandleNear` had its own inline copy of the old visibility rule (`IsVanished(...) || PlayerHasAccess(...)`), so it would have kept listing a staff member the viewer just chose to stop seeing. Updated it to match.

### Testing detail

No test project in this repo, same live-boot convention as always. Live test with one connected account (a second wasn't available this round): `/vanish`, `/vanish status`, `/vanish hideothers on`, status again to confirm the flip, `/near` with nothing to hide (no crash), `/vanish hideothers off`, then bare `/vanish` to confirm it still toggles vanish and not the preference. `stratum-audit.log` shows `vanish hideothers=on actor=Zaldaryon`, confirming the command path end to end.

What that doesn't cover: the actual mutual-invisibility effect needs two vanished staff who can see each other's screens, and `RefreshVanishedVisibilityForViewer`'s despawn push is exactly the part most likely to be wrong in a way single-account testing can't catch (see the hysteresis note above, wrong and it's an invisible bug at close range and a working one at long range). Worth a two-account pass before merge if that's easy on your end, happy to do it myself if a second account gets easier to arrange here.

@trevorftp @tehtelev

## Type

- [ ] Bug fix
- [ ] Performance
- [x] New feature
- [ ] Refactor or cleanup
- [ ] Docs or build

## Checklist

- [ ] `.\scripts\extract-patches.ps1` ran clean.
- [x] `dotnet build VintageStory.slnx -c Release` is green.
- [x] Every vanilla edit has a `// Stratum` marker. (No vanilla files touched, only Stratum-authored files under `sources/`.)
- [x] No vanilla source committed.
- [x] Tested on a real server start, not just compilation.

## Related issues

Fixes #213
