### PR TITLE
Stagger block entity listener startup

### DIFF
--- a/patches/VintagestoryLib/Vintagestory.Common/EventManager.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Common/EventManager.cs.patch
@@ -323,3 +323,45 @@ index 842d31f..2db0d99 100644
  	public virtual long AddGameTickListener(Action<float> handler, int millisecondInterval, int initialDelayOffsetMs = 0)
  	{
  		return AddGameTickListener(handler, null, millisecondInterval, initialDelayOffsetMs);
+@@ -303,6 +453,8 @@ public abstract class EventManager
+ 	public virtual long AddGameTickListener(Action<float> handler, BlockPos pos, Action<Exception> errorHandler, int millisecondInterval, int initialDelayOffsetMs = 0)
+ 	{
+ 		long newListenerId = ++listenerId;
++		// Stratum: stagger default block entity listeners by position.
+-		GameTickListenerBlock listener = new GameTickListenerBlock(newListenerId, millisecondInterval, InWorldEllapsedMs + initialDelayOffsetMs, pos.Copy(), handler, errorHandler);
++		int stratumInitialDelayOffsetMs = GetStratumBlockEntityInitialDelay(pos, millisecondInterval, initialDelayOffsetMs);
++		GameTickListenerBlock listener = new GameTickListenerBlock(newListenerId, millisecondInterval, InWorldEllapsedMs + stratumInitialDelayOffsetMs, pos.Copy(), handler, errorHandler);
+ 		return AddGameTickListenerBlockInternal(listener, newListenerId);
+ 	}
+@@ -310,6 +460,8 @@ public abstract class EventManager
+ 	public virtual long AddGameTickListener(Action<IWorldAccessor, BlockPos, float> handler, BlockPos pos, Action<Exception> errorHandler, int millisecondInterval, int initialDelayOffsetMs = 0)
+ 	{
+ 		long newListenerId = ++listenerId;
++		// Stratum: stagger default block entity listeners by position.
++		int stratumInitialDelayOffsetMs = GetStratumBlockEntityInitialDelay(pos, millisecondInterval, initialDelayOffsetMs);
+-		GameTickListenerBlock listener = new GameTickListenerBlock(newListenerId, millisecondInterval, InWorldEllapsedMs + initialDelayOffsetMs, pos.Copy(), handler, errorHandler);
++		GameTickListenerBlock listener = new GameTickListenerBlock(newListenerId, millisecondInterval, InWorldEllapsedMs + stratumInitialDelayOffsetMs, pos.Copy(), handler, errorHandler);
+ 		return AddGameTickListenerBlockInternal(listener, newListenerId);
+ 	}
+@@ -317,2 +467,21 @@ public abstract class EventManager
++	private static int GetStratumBlockEntityInitialDelay(BlockPos pos, int millisecondInterval, int initialDelayOffsetMs)
++	{
++		// Stratum: stagger default block entity listeners by position.
++		if (initialDelayOffsetMs != 0 || pos == null || StratumRuntime.Config?.Performance?.BlockEntityInit == null)
++		{
++			return initialDelayOffsetMs;
++		}
++
++		StratumBlockEntityInitConfig config = StratumRuntime.Config.Performance.BlockEntityInit;
++		if (!config.Enabled || config.MaxStaggerMs <= 0 || millisecondInterval <= 0)
++		{
++			return initialDelayOffsetMs;
++		}
++
++		int staggerWindowMs = Math.Min(config.MaxStaggerMs, millisecondInterval);
++		int positionHash = pos.GetHashCode() & int.MaxValue;
++		return positionHash % staggerWindowMs;
++	}
++
+ 	private long AddGameTickListenerBlockInternal(GameTickListenerBlock listener, long newListenerId)
+ 	{


### PR DESCRIPTION
## Summary

`StratumConfig` exposes `Performance.BlockEntityInit`, but `EventManager` ignored it when positional listeners used the default zero offset. This patch derives a stable offset from `BlockPos.GetHashCode()` and applies it to both positional listener overloads.

The change preserves explicit offsets, disabled configuration, null positions, and nonpositive intervals. The event API does not expose a block entity-only listener type, so positional listeners with the default offset share this behavior.

## Type

- [ ] Bug fix
- [x] Performance
- [ ] New feature
- [ ] Refactor or cleanup
- [ ] Docs or build

## Checklist

- [x] `bash scripts/extract-patches.sh` completed without patch errors.
- [x] `dotnet build VintageStory.slnx -c Release` passed with 0 errors.
- [x] Every vanilla edit has a `// Stratum` marker.
- [x] No vanilla source committed.
- [x] Tested on a real server start, not just compilation.

## Performance numbers

Local Atlas reproduction with 24 listeners:

- Before: 0 ms spread between first-update timestamps.
- After: at least 50 ms spread. The test uses a 250 ms configuration maximum and a 1000 ms listener interval.

The targeted Atlas scenarios pass 2/2. The full Atlas suite passes 21/21. The smoke test reaches `WorldReady` with no fatal errors.

## Related issues

Related to #223. This PR addresses the confirmed listener startup burst. It does not claim to solve the crash reports in the issue. The issue needs logs and a reproducible world to identify the remaining crash path.
