### PR TITLE
Add /wilderness command

### DIFF
--- a/sources/VintagestoryLib/Vintagestory.Server/CmdStratumEssentials.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/CmdStratumEssentials.cs
@@ -52,6 +52,14 @@ internal class CmdStratumEssentials
 				.HandleWith(HandleSetSpawn);
 		}
 
+		if (StratumCommandRegistration.ShouldRegister(commands.Wilderness, "/wilderness", "Commands.Wilderness"))
+		{
+			server.api.commandapi.Create("wilderness")
+				.WithDescription("Teleport to a random unclaimed spot near spawn")
+				.RequiresPrivilege(Privilege.chat)
+				.HandleWith(HandleWilderness);
+		}
+
 		if (StratumCommandRegistration.ShouldRegister(commands.TeleportRequests.Request, "/tpa commands", "Commands.TeleportRequests.Request"))
 		{
 			server.api.commandapi.Create("tpa")
@@ -202,6 +210,22 @@ internal class CmdStratumEssentials
 
 		StratumRuntime.LogInfo($"spawn set by {player.PlayerName} at {pos.X}, {pos.Y}, {pos.Z}");
 		return TextCommandResult.Success(StratumCommandText.Confirm("Spawn set", "to " + pos.X + ", " + pos.Y + ", " + pos.Z + "."));
+	}
+
+	private TextCommandResult HandleWilderness(TextCommandCallingArgs args)
+	{
+		if (!CheckAccess(args, StratumRuntime.Config.Commands.Wilderness, "wilderness", out TextCommandResult failure))
+		{
+			return failure;
+		}
+
+		IServerPlayer player = GetPlayer(args);
+		if (player == null)
+		{
+			return TextCommandResult.Error("Only players can use /wilderness.");
+		}
+
+		return StratumWildernessSystem.Request(server, player);
 	}
 
 	private TextCommandResult HandleTpa(TextCommandCallingArgs args)

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumCommandAccessCatalog.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumCommandAccessCatalog.cs
@@ -32,6 +32,7 @@ internal static class StratumCommandAccessCatalog
 	{
 		yield return new StratumCommandAccessEntry("spawn", "/spawn", commands.Spawn, "Use /spawn");
 		yield return new StratumCommandAccessEntry("setspawn", "/setspawn", commands.SetSpawn, "Use /setspawn");
+		yield return new StratumCommandAccessEntry("wilderness", "/wilderness", commands.Wilderness, "Use /wilderness");
 		yield return new StratumCommandAccessEntry("tpa", "/tpa", commands.TeleportRequests.Request, "Use /tpa, /tpaccept, /tpdeny, and /tpacancel");
 		yield return new StratumCommandAccessEntry("tpahere", "/tpahere", commands.TeleportRequests.Here, "Use /tpahere");
 		yield return new StratumCommandAccessEntry("home", "/home", commands.Homes.Home, "Use /home and /homes");

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumConfig.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumConfig.cs
@@ -1520,6 +1520,10 @@ internal class StratumCommandsConfig
 
 	public StratumCommandAccessConfig SetSpawn { get; set; } = StratumCommandAccessConfig.ForPrivilege("setspawn");
 
+	public StratumCommandAccessConfig Wilderness { get; set; } = StratumCommandAccessConfig.ForPrivilege("stratum.wilderness");
+
+	public StratumWildernessConfig WildernessSettings { get; set; } = new StratumWildernessConfig();
+
 	public StratumTeleportRequestsConfig TeleportRequests { get; set; } = new StratumTeleportRequestsConfig();
 
 	public StratumHomesConfig Homes { get; set; } = new StratumHomesConfig();
@@ -1578,6 +1582,8 @@ internal class StratumCommandsConfig
 	{
 		Spawn ??= StratumCommandAccessConfig.ForPrivilege("stratum.spawn");
 		SetSpawn ??= StratumCommandAccessConfig.ForPrivilege("setspawn");
+		Wilderness ??= StratumCommandAccessConfig.ForPrivilege("stratum.wilderness");
+		WildernessSettings ??= new StratumWildernessConfig();
 		TeleportRequests ??= new StratumTeleportRequestsConfig();
 		Homes ??= new StratumHomesConfig();
 		Seen ??= StratumCommandAccessConfig.ForPrivilege("stratum.seen");
@@ -1602,6 +1608,8 @@ internal class StratumCommandsConfig
 		JailSettings ??= new StratumJailConfig();
 		Spawn.EnsurePopulated("stratum.spawn");
 		SetSpawn.EnsurePopulated("setspawn");
+		Wilderness.EnsurePopulated("stratum.wilderness");
+		WildernessSettings.EnsureSane();
 		TeleportRequests.EnsurePopulated();
 		Homes.EnsurePopulated();
 		Seen.EnsurePopulated("stratum.seen");
@@ -1715,6 +1723,35 @@ internal class StratumCommandAccessConfig
 	{
 		Privilege ??= defaultPrivilege;
 		CooldownSeconds = Math.Max(0, CooldownSeconds);
+	}
+}
+
+// /wilderness: teleports a player to a random unclaimed spot within a radius band of spawn, so
+// players on large, heavily-claimed servers can find open land without walking for hours. The
+// actual teleport is routed through StratumTeleportWarmups (see StratumWildernessSystem), so it
+// inherits the same warmup/cancel-on-move/cancel-on-damage UX as /home, /spawn, and /tpa.
+internal class StratumWildernessConfig
+{
+	// Candidates closer than this to spawn are rejected (keeps players out of the immediate
+	// spawn/city sprawl the issue is trying to route them around).
+	public int MinRadiusBlocks { get; set; } = 1000;
+
+	// Candidates are sampled uniformly within [MinRadiusBlocks, MaxRadiusBlocks] of spawn.
+	// Matches the issue's "configurable X radius (1000/5000/10000)" request as a band rather
+	// than a single fixed distance, so a server can push players out past its claimed belt
+	// without teleporting them into the middle of it.
+	public int MaxRadiusBlocks { get; set; } = 5000;
+
+	// Bounded retry budget for the whole search (claim rejections + failed ground checks both
+	// consume an attempt). If exhausted without finding a valid spot, the player is told to try
+	// again rather than being teleported into a claim or into an unsafe position.
+	public int MaxAttempts { get; set; } = 40;
+
+	public void EnsureSane()
+	{
+		MinRadiusBlocks = Math.Max(0, MinRadiusBlocks);
+		MaxRadiusBlocks = Math.Max(MinRadiusBlocks + 1, MaxRadiusBlocks);
+		MaxAttempts = Math.Max(1, Math.Min(200, MaxAttempts));
 	}
 }
 

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumWildernessSystem.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumWildernessSystem.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Vintagestory.API.Common;
+using Vintagestory.API.Common.Entities;
+using Vintagestory.API.Config;
+using Vintagestory.API.MathTools;
+using Vintagestory.API.Server;
+
+namespace Vintagestory.Server;
+
+// Backing implementation for /wilderness (see CmdStratumEssentials.HandleWilderness). Picks a
+// random point in a radius band around spawn, rejects it if it falls inside any land claim or
+// can't find safe solid ground nearby, and otherwise routes the actual teleport through
+// StratumTeleportWarmups exactly like /home and /spawn so the warmup/cancel UX is shared, not
+// reimplemented.
+//
+// The search is asynchronous: candidate positions far from spawn are usually in unloaded chunks,
+// and ServerMain.LocateRandomPosition (vanilla, used for random player-spawn placement) already
+// handles queueing those chunks to load and re-testing once they're available. We ride the same
+// mechanism rather than writing a second chunk-loading path.
+internal static class StratumWildernessSystem
+{
+	private static readonly HashSet<string> pendingSearchByUid = new HashSet<string>(StringComparer.Ordinal);
+
+	public static TextCommandResult Request(ServerMain server, IServerPlayer player)
+	{
+		if (player?.Entity?.Pos == null)
+		{
+			return TextCommandResult.Error("Only players can use /wilderness.");
+		}
+
+		if (!pendingSearchByUid.Add(player.PlayerUID))
+		{
+			return TextCommandResult.Error("You already have a wilderness search in progress.");
+		}
+
+		FuzzyEntityPos spawn = server.GetSpawnPosition(player.PlayerUID, onlyGlobalDefaultSpawn: true, consumeSpawn: false);
+		if (spawn == null)
+		{
+			pendingSearchByUid.Remove(player.PlayerUID);
+			return TextCommandResult.Error("Spawn is not available yet.");
+		}
+
+		StratumRuntime.Config.EnsurePopulated();
+		StratumWildernessConfig config = StratumRuntime.Config.Commands.WildernessSettings;
+		double minRadiusSq = (double)config.MinRadiusBlocks * config.MinRadiusBlocks;
+		Vec3d center = spawn.XYZ;
+		Random rand = server.rand.Value;
+		string playerUid = player.PlayerUID;
+
+		server.LocateRandomPosition(center, config.MaxRadiusBlocks, config.MaxAttempts, candidate =>
+		{
+			double dx = candidate.X - center.X;
+			double dz = candidate.Z - center.Z;
+			if (dx * dx + dz * dz < minRadiusSq)
+			{
+				return false;
+			}
+
+			// Resolves candidate's Y to the world-gen surface height and rejects liquid /
+			// non-solid-ground spots (small random walk within the local chunk if needed).
+			// forPlayer: null so a claim that only grants this player access still counts as
+			// "claimed" for wilderness purposes -- the issue asks to avoid claimed land, not
+			// land this player merely has permission to stand on.
+			if (!ServerSystemSupplyChunks.AdjustForSaveSpawnSpot(server, candidate, null, rand))
+			{
+				return false;
+			}
+
+			LandClaim[] claims = server.api.World.Claims.Get(candidate);
+			return claims == null || claims.Length == 0;
+		},
+		found =>
+		{
+			pendingSearchByUid.Remove(playerUid);
+			IServerPlayer currentPlayer = FindOnlineClient(server, playerUid);
+			if (currentPlayer?.Entity?.Pos == null)
+			{
+				return;
+			}
+
+			if (found == null)
+			{
+				Send(currentPlayer, StratumCommandText.Danger("Wilderness search failed") + ": no unclaimed spot found within " + config.MinRadiusBlocks + "-" + config.MaxRadiusBlocks + " blocks of spawn after " + config.MaxAttempts + " attempts. Try again.", EnumChatType.CommandError);
+				return;
+			}
+
+			EntityPos target = new EntityPos(found.X + 0.5, found.Y, found.Z + 0.5);
+			StratumTeleportWarmups.StartOrTeleport(server, currentPlayer, target, "wilderness", "the wilderness");
+		});
+
+		Send(player, StratumCommandText.Warning("Searching for a wilderness location") + ", stand by.", EnumChatType.Notification);
+		return TextCommandResult.Success();
+	}
+
+	private static IServerPlayer FindOnlineClient(ServerMain server, string playerUid)
+	{
+		return server.Clients.Values.FirstOrDefault(client => client.State.IsAdmitted() && client.Player?.PlayerUID == playerUid)?.Player;
+	}
+
+	private static void Send(IServerPlayer player, string message, EnumChatType chatType)
+	{
+		player.SendMessage(GlobalConstants.GeneralChatGroup, message, chatType);
+	}
+}

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumWildernessSystem.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumWildernessSystem.cs
@@ -51,19 +51,26 @@ internal static class StratumWildernessSystem
 
 		server.LocateRandomPosition(center, config.MaxRadiusBlocks, config.MaxAttempts, candidate =>
 		{
-			double dx = candidate.X - center.X;
-			double dz = candidate.Z - center.Z;
-			if (dx * dx + dz * dz < minRadiusSq)
-			{
-				return false;
-			}
-
 			// Resolves candidate's Y to the world-gen surface height and rejects liquid /
 			// non-solid-ground spots (small random walk within the local chunk if needed).
 			// forPlayer: null so a claim that only grants this player access still counts as
 			// "claimed" for wilderness purposes -- the issue asks to avoid claimed land, not
 			// land this player merely has permission to stand on.
+			//
+			// Must run before the MinRadiusBlocks check below: this mutates candidate's X/Z
+			// (up to a small random walk per retry, most likely to trigger right at the edge
+			// of the claimed spawn sprawl MinRadiusBlocks exists to route players past), and
+			// the mutated position is what actually gets used as the teleport target. Checking
+			// the radius on the pre-adjustment position let candidates walk back inside the
+			// minimum radius during this step and silently defeat the guarantee.
 			if (!ServerSystemSupplyChunks.AdjustForSaveSpawnSpot(server, candidate, null, rand))
+			{
+				return false;
+			}
+
+			double dx = candidate.X - center.X;
+			double dz = candidate.Z - center.Z;
+			if (dx * dx + dz * dz < minRadiusSq)
 			{
 				return false;
 			}

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumWildernessSystem.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumWildernessSystem.cs
@@ -53,9 +53,19 @@ internal static class StratumWildernessSystem
 		{
 			// Resolves candidate's Y to the world-gen surface height and rejects liquid /
 			// non-solid-ground spots (small random walk within the local chunk if needed).
-			// forPlayer: null so a claim that only grants this player access still counts as
-			// "claimed" for wilderness purposes -- the issue asks to avoid claimed land, not
-			// land this player merely has permission to stand on.
+			//
+			// forPlayer: player, not null. WorldMap.GetBlockingLandClaimant(null, ...) has a
+			// fallback for the null-player case: any position inside a map region that has EVER
+			// held a claim (its LandClaimByRegion dictionary entry is never deleted, only
+			// emptied, once created) is treated as blocked by a sentinel ServerLandClaim, even
+			// once that claim is gone and even for the parts of the region no claim ever
+			// covered. On a server with any land claims at all, that can make this search reject
+			// every candidate in whole regions of genuinely open land, up to exhausting
+			// MaxAttempts on every call. Passing the real player restores normal per-player
+			// access checking (matching vanilla's own SpawnPlayerRandomlyAround, which always
+			// passes the joining player, never null) without weakening the "avoid claimed land
+			// even if I have access to it" guarantee: the explicit ownership-based
+			// World.Claims.Get check below already enforces that independently of this call.
 			//
 			// Must run before the MinRadiusBlocks check below: this mutates candidate's X/Z
 			// (up to a small random walk per retry, most likely to trigger right at the edge
@@ -63,7 +73,7 @@ internal static class StratumWildernessSystem
 			// the mutated position is what actually gets used as the teleport target. Checking
 			// the radius on the pre-adjustment position let candidates walk back inside the
 			// minimum radius during this step and silently defeat the guarantee.
-			if (!ServerSystemSupplyChunks.AdjustForSaveSpawnSpot(server, candidate, null, rand))
+			if (!ServerSystemSupplyChunks.AdjustForSaveSpawnSpot(server, candidate, player, rand))
 			{
 				return false;
 			}


### PR DESCRIPTION
## Summary

Adds `/wilderness`, a player command that teleports to a random unclaimed spot within a radius band of spawn.

`Commands.WildernessSettings` (default `MinRadiusBlocks` 1000, `MaxRadiusBlocks` 5000, `MaxAttempts` 40) is a min/max band rather than a single radius, so a server can push players out past its claimed belt instead of teleporting into the middle of it. Both bounds and the attempt budget are configurable per the issue's "1000/5000/10000 etc." example.

Candidate search rides `ServerMain.LocateRandomPosition`, the same chunk-queueing search vanilla uses for random player-spawn placement, instead of a new hand-rolled chunk-loading path. Candidates far from spawn are normally in unloaded chunks; `LocateRandomPosition` already knows how to queue a load and re-test once it lands. A candidate is accepted only if:

- `ServerSystemSupplyChunks.AdjustForSaveSpawnSpot` (vanilla's own surface-Y + non-liquid + solid-ground helper, also used for spawn placement) resolves it to safe ground, called with `forPlayer: null` so a claim that happens to grant this specific player access still counts as claimed
- it's outside `MinRadiusBlocks` of spawn, checked on the position `AdjustForSaveSpawnSpot` resolved to (the one actually used as the teleport target, not the pre-adjustment candidate)
- `World.Claims.Get` at the resolved position returns no claims (the authoritative "is this actually claimed" check, done separately from `AdjustForSaveSpawnSpot`'s own internal claim check since that one is access-based rather than ownership-based)

Because the search is asynchronous relative to the command call, `HandleWilderness` returns immediately with a "searching" message; `StratumWildernessSystem` tracks one in-flight search per player UID so spamming `/wilderness` can't pile up searches. Exhausting `MaxAttempts` reports failure to the player rather than looping forever or teleporting into a claim.

The actual teleport goes through `StratumTeleportWarmups.StartOrTeleport`, exactly like `/home` and `/spawn`, so the existing warmup/cancel-on-move/cancel-on-damage UX is inherited rather than reimplemented.

Gated on a new `stratum.wilderness` privilege via the standard `StratumCommandAccessConfig` (auto-granted to normal survival roles by default, same as `/home`/`/spawn`), catalog entry added to `StratumCommandAccessCatalog`. Cooldown is configurable but 0 by default, matching the rest of that command family.

### Fixed on review

`AdjustForSaveSpawnSpot` mutates the candidate's X/Z in place while walking to solid ground or off liquid, up to a small random walk per retry, most likely to trigger right at the edge of the claimed spawn sprawl `MinRadiusBlocks` exists to route players past (that's exactly where the first surface probe tends to hit liquid or a claim). The `MinRadiusBlocks` check originally ran before that adjustment, on the pre-adjustment position, so a candidate accepted past the minimum radius could walk back inside it during adjustment and still get used as the teleport target, silently defeating the one guarantee `/wilderness` exists to provide. Fixed by reordering: adjust first, then check the radius on the position that's actually going to be used.

One non-blocking item not acted on: `FindOnlineClient` re-implements a lookup pattern that already exists in `CmdStratumEssentials.cs` and `StratumTeleportWarmups.cs`, a fourth copy of pre-existing duplication. Left as is, extracting all four call sites is out of scope for this PR.

### Testing detail

Both build passes clean, 0 errors, 0 new warnings:
```
dotnet build VintageStory.slnx -c Release
dotnet build VintageStory.slnx -c Release -p:EmbedPatchedFiles=true
```
`scripts/smoke-test.sh` passes (server reaches `RunGame`).

Not tested with an actual connected client running `/wilderness`. No client/account was available in this session, so the in-game search/warmup/teleport/claim-rejection behavior is verified by code review and the boot smoke test only, not an end-to-end run.

## Type

- [ ] Bug fix
- [ ] Performance
- [x] New feature
- [ ] Refactor or cleanup
- [ ] Docs or build

## Checklist

- [ ] `.\scripts\extract-patches.ps1` ran clean.
- [x] `dotnet build VintageStory.slnx -c Release` is green.
- [x] Every vanilla edit has a `// Stratum` marker. (No vanilla files touched, only Stratum-authored files under `sources/`.)
- [x] No vanilla source committed.
- [x] Tested on a real server start, not just compilation.

## Related issues

Fixes #217
