### PR TITLE
Add runtime role editing

### DIFF
--- a/patches/VintagestoryLib/Vintagestory.Server/CmdPlayer.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/CmdPlayer.cs.patch
@@ -1,8 +1,46 @@
 diff --git a/VintagestoryLib/Vintagestory.Server/CmdPlayer.cs b/VintagestoryLib/Vintagestory.Server/CmdPlayer.cs
-index 8af710f..48cc033 100644
+index 8af710f..88910a9 100644
 --- a/VintagestoryLib/Vintagestory.Server/CmdPlayer.cs
 +++ b/VintagestoryLib/Vintagestory.Server/CmdPlayer.cs
-@@ -821,10 +821,17 @@ public class CmdPlayer : ServerSystem
+@@ -334,12 +334,18 @@ public class CmdPlayer : ServerSystem
+ 	private TextCommandResult OnRevokeCmd(TextCommandCallingArgs args)
+ 	{
+ 		IPlayerRole playerRole = (IPlayerRole)args.Parsers[0].GetValue();
+ 		string text = (string)args.Parsers[1].GetValue();
++		// Stratum: enforce role hierarchy before editing live privileges.
++		if (!StratumRoleRuntime.TryValidatePrivilegeEdit(server, args.Caller, playerRole, text, granting: false, out string stratumRoleError))
++		{
++			return TextCommandResult.Error(stratumRoleError);
++		}
+ 		if (!playerRole.Privileges.Contains(text))
+ 		{
+ 			return TextCommandResult.Error(Lang.Get("Role does not have this privilege"));
+ 		}
+ 		playerRole.RevokePrivilege(text);
++		StratumRoleRuntime.PersistRoleChanges(server, playerRole);
+ 		server.ConfigNeedsSaving = true;
+ 		return TextCommandResult.Success(Lang.Get("Ok, privilege '{0}' now revoked", text));
+ 	}
+@@ -347,12 +347,18 @@ public class CmdPlayer : ServerSystem
+ 	private TextCommandResult OnGrantCmd(TextCommandCallingArgs args)
+ 	{
+ 		IPlayerRole playerRole = (IPlayerRole)args.Parsers[0].GetValue();
+ 		string text = (string)args.Parsers[1].GetValue();
++		// Stratum: enforce role hierarchy before editing live privileges.
++		if (!StratumRoleRuntime.TryValidatePrivilegeEdit(server, args.Caller, playerRole, text, granting: true, out string stratumRoleError))
++		{
++			return TextCommandResult.Error(stratumRoleError);
++		}
+ 		if (playerRole.Privileges.Contains(text))
+ 		{
+ 			return TextCommandResult.Error(Lang.Get("Role already has this privilege"));
+ 		}
+ 		playerRole.GrantPrivilege(text);
++		StratumRoleRuntime.PersistRoleChanges(server, playerRole);
+ 		server.ConfigNeedsSaving = true;
+ 		return TextCommandResult.Success(Lang.Get("Ok, privilege '{0}' now granted", text));
+ 	}
+@@ -821,8 +821,15 @@ public class CmdPlayer : ServerSystem
  		{
  			server.SendOwnPlayerData(clientByPlayername.Player, sendInventory: false, sendPrivileges: true);
  			string message = ((playerRole.PrivilegeLevel > playerRole2.PrivilegeLevel) ? Lang.Get("You've been promoted to role {0}", playerRole.Name) : Lang.Get("You've been demoted to role {0}", playerRole.Name));
@@ -18,5 +56,3 @@ index 8af710f..48cc033 100644
  		}
  		return TextCommandResult.Success(Lang.Get("Ok, role {0} assigned to {1}", playerRole.Name, targetPlayer.Name));
  	}
- 
- 	private TextCommandResult removeDenyPrivilege(PlayerUidName targetPlayer, TextCommandCallingArgs args)

--- a/patches/VintagestoryLib/Vintagestory.Server/ServerSystemCommands.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/ServerSystemCommands.cs.patch
@@ -1,8 +1,8 @@
 diff --git a/VintagestoryLib/Vintagestory.Server/ServerSystemCommands.cs b/VintagestoryLib/Vintagestory.Server/ServerSystemCommands.cs
-index 1d4be19..e8394a8 100644
+index 1d4be19..d013ca6 100644
 --- a/VintagestoryLib/Vintagestory.Server/ServerSystemCommands.cs
 +++ b/VintagestoryLib/Vintagestory.Server/ServerSystemCommands.cs
