### PR TITLE
Add /restart and /clearitems commands

### DIFF
--- a/sources/VintagestoryLib/Vintagestory.Server/CmdStratumStaffCommands.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/CmdStratumStaffCommands.cs
@@ -290,6 +290,24 @@ internal class CmdStratumStaffCommands
 				.HandleWith(HandleReports);
 		}
 
+		if (StratumCommandRegistration.ShouldRegister(commands.Restart, "/restart", "Commands.Restart"))
+		{
+			server.api.commandapi.Create("restart")
+				.WithDescription("Schedule a server restart with countdown warnings")
+				.WithArgs(parsers.Word("minutes or cancel"))
+				.RequiresPrivilege(Privilege.chat)
+				.HandleWith(HandleRestart);
+		}
+
+		if (StratumCommandRegistration.ShouldRegister(commands.ClearItems, "/clearitems", "Commands.ClearItems"))
+		{
+			server.api.commandapi.Create("clearitems")
+				.WithDescription("Clear all dropped items on the ground")
+				.WithArgs(parsers.OptionalWordRange("mode", "now"))
+				.RequiresPrivilege(Privilege.chat)
+				.HandleWith(HandleClearItems);
+		}
+
 		StratumTargetCommandOverrides.Register(server);
 	}
 
@@ -1917,5 +1935,86 @@ internal class CmdStratumStaffCommands
 		}
 
 		return builder.ToString();
+	}
+
+	private TextCommandResult HandleRestart(TextCommandCallingArgs args)
+	{
+		if (!CheckAccess(args, StratumRuntime.Config.Commands.Restart, "restart", out TextCommandResult failure))
+		{
+			return failure;
+		}
+
+		if (StratumRuntime.RestartScheduler == null)
+		{
+			return TextCommandResult.Error("Restart scheduler not yet initialized.");
+		}
+
+		string input = args[0] as string;
+		if (string.Equals(input, "cancel", StringComparison.OrdinalIgnoreCase))
+		{
+			if (!StratumRuntime.RestartScheduler.IsRestartScheduled)
+			{
+				return TextCommandResult.Error("No restart is scheduled.");
+			}
+			StratumRuntime.RestartScheduler.Cancel();
+			server.SendMessageToGeneral(
+				StratumChatFormatter.ColorizeVtml("Scheduled restart cancelled.", StratumRuntime.Config?.Appearance?.Theme?.GoodColor),
+				EnumChatType.Notification);
+			return TextCommandResult.Success("Restart cancelled.");
+		}
+
+		if (!int.TryParse(input, out int minutes) || minutes < 1 || minutes > 60)
+		{
+			return TextCommandResult.Error("Usage: /restart <1-60> or /restart cancel");
+		}
+
+		if (StratumRuntime.RestartScheduler.IsRestartScheduled)
+		{
+			StratumRuntime.RestartScheduler.Cancel();
+		}
+
+		StratumRuntime.RestartScheduler.Schedule(minutes * 60);
+		return TextCommandResult.Success($"Restart scheduled in {minutes} minute(s).");
+	}
+
+	private TextCommandResult HandleClearItems(TextCommandCallingArgs args)
+	{
+		if (!CheckAccess(args, StratumRuntime.Config.Commands.ClearItems, "clearitems", out TextCommandResult failure))
+		{
+			return failure;
+		}
+
+		if (StratumRuntime.RestartScheduler == null)
+		{
+			return TextCommandResult.Error("Restart scheduler not yet initialized.");
+		}
+
+		string mode = args[0] as string;
+		if (string.Equals(mode, "now", StringComparison.OrdinalIgnoreCase))
+		{
+			int count = StratumRuntime.RestartScheduler.ClearGroundItems();
+			server.SendMessageToGeneral(
+				StratumChatFormatter.ColorizeVtml($"Cleaned up {count} ground items.", StratumRuntime.Config?.Appearance?.Theme?.AccentColor),
+				EnumChatType.Notification);
+			return TextCommandResult.Success($"Cleared {count} items.");
+		}
+
+		int leadSeconds = StratumRuntime.Config?.Performance?.Restart?.ClearGroundItemsLeadSeconds ?? 30;
+		string warningMsg = string.Format(
+			StratumRuntime.Config?.Performance?.Restart?.ClearItemsWarningMessage ?? "PICK UP ALL GROUND ITEMS! They will be cleared in {0} seconds.",
+			leadSeconds);
+		server.SendMessageToGeneral(
+			StratumChatFormatter.ColorizeVtml(warningMsg, StratumRuntime.Config?.Appearance?.Theme?.WarnColor),
+			EnumChatType.Notification);
+
+		server.RegisterCallback((_) =>
+		{
+			int count = StratumRuntime.RestartScheduler.ClearGroundItems();
+			server.SendMessageToGeneral(
+				StratumChatFormatter.ColorizeVtml($"Cleaned up {count} ground items.", StratumRuntime.Config?.Appearance?.Theme?.AccentColor),
+				EnumChatType.Notification);
+		}, leadSeconds * 1000);
+
+		return TextCommandResult.Success($"Ground items will be cleared in {leadSeconds} seconds.");
 	}
 }

