### PR TITLE
Allow microblock hybrid breaks

### DIFF
--- a/sources/VintagestoryLib/Vintagestory.Server/StratumBlockBreakGuard.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumBlockBreakGuard.cs
@@ -56,6 +56,12 @@ internal sealed class StratumBlockBreakGuard
 			return;
 		}
 
+		if (block.EntityClass != null && IsMicroblockEntity(server.WorldMap.GetBlockEntity(selection.Position)))
+		{
+			ClearBreak(player.ClientId);
+			return;
+		}
+
 		StratumBlockBreakGuardsConfig config = StratumRuntime.Config.BlockBreakGuards;
 		ItemSlot activeSlot = player.inventoryMgr.ActiveHotbarSlot;
 		float resistance = Math.Max(0f, block.GetResistance(server.BlockAccessor, selection.Position));
@@ -108,6 +114,11 @@ internal sealed class StratumBlockBreakGuard
 		if (CheckMultiBreak(server, client, player, requestedSelection.Position, requestedSelection.HitPosition, now, out disconnectReason))
 		{
 			return false;
+		}
+
+		if (block.EntityClass != null && IsMicroblockEntity(server.WorldMap.GetBlockEntity(requestedSelection.Position)))
+		{
+			return true;
 		}
 
 		ItemSlot activeSlot = player.inventoryMgr.ActiveHotbarSlot;
@@ -353,13 +364,26 @@ internal sealed class StratumBlockBreakGuard
 		return pos == null ? "none" : pos.ToString();
 	}
 
+	private static bool IsMicroblockEntity(BlockEntity blockEntity)
+	{
+		for (Type type = blockEntity?.GetType(); type != null; type = type.BaseType)
+		{
+			if (type.FullName == "Vintagestory.GameContent.BlockEntityMicroBlock")
+			{
+				return true;
+			}
+		}
+
+		return false;
+	}
+
 	private sealed class ClientBreakState
 	{
 		private readonly Dictionary<BreakKey, RememberedBreak> rememberedBreaks = new Dictionary<BreakKey, RememberedBreak>();
 		private readonly List<RecentBreak> recentBreaks = new List<RecentBreak>();
 		private BlockPos position;
 		private int blockId;
-		private long lastViolationLogMs = long.MinValue;
+		private long lastViolationLogMs = -2000;
 
 		public long MultiBreakCooldownUntilMs { get; set; }
 


### PR DESCRIPTION
## Summary

`StratumBlockBreakGuard` now recognizes block entities that inherit from `BlockEntityMicroBlock` before wrapper-based progress pricing. VS Roofing hybrid roofs can follow the vanilla break path in survival. The violation log window starts at `-2000`, so the first report can log.

The multi-break check still runs before the microblock exemption. Ordinary blocks keep their progress checks.

## Type

- [x] Bug fix
- [ ] Performance
- [ ] New feature
- [ ] Refactor or cleanup
- [ ] Docs or build

## Checklist

- [x] `./scripts/extract-patches.ps1` ran clean.
- [x] `dotnet build VintageStory.slnx -c Release` is green.
- [x] Every vanilla edit has a `// Stratum` marker. This PR changes no vanilla file.
- [x] No vanilla source committed.
- [x] Tested on a real server start, not just compilation.

## Validation

- Bootstrap with `ilspycmd` 10.1.0.8386 applied every patch.
- Baseline `VintagestoryLib` build passed with 0 errors.
- Embedded solution build passed with 0 errors.
- Focused Atlas regression passed 4/4 with VS Roofing 1.7.1 loaded.
- Existing Atlas suites passed 17/17 in serial execution.
- The native smoke test reached `RunGame` without fatal errors.
- The runtime DLL contains the sentinel fix and both microblock checks.

## Related issues

Fixes #240
Fixes #250
