### PR TITLE
Remove duplicate combat log instances

### DIFF
--- a/patches/VintagestoryLib/Vintagestory.Server/ServerSystemCommands.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/ServerSystemCommands.cs.patch
@@ -2,7 +2,7 @@ diff --git a/VintagestoryLib/Vintagestory.Server/ServerSystemCommands.cs b/Vinta
 index 1d4be19..e8394a8 100644
 --- a/VintagestoryLib/Vintagestory.Server/ServerSystemCommands.cs
 +++ b/VintagestoryLib/Vintagestory.Server/ServerSystemCommands.cs
-@@ -21,10 +21,21 @@ internal class ServerSystemCommands : ServerSystem
+@@ -21,10 +21,19 @@ internal class ServerSystemCommands : ServerSystem
  		new CmdEntity(server);
  		new CmdGive(server);
  		new CmdDebug(server);
@@ -13,8 +13,6 @@ index 1d4be19..e8394a8 100644
 +		new CmdStratumEssentials(server);
 +		new CmdStratumStaffCommands(server);
 +		new StratumLoginProtection(server);
-+		new StratumCombatLogSystem(server);
-+		new StratumCombatLogSystem(server);
 +		new StratumCombatLogSystem(server);
 +		new StratumCoopCombatSystem(server); // Stratum: cooperative PvE combat toggle
 +		new StratumNametags(server);


### PR DESCRIPTION
## Summary

`ServerSystemCommands.OnBeginConfiguration` created three `StratumCombatLogSystem` instances. Each instance subscribed to the combat events, so interactions, joins, and disconnects ran three handlers. This change keeps one instance.

## Type

- [x] Bug fix
- [ ] Performance
- [ ] New feature
- [ ] Refactor or cleanup
- [ ] Docs or build

## Checklist

- [ ] `./scripts/extract-patches.sh` ran clean. The Linux extractor exposed pre-existing decompiler drift in unrelated patches. Those generated changes stay out of this PR.
- [x] `dotnet build VintageStory.slnx -c Release` is green with 0 errors.
- [x] The patch adds no unmarked vanilla edit. It removes duplicate constructions from an existing Stratum patch.
- [x] The PR includes no vanilla source.
- [x] The native smoke test reached `RunGame` without a fatal error.

## Tests

- Fresh bootstrap with `ilspycmd` 10.1.0.8386.
- Embedded Release build: 0 errors.
- Generated source and embedded DLL: one combat log construction each.
- Focused Atlas regression: 1 passed, 0 failed, 0 skipped.
- Existing relevant Atlas suites: 14 passed, 0 failed, 0 skipped.
- Native smoke test: server reached `RunGame` without a fatal error.

## Related issues

Fixes #242