--- a/sources/VintagestoryLib/Vintagestory.Server/CmdStratumStaffCommands.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/CmdStratumStaffCommands.cs
@@ -303,7 +303,7 @@ internal class CmdStratumStaffCommands
 		{
 			server.api.commandapi.Create("clearitems")
 				.WithDescription("Clear all dropped items on the ground")
-				.WithArgs(parsers.OptionalWordRange("mode", "now"))
+				.WithArgs(parsers.OptionalWordRange("mode", "now", "cancel"))
 				.RequiresPrivilege(Privilege.chat)
 				.HandleWith(HandleClearItems);
 		}
@@ -1999,21 +1999,20 @@ internal class CmdStratumStaffCommands
 			return TextCommandResult.Success($"Cleared {count} items.");
 		}
 
-		int leadSeconds = StratumRuntime.Config?.Performance?.Restart?.ClearGroundItemsLeadSeconds ?? 30;
-		string warningMsg = string.Format(
-			StratumRuntime.Config?.Performance?.Restart?.ClearItemsWarningMessage ?? "PICK UP ALL GROUND ITEMS! They will be cleared in {0} seconds.",
-			leadSeconds);
-		server.SendMessageToGeneral(
-			StratumChatFormatter.ColorizeVtml(warningMsg, StratumRuntime.Config?.Appearance?.Theme?.WarnColor),
-			EnumChatType.Notification);
-
-		server.RegisterCallback((_) =>
+		if (string.Equals(mode, "cancel", StringComparison.OrdinalIgnoreCase))
 		{
-			int count = StratumRuntime.RestartScheduler.ClearGroundItems();
-			server.SendMessageToGeneral(
-				StratumChatFormatter.ColorizeVtml($"Cleaned up {count} ground items.", StratumRuntime.Config?.Appearance?.Theme?.AccentColor),
-				EnumChatType.Notification);
-		}, leadSeconds * 1000);
+			if (!StratumRuntime.RestartScheduler.CancelClearItemsWarning())
+			{
+				return TextCommandResult.Error("No ground item clear is scheduled.");
+			}
+			return TextCommandResult.Success("Ground item clear cancelled.");
+		}
+
+		int leadSeconds = StratumRuntime.Config?.Performance?.Restart?.ClearGroundItemsLeadSeconds ?? 30;
+		if (!StratumRuntime.RestartScheduler.ScheduleClearItemsWarning(leadSeconds))
+		{
+			return TextCommandResult.Error("A ground item clear is already scheduled. Use /clearitems cancel first.");
+		}
 
 		return TextCommandResult.Success($"Ground items will be cleared in {leadSeconds} seconds.");
 	}

--- a/sources/VintagestoryLib/Vintagestory.Server/ServerSystemStratum.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/ServerSystemStratum.cs
@@ -25,6 +25,7 @@ internal class ServerSystemStratum : ServerSystem
 	public override void OnBeginConfiguration()
 	{
 		bool loaded = StratumRuntime.LoadOrCreateConfig(server, out string message);
+		StratumRuntime.RestartScheduler = new StratumRestartScheduler(server);
 		if (StratumRuntime.Config.Diagnostics.LogStartupSummary)
 		{
 			LogStartupSummary(loaded, message);

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumChatFormatter.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumChatFormatter.cs
@@ -231,4 +231,13 @@ internal static class StratumChatFormatter
 
 		return builder.ToString();
 	}
+
+	public static string ColorizeVtml(string message, string color)
+	{
+		if (string.IsNullOrWhiteSpace(color))
+		{
+			return message;
+		}
+		return $"<font color='{color}'>{message}</font>";
+	}
 }

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumConfig.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumConfig.cs
@@ -528,6 +528,8 @@ internal class StratumPerformanceConfig
 
 	public StratumItemCleanupConfig ItemCleanup { get; set; } = new StratumItemCleanupConfig();
 
