### PR TITLE
Add server-side player lives

### DIFF
--- a/patches/VintagestoryLib/Vintagestory.Server/ServerSystemEntitySimulation.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/ServerSystemEntitySimulation.cs.patch
@@ -1,5 +1,5 @@
 diff --git a/VintagestoryLib/Vintagestory.Server/ServerSystemEntitySimulation.cs b/VintagestoryLib/Vintagestory.Server/ServerSystemEntitySimulation.cs
-index ea1d5c0..627fe32 100644
+index ea1d5c0..42aa2eb 100644
 --- a/VintagestoryLib/Vintagestory.Server/ServerSystemEntitySimulation.cs
 +++ b/VintagestoryLib/Vintagestory.Server/ServerSystemEntitySimulation.cs
 @@ -1,8 +1,13 @@
@@ -1536,7 +1536,7 @@ index ea1d5c0..627fe32 100644
  			player.Entity.EntitySelection = new EntitySelection
  			{
  				Entity = entity,
-@@ -279,10 +1593,43 @@ public class ServerSystemEntitySimulation : ServerSystem
+@@ -279,14 +1593,46 @@ public class ServerSystemEntitySimulation : ServerSystem
  		{
  			entity.OnInteract(player.Entity, player.InventoryManager.ActiveHotbarSlot, vec3d, (p.MouseButton != 0) ? EnumInteractMode.Interact : EnumInteractMode.Attack);
  		}
@@ -1577,10 +1577,15 @@ index ea1d5c0..627fe32 100644
 +
  	private void HandleSpecialKey(Packet_Client packet, ConnectedClient client)
  	{
- 		int num = server.SaveGameData?.WorldConfiguration.GetString("playerlives", "-1").ToInt(-1) ?? (-1);
- 		if (num < 0 || num > client.WorldData.Deaths)
+-		int num = server.SaveGameData?.WorldConfiguration.GetString("playerlives", "-1").ToInt(-1) ?? (-1);
+-		if (num < 0 || num > client.WorldData.Deaths)
++		if (StratumLivesStore.CanRespawn(server, client)) // Stratum: apply bonus lives to respawn requests
  		{
-@@ -384,11 +1731,20 @@ public class ServerSystemEntitySimulation : ServerSystem
+ 			ServerMain.Logger.VerboseDebug("Received respawn request from {0}", client.PlayerName);
+ 			server.EventManager.TriggerPlayerRespawn(client.Player);
+ 		}
+ 		else
+@@ -384,16 +1730,24 @@ public class ServerSystemEntitySimulation : ServerSystem
  	{
  		if (deathMessagesCache == null)
  		{
@@ -1601,8 +1606,30 @@ index ea1d5c0..627fe32 100644
  		{
  			return;
  		}
- 		int num = server.SaveGameData?.WorldConfiguration.GetString("playerlives", "-1").ToInt(-1) ?? (-1);
-@@ -422,10 +1778,11 @@ public class ServerSystemEntitySimulation : ServerSystem
+-		int num = server.SaveGameData?.WorldConfiguration.GetString("playerlives", "-1").ToInt(-1) ?? (-1);
+ 		foreach (ConnectedClient item in list)
+ 		{
+ 			item.Entityplayer.DeadNotify = false;
+ 			item.WorldData.Deaths++;
+ 			server.EventManager.TriggerPlayerDeath(item.Player, item.Entityplayer.DeathReason);
+@@ -401,11 +1755,15 @@ public class ServerSystemEntitySimulation : ServerSystem
+ 			{
+ 				Id = 45,
+ 				PlayerDeath = new Packet_PlayerDeath
+ 				{
+ 					ClientId = item.Id,
+-					LivesLeft = ((num < 0) ? (-1) : Math.Max(0, num - item.WorldData.Deaths))
++					LivesLeft = StratumLivesStore.GetLivesLeft(server, item.ServerData, item.WorldData) // Stratum: include bonus lives in death packets
+ 				}
+ 			});
++			if (StratumLivesStore.ShouldAutoRespawn(server, item)) // Stratum: auto-respawn players with bonus lives
++			{
++				server.EventManager.TriggerPlayerRespawn(item.Player);
++			}
+ 			DamageSource deathReason = item.Entityplayer.DeathReason;
+ 			bool num2 = !server.api.World.Config.GetBool("disableDeathMessages");
+ 			string text = "";
+@@ -422,10 +1776,11 @@ public class ServerSystemEntitySimulation : ServerSystem
  			else
  			{
  				ServerMain.Logger.Audit(Lang.Get("{0} died. Death message: {1}", item.PlayerName, text));

--- a/sources/VintagestoryLib/Vintagestory.Server/CmdStratumStaffCommands.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/CmdStratumStaffCommands.cs
@@ -198,6 +198,18 @@ internal class CmdStratumStaffCommands
 				.HandleWith(HandleRevive);
 		}
 
+		if (StratumCommandRegistration.ShouldRegister(commands.Lives, "/lives", "Commands.Lives"))
+		{
+			server.api.commandapi.Create("lives")
+				.WithDescription("Manage player lives and show the lives leaderboard")
+				.WithArgs(
+					parsers.OptionalWordRange("action", "list", "leaderboard", "check", "give", "take", "set"),
+					parsers.OptionalWord("player or group:<id>"),
+					parsers.OptionalInt("amount", 1))
+				.RequiresPrivilege(Privilege.chat)
+				.HandleWith(HandleLives);
+		}
+
 		if (StratumCommandRegistration.ShouldRegister(commands.Jail, "/jail commands", "Commands.Jail"))
 		{
 			server.api.commandapi.Create("setjail")
@@ -980,6 +992,281 @@ internal class CmdStratumStaffCommands
 		Send(target.Player, StratumCommandText.Confirm("You have been revived by staff."), EnumChatType.Notification);
 		StratumRuntime.LogAudit("revive target=" + target.PlayerName + " actor=" + actorName, true);
 		return TextCommandResult.Success(StratumCommandText.Confirm("Revived", StratumCommandText.Escape(target.PlayerName) + " in place."));
+	}
+
+	private TextCommandResult HandleLives(TextCommandCallingArgs args)
+	{
+		if (!CheckAccess(args, StratumRuntime.Config.Commands.Lives, "lives", out TextCommandResult failure))
+		{
+			return failure;
+		}
+
+		string action = args[0] as string;
+		if (string.IsNullOrWhiteSpace(action) || string.Equals(action, "list", StringComparison.OrdinalIgnoreCase))
+		{
+			return FormatLivesList(leaderboard: false);
+		}
+
+		if (string.Equals(action, "leaderboard", StringComparison.OrdinalIgnoreCase))
+		{
+			return FormatLivesList(leaderboard: true);
+		}
+
+		string token = args[1] as string;
+		if (string.IsNullOrWhiteSpace(token))
+		{
+			return TextCommandResult.Error("Usage: /lives check <player> or /lives <give|take|set> <player|group:<id>> [amount]");
+		}
+
+		if (LooksLikeLivesTeam(token))
+		{
+			return TextCommandResult.Error("Team targets are not supported. Use a player or group:<id>.");
+		}
+
+		if (string.Equals(action, "check", StringComparison.OrdinalIgnoreCase))
+		{
+			return RunLivesTargets(token, DescribeLives);
+		}
+
+		if (!string.Equals(action, "give", StringComparison.OrdinalIgnoreCase) &&
+			!string.Equals(action, "take", StringComparison.OrdinalIgnoreCase) &&
+			!string.Equals(action, "set", StringComparison.OrdinalIgnoreCase))
+		{
+			return TextCommandResult.Error("Usage: /lives [list|leaderboard|check|give|take|set] <player|group:<id>> [amount]");
+		}
+
+		int amount = (int)args[2];
+		if (amount < 0 || (amount == 0 && !string.Equals(action, "set", StringComparison.OrdinalIgnoreCase)))
+		{
+			return TextCommandResult.Error("Amount must be positive. Use zero only with /lives set.");
+		}
+
+		string actorName = args.Caller.GetName();
+		System.Func<ServerPlayerData, ConnectedClient, TextCommandResult> apply = (targetData, onlineTarget) => AdjustLives(targetData, onlineTarget, action, amount, actorName);
+		if (LooksLikeLivesGroup(token))
+		{
+			return RunForLivesGroupTargets(token, apply);
+		}
+
+		return RunForKnownTargets(token, apply);
+	}
+
+	private TextCommandResult RunLivesTargets(string token, System.Func<ServerPlayerData, ConnectedClient, TextCommandResult> perTarget)
+	{
+		if (LooksLikeLivesGroup(token))
+		{
+			return RunForLivesGroupTargets(token, perTarget);
+		}
+
+		return RunForKnownTargets(token, perTarget);
+	}
+
+	private TextCommandResult RunForLivesGroupTargets(string token, System.Func<ServerPlayerData, ConnectedClient, TextCommandResult> perTarget)
+	{
+		if (!TryResolveLivesGroup(token, out PlayerGroup group))
+		{
+			return TextCommandResult.Error("No player group found for '" + token + "'. Use group:<id> or group:<name>.");
+		}
+
+		List<(ServerPlayerData data, ConnectedClient client)> targets = new List<(ServerPlayerData, ConnectedClient)>();
+		foreach (ServerPlayerData playerData in server.PlayerDataManager.PlayerDataByUid.Values)
+		{
+			if (playerData?.PlayerGroupMemberShips == null || !playerData.PlayerGroupMemberShips.TryGetValue(group.Uid, out PlayerGroupMembership membership) || membership.Level == EnumPlayerGroupMemberShip.None)
+			{
+				continue;
+			}
+
+			targets.Add((playerData, FindOnlineClientByUid(playerData.PlayerUID)));
+		}
+
+		if (targets.Count == 0)
+		{
+			return TextCommandResult.Error("Player group '" + group.Name + "' has no known members.");
+		}
+
+		if (targets.Count == 1)
+		{
+			return perTarget(targets[0].data, targets[0].client);
+		}
+
+		int success = 0;
+		List<string> failures = new List<string>();
+		foreach ((ServerPlayerData data, ConnectedClient client) target in targets)
+		{
+			TextCommandResult result;
+			try
+			{
+				result = perTarget(target.data, target.client);
+			}
+			catch (Exception exception)
+			{
+				failures.Add(target.data.LastKnownPlayername + " (" + exception.GetType().Name + ")");
+				continue;
+			}
+
+			if (result != null && result.Status == EnumCommandStatus.Success)
+			{
+				success++;
+			}
+			else
+			{
+				failures.Add(target.data.LastKnownPlayername);
+			}
+		}
+
+		string message = StratumCommandText.Confirm("Applied", success + "/" + targets.Count + " players in " + group.Name);
+		if (failures.Count > 0)
+		{
+			message += " " + StratumCommandText.Warning("skipped: " + string.Join(", ", failures));
+		}
+		return TextCommandResult.Success(message);
+	}
+
+	private TextCommandResult AdjustLives(ServerPlayerData targetData, ConnectedClient onlineTarget, string action, int amount, string actorName)
+	{
+		int bonusLives;
+		if (string.Equals(action, "set", StringComparison.OrdinalIgnoreCase))
+		{
+			bonusLives = StratumLivesStore.SetBonus(server, targetData, amount);
+		}
+		else
+		{
+			int delta = string.Equals(action, "take", StringComparison.OrdinalIgnoreCase) ? -amount : amount;
+			bonusLives = StratumLivesStore.AddBonus(server, targetData, delta);
+		}
+
+		int livesLeft = StratumLivesStore.GetLivesLeft(server, targetData, StratumLivesStore.GetWorldData(server, targetData));
+		string targetName = targetData.LastKnownPlayername ?? targetData.PlayerUID;
+		bool revived = false;
+		if ((string.Equals(action, "give", StringComparison.OrdinalIgnoreCase) || string.Equals(action, "set", StringComparison.OrdinalIgnoreCase)) &&
+			livesLeft > 0 && onlineTarget?.Player?.Entity is EntityPlayer targetEntity && !targetEntity.Alive)
+		{
+			targetEntity.Revive();
+			revived = true;
+			Send(onlineTarget.Player, StratumCommandText.Confirm("You have been revived.", "A life was granted."), EnumChatType.Notification);
+		}
+
+		StratumRuntime.LogAudit("lives action=" + action + " target=" + targetName + " amount=" + amount + " actor=" + actorName, true);
+		StringBuilder result = new StringBuilder(StratumCommandText.Confirm("Lives updated", targetName));
+		result.Append(StratumCommandText.Row("Bonus", bonusLives.ToString(GlobalConstants.DefaultCultureInfo)));
+		result.Append(StratumCommandText.Row("Remaining", FormatLivesLeft(livesLeft)));
+		if (revived)
+		{
+			result.Append(StratumCommandText.Row("Status", "revived"));
+		}
+		return TextCommandResult.Success(result.ToString());
+	}
+
+	private TextCommandResult DescribeLives(ServerPlayerData targetData, ConnectedClient onlineTarget)
+	{
+		ServerWorldPlayerData worldData = StratumLivesStore.GetWorldData(server, targetData);
+		int deaths = Math.Max(0, worldData?.Deaths ?? 0);
+		int bonusLives = StratumLivesStore.GetBonus(targetData);
+		int livesLeft = StratumLivesStore.GetLivesLeft(server, targetData, worldData);
+		string targetName = targetData.LastKnownPlayername ?? targetData.PlayerUID;
+		StringBuilder result = new StringBuilder(StratumCommandText.Title("Lives: " + targetName));
+		result.Append(StratumCommandText.Row("Deaths", deaths.ToString(GlobalConstants.DefaultCultureInfo)));
+		result.Append(StratumCommandText.Row("Bonus", bonusLives.ToString(GlobalConstants.DefaultCultureInfo)));
+		result.Append(StratumCommandText.Row("Remaining", FormatLivesLeft(livesLeft)));
+		return TextCommandResult.Success(result.ToString());
+	}
+
+	private TextCommandResult FormatLivesList(bool leaderboard)
+	{
+		List<(ServerPlayerData data, int remaining)> rows = new List<(ServerPlayerData, int)>();
+		foreach (ServerPlayerData playerData in server.PlayerDataManager.PlayerDataByUid.Values)
+		{
+			if (playerData == null)
+			{
+				continue;
+			}
+
+			int remaining = StratumLivesStore.GetLivesLeft(server, playerData, StratumLivesStore.GetWorldData(server, playerData));
+			if (leaderboard)
+			{
+				ConnectedClient onlineTarget = FindOnlineClientByUid(playerData.PlayerUID);
+				if (remaining == 0 || onlineTarget?.Player?.Entity == null || !onlineTarget.Player.Entity.Alive)
+				{
+					continue;
+				}
+			}
+
+			rows.Add((playerData, remaining));
+		}
+
+		rows.Sort((left, right) =>
+		{
+			if (left.remaining < 0) return right.remaining < 0 ? ComparePlayerNames(left.data, right.data) : -1;
+			if (right.remaining < 0) return 1;
+			int remainingComparison = right.remaining.CompareTo(left.remaining);
+			return remainingComparison != 0 ? remainingComparison : ComparePlayerNames(left.data, right.data);
+		});
+
+		if (rows.Count == 0)
+		{
+			return TextCommandResult.Success(StratumCommandText.Empty(leaderboard ? "No living players have lives remaining." : "No player lives recorded."));
+		}
+
+		StringBuilder result = new StringBuilder(StratumCommandText.Title(leaderboard ? "Lives Leaderboard" : "Player Lives"));
+		for (int index = 0; index < rows.Count; index++)
+		{
+			(string name, int remaining) row = (rows[index].data.LastKnownPlayername ?? rows[index].data.PlayerUID, rows[index].remaining);
+			result.Append(StratumCommandText.Bullet((index + 1).ToString(GlobalConstants.DefaultCultureInfo) + ". " + row.name, FormatLivesLeft(row.remaining)));
+		}
+
+		return TextCommandResult.Success(result.ToString());
+	}
+
+	private static int ComparePlayerNames(ServerPlayerData left, ServerPlayerData right)
+	{
+		return string.Compare(left.LastKnownPlayername, right.LastKnownPlayername, StringComparison.OrdinalIgnoreCase);
+	}
+
+	private static string FormatLivesLeft(int livesLeft)
+	{
+		return livesLeft < 0 ? "unlimited" : livesLeft.ToString(GlobalConstants.DefaultCultureInfo);
+	}
+
+	private bool LooksLikeLivesGroup(string token)
+	{
+		return token.StartsWith("group:", StringComparison.OrdinalIgnoreCase);
+	}
+
+	private bool LooksLikeLivesTeam(string token)
+	{
+		return token.StartsWith("team:", StringComparison.OrdinalIgnoreCase);
+	}
+
+	private bool TryResolveLivesGroup(string token, out PlayerGroup group)
+	{
+		group = null;
+		if (!LooksLikeLivesGroup(token) || server.PlayerDataManager.PlayerGroupsById == null)
+		{
+			return false;
+		}
+
+		int separator = token.IndexOf(':');
+		string identifier = token.Substring(separator + 1).Trim();
+		if (identifier.Length == 0)
+		{
+			return false;
+		}
+
+		if (int.TryParse(identifier, out int groupId))
+		{
+			return server.PlayerDataManager.PlayerGroupsById.TryGetValue(groupId, out group);
+		}
+
+		foreach (PlayerGroup candidate in server.PlayerDataManager.PlayerGroupsById.Values)
+		{
+			if (string.Equals(candidate.Name, identifier, StringComparison.OrdinalIgnoreCase))
+			{
+				group = candidate;
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	private TextCommandResult HandleSetJail(TextCommandCallingArgs args)

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumCommandAccessCatalog.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumCommandAccessCatalog.cs
@@ -52,6 +52,7 @@ internal static class StratumCommandAccessCatalog
 		yield return new StratumCommandAccessEntry("vanish", "/vanish", commands.Vanish, "Use /vanish and /vanish hideothers");
 		yield return new StratumCommandAccessEntry("pvp", "/pvp", commands.Pvp, "Use /pvp");
 		yield return new StratumCommandAccessEntry("freeze", "/freeze", commands.Freeze, "Use /freeze");
+		yield return new StratumCommandAccessEntry("lives", "/lives", commands.Lives, "Use /lives");
 		yield return new StratumCommandAccessEntry("jail", "/jail", commands.Jail, "Use /setjail, /jail, /unjail, and /jailstatus");
 		yield return new StratumCommandAccessEntry("warn", "/warn", commands.Warn, "Use /warn, /warnings, and /delwarn");
 		yield return new StratumCommandAccessEntry("mute", "/mute", commands.Mute, "Use /mute, /unmute, and /mutestatus");

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumConfig.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumConfig.cs
@@ -1591,6 +1591,8 @@ internal class StratumCommandsConfig
 
 	public StratumCommandAccessConfig Revive { get; set; } = StratumCommandAccessConfig.ForPrivilege("stratum.revive");
 
+	public StratumCommandAccessConfig Lives { get; set; } = StratumCommandAccessConfig.ForPrivilege("stratum.lives");
+
 	public StratumCommandAccessConfig Jail { get; set; } = StratumCommandAccessConfig.ForPrivilege("stratum.jail");
 
 	public StratumCommandAccessConfig Warn { get; set; } = StratumCommandAccessConfig.ForPrivilege("stratum.warn");
@@ -1639,6 +1641,7 @@ internal class StratumCommandsConfig
 		Pvp ??= StratumCommandAccessConfig.ForPrivilege("stratum.pvp");
 		Freeze ??= StratumCommandAccessConfig.ForPrivilege("stratum.freeze");
 		Revive ??= StratumCommandAccessConfig.ForPrivilege("stratum.revive");
+		Lives ??= StratumCommandAccessConfig.ForPrivilege("stratum.lives");
 		Jail ??= StratumCommandAccessConfig.ForPrivilege("stratum.jail");
 		Warn ??= StratumCommandAccessConfig.ForPrivilege("stratum.warn");
 		Mute ??= StratumCommandAccessConfig.ForPrivilege("stratum.mute");
@@ -1668,6 +1671,7 @@ internal class StratumCommandsConfig
 		Pvp.EnsurePopulated("stratum.pvp");
 		Freeze.EnsurePopulated("stratum.freeze");
 		Revive.EnsurePopulated("stratum.revive");
+		Lives.EnsurePopulated("stratum.lives");
 		Jail.EnsurePopulated("stratum.jail");
 		Warn.EnsurePopulated("stratum.warn");
 		Mute.EnsurePopulated("stratum.mute");

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumLivesStore.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumLivesStore.cs
@@ -1,0 +1,124 @@
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using Vintagestory.API.Util;
+
+namespace Vintagestory.Server;
+
+internal static class StratumLivesStore
+{
+	private const string BonusLivesKey = "stratum.player-lives.v1";
+
+	public static int GetBonus(ServerPlayerData playerData)
+	{
+		if (playerData?.CustomPlayerData == null || !playerData.CustomPlayerData.TryGetValue(BonusLivesKey, out string json) || string.IsNullOrWhiteSpace(json))
+		{
+			return 0;
+		}
+
+		try
+		{
+			return Math.Max(0, JsonConvert.DeserializeObject<int>(json));
+		}
+		catch (Exception exception)
+		{
+			StratumRuntime.LogWarning("failed to read bonus lives for " + playerData.LastKnownPlayername + ": " + exception.Message);
+			return 0;
+		}
+	}
+
+	public static int SetBonus(ServerMain server, ServerPlayerData playerData, int bonusLives)
+	{
+		if (playerData == null)
+		{
+			return 0;
+		}
+
+		int normalized = Math.Max(0, bonusLives);
+		playerData.CustomPlayerData ??= new Dictionary<string, string>();
+		if (normalized == 0)
+		{
+			if (playerData.CustomPlayerData.Remove(BonusLivesKey))
+			{
+				server.PlayerDataManager.playerDataDirty = true;
+			}
+			return 0;
+		}
+
+		string json = JsonConvert.SerializeObject(normalized);
+		if (!playerData.CustomPlayerData.TryGetValue(BonusLivesKey, out string existing) || existing != json)
+		{
+			playerData.CustomPlayerData[BonusLivesKey] = json;
+			server.PlayerDataManager.playerDataDirty = true;
+		}
+		return normalized;
+	}
+
+	public static int AddBonus(ServerMain server, ServerPlayerData playerData, int amount)
+	{
+		long total = (long)GetBonus(playerData) + amount;
+		if (total <= 0)
+		{
+			return SetBonus(server, playerData, 0);
+		}
+
+		return SetBonus(server, playerData, total > int.MaxValue ? int.MaxValue : (int)total);
+	}
+
+	public static int GetBaseLives(ServerMain server)
+	{
+		string configured = server.SaveGameData?.WorldConfiguration.GetString("playerlives", "-1");
+		int lives = configured?.ToInt(-1) ?? -1;
+		return lives < 0 ? -1 : lives;
+	}
+
+	public static ServerWorldPlayerData GetWorldData(ServerMain server, ServerPlayerData playerData)
+	{
+		if (server?.PlayerDataManager?.WorldDataByUID == null || playerData == null)
+		{
+			return null;
+		}
+
+		server.PlayerDataManager.WorldDataByUID.TryGetValue(playerData.PlayerUID, out ServerWorldPlayerData worldData);
+		return worldData;
+	}
+
+	public static int GetLivesLeft(ServerMain server, ServerPlayerData playerData, ServerWorldPlayerData worldData)
+	{
+		int baseLives = GetBaseLives(server);
+		if (baseLives < 0)
+		{
+			return -1;
+		}
+
+		long deaths = Math.Max(0, worldData?.Deaths ?? 0);
+		long remaining = (long)baseLives + GetBonus(playerData) - deaths;
+		if (remaining <= 0)
+		{
+			return 0;
+		}
+
+		return remaining > int.MaxValue ? int.MaxValue : (int)remaining;
+	}
+
+	public static bool CanRespawn(ServerMain server, ConnectedClient client)
+	{
+		if (client?.ServerData == null || client.WorldData == null)
+		{
+			return false;
+		}
+
+		return GetLivesLeft(server, client.ServerData, client.WorldData) != 0;
+	}
+
+	public static bool ShouldAutoRespawn(ServerMain server, ConnectedClient client)
+	{
+		if (client?.ServerData == null || client.WorldData == null || GetBonus(client.ServerData) == 0)
+		{
+			return false;
+		}
+
+		int baseLives = GetBaseLives(server);
+		return baseLives >= 0 && client.WorldData.Deaths >= baseLives && GetLivesLeft(server, client.ServerData, client.WorldData) > 0;
+	}
+}


### PR DESCRIPTION
## Summary

Add `/lives` for staff to list and manage bonus lives for known players and existing player groups. Store bonuses in `ServerPlayerData.CustomPlayerData`, include them in respawn checks and death packets, and auto-respawn a dead player when a granted life remains.

The change runs on the server and uses the stock client. The stock death dialog still calculates its count from world config, so `/lives check`, `/lives list`, and `/lives leaderboard` report the Stratum value. Vintage Story has no team model in this codebase, so `team:` targets return an error. Player and `group:` targets work.

## Type

- [ ] Bug fix
- [ ] Performance
- [x] New feature
- [ ] Refactor or cleanup
- [ ] Docs or build

## Checklist

- [x] `.\scripts\extract-patches.ps1` ran clean in `pwsh`; generated normalization changes stayed out of the commit.
- [x] `dotnet build VintageStory.slnx -c Release` is green.
- [x] Every vanilla edit has a `// Stratum` marker.
- [x] No vanilla source committed.
- [x] Tested on a real server start, not just compilation.

## Related issues

Fixes #220
