### PR TITLE
Add server-side mob spawning controls

### DIFF
--- a/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/93.GenCreatures.cs.patch
+++ b/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/93.GenCreatures.cs.patch
@@ -1,19 +1,19 @@
 diff --git a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/93.GenCreatures.cs b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/93.GenCreatures.cs
-index 647310c..0eb2ea3 100644
+index 647310c..540409d 100644
 --- a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/93.GenCreatures.cs
 +++ b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/93.GenCreatures.cs
 @@ -48,6 +48,9 @@ namespace Vintagestory.ServerMods
          protected int shrubsBotRight;
          protected List<SpawnOppurtunity> spawnPositions = new List<SpawnOppurtunity>();
- 
+
 +        // Stratum: each worldgen thread gets a complete generator so protected fields stay mod-visible.
 +        StratumWorkerInstances<GenCreatures> stratumWorkers;
 +
- 
+
          public override bool ShouldLoad(EnumAppSide side) => side == EnumAppSide.Server;
          public override double ExecuteOrder() => 0.1;
 @@ -58,8 +61,9 @@ namespace Vintagestory.ServerMods
- 
+
              if (TerraGenConfig.DoDecorationPass)
              {
 +                stratumWorkers = new StratumWorkerInstances<GenCreatures>(StratumCreateWorker); // Stratum: isolate per-column state without changing vanilla fields
@@ -26,7 +26,7 @@ index 647310c..0eb2ea3 100644
 @@ -141,6 +145,33 @@ namespace Vintagestory.ServerMods
              loadAnimalMaps();
          }