-@@ -21,10 +21,19 @@ internal class ServerSystemCommands : ServerSystem
+@@ -21,10 +21,20 @@ internal class ServerSystemCommands : ServerSystem
  		new CmdEntity(server);
  		new CmdGive(server);
  		new CmdDebug(server);
@@ -12,6 +12,7 @@ index 1d4be19..e8394a8 100644
 +		new CmdStratumUtility(server);
 +		new CmdStratumEssentials(server);
 +		new CmdStratumStaffCommands(server);
++		new CmdStratumRoles(server); // Stratum: runtime role editing
 +		new StratumLoginProtection(server);
 +		new StratumCombatLogSystem(server);
 +		new StratumCoopCombatSystem(server); // Stratum: cooperative PvE combat toggle

--- a/patches/VintagestoryLib/Vintagestory.Server/ServerSystemLoadConfig.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/ServerSystemLoadConfig.cs.patch
@@ -1,5 +1,5 @@
 diff --git a/VintagestoryLib/Vintagestory.Server/ServerSystemLoadConfig.cs b/VintagestoryLib/Vintagestory.Server/ServerSystemLoadConfig.cs
-index 425b841..d054939 100644
+index 425b841..20aa12e 100644
 --- a/VintagestoryLib/Vintagestory.Server/ServerSystemLoadConfig.cs
 +++ b/VintagestoryLib/Vintagestory.Server/ServerSystemLoadConfig.cs
 @@ -8,10 +8,13 @@ using Vintagestory.Common;
@@ -106,7 +106,7 @@ index 425b841..d054939 100644
 +		}
 +	}
 +