+	public StratumRestartConfig Restart { get; set; } = new StratumRestartConfig();
+
 	public StratumNetworkConfig Network { get; set; } = new StratumNetworkConfig();
 
 	public void EnsurePopulated()
@@ -554,6 +556,7 @@ internal class StratumPerformanceConfig
 		Join ??= new StratumJoinConfig();
 		AdaptiveRadius ??= new StratumAdaptiveRadiusConfig();
 		ItemCleanup ??= new StratumItemCleanupConfig();
+		Restart ??= new StratumRestartConfig();
 		Network ??= new StratumNetworkConfig();
 		ChunkSending.EnsureSane();
 		ChunkGeneration.EnsureSane();
@@ -577,6 +580,7 @@ internal class StratumPerformanceConfig
 		Join.EnsureSane();
 		AdaptiveRadius.EnsureSane();
 		ItemCleanup.EnsureSane();
+		Restart.EnsureSane();
 		Network.EnsureSane();
 	}
 }
@@ -671,6 +675,26 @@ internal class StratumItemCleanupConfig
 		CleanupWarningTimeOffsets ??= [];
 
 		CleanupWarningTimeOffsets = CleanupWarningTimeOffsets.Select(n => Math.Clamp(n, 1, IntervalSeconds)).Distinct().ToArray();
+	}
+}
+
+internal class StratumRestartConfig
+{
+	public int[] CountdownAnnouncementsSeconds { get; set; } = [300, 120, 60, 45, 30, 15, 5];
+	public bool ClearGroundItemsBeforeStop { get; set; } = true;
+	public int ClearGroundItemsLeadSeconds { get; set; } = 30;
+	public string CountdownMessage { get; set; } = "Server restarting in {0}.";
+	public string ClearItemsWarningMessage { get; set; } = "PICK UP ALL GROUND ITEMS! They will be cleared in {0} seconds.";
+	public string RestartingNowMessage { get; set; } = "Server restarting now.";
+	public int ExitCode { get; set; } = 0;
+
+	public void EnsureSane()
+	{
+		CountdownAnnouncementsSeconds ??= [300, 120, 60, 45, 30, 15, 5];
+		ClearGroundItemsLeadSeconds = Math.Max(0, ClearGroundItemsLeadSeconds);
+		CountdownMessage ??= "";
+		ClearItemsWarningMessage ??= "";
+		RestartingNowMessage ??= "";
 	}
 }
 
@@ -1564,6 +1588,10 @@ internal class StratumCommandsConfig
 
 	public StratumCommandAccessConfig ReportManage { get; set; } = StratumCommandAccessConfig.ForPrivilege("stratum.reports");
 
+	public StratumCommandAccessConfig Restart { get; set; } = StratumCommandAccessConfig.ForPrivilege("stratum.restart");
+
+	public StratumCommandAccessConfig ClearItems { get; set; } = StratumCommandAccessConfig.ForPrivilege("stratum.clearitems");
+
 	public int NearDefaultRadiusBlocks { get; set; } = 128;
 
 	public int NearMaxRadiusBlocks { get; set; } = 512;
@@ -1599,6 +1627,8 @@ internal class StratumCommandsConfig
 		Notes ??= StratumCommandAccessConfig.ForPrivilege("stratum.notes");
 		Report ??= StratumCommandAccessConfig.ForPrivilege("stratum.report");
 		ReportManage ??= StratumCommandAccessConfig.ForPrivilege("stratum.reports");
+		Restart ??= StratumCommandAccessConfig.ForPrivilege("stratum.restart");
+		ClearItems ??= StratumCommandAccessConfig.ForPrivilege("stratum.clearitems");
 		JailSettings ??= new StratumJailConfig();
 		Spawn.EnsurePopulated("stratum.spawn");
 		SetSpawn.EnsurePopulated("setspawn");