- 
+
 +        private void StratumOnChunkColumnGen(IChunkColumnGenerateRequest request)
 +        {
 +            stratumWorkers.Current.OnChunkColumnGen(request);
@@ -67,3 +67,14 @@ index 647310c..0eb2ea3 100644
              wgenBlockAccessor.BeginColumn();
              IntDataMap2D climateMap = chunks[0].MapChunk.MapRegion.ClimateMap;
              ushort[] heightMap = chunks[0].MapChunk.WorldGenTerrainHeightMap;
+@@ -220,7 +254,10 @@ namespace Vintagestory.ServerMods
+                 if (tries == 0f) continue;
+
+                 var scRuntime = entitytype.Server.SpawnConditions.Runtime;   // the Group ("hostile"/"neutral"/"passive") is only held in the Runtime spawn conditions
++                float stratumSpawnMultiplier = StratumMobSpawningHook.GetNaturalSpawnMultiplier(scRuntime?.Group); // Stratum: issue #216 natural worldgen control
++                if (stratumSpawnMultiplier <= 0f) continue;
+                 if (scRuntime == null || scRuntime.Group != "hostile") tries *= gcfg.neutralCreatureSpawnMultiplier;
++                tries *= stratumSpawnMultiplier; // Stratum: issue #216 lower natural worldgen volume
+
+                 while (tries-- > rnd.NextDouble())
+                 {

--- a/patches/VintagestoryLib/Vintagestory.Server/ServerSystemCommands.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/ServerSystemCommands.cs.patch
@@ -1,8 +1,8 @@
 diff --git a/VintagestoryLib/Vintagestory.Server/ServerSystemCommands.cs b/VintagestoryLib/Vintagestory.Server/ServerSystemCommands.cs
-index 1d4be19..d013ca6 100644
+index 1d4be19..7938c76 100644
 --- a/VintagestoryLib/Vintagestory.Server/ServerSystemCommands.cs
 +++ b/VintagestoryLib/Vintagestory.Server/ServerSystemCommands.cs
-@@ -21,10 +21,20 @@ internal class ServerSystemCommands : ServerSystem
+@@ -21,10 +21,21 @@ internal class ServerSystemCommands : ServerSystem
  		new CmdEntity(server);
  		new CmdGive(server);
  		new CmdDebug(server);
@@ -13,6 +13,7 @@ index 1d4be19..d013ca6 100644
 +		new CmdStratumEssentials(server);
 +		new CmdStratumStaffCommands(server);
 +		new CmdStratumRoles(server); // Stratum: runtime role editing
++		new StratumMobSpawningSystem(server); // Stratum: issue #216 natural mob spawning controls
 +		new StratumLoginProtection(server);
 +		new StratumCombatLogSystem(server);
 +		new StratumCoopCombatSystem(server); // Stratum: cooperative PvE combat toggle
@@ -23,7 +24,7 @@ index 1d4be19..d013ca6 100644
  		new CmdModDBUtil(server);
  		if (!server.IsDedicatedServer)
  		{
-@@ -33,6 +43,10 @@ internal class ServerSystemCommands : ServerSystem
+@@ -33,6 +44,10 @@ internal class ServerSystemCommands : ServerSystem
  		new CmdSetBlock(server);
  		new CmdExecuteAs(server);
  		new CmdActivate(server);

--- a/patches/VintagestoryLib/Vintagestory.Server/ServerSystemEntitySpawner.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/ServerSystemEntitySpawner.cs.patch
@@ -1,5 +1,5 @@
 diff --git a/VintagestoryLib/Vintagestory.Server/ServerSystemEntitySpawner.cs b/VintagestoryLib/Vintagestory.Server/ServerSystemEntitySpawner.cs
-index 52a073b..3c68d39 100644
+index 52a073b..87610a6 100644
 --- a/VintagestoryLib/Vintagestory.Server/ServerSystemEntitySpawner.cs
 +++ b/VintagestoryLib/Vintagestory.Server/ServerSystemEntitySpawner.cs
 @@ -65,10 +65,19 @@ public class ServerSystemEntitySpawner : ServerSystem
@@ -64,7 +64,7 @@ index 52a073b..3c68d39 100644
  			if (!(value5.Code == null))
  			{
  				string text = value5.Attributes.GetString("originaltype");
-@@ -658,11 +670,12 @@ public class ServerSystemEntitySpawner : ServerSystem
+@@ -658,34 +670,39 @@ public class ServerSystemEntitySpawner : ServerSystem
  					dictionary.TryGetValue(quantityByGroup.Code, out value);
  					dictionary[quantityByGroup.Code] = value + 1;
  				}
@@ -78,7 +78,22 @@ index 52a073b..3c68d39 100644
  		foreach (EntityProperties entityType in server.EntityTypes)
  		{
  			RuntimeSpawnConditions runtimeSpawnConditions = entityType.Server.SpawnConditions?.Runtime;
-@@ -681,11 +694,14 @@ public class ServerSystemEntitySpawner : ServerSystem
+-			if (runtimeSpawnConditions == null || runtimeSpawnConditions.MaxQuantity == 0 || (num > 0.0 && runtimeSpawnConditions.Group == "hostile") || random.NextDouble() >= 1.0 * runtimeSpawnConditions.Chance)
++			float stratumSpawnMultiplier = runtimeSpawnConditions == null ? 0f : Vintagestory.API.Server.StratumMobSpawningHook.GetNaturalSpawnMultiplier(runtimeSpawnConditions.Group); // Stratum: issue #216 group control
++			if (runtimeSpawnConditions == null || stratumSpawnMultiplier <= 0f || runtimeSpawnConditions.MaxQuantity == 0 || (num > 0.0 && runtimeSpawnConditions.Group == "hostile") || random.NextDouble() >= 1.0 * runtimeSpawnConditions.Chance)
+ 			{
+ 				continue;
+ 			}
+ 			dictionary.TryGetValue(entityType.Code, out var value2);
+ 			float num3 = 1f + Math.Max(0f, (float)(num2 - 1) * server.Config.SpawnCapPlayerScaling * runtimeSpawnConditions.SpawnCapPlayerScaling);
+-			int num4 = (int)((float)runtimeSpawnConditions.MaxQuantity * num3 - (float)value2);
++			int num4 = (int)((float)runtimeSpawnConditions.MaxQuantity * num3 * stratumSpawnMultiplier - (float)value2); // Stratum: issue #216 lower natural spawn caps
+ 			if (runtimeSpawnConditions.MaxQuantityByGroup != null)
+ 			{
+ 				dictionary.TryGetValue(runtimeSpawnConditions.MaxQuantityByGroup.Code, out var value3);
+-				num4 = Math.Min(num4, (int)((float)runtimeSpawnConditions.MaxQuantityByGroup.MaxQuantity * num3) - value3);
++				num4 = Math.Min(num4, (int)((float)runtimeSpawnConditions.MaxQuantityByGroup.MaxQuantity * num3 * stratumSpawnMultiplier) - value3); // Stratum: issue #216 lower grouped caps
+ 			}
  			if (num4 <= 0)
  			{
  				continue;

--- a/sources/VintagestoryApi/Server/StratumMobSpawningHook.cs
+++ b/sources/VintagestoryApi/Server/StratumMobSpawningHook.cs
@@ -1,0 +1,39 @@
+namespace Vintagestory.API.Server;
+
+// Server-side bridge for Stratum's natural mob spawning controls. The server assembly owns the
+// persisted configuration. Worldgen code reads this bridge because it lives in VSEssentials, which
+// references the API assembly but not VintagestoryLib.
+public static class StratumMobSpawningHook
+{
+	public static volatile bool Enabled = true;
+	public static volatile bool HostileEnabled = true;
+	public static volatile bool NeutralEnabled = true;
+	public static volatile bool PassiveEnabled = true;
+	public static volatile float NaturalSpawnMultiplier = 1f;
+
+	public static float GetNaturalSpawnMultiplier(string group)
+	{
+		if (!Enabled || NaturalSpawnMultiplier <= 0f)
+		{
+			return 0f;
+		}
+
+		if (string.Equals(group, "hostile", System.StringComparison.OrdinalIgnoreCase))
+		{
+			return HostileEnabled ? NaturalSpawnMultiplier : 0f;
+		}
+
+		if (string.Equals(group, "neutral", System.StringComparison.OrdinalIgnoreCase))
+		{
+			return NeutralEnabled ? NaturalSpawnMultiplier : 0f;
+		}
+
+		if (string.Equals(group, "passive", System.StringComparison.OrdinalIgnoreCase))
+		{
+			return PassiveEnabled ? NaturalSpawnMultiplier : 0f;
+		}
+
+		// Keep custom entities with no vanilla group compatible with existing servers.
+		return NaturalSpawnMultiplier;
+	}
+}

--- a/sources/VintagestoryLib/Vintagestory.Server/CmdStratum.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/CmdStratum.cs
@@ -213,6 +213,7 @@ internal class CmdStratum
 		{
 			CmdStratumEssentials.RegisterConfiguredPrivileges(server);
 			StratumCoopCombatSystem.Apply(StratumRuntime.Config.CoopCombat);
+			StratumMobSpawning.Refresh(); // Stratum: issue #216 resync after config reload
 			// Stratum: clear region ticking fallback state on reload (#10)
 			var sim = server.Systems.OfType<ServerSystemEntitySimulation>().FirstOrDefault();
 			sim?.StratumClearFallbackState();
@@ -810,6 +811,7 @@ internal class CmdStratum
 		try
 		{
 			StratumRuntime.Config.EnsurePopulated();
+			StratumMobSpawning.Refresh(); // Stratum: issue #216 apply live config changes
 			StratumRuntime.SaveConfig();
 		}
 		catch (Exception ex)

--- a/sources/VintagestoryLib/Vintagestory.Server/CmdStratumStaffCommands.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/CmdStratumStaffCommands.cs
@@ -210,6 +210,15 @@ internal class CmdStratumStaffCommands
 				.HandleWith(HandleLives);
 		}
 
+		if (StratumCommandRegistration.ShouldRegister(commands.MobSpawning, "/mobs", "Commands.MobSpawning"))
+		{
+			server.api.commandapi.Create("mobs")
+				.WithDescription("Control natural mob spawning and wipe loaded creatures")
+				.WithArgs(parsers.OptionalWordRange("action", "status", "set", "scale", "wipe"), parsers.OptionalWord("category or multiplier"), parsers.OptionalWord("state or confirm"))
+				.RequiresPrivilege(Privilege.controlserver)
+				.HandleWith(HandleMobSpawning);
+		}
+
 		if (StratumCommandRegistration.ShouldRegister(commands.Jail, "/jail commands", "Commands.Jail"))
 		{
 			server.api.commandapi.Create("setjail")
@@ -749,6 +758,125 @@ internal class CmdStratumStaffCommands
 		}
 
 		return !current;
+	}
+
+	private TextCommandResult HandleMobSpawning(TextCommandCallingArgs args)
+	{
+		if (!CheckAccess(args, StratumRuntime.Config.Commands.MobSpawning, "mobs", out TextCommandResult failure))
+		{
+			return failure;
+		}
+
+		StratumMobSpawningConfig config = StratumRuntime.Config.MobSpawning;
+		string action = args.Parsers[0].IsMissing ? "status" : args[0] as string;
+		string category = args.Parsers[1].IsMissing ? null : args[1] as string;
+		string value = args.Parsers[2].IsMissing ? null : args[2] as string;
+
+		if (string.Equals(action, "status", StringComparison.OrdinalIgnoreCase))
+		{
+			return TextCommandResult.Success(DescribeMobSpawning(config));
+		}
+
+		if (string.Equals(action, "set", StringComparison.OrdinalIgnoreCase))
+		{
+			if (!StratumMobSpawning.IsKnownCategory(category) || (!string.Equals(value, "on", StringComparison.OrdinalIgnoreCase) && !string.Equals(value, "off", StringComparison.OrdinalIgnoreCase)))
+			{
+				return TextCommandResult.Error("Usage: /mobs set <hostile|neutral|passive|all> <on|off>");
+			}
+
+			bool enabled = string.Equals(value, "on", StringComparison.OrdinalIgnoreCase);
+			if (string.Equals(category, "all", StringComparison.OrdinalIgnoreCase))
+			{
+				config.Enabled = enabled;
+				config.HostileEnabled = enabled;
+				config.NeutralEnabled = enabled;
+				config.PassiveEnabled = enabled;
+			}
+			else
+			{
+				config.Enabled = true;
+				SetMobCategory(config, category, enabled);
+			}
+
+			return SaveMobSpawningConfig(config, "set " + category + "=" + (enabled ? "on" : "off"), args.Caller.GetName());
+		}
+
+		if (string.Equals(action, "scale", StringComparison.OrdinalIgnoreCase))
+		{
+			if (!float.TryParse(category, NumberStyles.Float, CultureInfo.InvariantCulture, out float multiplier) || multiplier < 0f || multiplier > 1f)
+			{
+				return TextCommandResult.Error("Usage: /mobs scale <0..1>");
+			}
+
+			config.NaturalSpawnMultiplier = multiplier;
+			return SaveMobSpawningConfig(config, "scale=" + multiplier.ToString(CultureInfo.InvariantCulture), args.Caller.GetName());
+		}
+
+		if (string.Equals(action, "wipe", StringComparison.OrdinalIgnoreCase))
+		{
+			if (!StratumMobSpawning.IsKnownCategory(category))
+			{
+				return TextCommandResult.Error("Usage: /mobs wipe <hostile|neutral|passive|all> confirm");
+			}
+
+			if (!string.Equals(value, "confirm", StringComparison.OrdinalIgnoreCase))
+			{
+				return TextCommandResult.Error("This removes loaded creatures. Repeat the command with the final argument 'confirm'.");
+			}
+
+			int wiped = 0;
+			EntityDespawnData despawnData = new EntityDespawnData { Reason = EnumDespawnReason.Unload };
+			foreach (Entity entity in server.LoadedEntities.Values.ToArray())
+			{
+				if (!StratumMobSpawning.IsCategory(entity, category) || entity.ShouldDespawn)
+				{
+					continue;
+				}
+
+				server.DespawnEntity(entity, despawnData);
+				wiped++;
+			}
+
+			StratumRuntime.LogAudit("mobs wipe=" + category + " count=" + wiped + " actor=" + args.Caller.GetName(), true);
+			return TextCommandResult.Success(StratumCommandText.Confirm("Removed " + wiped + " loaded " + category + " creature" + (wiped == 1 ? "" : "s") + "."));
+		}
+
+		return TextCommandResult.Error("Usage: /mobs status, /mobs set <category> <on|off>, /mobs scale <0..1>, or /mobs wipe <category> confirm");
+	}
+
+	private static string DescribeMobSpawning(StratumMobSpawningConfig config)
+	{
+		StringBuilder result = new StringBuilder(StratumCommandText.Title("Natural Mob Spawning"));
+		result.Append(StratumCommandText.Row("Enabled", config.Enabled ? "on" : "off"));
+		result.Append(StratumCommandText.Row("Hostile", config.HostileEnabled ? "on" : "off"));
+		result.Append(StratumCommandText.Row("Neutral", config.NeutralEnabled ? "on" : "off"));
+		result.Append(StratumCommandText.Row("Passive", config.PassiveEnabled ? "on" : "off"));
+		result.Append(StratumCommandText.Row("Natural scale", config.NaturalSpawnMultiplier.ToString("0.##", CultureInfo.InvariantCulture)));
+		return result.ToString();
+	}
+
+	private static void SetMobCategory(StratumMobSpawningConfig config, string category, bool enabled)
+	{
+		if (string.Equals(category, "hostile", StringComparison.OrdinalIgnoreCase)) config.HostileEnabled = enabled;
+		if (string.Equals(category, "neutral", StringComparison.OrdinalIgnoreCase)) config.NeutralEnabled = enabled;
+		if (string.Equals(category, "passive", StringComparison.OrdinalIgnoreCase)) config.PassiveEnabled = enabled;
+	}
+
+	private static TextCommandResult SaveMobSpawningConfig(StratumMobSpawningConfig config, string action, string actor)
+	{
+		config.EnsureSane();
+		StratumMobSpawning.Refresh();
+		try
+		{
+			StratumRuntime.SaveConfig();
+		}
+		catch (Exception exception)
+		{
+			return TextCommandResult.Error(StratumCommandText.Warning("Applied in memory but failed to write config") + ": " + exception.Message);
+		}
+
+		StratumRuntime.LogAudit("mobs " + action + " actor=" + actor, true);
+		return TextCommandResult.Success(DescribeMobSpawning(config));
 	}
 
 	private static string DescribeChatChannel(StratumChatChannelConfig channel)

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumCommandAccessCatalog.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumCommandAccessCatalog.cs
@@ -54,6 +54,7 @@ internal static class StratumCommandAccessCatalog
 		yield return new StratumCommandAccessEntry("freeze", "/freeze", commands.Freeze, "Use /freeze");
 		yield return new StratumCommandAccessEntry("lives", "/lives", commands.Lives, "Use /lives");
 		yield return new StratumCommandAccessEntry("roles", "/roles", commands.RoleEditing, "Edit server roles at runtime");
+		yield return new StratumCommandAccessEntry("mobs", "/mobs", commands.MobSpawning, "Manage natural mob spawning and loaded creature wipes");
 		yield return new StratumCommandAccessEntry("jail", "/jail", commands.Jail, "Use /setjail, /jail, /unjail, and /jailstatus");
 		yield return new StratumCommandAccessEntry("warn", "/warn", commands.Warn, "Use /warn, /warnings, and /delwarn");
 		yield return new StratumCommandAccessEntry("mute", "/mute", commands.Mute, "Use /mute, /unmute, and /mutestatus");

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumConfig.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumConfig.cs
@@ -30,6 +30,8 @@ internal class StratumConfig
 
 	public StratumWorldgenConfig Worldgen { get; set; } = new StratumWorldgenConfig();
 
+	public StratumMobSpawningConfig MobSpawning { get; set; } = new StratumMobSpawningConfig();
+
 	public StratumCommandsConfig Commands { get; set; } = new StratumCommandsConfig();
 
 	public StratumChatConfig Chat { get; set; } = new StratumChatConfig();
@@ -68,6 +70,7 @@ internal class StratumConfig
 		ClientModPolicy ??= new StratumClientModPolicyConfig();
 		Performance ??= new StratumPerformanceConfig();
 		Worldgen ??= new StratumWorldgenConfig();
+		MobSpawning ??= new StratumMobSpawningConfig();
 		Commands ??= new StratumCommandsConfig();
 		Chat ??= new StratumChatConfig();
 		Appearance ??= new StratumAppearanceConfig();
@@ -87,6 +90,7 @@ internal class StratumConfig
 		Anticheat.EnsureSane();
 		ClientModPolicy.EnsurePopulated();
 		Performance.EnsurePopulated();
+		MobSpawning.EnsureSane();
 		Commands.EnsurePopulated();
 		Chat.EnsurePopulated();
 		Appearance.EnsurePopulated();
@@ -132,6 +136,24 @@ internal class StratumConfig
 			}
 			return prop;
 		}
+	}
+}
+
+internal class StratumMobSpawningConfig
+{
+	public bool Enabled { get; set; } = true;
+
+	public bool HostileEnabled { get; set; } = true;
+
+	public bool NeutralEnabled { get; set; } = true;
+
+	public bool PassiveEnabled { get; set; } = true;
+
+	public float NaturalSpawnMultiplier { get; set; } = 1f;
+
+	public void EnsureSane()
+	{
+		NaturalSpawnMultiplier = Math.Clamp(NaturalSpawnMultiplier, 0f, 1f);
 	}
 }
 
