### PR TITLE
Add /pvecombat cooperative combat toggle

### DIFF
--- a/patches/VSEssentials/Entity/Behavior/BehaviorHealth.cs.patch
+++ b/patches/VSEssentials/Entity/Behavior/BehaviorHealth.cs.patch
@@ -1,0 +1,34 @@
+diff --git a/VSEssentials/Entity/Behavior/BehaviorHealth.cs b/VSEssentials/Entity/Behavior/BehaviorHealth.cs
+index c961b3a..ee4c4cb 100644
+--- a/VSEssentials/Entity/Behavior/BehaviorHealth.cs
++++ b/VSEssentials/Entity/Behavior/BehaviorHealth.cs
+@@ -8,10 +8,11 @@ using Vintagestory.API.Client;
+ using Vintagestory.API.Common;
+ using Vintagestory.API.Common.Entities;
+ using Vintagestory.API.Config;
+ using Vintagestory.API.Datastructures;
+ using Vintagestory.API.MathTools;
++using Vintagestory.API.Server; // Stratum: cooperative PvE combat toggle hook
+ using Vintagestory.API.Util;
+ 
+ namespace Vintagestory.GameContent;
+ 
+ public interface ICanHealCreature
+@@ -235,11 +236,16 @@ public class EntityBehaviorHealth : EntityBehavior
+                 entity.Attributes.SetInt("dmgkb", 1);
+             }
+ 
+             if (damage > 0.05)
+             {
+-                entity.SetActivityRunning("invulnerable", 500);
++                // Stratum: cooperative PvE combat toggle shortens (or removes) this window for
++                // non-player entities only, so several players can land hits on the same
++                // creature inside the window that used to block every attacker but the first.
++                // Players keep the vanilla 500ms always, this never touches PvP or self-hits.
++                int invulnerableMs = entity is EntityPlayer ? 500 : StratumCoopCombatHook.CreatureInvulnerableMs;
++                entity.SetActivityRunning("invulnerable", invulnerableMs);
+                 // Gets already called on the server directly
+                 if (entity.World.Side == EnumAppSide.Client)
+                 {
+                     entity.OnHurt(null, entity.WatchedAttributes.GetFloat("onHurt", 0));
+                 }

--- a/patches/VintagestoryLib/Vintagestory.Server/ServerSystemCommands.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/ServerSystemCommands.cs.patch
@@ -2,7 +2,7 @@ diff --git a/VintagestoryLib/Vintagestory.Server/ServerSystemCommands.cs b/Vinta
 index 1d4be19..e8394a8 100644
 --- a/VintagestoryLib/Vintagestory.Server/ServerSystemCommands.cs
 +++ b/VintagestoryLib/Vintagestory.Server/ServerSystemCommands.cs
-@@ -21,10 +21,20 @@ internal class ServerSystemCommands : ServerSystem
+@@ -21,10 +21,21 @@ internal class ServerSystemCommands : ServerSystem
  		new CmdEntity(server);
  		new CmdGive(server);
  		new CmdDebug(server);
@@ -16,6 +16,7 @@ index 1d4be19..e8394a8 100644
 +		new StratumCombatLogSystem(server);
 +		new StratumCombatLogSystem(server);
 +		new StratumCombatLogSystem(server);
++		new StratumCoopCombatSystem(server); // Stratum: cooperative PvE combat toggle
 +		new StratumNametags(server);
 +		new StratumEntityCaps(server);
  		new CmdInfo(server);

--- a/sources/VintagestoryApi/Server/StratumCoopCombatHook.cs
+++ b/sources/VintagestoryApi/Server/StratumCoopCombatHook.cs
@@ -1,0 +1,10 @@
+namespace Vintagestory.API.Server;
+
+// Bridge for the cooperative PvE combat toggle. EntityBehaviorHealth (in VSEssentials) reads
+// CreatureInvulnerableMs instead of its hardcoded 500ms post-hit invulnerability window when
+// the entity being hit isn't a player. StratumCoopCombatSystem owns the value and updates it
+// from config/command. When the feature is off, this stays 500 and behavior is untouched.
+public static class StratumCoopCombatHook
+{
+	public static int CreatureInvulnerableMs = 500;
+}

--- a/sources/VintagestoryLib/Vintagestory.Server/CmdStratum.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/CmdStratum.cs
@@ -212,6 +212,7 @@ internal class CmdStratum
 		if (loaded)
 		{
 			CmdStratumEssentials.RegisterConfiguredPrivileges(server);
+			StratumCoopCombatSystem.Apply(StratumRuntime.Config.CoopCombat);
 			// Stratum: clear region ticking fallback state on reload (#10)
 			var sim = server.Systems.OfType<ServerSystemEntitySimulation>().FirstOrDefault();
 			sim?.StratumClearFallbackState();

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumCommandAccessCatalog.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumCommandAccessCatalog.cs
@@ -45,6 +45,7 @@ internal static class StratumCommandAccessCatalog
 		yield return new StratumCommandAccessEntry("reply", "/reply", commands.Message, "Use /reply");
 		yield return new StratumCommandAccessEntry("staffchat", "/staffchat", commands.StaffChat, "Use /staffchat");
 		yield return new StratumCommandAccessEntry("chatcontrol", "/slowmode", commands.ChatControl, "Use /slowmode, /lockchat, and /chatclear");
+		yield return new StratumCommandAccessEntry("coopcombat", "/pvecombat", commands.CoopCombat, "Use /pvecombat");
 		yield return new StratumCommandAccessEntry("staffbroadcast", "/staffbroadcast", commands.StaffBroadcast, "Use /staffbroadcast");
 		yield return new StratumCommandAccessEntry("info", "/rules", commands.InfoCommands, "Use /rules, /discord, /website, and /motd");
 		yield return new StratumCommandAccessEntry("vanish", "/vanish", commands.Vanish, "Use /vanish");

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumConfig.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumConfig.cs
@@ -52,6 +52,8 @@ internal class StratumConfig
 
 	public StratumCombatLogConfig CombatLog { get; set; } = new StratumCombatLogConfig();
 
+	public StratumCoopCombatConfig CoopCombat { get; set; } = new StratumCoopCombatConfig();
+
 	public StratumServerStatsConfig ServerStats { get; set; } = new StratumServerStatsConfig();
 
 	public void EnsurePopulated()
@@ -77,6 +79,7 @@ internal class StratumConfig
 		Backup ??= new StratumBackupConfig();
 		Announcements ??= new StratumAnnouncementsConfig();
 		CombatLog ??= new StratumCombatLogConfig();
+		CoopCombat ??= new StratumCoopCombatConfig();
 		ServerStats ??= new StratumServerStatsConfig();
 		PacketLimits.EnsureSane();
 		PacketBackPressure.EnsureSane();
@@ -95,6 +98,7 @@ internal class StratumConfig
 		Backup.EnsureSane();
 		Announcements.EnsureSane();
 		CombatLog.EnsureSane();
+		CoopCombat.EnsureSane();
 		ServerStats.EnsureSane();
 		UpdateChecker.EnsureSane();
 	}
@@ -1537,6 +1541,8 @@ internal class StratumCommandsConfig
 	public StratumCommandAccessConfig StaffChat { get; set; } = StratumCommandAccessConfig.ForPrivilege("stratum.staffchat");
 
 	public StratumCommandAccessConfig ChatControl { get; set; } = StratumCommandAccessConfig.ForPrivilege("stratum.chatcontrol");
+
+	public StratumCommandAccessConfig CoopCombat { get; set; } = StratumCommandAccessConfig.ForPrivilege("stratum.coopcombat");
 
 	public StratumCommandAccessConfig StaffBroadcast { get; set; } = StratumCommandAccessConfig.ForPrivilege("stratum.staffbroadcast");
 

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumCoopCombatConfig.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumCoopCombatConfig.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace Vintagestory.Server;
+
+internal sealed class StratumCoopCombatConfig
+{
+	/// <summary>Enable cooperative PvE combat. Off by default (vanilla 500ms creature invulnerability).</summary>
+	public bool Enabled { get; set; } = false;
+
+	/// <summary>
+	/// Creature post-hit invulnerability window in milliseconds while enabled. Vanilla is 500.
+	/// Lower values let more players land hits on the same creature inside the window that used
+	/// to block every attacker but the first. Never applied to players.
+	/// </summary>
+	public int CreatureInvulnerableMs { get; set; } = 100;
+
+	public void EnsureSane()
+	{
+		CreatureInvulnerableMs = Math.Clamp(CreatureInvulnerableMs, 0, 500);
+	}
+}

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumCoopCombatSystem.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumCoopCombatSystem.cs
@@ -1,5 +1,7 @@
+using System;
 using Vintagestory.API.Common;
 using Vintagestory.API.Common.CommandAbbr;
+using Vintagestory.API.Config;
 using Vintagestory.API.Server;
 
 namespace Vintagestory.Server;
@@ -46,8 +48,46 @@ internal sealed class StratumCoopCombatSystem
 		StratumCoopCombatHook.CreatureInvulnerableMs = cfg?.Enabled == true ? cfg.CreatureInvulnerableMs : 500;
 	}
 