@@ -1623,6 +1653,8 @@ internal class StratumCommandsConfig
 		Notes.EnsurePopulated("stratum.notes");
 		Report.EnsurePopulated("stratum.report");
 		ReportManage.EnsurePopulated("stratum.reports");
+		Restart.EnsurePopulated("stratum.restart");
+		ClearItems.EnsurePopulated("stratum.clearitems");
 		NearDefaultRadiusBlocks = Math.Max(1, NearDefaultRadiusBlocks);
 		NearMaxRadiusBlocks = Math.Max(NearDefaultRadiusBlocks, NearMaxRadiusBlocks);
 		SlowmodeMaxSeconds = Math.Max(0, SlowmodeMaxSeconds);

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumItemCleanup.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumItemCleanup.cs
@@ -21,16 +21,6 @@ internal sealed class StratumItemCleanup
 		RegisterCallbacks();
 	}
 
-	private static string ColorizeVtml(string message, string color)
-	{
-		if (string.IsNullOrWhiteSpace(color))
-		{
-			return message;
-		}
-
-		return $"<font color='{color}'>{message}</font>";
-	}
-
 	private void RegisterCallbacks()
 	{
 		var pendingEntities = GetItemEntities();
@@ -59,14 +49,14 @@ internal sealed class StratumItemCleanup
 	private void DoCleanupWarning(int seconds)
 	{
 		StratumRuntime.LogInfo($"Cleaning up ground items in {seconds} seconds");
-		server.SendMessageToGeneral(ColorizeVtml(string.Format(Cfg.CleanupWarningMessage, seconds), Theme?.WarnColor), EnumChatType.Notification);
+		server.SendMessageToGeneral(StratumChatFormatter.ColorizeVtml(string.Format(Cfg.CleanupWarningMessage, seconds), Theme?.WarnColor), EnumChatType.Notification);
 	}
 
 	private void DoCleanup(float dt)
 	{
 		if (!string.IsNullOrEmpty(Cfg.CleanupStartingMessage))
 		{
-			server.SendMessageToGeneral(ColorizeVtml(Cfg.CleanupStartingMessage, Theme?.AccentColor), EnumChatType.Notification);
+			server.SendMessageToGeneral(StratumChatFormatter.ColorizeVtml(Cfg.CleanupStartingMessage, Theme?.AccentColor), EnumChatType.Notification);
 		}
 		StratumRuntime.LogInfo($"Cleaning up ground items...");
 
@@ -81,7 +71,7 @@ internal sealed class StratumItemCleanup
 
             if (!string.IsNullOrEmpty(Cfg.CleanupDoneMessage))
             {
-                server.SendMessageToGeneral(ColorizeVtml(string.Format(Cfg.CleanupDoneMessage, count), Theme?.GoodColor), EnumChatType.Notification);
+                server.SendMessageToGeneral(StratumChatFormatter.ColorizeVtml(string.Format(Cfg.CleanupDoneMessage, count), Theme?.GoodColor), EnumChatType.Notification);
             }
             StratumRuntime.LogInfo($"Cleaned up {count} ground items in {s.ElapsedMilliseconds} ms");
         }
@@ -97,17 +87,32 @@ internal sealed class StratumItemCleanup
 
 	private Entity[] GetItemEntities()
 	{
-		// If the item is on the ground and has been around for longer than the minimum age, remove it
-		return server.LoadedEntities.Where(e => e.Value is EntityItem item
-			&& (item.OnGround || item.FeetInLiquid)
-			&& server.ElapsedMilliseconds - item.itemSpawnedMilliseconds > (Cfg?.MinimumEntityAgeSeconds ?? 1) * 1000)
-			.Select(e => e.Value)
-			.ToArray();
+		return GetItemEntities(server, Cfg?.MinimumEntityAgeSeconds ?? 1);
 	}
 
 	private int RemoveGroundEntities()
 	{
-		var entities = GetItemEntities();
+		return RemoveGroundEntities(server, Cfg?.MinimumEntityAgeSeconds ?? 1);
+	}
+
+	/// <summary>
+	/// Shared with StratumRestartScheduler, which sweeps with a minimum age of 0
+	/// (restart/clearitems is an explicit admin action meant to clear everything
+	/// on the ground after its own warning, not just items abandoned a while ago).
+	/// </summary>
+	internal static Entity[] GetItemEntities(ServerMain server, int minimumAgeSeconds)
+	{
+		// If the item is on the ground and has been around for at least the minimum age, remove it
+		return server.LoadedEntities.Where(e => e.Value is EntityItem item
+			&& (item.OnGround || item.FeetInLiquid)
+			&& server.ElapsedMilliseconds - item.itemSpawnedMilliseconds > minimumAgeSeconds * 1000)
+			.Select(e => e.Value)
+			.ToArray();
+	}
+
+	internal static int RemoveGroundEntities(ServerMain server, int minimumAgeSeconds)
+	{
+		var entities = GetItemEntities(server, minimumAgeSeconds);
 		var count = entities.Length;
 
 		foreach (var p in entities)

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumRestartScheduler.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumRestartScheduler.cs
@@ -1,0 +1,143 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Vintagestory.API.Common;
+using Vintagestory.API.Common.Entities;
+
+namespace Vintagestory.Server;
+
+internal sealed class StratumRestartScheduler
+{
+	private readonly ServerMain server;
+	private readonly List<long> pendingCallbackIds = new List<long>();
+	private bool restartInProgress;
+
+	private static StratumRestartConfig Cfg => StratumRuntime.Config?.Performance?.Restart;
+	private static StratumThemeConfig Theme => StratumRuntime.Config?.Appearance?.Theme;
+
+	public bool IsRestartScheduled => restartInProgress;
+
+	public StratumRestartScheduler(ServerMain server)
+	{
+		this.server = server;
+	}
+
+	public void Schedule(int totalSeconds)
+	{
+		Cancel();
+		restartInProgress = true;
+
+		int[] announcements = Cfg?.CountdownAnnouncementsSeconds ?? [300, 120, 60, 45, 30, 15, 5];
+		int clearLeadSeconds = Cfg?.ClearGroundItemsBeforeStop == true ? (Cfg?.ClearGroundItemsLeadSeconds ?? 30) : 0;
+
+		foreach (int secondsBefore in announcements)
+		{
+			if (secondsBefore >= totalSeconds)
+			{
+				continue;
+			}
+
+			int delayMs = (totalSeconds - secondsBefore) * 1000;
+			long id = server.RegisterCallback((_) => BroadcastCountdown(secondsBefore), delayMs);
+			pendingCallbackIds.Add(id);
+		}
+
+		BroadcastCountdown(totalSeconds);
+
+		if (clearLeadSeconds > 0 && clearLeadSeconds < totalSeconds)
+		{
+			int clearDelayMs = (totalSeconds - clearLeadSeconds) * 1000;
+			long id = server.RegisterCallback((_) => BroadcastClearWarning(clearLeadSeconds), clearDelayMs);
+			pendingCallbackIds.Add(id);
+		}
+
+		long stopId = server.RegisterCallback((_) => ExecuteStop(), totalSeconds * 1000);
+		pendingCallbackIds.Add(stopId);
+	}
+
+	public void Cancel()
+	{
+		if (!restartInProgress)
+		{
+			return;
+		}
+
+		foreach (long id in pendingCallbackIds)
+		{
+			server.UnregisterCallback(id);
+		}
+		pendingCallbackIds.Clear();
+		restartInProgress = false;
+	}
+
+	public int ClearGroundItems()
+	{
+		Entity[] entities = server.LoadedEntities
+			.Where(e => e.Value is EntityItem item && (item.OnGround || item.FeetInLiquid))
+			.Select(e => e.Value)
+			.ToArray();
+
+		foreach (Entity entity in entities)
+		{
+			entity.Die(EnumDespawnReason.Expire);
+		}
+
+		return entities.Length;
+	}
+
+	private void BroadcastCountdown(int secondsRemaining)
+	{
+		string message = string.Format(Cfg?.CountdownMessage ?? "Server restarting in {0}.", FormatTime(secondsRemaining));
+		server.SendMessageToGeneral(ColorizeVtml(message, Theme?.WarnColor), EnumChatType.Notification);
+		StratumRuntime.LogInfo($"Restart countdown: {secondsRemaining}s remaining");
+	}
+
+	private void BroadcastClearWarning(int secondsUntilClear)
+	{
+		string message = string.Format(Cfg?.ClearItemsWarningMessage ?? "PICK UP ALL GROUND ITEMS! They will be cleared in {0} seconds.", secondsUntilClear);
+		server.SendMessageToGeneral(ColorizeVtml(message, Theme?.WarnColor), EnumChatType.Notification);
+	}
+
+	private void ExecuteStop()
+	{
+		restartInProgress = false;
+		pendingCallbackIds.Clear();
+
+		if (Cfg?.ClearGroundItemsBeforeStop == true)
+		{
+			int count = ClearGroundItems();
+			StratumRuntime.LogInfo($"Pre-restart cleanup removed {count} ground items");
+		}
+
+		string nowMessage = Cfg?.RestartingNowMessage ?? "Server restarting now.";
+		server.SendMessageToGeneral(ColorizeVtml(nowMessage, Theme?.WarnColor), EnumChatType.Notification);
+
+		int exitCode = Cfg?.ExitCode ?? 0;
+		server.ExitCode = exitCode;
+		server.Stop("Scheduled restart", EnumExitMode.SoftExit);
+	}
+
+	private static string FormatTime(int totalSeconds)
+	{
+		if (totalSeconds >= 60)
+		{
+			int minutes = totalSeconds / 60;
+			int seconds = totalSeconds % 60;
+			if (seconds == 0)
+			{
+				return minutes == 1 ? "1 minute" : $"{minutes} minutes";
+			}
+			return $"{minutes}m {seconds}s";
+		}
+		return totalSeconds == 1 ? "1 second" : $"{totalSeconds} seconds";
+	}
+
+	private static string ColorizeVtml(string message, string color)
+	{
+		if (string.IsNullOrWhiteSpace(color))
+		{
+			return message;
+		}
+		return $"<font color='{color}'>{message}</font>";
+	}
+}

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumRestartScheduler.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumRestartScheduler.cs
@@ -11,11 +11,13 @@ internal sealed class StratumRestartScheduler
 	private readonly ServerMain server;
 	private readonly List<long> pendingCallbackIds = new List<long>();
 	private bool restartInProgress;
+	private long? clearItemsCallbackId;
 
 	private static StratumRestartConfig Cfg => StratumRuntime.Config?.Performance?.Restart;
 	private static StratumThemeConfig Theme => StratumRuntime.Config?.Appearance?.Theme;
 
 	public bool IsRestartScheduled => restartInProgress;
+	public bool IsClearItemsScheduled => clearItemsCallbackId.HasValue;
 
 	public StratumRestartScheduler(ServerMain server)
 	{
@@ -44,9 +46,11 @@ internal sealed class StratumRestartScheduler
 
 		BroadcastCountdown(totalSeconds);
 
-		if (clearLeadSeconds > 0 && clearLeadSeconds < totalSeconds)
+		if (clearLeadSeconds > 0)
 		{
-			int clearDelayMs = (totalSeconds - clearLeadSeconds) * 1000;
+			// Clamp to 0: if the configured lead time doesn't fit before totalSeconds,
+			// warn immediately rather than skipping the warning and clearing silently.
+			int clearDelayMs = Math.Max(0, (totalSeconds - clearLeadSeconds) * 1000);
 			long id = server.RegisterCallback((_) => BroadcastClearWarning(clearLeadSeconds), clearDelayMs);
 			pendingCallbackIds.Add(id);
 		}
@@ -70,32 +74,65 @@ internal sealed class StratumRestartScheduler
 		restartInProgress = false;
 	}
 
+	/// <summary>
+	/// Sweeps every ground item regardless of age (minimum age 0): unlike the
+	/// periodic StratumItemCleanup pass, this only runs after its own warning
+	/// (from /clearitems or the restart countdown), so nothing abandoned-vs-fresh
+	/// distinction applies, everything on the ground is fair game.
+	/// </summary>
 	public int ClearGroundItems()
 	{
-		Entity[] entities = server.LoadedEntities
-			.Where(e => e.Value is EntityItem item && (item.OnGround || item.FeetInLiquid))
-			.Select(e => e.Value)
-			.ToArray();
+		return StratumItemCleanup.RemoveGroundEntities(server, 0);
+	}
 
-		foreach (Entity entity in entities)
+	/// <summary>
+	/// Warns global chat, then clears ground items after leadSeconds. Tracked so a
+	/// pending /clearitems warning can be cancelled instead of always firing.
+	/// </summary>
+	public bool ScheduleClearItemsWarning(int leadSeconds)
+	{
+		if (clearItemsCallbackId.HasValue)
 		{
-			entity.Die(EnumDespawnReason.Expire);
+			return false;
 		}
 
-		return entities.Length;
+		BroadcastClearWarning(leadSeconds);
+
+		clearItemsCallbackId = server.RegisterCallback((_) =>
+		{
+			clearItemsCallbackId = null;
+			int count = ClearGroundItems();
+			server.SendMessageToGeneral(
+				StratumChatFormatter.ColorizeVtml($"Cleaned up {count} ground items.", Theme?.AccentColor),
+				EnumChatType.Notification);
+		}, leadSeconds * 1000);
+
+		return true;
+	}
+
+	public bool CancelClearItemsWarning()
+	{
+		if (!clearItemsCallbackId.HasValue)
+		{
+			return false;
+		}
+
+		server.UnregisterCallback(clearItemsCallbackId.Value);
+		clearItemsCallbackId = null;
+		return true;
 	}
 
 	private void BroadcastCountdown(int secondsRemaining)
 	{
 		string message = string.Format(Cfg?.CountdownMessage ?? "Server restarting in {0}.", FormatTime(secondsRemaining));
-		server.SendMessageToGeneral(ColorizeVtml(message, Theme?.WarnColor), EnumChatType.Notification);
+		server.SendMessageToGeneral(StratumChatFormatter.ColorizeVtml(message, Theme?.WarnColor), EnumChatType.Notification);
 		StratumRuntime.LogInfo($"Restart countdown: {secondsRemaining}s remaining");
 	}
 
 	private void BroadcastClearWarning(int secondsUntilClear)
 	{
 		string message = string.Format(Cfg?.ClearItemsWarningMessage ?? "PICK UP ALL GROUND ITEMS! They will be cleared in {0} seconds.", secondsUntilClear);
-		server.SendMessageToGeneral(ColorizeVtml(message, Theme?.WarnColor), EnumChatType.Notification);
+		server.SendMessageToGeneral(StratumChatFormatter.ColorizeVtml(message, Theme?.WarnColor), EnumChatType.Notification);
 	}
 
 	private void ExecuteStop()
@@ -105,12 +142,20 @@ internal sealed class StratumRestartScheduler
 
 		if (Cfg?.ClearGroundItemsBeforeStop == true)
 		{
-			int count = ClearGroundItems();
-			StratumRuntime.LogInfo($"Pre-restart cleanup removed {count} ground items");
+			// Never let a cleanup failure prevent the restart itself from happening.
+			try
+			{
+				int count = ClearGroundItems();
+				StratumRuntime.LogInfo($"Pre-restart cleanup removed {count} ground items");
+			}
+			catch (Exception ex)
+			{
+				StratumRuntime.LogError("Error clearing ground items before restart: " + ex);
+			}
 		}
 
 		string nowMessage = Cfg?.RestartingNowMessage ?? "Server restarting now.";
-		server.SendMessageToGeneral(ColorizeVtml(nowMessage, Theme?.WarnColor), EnumChatType.Notification);
+		server.SendMessageToGeneral(StratumChatFormatter.ColorizeVtml(nowMessage, Theme?.WarnColor), EnumChatType.Notification);
 
 		int exitCode = Cfg?.ExitCode ?? 0;
 		server.ExitCode = exitCode;
@@ -130,14 +175,5 @@ internal sealed class StratumRestartScheduler
 			return $"{minutes}m {seconds}s";
 		}
 		return totalSeconds == 1 ? "1 second" : $"{totalSeconds} seconds";
-	}
-
-	private static string ColorizeVtml(string message, string color)
-	{
-		if (string.IsNullOrWhiteSpace(color))
-		{
-			return message;
-		}
-		return $"<font color='{color}'>{message}</font>";
 	}
 }

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumRuntime.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumRuntime.cs
@@ -31,6 +31,9 @@ internal static class StratumRuntime
 	public static StratumPregenManager Pregen { get; } = new StratumPregenManager();
 
 	public static StratumAdaptiveRadiusController AdaptiveRadius { get; private set; }