@@ -1595,6 +1617,8 @@ internal class StratumCommandsConfig
 
 	public StratumCommandAccessConfig RoleEditing { get; set; } = StratumCommandAccessConfig.ForPrivilege("controlserver");
 
+	public StratumCommandAccessConfig MobSpawning { get; set; } = StratumCommandAccessConfig.ForPrivilege("controlserver");
+
 	public StratumCommandAccessConfig Jail { get; set; } = StratumCommandAccessConfig.ForPrivilege("stratum.jail");
 
 	public StratumCommandAccessConfig Warn { get; set; } = StratumCommandAccessConfig.ForPrivilege("stratum.warn");
@@ -1645,6 +1669,7 @@ internal class StratumCommandsConfig
 		Revive ??= StratumCommandAccessConfig.ForPrivilege("stratum.revive");
 		Lives ??= StratumCommandAccessConfig.ForPrivilege("stratum.lives");
 		RoleEditing ??= StratumCommandAccessConfig.ForPrivilege("controlserver");
+		MobSpawning ??= StratumCommandAccessConfig.ForPrivilege("controlserver");
 		Jail ??= StratumCommandAccessConfig.ForPrivilege("stratum.jail");
 		Warn ??= StratumCommandAccessConfig.ForPrivilege("stratum.warn");
 		Mute ??= StratumCommandAccessConfig.ForPrivilege("stratum.mute");