+	private bool CheckAccess(TextCommandCallingArgs args, out TextCommandResult failure)
+	{
+		StratumRuntime.Config.EnsurePopulated();
+		failure = null;
+
+		if (!StratumRuntime.Config.Commands.Enabled)
+		{
+			failure = TextCommandResult.Error("Stratum commands are disabled.");
+			return false;
+		}
+
+		StratumCommandAccessConfig access = StratumRuntime.Config.Commands.CoopCombat;
+		if (access == null || !access.Enabled)
+		{
+			failure = TextCommandResult.Error("/pvecombat is disabled.");
+			return false;
+		}
+
+		if (StratumCommandAccessCatalog.CallerHasAccess(args.Caller, server, access))
+		{
+			if (!StratumCommandCooldowns.TryUse(args.Caller, server, "pvecombat", access, out TimeSpan remaining))
+			{
+				failure = TextCommandResult.Error("Wait " + Math.Ceiling(remaining.TotalSeconds).ToString(GlobalConstants.DefaultCultureInfo) + "s before using /pvecombat again.");
+				return false;
+			}
+
+			return true;
+		}
+
+		failure = TextCommandResult.Error("You do not have permission to use /pvecombat.");
+		return false;
+	}
+
 	private TextCommandResult HandleToggle(TextCommandCallingArgs args)
 	{
+		if (!CheckAccess(args, out TextCommandResult failure))
+		{
+			return failure;
+		}
+
 		StratumCoopCombatConfig cfg = Cfg;
 		if (cfg == null)
 		{

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumCoopCombatSystem.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumCoopCombatSystem.cs
@@ -1,0 +1,76 @@
+using Vintagestory.API.Common;
+using Vintagestory.API.Common.CommandAbbr;
+using Vintagestory.API.Server;
+
+namespace Vintagestory.Server;
+
+// Cooperative PvE combat toggle. EntityBehaviorHealth (VSEssentials) puts every entity that
+// takes damage on a 500ms "invulnerable" activity timer, so a second hit from anyone else
+// inside that window does zero damage regardless of source. That is fine for a single attacker,
+// but it means a group fighting one strong creature only ever lands one effective hit every
+// 500ms combined, not per player: the second, third, and further attackers' hits are wasted the
+// moment they land inside the first attacker's window.
+//
+// StratumCoopCombatHook (in VintagestoryAPI, reachable from both this assembly and VSEssentials)
+// is the cross-assembly bridge: this system owns the value and pushes it in from config, the
+// behavior reads it instead of the hardcoded 500 for any entity that isn't a player. Player
+// invulnerability (join protection, PvP) is untouched, this only ever affects creatures.
+internal sealed class StratumCoopCombatSystem
+{
+	private readonly ServerMain server;
+
+	private static StratumCoopCombatConfig Cfg => StratumRuntime.Config?.CoopCombat;
+
+	public StratumCoopCombatSystem(ServerMain server)
+	{
+		this.server = server;
+
+		StratumRuntime.Config.EnsurePopulated();
+		Apply(Cfg);
+
+		if (StratumCommandRegistration.ShouldRegister(StratumRuntime.Config.Commands.CoopCombat, "/pvecombat", "Commands.CoopCombat"))
+		{
+			CommandArgumentParsers parsers = server.api.commandapi.Parsers;
+			server.api.commandapi.Create("pvecombat")
+				.WithDescription("Toggle cooperative PvE combat (lowers creature hit invulnerability so multiple players can damage the same target)")
+				.WithArgs(parsers.OptionalWordRange("mode", "on", "off", "toggle", "status"))
+				.RequiresPrivilege(Privilege.chat)
+				.HandleWith(HandleToggle);
+		}
+	}
+
+	// Re-applies the configured window, called after StratumRuntime.Config is replaced by a
+	// live /stratum reload so the hook doesn't keep serving a stale value.
+	public static void Apply(StratumCoopCombatConfig cfg)
+	{
+		StratumCoopCombatHook.CreatureInvulnerableMs = cfg?.Enabled == true ? cfg.CreatureInvulnerableMs : 500;
+	}
+
+	private TextCommandResult HandleToggle(TextCommandCallingArgs args)
+	{
+		StratumCoopCombatConfig cfg = Cfg;
+		if (cfg == null)
+		{
+			return TextCommandResult.Error("Config not ready yet.");
+		}
+
+		string mode = args[0] as string;
+		if (string.IsNullOrEmpty(mode) || string.Equals(mode, "status", System.StringComparison.OrdinalIgnoreCase))
+		{
+			return TextCommandResult.Success(cfg.Enabled
+				? "Cooperative PvE combat is on, creature invulnerability " + cfg.CreatureInvulnerableMs + "ms."
+				: "Cooperative PvE combat is off, vanilla 500ms creature invulnerability.");
+		}
+
+		bool next = string.Equals(mode, "toggle", System.StringComparison.OrdinalIgnoreCase) ? !cfg.Enabled : string.Equals(mode, "on", System.StringComparison.OrdinalIgnoreCase);
+		cfg.Enabled = next;
+		Apply(cfg);
+		StratumRuntime.SaveConfig();
+
+		string message = next
+			? "Cooperative PvE combat enabled, creature invulnerability now " + cfg.CreatureInvulnerableMs + "ms."
+			: "Cooperative PvE combat disabled, back to vanilla 500ms.";
+		StratumRuntime.LogAudit("pvecombat " + (next ? "on" : "off") + " actor=" + args.Caller.GetName(), true);
+		return TextCommandResult.Success(message);
+	}
+}


### PR DESCRIPTION
## Summary

Adds `/pvecombat on|off|toggle|status`, a config-backed toggle that lowers (or removes) the post-hit invulnerability window on creatures so a group can cooperatively damage the same target instead of one attacker's hit blocking everyone else's.

`EntityBehaviorHealth` (VSEssentials) puts every entity that takes damage on a hardcoded 500ms `invulnerable` activity timer. That's fine for a single attacker, but it means a group fighting one strong creature only ever lands one effective hit every 500ms combined, not per player: whichever attacker's hit lands first inside that window is the only one that counts, everyone else's simultaneous or near-simultaneous hits do zero damage.

`StratumCoopCombatHook` is a small static holder added to `VintagestoryAPI`, the one assembly both `VintagestoryLib` (where Stratum's server config lives) and `VSEssentials` (where `EntityBehaviorHealth` lives) can reach, since neither references the other directly. `EntityBehaviorHealth` reads `CreatureInvulnerableMs` from it instead of the literal 500 whenever the entity taking damage isn't a player, so this never touches PvP or a player's own hit-stun, only creature-side invulnerability. `StratumCoopCombatSystem` owns the value, applies it from config at boot, and the command flips it live, persisted through the existing `SaveConfig` path the same way `/chattoggle` is.

Config lives in a new `CoopCombat` section:
```json
{
  "Enabled": false,
  "CreatureInvulnerableMs": 100
}
```
`CreatureInvulnerableMs` is clamped 0-500. Off by default, vanilla 500ms behavior untouched until a server opts in.

### Anticheat interaction checked

`StratumCombatGuard`'s kill-aura heuristic keys on how many distinct entities *one attacker* hits inside a short window (`MultiTargetThreshold`), not on how many attackers hit *one entity*. Cooperative PvE combat is several players sharing one target, so it never touches that heuristic, each attacker still only ever hits the one creature.

### Also found, unrelated

While adding this system's construction line next to the existing combat log system's in `ServerSystemCommands.cs.patch`, found `StratumCombatLogSystem` is constructed three times there instead of once (pre-existing, from the PvP combat log prevention change already on `indev`). Left untouched and filed separately: #242.

### Testing detail

Both build passes clean (`dotnet build VintageStory.slnx -c Release`, `-p:EmbedPatchedFiles=true`), 0 errors. `scripts/smoke-test.sh` passes (server reaches `RunGame`). `/pvecombat` itself not tested with a connected client, no account available this session; command registration and config wiring verified by code review and the boot smoke test only.

## Type

- [ ] Bug fix
- [ ] Performance
- [x] New feature
- [ ] Refactor or cleanup
- [ ] Docs or build

## Checklist

- [ ] `.\scripts\extract-patches.ps1` ran clean.
- [x] `dotnet build VintageStory.slnx -c Release` is green.
- [x] Every vanilla edit has a `// Stratum` marker.
- [x] No vanilla source committed.
- [x] Tested on a real server start, not just compilation.

## Related issues

Fixes #215