+
+	public static StratumRestartScheduler RestartScheduler { get; internal set; }
+
 	public static string ConfigPath { get; private set; } = "stratum.json";
 
 	public static string CommandsConfigPath { get; private set; } = "stratum-commands.json";


### PR DESCRIPTION
## Summary

Adds two staff commands for server lifecycle management.

**`/restart <1-60>`** schedules a server restart with countdown warnings broadcast to all players at configurable intervals (default: 5m, 2m, 1m, 45s, 30s, 15s, 5s). Ground items are cleared before the stop sequence when `ClearGroundItemsBeforeStop` is true. The countdown is cancelable via `/restart cancel`.

**`/clearitems [now|cancel]`** triggers a manual ground-item cleanup. Without arguments, it broadcasts a 30-second pickup warning first, cancelable via `/clearitems cancel`. With `now`, items are removed at once.

Both commands use the existing `StratumCommandAccess` permission system (`stratum.restart`, `stratum.clearitems`). Configuration lives in `Performance.Restart` within `stratum-performance.json`:

```json
{
  "CountdownAnnouncementsSeconds": [300, 120, 60, 45, 30, 15, 5],
  "ClearGroundItemsBeforeStop": true,
  "ClearGroundItemsLeadSeconds": 30,
  "CountdownMessage": "Server restarting in {0}.",
  "ClearItemsWarningMessage": "PICK UP ALL GROUND ITEMS! They will be cleared in {0} seconds.",
  "RestartingNowMessage": "Server restarting now.",
  "ExitCode": 0
}
```