@@ -1676,6 +1701,7 @@ internal class StratumCommandsConfig
 		Revive.EnsurePopulated("stratum.revive");
 		Lives.EnsurePopulated("stratum.lives");
 		RoleEditing.EnsurePopulated("controlserver");
+		MobSpawning.EnsurePopulated("controlserver");
 		Jail.EnsurePopulated("stratum.jail");
 		Warn.EnsurePopulated("stratum.warn");
 		Mute.EnsurePopulated("stratum.mute");

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumMobSpawning.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumMobSpawning.cs
@@ -1,0 +1,52 @@
+using System;
+using Vintagestory.API.Common;
+using Vintagestory.API.Common.Entities;
+using Vintagestory.API.Server;
+
+namespace Vintagestory.Server;
+
+internal static class StratumMobSpawning
+{
+	public static void Refresh()
+	{
+		StratumRuntime.Config.EnsurePopulated();
+		StratumMobSpawningConfig config = StratumRuntime.Config.MobSpawning;
+		StratumMobSpawningHook.Enabled = config.Enabled;
+		StratumMobSpawningHook.HostileEnabled = config.HostileEnabled;
+		StratumMobSpawningHook.NeutralEnabled = config.NeutralEnabled;
+		StratumMobSpawningHook.PassiveEnabled = config.PassiveEnabled;
+		StratumMobSpawningHook.NaturalSpawnMultiplier = config.NaturalSpawnMultiplier;
+	}
+
+	public static bool IsCategory(Entity entity, string category)
+	{
+		if (entity == null || !entity.IsCreature)
+		{
+			return false;
+		}
+
+		if (string.Equals(category, "all", StringComparison.OrdinalIgnoreCase))
+		{
+			return true;
+		}
+
+		string group = entity.Properties?.Server?.SpawnConditions?.Runtime?.Group;
+		return string.Equals(group, category, StringComparison.OrdinalIgnoreCase);
+	}
+
+	public static bool IsKnownCategory(string category)
+	{
+		return string.Equals(category, "all", StringComparison.OrdinalIgnoreCase)
+			|| string.Equals(category, "hostile", StringComparison.OrdinalIgnoreCase)
+			|| string.Equals(category, "neutral", StringComparison.OrdinalIgnoreCase)
+			|| string.Equals(category, "passive", StringComparison.OrdinalIgnoreCase);
+	}
+}
+
+internal sealed class StratumMobSpawningSystem
+{
+	public StratumMobSpawningSystem(ServerMain server)
+	{
+		StratumMobSpawning.Refresh();
+	}
+}


### PR DESCRIPTION
## Summary

Issue #216 adds server-side controls for natural mob spawning.

- Add persistent switches for hostile, neutral, and passive groups.
- Add natural spawn scaling from 0 to 1.
- Add `/mobs status`, `/mobs set`, `/mobs scale`, and confirmed `/mobs wipe` commands.
- Apply the settings to runtime spawning and natural creature worldgen.
- Keep explicit spawns and client behavior unchanged.
- Use the existing `controlserver` access policy and audit log.

## Scope

This change controls spawn groups. It does not add per-species filters. Wipe commands affect loaded creatures only. The `ItemCreature` item and other explicit entity creation paths remain unchanged because the available spawn hook does not identify the creation source.

## Validation

- `bash scripts/bootstrap.sh` with ilspycmd 10.1.0.8386: all patches applied.
- Release build and embedded patched build: 0 errors.
- Linux smoke test: server reached WorldReady with no fatal errors.
- Focused Atlas scenario: 1 of 1 passed.
- Full Atlas suite: 11 of 11 passed.
- Real TCP protocol probe: 1 of 1 bot fully joined with 0 errors.

Fixes #216