-+	private static void SaveRolesConfig(ServerMain server)
++	internal static void SaveRolesConfig(ServerMain server)
 +	{
 +		ServerRolesConfig rolesConfig = new ServerRolesConfig
 +		{

--- a/sources/VintagestoryLib/Vintagestory.Server/CmdStratumRoles.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/CmdStratumRoles.cs
@@ -1,0 +1,248 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Vintagestory.API.Common;
+using Vintagestory.API.Common.CommandAbbr;
+using Vintagestory.API.Config;
+using Vintagestory.API.Server;
+using Vintagestory.Common;
+
+namespace Vintagestory.Server;
+
+internal class CmdStratumRoles
+{
+	private readonly ServerMain server;
+
+	public CmdStratumRoles(ServerMain server)
+	{
+		this.server = server;
+		StratumRuntime.Config.EnsurePopulated();
+		if (!StratumRuntime.Config.Commands.Enabled)
+		{
+			return;
+		}
+
+		StratumCommandAccessConfig access = StratumRuntime.Config.Commands.RoleEditing;
+		if (!StratumCommandRegistration.ShouldRegister(access, "/roles", "Commands.RoleEditing"))
+		{
+			return;
+		}
+
+		CommandArgumentParsers parsers = server.api.commandapi.Parsers;
+		server.api.commandapi.Create("roles")
+			.WithDescription("Edit server roles while the server is running")
+			.WithArgs(
+				parsers.OptionalWordRange("action", "list", "info", "grant", "revoke", "applyall"),
+				parsers.OptionalWord("role"),
+				parsers.OptionalWord("privilege or confirm"))
+			.RequiresPrivilege(Privilege.controlserver)
+			.HandleWith(HandleRoles);
+	}
+
+	private TextCommandResult HandleRoles(TextCommandCallingArgs args)
+	{
+		if (!CheckAccess(args, out TextCommandResult failure))
+		{
+			return failure;
+		}
+
+		string action = args.Parsers[0].IsMissing ? "list" : args[0] as string;
+		if (string.Equals(action, "list", StringComparison.OrdinalIgnoreCase))
+		{
+			return ListRoles();
+		}
+
+		string roleCode = args.Parsers[1].IsMissing ? null : args[1] as string;
+		if (string.Equals(action, "info", StringComparison.OrdinalIgnoreCase))
+		{
+			return DescribeRole(roleCode);
+		}
+
+		if (string.Equals(action, "grant", StringComparison.OrdinalIgnoreCase)
+			|| string.Equals(action, "revoke", StringComparison.OrdinalIgnoreCase))
+		{
+			string privilege = args.Parsers[2].IsMissing ? null : args[2] as string;
+			return ChangePrivilege(roleCode, privilege, string.Equals(action, "grant", StringComparison.OrdinalIgnoreCase), args.Caller);
+		}
+
+		if (string.Equals(action, "applyall", StringComparison.OrdinalIgnoreCase))
+		{
+			bool confirmed = !args.Parsers[2].IsMissing
+				&& string.Equals(args[2] as string, "confirm", StringComparison.OrdinalIgnoreCase);
+			return ApplyRoleToPlayers(roleCode, confirmed, args.Caller);
+		}
+
+		return TextCommandResult.Error("Usage: /roles [list|info <role>|grant <role> <privilege>|revoke <role> <privilege>|applyall <role> confirm]");
+	}
+
+	private TextCommandResult ListRoles()
+	{
+		StringBuilder output = new StringBuilder(StratumCommandText.Title("Server roles"));
+		output.Append(StratumCommandText.Row("Default", server.Config.DefaultRoleCode));
+
+		foreach (PlayerRole role in server.Config.Roles.OrderByDescending(value => value.PrivilegeLevel).ThenBy(value => value.Code, StringComparer.OrdinalIgnoreCase))
+		{
+			string privileges = role.Privileges == null || role.Privileges.Count == 0
+				? "none"
+				: string.Join(", ", role.Privileges.OrderBy(value => value, StringComparer.OrdinalIgnoreCase));
+			output.Append(StratumCommandText.Bullet(role.Code, role.Name + " level=" + role.PrivilegeLevel + " privileges=" + privileges));
+		}
+
+		return TextCommandResult.Success(output.ToString());
+	}
+
+	private TextCommandResult DescribeRole(string roleCode)
+	{
+		PlayerRole role = StratumRoleRuntime.FindRole(server, roleCode);
+		if (role == null)
+		{
+			return TextCommandResult.Error("No role found for '" + roleCode + "'.");
+		}
+
+		string privileges = role.Privileges == null || role.Privileges.Count == 0
+			? "none"
+			: string.Join(", ", role.Privileges.OrderBy(value => value, StringComparer.OrdinalIgnoreCase));
+		StringBuilder output = new StringBuilder(StratumCommandText.Title("Role: " + role.Code));
+		output.Append(StratumCommandText.Row("Name", role.Name));
+		output.Append(StratumCommandText.Row("Privilege level", role.PrivilegeLevel.ToString()));
+		output.Append(StratumCommandText.Row("Privileges", privileges));
+		output.Append(StratumCommandText.Row("Staff role", StratumRoleRuntime.IsStaffRole(role) ? "yes" : "no"));
+		return TextCommandResult.Success(output.ToString());
+	}
+
+	private TextCommandResult ChangePrivilege(string roleCode, string privilege, bool granting, Caller caller)
+	{
+		PlayerRole role = StratumRoleRuntime.FindRole(server, roleCode);
+		if (role == null)
+		{
+			return TextCommandResult.Error("No role found for '" + roleCode + "'.");
+		}
+
+		string existingPrivilege = FindPrivilege(role, privilege);
+		if (granting && existingPrivilege != null)
+		{
+			return TextCommandResult.Error("Role already has privilege '" + existingPrivilege + "'.");
+		}
+
+		if (!granting && existingPrivilege == null)
+		{
+			return TextCommandResult.Error("Role does not have privilege '" + privilege + "'.");
+		}
+
+		string requestedPrivilege = granting ? privilege : existingPrivilege;
+		if (!StratumRoleRuntime.TryValidatePrivilegeEdit(server, caller, role, requestedPrivilege, granting, out string error))
+		{
+			return TextCommandResult.Error(error);
+		}
+
+		if (granting)
+		{
+			role.GrantPrivilege(requestedPrivilege);
+		}
+		else
+		{
+			role.RevokePrivilege(requestedPrivilege);
+		}
+
+		StratumRoleRuntime.PersistRoleChanges(server, role);
+		string action = granting ? "granted" : "revoked";
+		StratumRuntime.LogAudit("roles " + action + " privilege=" + requestedPrivilege + " role=" + role.Code + " actor=" + caller.GetName(), true);
+		return TextCommandResult.Success(StratumCommandText.Confirm("Privilege " + requestedPrivilege + " " + action, "role=" + role.Code));
+	}
+
+	private TextCommandResult ApplyRoleToPlayers(string roleCode, bool confirmed, Caller caller)
+	{
+		PlayerRole role = StratumRoleRuntime.FindRole(server, roleCode);
+		if (!StratumRoleRuntime.TryValidateApplyAll(server, caller, role, out string error))
+		{
+			return TextCommandResult.Error(error);
+		}
+
+		List<ServerPlayerData> targets = new List<ServerPlayerData>();
+		int staffCount = 0;
+		int unchangedCount = 0;
+		foreach (ServerPlayerData playerData in server.PlayerDataManager.PlayerDataByUid.Values)
+		{
+			if (playerData == null)
+			{
+				continue;
+			}
+
+			PlayerRole currentRole = StratumRoleRuntime.FindRole(server, playerData.RoleCode);
+			if (StratumRoleRuntime.IsStaffRole(currentRole))
+			{
+				staffCount++;
+				continue;
+			}
+
+			if (string.Equals(playerData.RoleCode, role.Code, StringComparison.OrdinalIgnoreCase))
+			{
+				unchangedCount++;
+				continue;
+			}
+
+			targets.Add(playerData);
+		}
+
+		if (!confirmed)
+		{
+			return TextCommandResult.Success(StratumCommandText.Warning("No changes made. This would assign " + role.Code + " to " + targets.Count + " players and skip " + staffCount + " staff players. Run /roles applyall " + role.Code + " confirm to continue."));
+		}
+
+		int changedCount = 0;
+		foreach (ServerPlayerData playerData in targets)
+		{
+			playerData.SetRole(role);
+			changedCount++;
+			ConnectedClient client = server.GetClientByUID(playerData.PlayerUID);
+			if (client?.Player != null && client.State.IsAdmitted())
+			{
+				StratumRoleRuntime.RefreshPlayer(server, client.Player);
+			}
+		}
+
+		if (changedCount > 0)
+		{
+			server.PlayerDataManager.playerDataDirty = true;
+		}
+
+		StratumRuntime.LogAudit("roles applyall role=" + role.Code + " changed=" + changedCount + " skippedStaff=" + staffCount + " unchanged=" + unchangedCount + " actor=" + caller.GetName(), true);
+		return TextCommandResult.Success(StratumCommandText.Confirm("Role applied", changedCount + " players changed; " + staffCount + " staff skipped."));
+	}
+
+	private bool CheckAccess(TextCommandCallingArgs args, out TextCommandResult failure)
+	{
+		failure = null;
+		StratumCommandAccessConfig access = StratumRuntime.Config.Commands.RoleEditing;
+		if (access == null || !access.Enabled)
+		{
+			failure = TextCommandResult.Error("/roles is disabled.");
+			return false;
+		}
+
+		if (!StratumCommandAccessCatalog.CallerHasAccess(args.Caller, server, access))
+		{
+			failure = TextCommandResult.Error("You do not have permission to use /roles.");
+			return false;
+		}
+
+		if (!StratumCommandCooldowns.TryUse(args.Caller, server, "roles", access, out TimeSpan remaining))
+		{
+			failure = TextCommandResult.Error("Wait " + Math.Ceiling(remaining.TotalSeconds) + "s before using /roles again.");
+			return false;
+		}
+
+		return true;
+	}
+
+	private static string FindPrivilege(PlayerRole role, string privilege)
+	{
+		if (role?.Privileges == null || string.IsNullOrWhiteSpace(privilege))
+		{
+			return null;
+		}
+
+		return role.Privileges.FirstOrDefault(value => string.Equals(value, privilege, StringComparison.OrdinalIgnoreCase));
+	}
+}

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumCommandAccessCatalog.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumCommandAccessCatalog.cs
@@ -53,6 +53,7 @@ internal static class StratumCommandAccessCatalog
 		yield return new StratumCommandAccessEntry("pvp", "/pvp", commands.Pvp, "Use /pvp");
 		yield return new StratumCommandAccessEntry("freeze", "/freeze", commands.Freeze, "Use /freeze");
 		yield return new StratumCommandAccessEntry("lives", "/lives", commands.Lives, "Use /lives");
+		yield return new StratumCommandAccessEntry("roles", "/roles", commands.RoleEditing, "Edit server roles at runtime");
 		yield return new StratumCommandAccessEntry("jail", "/jail", commands.Jail, "Use /setjail, /jail, /unjail, and /jailstatus");
 		yield return new StratumCommandAccessEntry("warn", "/warn", commands.Warn, "Use /warn, /warnings, and /delwarn");
 		yield return new StratumCommandAccessEntry("mute", "/mute", commands.Mute, "Use /mute, /unmute, and /mutestatus");

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumConfig.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumConfig.cs
@@ -1593,6 +1593,8 @@ internal class StratumCommandsConfig
 
 	public StratumCommandAccessConfig Lives { get; set; } = StratumCommandAccessConfig.ForPrivilege("stratum.lives");
 
+	public StratumCommandAccessConfig RoleEditing { get; set; } = StratumCommandAccessConfig.ForPrivilege("controlserver");
+
 	public StratumCommandAccessConfig Jail { get; set; } = StratumCommandAccessConfig.ForPrivilege("stratum.jail");
 
 	public StratumCommandAccessConfig Warn { get; set; } = StratumCommandAccessConfig.ForPrivilege("stratum.warn");
@@ -1642,6 +1644,7 @@ internal class StratumCommandsConfig
 		Freeze ??= StratumCommandAccessConfig.ForPrivilege("stratum.freeze");
 		Revive ??= StratumCommandAccessConfig.ForPrivilege("stratum.revive");
 		Lives ??= StratumCommandAccessConfig.ForPrivilege("stratum.lives");
+		RoleEditing ??= StratumCommandAccessConfig.ForPrivilege("controlserver");
 		Jail ??= StratumCommandAccessConfig.ForPrivilege("stratum.jail");
 		Warn ??= StratumCommandAccessConfig.ForPrivilege("stratum.warn");
 		Mute ??= StratumCommandAccessConfig.ForPrivilege("stratum.mute");
@@ -1672,6 +1675,7 @@ internal class StratumCommandsConfig
 		Freeze.EnsurePopulated("stratum.freeze");
 		Revive.EnsurePopulated("stratum.revive");
 		Lives.EnsurePopulated("stratum.lives");
+		RoleEditing.EnsurePopulated("controlserver");
 		Jail.EnsurePopulated("stratum.jail");
 		Warn.EnsurePopulated("stratum.warn");
 		Mute.EnsurePopulated("stratum.mute");

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumRoleRuntime.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumRoleRuntime.cs
@@ -1,0 +1,164 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Vintagestory.API.Common;
+using Vintagestory.API.Config;
+using Vintagestory.API.Server;
+using Vintagestory.Common;
+
+namespace Vintagestory.Server;
+
+internal static class StratumRoleRuntime
+{
+	public static PlayerRole FindRole(ServerMain server, string roleCode)
+	{
+		if (server?.Config?.RolesByCode == null || string.IsNullOrWhiteSpace(roleCode))
+		{
+			return null;
+		}
+
+		foreach (KeyValuePair<string, PlayerRole> entry in server.Config.RolesByCode)
+		{
+			if (string.Equals(entry.Key, roleCode, StringComparison.OrdinalIgnoreCase))
+			{
+				return entry.Value;
+			}
+		}
+
+		return null;
+	}
+
+	public static bool TryValidatePrivilegeEdit(ServerMain server, Caller caller, IPlayerRole targetRole, string privilege, bool granting, out string error)
+	{
+		error = null;
+		if (targetRole == null || string.IsNullOrWhiteSpace(targetRole.Code))
+		{
+			error = "The target role does not exist.";
+			return false;
+		}
+
+		if (string.IsNullOrWhiteSpace(privilege))
+		{
+			error = "A privilege is required.";
+			return false;
+		}
+
+		if (IsRootCaller(server, caller))
+		{
+			return true;
+		}
+
+		PlayerRole callerRole = FindCallerRole(server, caller);
+		if (callerRole == null || targetRole.PrivilegeLevel >= callerRole.PrivilegeLevel)
+		{
+			error = "You can only edit roles below your own level.";
+			return false;
+		}
+
+		if (granting && !caller.HasPrivilege(privilege))
+		{
+			error = "You cannot grant a privilege you do not hold.";
+			return false;
+		}
+
+		return true;
+	}
+
+	public static bool TryValidateApplyAll(ServerMain server, Caller caller, PlayerRole targetRole, out string error)
+	{
+		error = null;
+		if (targetRole == null)
+		{
+			error = "The target role does not exist.";
+			return false;
+		}
+
+		if (IsStaffRole(targetRole))
+		{
+			error = "applyall cannot assign a staff role. Use /player <player> role for individual staff changes.";
+			return false;
+		}
+
+		if (IsRootCaller(server, caller))
+		{
+			return true;
+		}
+
+		PlayerRole callerRole = FindCallerRole(server, caller);
+		if (callerRole == null || targetRole.PrivilegeLevel >= callerRole.PrivilegeLevel)
+		{
+			error = "You can only assign roles below your own level.";
+			return false;
+		}
+
+		return true;
+	}
+
+	public static bool IsStaffRole(IPlayerRole role)
+	{
+		if (role == null)
+		{
+			return false;
+		}
+
+		return string.Equals(role.Code, "sumod", StringComparison.OrdinalIgnoreCase)
+			|| string.Equals(role.Code, "crmod", StringComparison.OrdinalIgnoreCase)
+			|| string.Equals(role.Code, "admin", StringComparison.OrdinalIgnoreCase)
+			|| role.Privileges?.Contains(Privilege.controlserver) == true
+			|| role.Privileges?.Contains(Privilege.grantrevoke) == true;
+	}
+
+	public static void PersistRoleChanges(ServerMain server, IPlayerRole changedRole)
+	{
+		server.Config.SetRoles(server.Config.Roles, server.Config.DefaultRoleCode);
+		server.ConfigNeedsSaving = true;
+		ServerSystemLoadConfig.SaveRolesConfig(server);
+
+		foreach (ConnectedClient client in server.Clients.Values)
+		{
+			if (client?.Player == null || !client.State.IsAdmitted())
+			{
+				continue;
+			}
+
+			if (changedRole != null && !string.Equals(client.ServerData?.RoleCode, changedRole.Code, StringComparison.OrdinalIgnoreCase))
+			{
+				continue;
+			}
+
+			RefreshPlayer(server, client.Player);
+		}
+	}
+
+	public static void RefreshPlayer(ServerMain server, IServerPlayer player)
+	{
+		server.SendOwnPlayerData(player, sendInventory: false, sendPrivileges: true);
+		server.SendRoles(player);
+		if (StratumNametags.RefreshFor(player))
+		{
+			server.BroadcastPlayerData(player, sendInventory: false, sendPrivileges: false);
+		}
+	}
+
+	private static bool IsRootCaller(ServerMain server, Caller caller)
+	{
+		return caller?.Type == EnumCallerType.Console || caller?.HasPrivilege(Privilege.root) == true;
+	}
+
+	private static PlayerRole FindCallerRole(ServerMain server, Caller caller)
+	{
+		if (caller == null)
+		{
+			return null;
+		}
+
+		string roleCode = caller.CallerRole;
+		if (caller.Player != null)
+		{
+			ServerPlayerData playerData = server.PlayerDataManager.GetServerPlayerData(caller.Player.PlayerUID);
+			roleCode = playerData?.RoleCode ?? roleCode;
+		}
+
+		return FindRole(server, roleCode);
+	}
+}


### PR DESCRIPTION
## Summary

Adds `/roles` for live role inspection, privilege changes, and bulk assignment. The command persists updates to `serverroles.json`, refreshes connected players, and records each change in the server log. Vanilla `/role ... privilege ...` commands now use the same hierarchy guard.

`applyall <role> confirm` skips staff roles. Callers can edit only roles below their own level and can grant only privileges they hold.

## Type

- [ ] Bug fix
- [ ] Performance
- [x] New feature
- [ ] Refactor or cleanup
- [ ] Docs or build

## Checklist

- [x] `pwsh -NoProfile -File scripts/extract-patches.ps1` ran clean.
- [x] `dotnet build VintageStory.slnx -c Release` is green.
- [x] Every vanilla edit has a `// Stratum` marker.
- [x] No vanilla source committed.
- [x] Tested on a real server start, not just compilation.

## Validation

- `bash scripts/bootstrap.sh --refresh` applied all patches.
- Release build passed with zero errors.
- Embedded release build passed with zero errors.
- Server smoke test reached `WorldReady` without fatal errors.
- Atlas focused role scenario passed: 1 test.
- Atlas validation suite passed: 10 tests.

## Related issues

Fixes #214