The actual process restart depends on the external process manager (systemd, Docker, etc.). The server calls `Stop()` with a configurable exit code.

### Fixed on review

- The pre-clear warning only got scheduled when `ClearGroundItemsLeadSeconds` fit before the restart's total seconds. A lead time configured longer than the restart itself (e.g. lead 120s on `/restart 1`) silently skipped the warning while still clearing on schedule, destroying items with zero notice. Fixed by clamping the delay to 0 instead of skipping the callback, so the warning always fires, at worst simultaneously with the clear.
- `ExecuteStop`'s cleanup call had no try/catch, unlike the sibling `StratumItemCleanup.DoCleanup`. An exception during `Die()` would propagate out of the `RegisterCallback`-invoked `ExecuteStop` before reaching `server.Stop()`, so a scheduled restart could silently never happen. Now caught and logged, restart still proceeds.
- `/clearitems` had no way to cancel its 30-second warning once issued, the one asymmetry against `/restart cancel`. Added `/clearitems cancel`.
- Collapsed three separate `ColorizeVtml` implementations into the one `StratumChatFormatter` already exposes, and pulled the ground-item sweep into a shared, age-parameterized static method on `StratumItemCleanup` so the restart path stops duplicating the `LoadedEntities` filter and `Die()` loop (deliberately passes minimum age 0, since `/restart`/`/clearitems` clear everything after their own warning, unlike the periodic pass which only takes abandoned items).

### Testing detail

Both build passes clean (`dotnet build VintageStory.slnx -c Release`, `-p:EmbedPatchedFiles=true`). Smoke-tested with startup commands: `/restart 1` shows countdown, `/clearitems now` runs cleanup, `/restart cancel` aborts the scheduled restart. Not tested with a connected client end to end.

## Type

- [ ] Bug fix
- [ ] Performance
- [x] New feature
- [ ] Refactor or cleanup
- [ ] Docs or build

## Checklist

- [ ] `.\scripts\extract-patches.ps1` ran clean.
- [x] `dotnet build VintageStory.slnx -c Release` is green.
- [x] Every vanilla edit has a `// Stratum` marker. (No vanilla files touched, only Stratum-authored files under `sources/`.)
- [x] No vanilla source committed.
- [x] Tested on a real server start, not just compilation.

## Related issues

Fixes #219
