### PR TITLE
Guard boat selection box indices

### DIFF
--- a/patches/VSEssentials/Entity/Behavior/BehaviorSelectionBoxes.cs.patch
+++ b/patches/VSEssentials/Entity/Behavior/BehaviorSelectionBoxes.cs.patch
@@ -1,0 +1,58 @@
+diff --git a/VSEssentials/Entity/Behavior/BehaviorSelectionBoxes.cs b/VSEssentials/Entity/Behavior/BehaviorSelectionBoxes.cs
+index 75cb94b..32a4977 100644
+--- a/VSEssentials/Entity/Behavior/BehaviorSelectionBoxes.cs
++++ b/VSEssentials/Entity/Behavior/BehaviorSelectionBoxes.cs
+@@ -282,14 +282,16 @@ namespace Vintagestory.GameContent
+             }
+
+             return foundIndex;
+         }
+
+-        public Vec3d GetCenterPosOfBox(int selectionBoxIndex)
+-        {
+-            if (selectionBoxIndex >= selectionBoxes.Length) return null;
+-            var apap = selectionBoxes[selectionBoxIndex];
++		public Vec3d GetCenterPosOfBox(int selectionBoxIndex)
++		{
++            // Stratum: reject selection-box indices outside the resolved array.
++			AttachmentPointAndPose[] selectionBoxArray = selectionBoxes;
++			if (selectionBoxArray == null || (uint)selectionBoxIndex >= (uint)selectionBoxArray.Length) return null;
++			var apap = selectionBoxArray[selectionBoxIndex];
+             mvmat.Identity();
+             applyBoxTransform(mvmat, apap);
+
+             var pe = apap.AttachPoint.ParentElement;
+             Vec4d centerPos = new Vec4d((pe.To[0] - pe.From[0]) / 2/16, (pe.To[1] - pe.From[1]) / 2/16, (pe.To[2] - pe.From[2]) / 2/16, 1);
+@@ -355,21 +357,21 @@ namespace Vintagestory.GameContent
+             return false;
+         }
+
+
+
+-        public bool IsAPCode(EntitySelection es, string apcode)
+-        {
+-            var ebs = entity.GetBehavior<EntityBehaviorSelectionBoxes>();
+-            if (ebs != null)
+-            {
+-                int seleBox = es?.SelectionBoxIndex - 1 ?? -1;
+-                var seleBoxes = ebs.selectionBoxes;
+-                if (seleBox > 0 && seleBoxes.Length >= seleBox)
+-                {
+-                    string apCode = seleBoxes[seleBox].AttachPoint.Code;
+-                    return apCode == apcode;
++		public bool IsAPCode(EntitySelection es, string apcode)
++		{
++			var ebs = entity.GetBehavior<EntityBehaviorSelectionBoxes>();
++			var selectionBoxArray = ebs?.selectionBoxes;
++			if (selectionBoxArray != null)
++			{
++				int seleBox = es?.SelectionBoxIndex - 1 ?? -1;
++				if ((uint)seleBox < (uint)selectionBoxArray.Length)
++				{
++					string apCode = selectionBoxArray[seleBox].AttachPoint.Code;
++					return apCode == apcode;
+                 }
+             }
+
+             return false;
+         }

--- a/patches/VSSurvivalMod/Entity/Behavior/BehaviorAttachable.cs.patch
+++ b/patches/VSSurvivalMod/Entity/Behavior/BehaviorAttachable.cs.patch
@@ -1,58 +1,99 @@
 diff --git a/VSSurvivalMod/Entity/Behavior/BehaviorAttachable.cs b/VSSurvivalMod/Entity/Behavior/BehaviorAttachable.cs
-index ca7d5e3..80e7513 100644
+index ca7d5e3..69e50ea 100644
 --- a/VSSurvivalMod/Entity/Behavior/BehaviorAttachable.cs
 +++ b/VSSurvivalMod/Entity/Behavior/BehaviorAttachable.cs
-@@ -374,19 +374,21 @@ namespace Vintagestory.GameContent
+@@ -301,12 +301,13 @@ namespace Vintagestory.GameContent
+         public override void OnInteract(EntityAgent byEntity, ItemSlot itemslot, Vec3d hitPosition, EnumInteractMode mode, ref EnumHandling handled)
+         {
+             int seleBox = (byEntity as EntityPlayer).EntitySelection?.SelectionBoxIndex ?? -1;
+             if (seleBox <= 0) return;
+
+-            var index = GetSlotIndexFromSelectionBoxIndex(seleBox - 1);
+-            var slot = index >= 0 ? inv[index] : null;
++            // Stratum: reject stale selection boxes before indexing attachments.
++			var index = GetSlotIndexFromSelectionBoxIndex(seleBox - 1);
++			var slot = index >= 0 && index < inv.Count ? inv[index] : null;
+             if (slot == null) return;
+             handled = EnumHandling.PreventSubsequent;
+
+             var controls = byEntity.MountedOn?.Controls ?? byEntity.Controls;
+             var attachKey = UseShiftAttach ? controls.ShiftKey : controls.CtrlKey;
+@@ -374,20 +375,24 @@ namespace Vintagestory.GameContent
          }
- 
+
          private bool TryRemoveAttachment(EntityAgent byEntity, int selectionBoxIndex)
          {
              int slotIndex = GetSlotIndexFromSelectionBoxIndex(selectionBoxIndex);
 +            if (slotIndex < 0) return false;
              ItemSlot slot = inv[slotIndex];
- 
+
              if (slot.Empty) return false;
- 
+
              // Don't allow removal of seats where somebody sits on
-             var ebh = entity.GetBehavior<EntityBehaviorSeatable>();
-             if (ebh != null)
-             {
-                 var bhs = entity.GetBehavior<EntityBehaviorSelectionBoxes>();
-+                if (bhs?.selectionBoxes == null || selectionBoxIndex < 0 || selectionBoxIndex >= bhs.selectionBoxes.Length) return false;
-                 var apap = bhs.selectionBoxes[selectionBoxIndex];
+-            var ebh = entity.GetBehavior<EntityBehaviorSeatable>();
+-            if (ebh != null)
+-            {
+-                var bhs = entity.GetBehavior<EntityBehaviorSelectionBoxes>();
+-                var apap = bhs.selectionBoxes[selectionBoxIndex];
++            // Stratum: stop invalid attachment indices before seat lookup.
++			var ebh = entity.GetBehavior<EntityBehaviorSeatable>();
++			if (ebh != null)
++			{
++				var bhs = entity.GetBehavior<EntityBehaviorSelectionBoxes>();
++				var selectionBoxes = bhs?.selectionBoxes;
++				if (selectionBoxes == null || (uint)selectionBoxIndex >= (uint)selectionBoxes.Length) return false;
++				var apap = selectionBoxes[selectionBoxIndex];
                  string apname = apap.AttachPoint.Code;
                  var seat = ebh.Seats.FirstOrDefault((seat) => seat.Config.APName == apname || seat.Config.SelectionBox == apname);
                  if (seat?.Passenger != null)
                  {
-@@ -432,10 +434,11 @@ namespace Vintagestory.GameContent
+                     (entity.World.Api as ICoreClientAPI)?.TriggerIngameError(this, "requiredisembark", Lang.Get("Passenger must disembark first before being able to remove this seat"));
+@@ -432,10 +437,11 @@ namespace Vintagestory.GameContent
          {
              var iatta = IAttachableToEntity.FromCollectible(itemslot.Itemstack.Collectible);
              if (iatta == null || !iatta.IsAttachable(entity, itemslot.Itemstack)) return false;
- 
+
              int slotIndex = GetSlotIndexFromSelectionBoxIndex(selectionBoxIndex);
 +            if (slotIndex < 0) return false;
              ItemSlot targetSlot = inv[slotIndex];
              string code = iatta.GetCategoryCode(itemslot.Itemstack);
              WearableSlotConfig slotConfig = wearableSlots[slotIndex];
- 
+
              var ebhs = entity.GetBehavior<EntityBehaviorSeatable>();
-@@ -535,13 +538,12 @@ namespace Vintagestory.GameContent
-         public int GetSlotIndexFromSelectionBoxIndex(int boxIndex)
-         {
-             if (boxIndex < 0) return -1;
- 
-             var selectionBehavior = entity.GetBehavior<EntityBehaviorSelectionBoxes>();
--            ArgumentNullException.ThrowIfNull(selectionBehavior);
-+            if (selectionBehavior?.selectionBoxes == null || boxIndex >= selectionBehavior.selectionBoxes.Length) return -1;
- 
--            // Allow throwing if the index is out of bounds, since that shouldn't be happening
-             string apCode = selectionBehavior.selectionBoxes[boxIndex].AttachPoint.Code;
- 
-             return wearableSlots.IndexOf(elem => elem.AttachmentPointCode == apCode);
+@@ -530,21 +536,23 @@ namespace Vintagestory.GameContent
+             var index = GetSlotIndexFromSelectionBoxIndex(boxIndex);
+             if (index == -1) return null;
+             return inv[index];
          }
- 
-@@ -590,11 +592,13 @@ namespace Vintagestory.GameContent
- 
+
+-        public int GetSlotIndexFromSelectionBoxIndex(int boxIndex)
+-        {
+-            if (boxIndex < 0) return -1;
++		public int GetSlotIndexFromSelectionBoxIndex(int boxIndex)
++		{
++			if (boxIndex < 0) return -1;
+
+-            var selectionBehavior = entity.GetBehavior<EntityBehaviorSelectionBoxes>();
+-            ArgumentNullException.ThrowIfNull(selectionBehavior);
++            // Stratum: bound selection-box and inventory indices before lookup.
++			var selectionBehavior = entity.GetBehavior<EntityBehaviorSelectionBoxes>();
++			var selectionBoxes = selectionBehavior?.selectionBoxes;
++			if (selectionBoxes == null || (uint)boxIndex >= (uint)selectionBoxes.Length) return -1;
+
+-            // Allow throwing if the index is out of bounds, since that shouldn't be happening
+-            string apCode = selectionBehavior.selectionBoxes[boxIndex].AttachPoint.Code;
++			string apCode = selectionBoxes[boxIndex].AttachPoint.Code;
+
+-            return wearableSlots.IndexOf(elem => elem.AttachmentPointCode == apCode);
++			int slotIndex = wearableSlots.IndexOf(elem => elem.AttachmentPointCode == apCode);
++			return slotIndex >= 0 && slotIndex < inv.Count ? slotIndex : -1;
+         }
+
+         public ItemSlot GetSlotConfigFromAPName(string apCode)
+         {
+             var seleBoxes = entity.GetBehavior<EntityBehaviorSelectionBoxes>().selectionBoxes;
+@@ -590,11 +598,13 @@ namespace Vintagestory.GameContent
+
          public override WorldInteraction[] GetInteractionHelp(IClientWorldAccessor world, EntitySelection es, IClientPlayer player, ref EnumHandling handled)
          {
              if (es.SelectionBoxIndex > 0)
@@ -62,23 +103,24 @@ index ca7d5e3..80e7513 100644
 +                if (slot == null) return base.GetInteractionHelp(world, es, player, ref handled);
 +                return AttachableInteractionHelp.GetOrCreateInteractionHelp(world.Api, this, wearableSlots, es.SelectionBoxIndex - 1, slot);
              }
- 
+
              return base.GetInteractionHelp(world, es, player, ref handled);
          }
- 
-@@ -608,11 +612,14 @@ namespace Vintagestory.GameContent
+
+@@ -608,11 +618,15 @@ namespace Vintagestory.GameContent
              if (capi.World.Player.CurrentEntitySelection == null) return null;
- 
+
              var selebox = capi.World.Player.CurrentEntitySelection.SelectionBoxIndex - 1;
              if (selebox < 0) return null;
- 
+
 -            return entity.GetBehavior<EntityBehaviorSelectionBoxes>().GetCenterPosOfBox(selebox)?.Add(0, 0.5, 0);
-+            var selectionBoxes = entity.GetBehavior<EntityBehaviorSelectionBoxes>();
-+            if (selectionBoxes?.selectionBoxes == null || selebox >= selectionBoxes.selectionBoxes.Length) return null;
++			var selectionBoxes = entity.GetBehavior<EntityBehaviorSelectionBoxes>();
++			var selectionBoxArray = selectionBoxes?.selectionBoxes;
++			if (selectionBoxArray == null || (uint)selebox >= (uint)selectionBoxArray.Length) return null;
 +
 +            return selectionBoxes.GetCenterPosOfBox(selebox)?.Add(0, 0.5, 0);
          }
- 
+
          public override void OnEntityDeath(DamageSource damageSourceForDeath)
          {
              int i = 0;

--- a/patches/VSSurvivalMod/Systems/Boats/EntityBehaviorSeatable.cs.patch
+++ b/patches/VSSurvivalMod/Systems/Boats/EntityBehaviorSeatable.cs.patch
@@ -1,46 +1,57 @@
 diff --git a/VSSurvivalMod/Systems/Boats/EntityBehaviorSeatable.cs b/VSSurvivalMod/Systems/Boats/EntityBehaviorSeatable.cs
-index e0e3ce5..2e86ae0 100644
+index e0e3ce5..fc566a2 100644
 --- a/VSSurvivalMod/Systems/Boats/EntityBehaviorSeatable.cs
 +++ b/VSSurvivalMod/Systems/Boats/EntityBehaviorSeatable.cs
-@@ -135,14 +135,16 @@ namespace Vintagestory.GameContent
+@@ -133,16 +133,20 @@ namespace Vintagestory.GameContent
+         {
+             if (mode != EnumInteractMode.Interact || !entity.Alive || !byEntity.Alive) return;
              if (!allowSit(byEntity)) return;
              if (itemslot.Itemstack?.Collectible is ItemRope) return;
- 
-             int seleBox = (byEntity as EntityPlayer).EntitySelection?.SelectionBoxIndex ?? -1;
-             var bhs = entity.GetBehavior<EntityBehaviorSelectionBoxes>();
-+            int selectionBoxIndex = seleBox - 1;
-+            bool hasSelectionBox = bhs?.selectionBoxes != null && selectionBoxIndex >= 0 && selectionBoxIndex < bhs.selectionBoxes.Length;
- 
+
+-            int seleBox = (byEntity as EntityPlayer).EntitySelection?.SelectionBoxIndex ?? -1;
+-            var bhs = entity.GetBehavior<EntityBehaviorSelectionBoxes>();
+-
 -            if (bhs != null && byEntity.MountedOn == null && seleBox > 0)
-+            if (hasSelectionBox && byEntity.MountedOn == null)
-             {
+-            {
 -                var apap = bhs.selectionBoxes[seleBox - 1];
-+                var apap = bhs.selectionBoxes[selectionBoxIndex];
++            // Stratum: ignore selection boxes outside the resolved seat array.
++			int seleBox = (byEntity as EntityPlayer).EntitySelection?.SelectionBoxIndex ?? -1;
++			var bhs = entity.GetBehavior<EntityBehaviorSelectionBoxes>();
++			var selectionBoxes = bhs?.selectionBoxes;
++			int selectionBoxIndex = seleBox - 1;
++			bool hasSelectionBox = selectionBoxes != null && (uint)selectionBoxIndex < (uint)selectionBoxes.Length;
++
++			if (hasSelectionBox && byEntity.MountedOn == null)
++			{
++				var apap = selectionBoxes[selectionBoxIndex];
                  string apname = apap.AttachPoint.Code;
                  var seat = Seats.FirstOrDefault((seat) => seat.Config.APName == apname || seat.Config.SelectionBox == apname);
                  if (seat != null && seat.Passenger != null && seat.Passenger.HasBehavior<EntityBehaviorRopeTieable>())
                  {
                      (seat.Passenger as EntityAgent).TryUnmount();
-@@ -155,13 +157,13 @@ namespace Vintagestory.GameContent
+@@ -154,14 +157,14 @@ namespace Vintagestory.GameContent
+             if (byEntity.Controls.CtrlKey)
              {
                  return;
              }
- 
-             // If we have the selection boxes behavior, use that
+
+-            // If we have the selection boxes behavior, use that
 -            if (seleBox > 0 && bhs != null)
-+            if (hasSelectionBox)
-             {
+-            {
 -                var apap = bhs.selectionBoxes[seleBox - 1];
-+                var apap = bhs.selectionBoxes[selectionBoxIndex];
++			// If we have the selection boxes behavior, use that
++			if (hasSelectionBox)
++			{
++				var apap = selectionBoxes[selectionBoxIndex];
                  string apname = apap.AttachPoint.Code;
- 
+
                  var seat = Seats.FirstOrDefault((seat) => seat.Config.APName == apname || seat.Config.SelectionBox == apname);
                  if (seat != null && CanSitOn(seat) && byEntity.TryMount(seat))
                  {
-@@ -367,18 +369,25 @@ namespace Vintagestory.GameContent
- 
- 
- 
+@@ -367,18 +370,25 @@ namespace Vintagestory.GameContent
+
+
+
          public override WorldInteraction[] GetInteractionHelp(IClientWorldAccessor world, EntitySelection es, IClientPlayer player, ref EnumHandling handled)
          {
 -            if (es.SelectionBoxIndex > 0)
@@ -50,31 +61,40 @@ index e0e3ce5..2e86ae0 100644
 -                return SeatableInteractionHelp.GetOrCreateInteractionHelp(world.Api, this, Seats, es.SelectionBoxIndex - 1);
 +                return SeatableInteractionHelp.GetOrCreateInteractionHelp(world.Api, this, Seats, selectionBoxIndex);
              }
- 
+
              return base.GetInteractionHelp(world, es, player, ref handled);
          }
- 
-+        public bool HasSelectionBox(int selectionBoxIndex)
-+        {
-+            var bhs = entity.GetBehavior<EntityBehaviorSelectionBoxes>();
-+            return bhs?.selectionBoxes != null && selectionBoxIndex >= 0 && selectionBoxIndex < bhs.selectionBoxes.Length;
+
++		public bool HasSelectionBox(int selectionBoxIndex)
++		{
++			var selectionBoxes = entity.GetBehavior<EntityBehaviorSelectionBoxes>()?.selectionBoxes;
++			return selectionBoxes != null && (uint)selectionBoxIndex < (uint)selectionBoxes.Length;
 +        }
 +
          public override void OnEntityDeath(DamageSource damageSourceForDeath)
          {
              base.OnEntityDeath(damageSourceForDeath);
- 
+
              foreach (var seat in Seats) {
-@@ -447,11 +456,11 @@ namespace Vintagestory.GameContent
+@@ -444,16 +454,16 @@ namespace Vintagestory.GameContent
+             }
+
+             return null;
          }
- 
-         private static IMountableSeat getSeat(EntityBehaviorSeatable eba, IMountableSeat[] seats, int slotIndex)
-         {
-             var bhs = eba.entity.GetBehavior<EntityBehaviorSelectionBoxes>();
+
+-        private static IMountableSeat getSeat(EntityBehaviorSeatable eba, IMountableSeat[] seats, int slotIndex)
+-        {
+-            var bhs = eba.entity.GetBehavior<EntityBehaviorSelectionBoxes>();
 -            if (bhs == null) return null;
-+            if (bhs?.selectionBoxes == null || slotIndex < 0 || slotIndex >= bhs.selectionBoxes.Length) return null;
- 
-             var apap = bhs.selectionBoxes[slotIndex];
++		private static IMountableSeat getSeat(EntityBehaviorSeatable eba, IMountableSeat[] seats, int slotIndex)
++		{
++			var selectionBoxes = eba.entity.GetBehavior<EntityBehaviorSelectionBoxes>()?.selectionBoxes;
++			if (selectionBoxes == null || (uint)slotIndex >= (uint)selectionBoxes.Length) return null;
+
+-            var apap = bhs.selectionBoxes[slotIndex];
++			var apap = selectionBoxes[slotIndex];
              string apname = apap.AttachPoint.Code;
- 
+
              return seats.FirstOrDefault((seat) => seat.Config.APName == apname || seat.Config.SelectionBox == apname);
+         }
+     }

--- a/patches/VintagestoryLib/Vintagestory.Server/ServerSystemEntitySimulation.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/ServerSystemEntitySimulation.cs.patch
@@ -1,13 +1,14 @@
 diff --git a/VintagestoryLib/Vintagestory.Server/ServerSystemEntitySimulation.cs b/VintagestoryLib/Vintagestory.Server/ServerSystemEntitySimulation.cs
-index ea1d5c0..51c993b 100644
+index ea1d5c0..627fe32 100644
 --- a/VintagestoryLib/Vintagestory.Server/ServerSystemEntitySimulation.cs
 +++ b/VintagestoryLib/Vintagestory.Server/ServerSystemEntitySimulation.cs
-@@ -1,8 +1,12 @@
+@@ -1,8 +1,13 @@
  using System;
 +using System.Collections.Concurrent;
  using System.Collections.Generic;
 -using System.Linq;
 +using System.Diagnostics;
++using System.Reflection;
 +using System.Text;
 +using System.Threading;
 +using System.Threading.Tasks;
@@ -16,12 +17,12 @@ index ea1d5c0..51c993b 100644
  using Vintagestory.API.Common.Entities;
  using Vintagestory.API.Config;
  using Vintagestory.API.Datastructures;
-@@ -22,13 +26,152 @@ public class ServerSystemEntitySimulation : ServerSystem
- 
+@@ -22,13 +27,152 @@ public class ServerSystemEntitySimulation : ServerSystem
+
  	private Dictionary<string, List<string>> deathMessagesCache;
- 
+
  	private int skippedDespawnTicks;
- 
+
 +	private ConcurrentDictionary<long, StratumEntityTickState> stratumEntityTickStates = new ConcurrentDictionary<long, StratumEntityTickState>();
 +	private int stratumTicksSinceTickStateReconcile; // Stratum: periodic orphan eviction
 +
@@ -169,10 +170,10 @@ index ea1d5c0..51c993b 100644
  		server.RegisterGameTickListener(UpdateEvery100ms, 100);
  		server.clientAwarenessEvents[EnumClientAwarenessEvent.ChunkTransition].Add(OnPlayerLeaveChunk);
  		server.PacketHandlers[17] = HandleEntityInteraction;
-@@ -43,26 +186,33 @@ public class ServerSystemEntitySimulation : ServerSystem
+@@ -43,26 +187,33 @@ public class ServerSystemEntitySimulation : ServerSystem
  		player.Player.ItemCollectMode = packet.RuntimeSetting.ItemCollectMode;
  	}
- 
+
  	private void EventManager_OnPlayerChat(IServerPlayer byPlayer, int channelId, ref string message, ref string data, BoolRef consumed)
  	{
 +		string messageBody = StratumChatFormatter.FormatMessageBody(message);
@@ -202,13 +203,13 @@ index ea1d5c0..51c993b 100644
 -		message = $"<strong>{byPlayer.PlayerName}:</strong> {message}";
 +		message = $"<strong>{byPlayer.PlayerName}:</strong> {messageBody}";
  	}
- 
+
  	private void EventManager_OnGameWorldBeingSaved()
  	{
  		if (server.RunPhase != EnumServerRunPhase.Shutdown)
-@@ -77,66 +227,257 @@ public class ServerSystemEntitySimulation : ServerSystem
+@@ -77,66 +228,257 @@ public class ServerSystemEntitySimulation : ServerSystem
  	}
- 
+
  	public override void OnBeginModsAndConfigReady()
  	{
  		server.EventManager.OnPlayerRespawn += OnPlayerRespawn;
@@ -220,7 +221,7 @@ index ea1d5c0..51c993b 100644
 +			ServerMain.Logger.Warning("[Stratum] Region ticking is ENABLED (experimental). Not all entity behaviors are thread-safe. Monitor with /stratum regions.");
 +		}
  	}
- 
+
  	public override void OnPlayerJoin(ServerPlayer player)
  	{
 +		// Stratum: reconnect only player animators. Mob/global server animators remain deferred
@@ -228,7 +229,7 @@ index ea1d5c0..51c993b 100644
 +		StratumEnsurePlayerAnimator(player?.Entity);
  		physicsManager.ForceClientUpdateTick(player.client);
  	}
- 
+
 +	private void StratumLoadPlayerEntityShapes()
 +	{
 +		List<EntityProperties> playerTypes = new List<EntityProperties>(1);
@@ -327,12 +328,12 @@ index ea1d5c0..51c993b 100644
  		physicsManager.ForceClientUpdateTick(player.client);
 +		stratumSelectionState.Remove(player.client.Id);
  	}
- 
+
  	private void OnPlayerLeaveChunk(ClientStatistics clientStats)
  	{
  		physicsManager.ForceClientUpdateTick(clientStats.client);
  	}
- 
+
  	public override void OnServerTick(float dt)
  	{
 +		long stratumSelectionTimingStart = StratumRuntime.Timings.GetTimestamp();
@@ -429,7 +430,7 @@ index ea1d5c0..51c993b 100644
  		TickEntities(dt);
  		SendPlayerEntityDeaths();
  	}
- 
+
 +	// Stratum: per-client raytrace throttle state.
 +	private sealed class StratumSelectionState
 +	{
@@ -484,10 +485,10 @@ index ea1d5c0..51c993b 100644
  		SendEntityDespawns();
  		int count = server.DelayedSpawnQueue.Count;
  		if (count <= 0)
-@@ -185,19 +526,150 @@ public class ServerSystemEntitySimulation : ServerSystem
+@@ -185,19 +527,150 @@ public class ServerSystemEntitySimulation : ServerSystem
  		}
  	}
- 
+
  	private void TickEntities(float dt)
  	{
 -		List<KeyValuePair<Entity, EntityDespawnData>> list = new List<KeyValuePair<Entity, EntityDespawnData>>();
@@ -638,7 +639,7 @@ index ea1d5c0..51c993b 100644
  				{
  					if (value is EntityPlayer entityPlayer)
  					{
-@@ -209,12 +681,17 @@ public class ServerSystemEntitySimulation : ServerSystem
+@@ -209,12 +682,17 @@ public class ServerSystemEntitySimulation : ServerSystem
  						ServerMain.Logger.Warning("Exception while ticking entity {0} ({1}) at {2}: ", value.GetName(), value.Properties?.Class, value.Pos);
  						ServerMain.Logger.Error(e);
  					}
@@ -656,7 +657,7 @@ index ea1d5c0..51c993b 100644
  		}
  		ServerMain.FrameProfiler.Enter("despawning");
  		foreach (KeyValuePair<Entity, EntityDespawnData> item in list)
-@@ -222,27 +699,857 @@ public class ServerSystemEntitySimulation : ServerSystem
+@@ -222,27 +700,857 @@ public class ServerSystemEntitySimulation : ServerSystem
  			server.DespawnEntity(item.Key, item.Value);
  			ServerMain.FrameProfiler.Mark("despawned-", item.Key.Code.Path);
  		}
@@ -1474,7 +1475,7 @@ index ea1d5c0..51c993b 100644
 +		}
 +		return false;
  	}
- 
+
  	private void HandleEntityInteraction(Packet_Client packet, ConnectedClient client)
  	{
  		ServerPlayer player = client.Player;
@@ -1518,7 +1519,68 @@ index ea1d5c0..51c993b 100644
  		ItemStack itemStack = client.Player.InventoryManager?.ActiveHotbarSlot?.Itemstack;
  		float num = itemStack?.Collectible.GetAttackRange(itemStack) ?? GlobalConstants.DefaultAttackRange;
  		double x = pos.X + client.Entityplayer.LocalEyePos.X;
-@@ -384,11 +1691,20 @@ public class ServerSystemEntitySimulation : ServerSystem
+@@ -257,10 +1565,16 @@ public class ServerSystemEntitySimulation : ServerSystem
+ 		if (server.Config.AntiAbuse >= EnumProtectionLevel.Basic && !player.IsInInteractionRangeOf(entity))
+ 		{
+ 			ServerMain.Logger.Audit("{0} tried to interact with an entity out of range.", player.PlayerName);
+ 			return;
+ 		}
++		// Stratum: reject invalid selection box indices before dispatching to mod behaviors.
++		if (p.MouseButton != 0 && !StratumHasValidSelectionBox(entity, p.SelectionBoxIndex))
++		{
++			ServerMain.Logger.Debug("HandleEntityInteraction from " + client.PlayerName + " rejected: invalid selection box " + p.SelectionBoxIndex + " for entity " + p.EntityId + "!");
++			return;
++		}
+ 		if (p.EntityId != player.CurrentEntitySelection?.Entity?.EntityId)
+ 		{
+ 			player.Entity.EntitySelection = new EntitySelection
+ 			{
+ 				Entity = entity,
+@@ -279,10 +1593,43 @@ public class ServerSystemEntitySimulation : ServerSystem
+ 		{
+ 			entity.OnInteract(player.Entity, player.InventoryManager.ActiveHotbarSlot, vec3d, (p.MouseButton != 0) ? EnumInteractMode.Interact : EnumInteractMode.Attack);
+ 		}
+ 	}
+
++	private static bool StratumHasValidSelectionBox(Entity entity, int selectionBoxIndex)
++	{
++		if (selectionBoxIndex == 0)
++		{
++			return true;
++		}
++
++		if (selectionBoxIndex < 0)
++		{
++			return false;
++		}
++
++		EntityBehavior selectionBehavior = entity.GetBehavior("selectionboxes");
++		if (selectionBehavior == null)
++		{
++			return true;
++		}
++
++		FieldInfo selectionBoxesField = selectionBehavior.GetType().GetField("selectionBoxes", BindingFlags.Instance | BindingFlags.Public);
++		if (selectionBoxesField == null)
++		{
++			return true;
++		}
++
++		if (selectionBoxesField.GetValue(selectionBehavior) is not Array selectionBoxes)
++		{
++			return false;
++		}
++
++		int selectionBoxIndexZeroBased = selectionBoxIndex - 1;
++		return (uint)selectionBoxIndexZeroBased < (uint)selectionBoxes.Length;
++	}
++
+ 	private void HandleSpecialKey(Packet_Client packet, ConnectedClient client)
+ 	{
+ 		int num = server.SaveGameData?.WorldConfiguration.GetString("playerlives", "-1").ToInt(-1) ?? (-1);
+ 		if (num < 0 || num > client.WorldData.Deaths)
+ 		{
+@@ -384,11 +1731,20 @@ public class ServerSystemEntitySimulation : ServerSystem
  	{
  		if (deathMessagesCache == null)
  		{
@@ -1540,7 +1602,7 @@ index ea1d5c0..51c993b 100644
  			return;
  		}
  		int num = server.SaveGameData?.WorldConfiguration.GetString("playerlives", "-1").ToInt(-1) ?? (-1);
-@@ -422,10 +1738,11 @@ public class ServerSystemEntitySimulation : ServerSystem
+@@ -422,10 +1778,11 @@ public class ServerSystemEntitySimulation : ServerSystem
  			else
  			{
  				ServerMain.Logger.Audit(Lang.Get("{0} died. Death message: {1}", item.PlayerName, text));
@@ -1548,7 +1610,7 @@ index ea1d5c0..51c993b 100644
  		}
 +		list.Clear();
  	}
- 
+
  	private string GetDeathMessage(ConnectedClient client, DamageSource src)
  	{
  		if (src == null)


### PR DESCRIPTION
## Summary

Issue #245 fails on boat seats when the server receives a selection-box index outside the resolved attachment-point array. Vanilla accepts one past the end after it converts the one-based network index to zero-based. Shipwright calls `EntityBehaviorSelectionBoxes.IsAPCode` from `EntityShipwrightBoat.OnInteract`, so the same stale index reaches vanilla and Shipwright boats.

This patch bounds selection-box access in `EntityBehaviorSelectionBoxes`, `EntityBehaviorAttachable`, and `EntityBehaviorSeatable`. The server interaction handler rejects invalid positive indices before it dispatches to entity behaviors. It accepts the body selection index and entities without the selection-box behavior to preserve existing custom entity behavior.

I traced Shipwright 1.4.1 from the downloaded archive and its decompiled `EntityShipwrightBoat.OnInteract` path. The fix covers the stack traces reported in #245 for vanilla sailboats and Shipwright boats.

Validation passed:

- The Linux bootstrap with ilspycmd 10.1.0.8386 applied every patch.
- The Release build completed with 0 errors and two existing NU1904 warnings for System.Drawing.Common.
- The smoke test reached WorldReady and shut down cleanly.
- The Atlas Shipwright scenario passed 1/1 in 543 ms.
- A native Stratum boot with Shipwright 1.4.1 loaded the mod, applied 37 JSON patches without errors, reached RunGame, and shut down cleanly.

## Type

- [x] Bug fix
- [ ] Performance
- [ ] New feature
- [ ] Refactor or cleanup
- [ ] Docs or build

## Checklist

- [x] `.\\scripts\\extract-patches.ps1` ran clean. The Linux equivalent, `scripts/extract-patches.sh`, ran without errors.
- [x] `dotnet build VintageStory.slnx -c Release` is green.
- [x] Every vanilla edit has a `// Stratum` marker.
- [x] No vanilla source committed.
- [x] Tested on a real server start, not just compilation.

## Related issues

Fixes #245
