### PR TITLE
Speeding up initialization in FillWithInitialValue

### DIFF
--- a/patches/VintagestoryLib/Vintagestory.Common/ChunkDataLayer.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Common/ChunkDataLayer.cs.patch
@@ -1,5 +1,5 @@
 diff --git a/VintagestoryLib/Vintagestory.Common/ChunkDataLayer.cs b/VintagestoryLib/Vintagestory.Common/ChunkDataLayer.cs
-index 4d0bf91..caad0da 100644
+index 4d0bf91..e052cd9 100644
 --- a/VintagestoryLib/Vintagestory.Common/ChunkDataLayer.cs
 +++ b/VintagestoryLib/Vintagestory.Common/ChunkDataLayer.cs
 @@ -25,10 +25,72 @@ public class ChunkDataLayer
@@ -222,7 +222,8 @@ index 4d0bf91..caad0da 100644
 +                       + 4 * ((dataBit2[num] >> index3d) & 1)
 +                       + 8 * ((dataBit3[num] >> index3d) & 1)];
 +    }
-+
+ 
+-	private Func<int, int> selectDelegate(int newBlockBitsize)
 +    [MethodImpl(MethodImplOptions.AggressiveInlining)]
 +    private int GetFromBits5(int index3d)
 +    {
@@ -235,8 +236,7 @@ index 4d0bf91..caad0da 100644
 +    }
 +
 +    // Stratun end.
- 
--	private Func<int, int> selectDelegate(int newBlockBitsize)
++
 +    private Func<int, int> selectDelegate(int newBlockBitsize)
  	{
  		if (palette == null)
@@ -346,3 +346,23 @@ index 4d0bf91..caad0da 100644
  		if (value != 0)
  		{
  			if (value == setBlockValueCached)
+@@ -701,18 +773,11 @@ public class ChunkDataLayer
+ 	}
+ 
+ 	internal void FillWithInitialValue(int value)
+ 	{
+ 		NewDataBitsWithFirstValue(value);
+-		int[] array = dataBit0;
+-		for (int i = 0; i < array.Length; i += 4)
+-		{
+-			array[i] = -1;
+-			array[i + 1] = -1;
+-			array[i + 2] = -1;
+-			array[i + 3] = -1;
+-		}
++		Array.Fill(dataBit0, -1); // Stratum: no need for loop, Array.Fill is faster and more readable.
+ 	}
+ 
+ 	public void Clear(List<int[]> datas)
+ 	{
+ 		Get = GetFromBits0;


### PR DESCRIPTION
## Summary

We use fast filling with Array.Fill instead of a loop.
Before: ~30K–50K CPU cycles
After: ~8K–15K CPU cycles

Figures may vary depending on the processor.
The improvement is most noticeable on single and six generation threads.

## Type

- [ ] Bug fix
- [x] Performance
- [ ] New feature
- [ ] Refactor or cleanup
- [ ] Docs or build

## Checklist

- [x] `.\scripts\extract-patches.ps1` ran clean.
- [x] `dotnet build VintageStory.slnx -c Release` is green.
- [x] Every vanilla edit has a `// Stratum` marker.
- [x] No vanilla source committed.
- [x] Tested on a real server start, not just compilation.

## Performance numbers

Both tests used the same seed and generation command.
`/stratum pregen start radius 100 16000 16000`

**Before**
<img width="1337" height="454" alt="before fillinitial" src="https://github.com/user-attachments/assets/dad8e538-9b18-4b44-a6df-7903360d98bb" />



**After**
<img width="1329" height="458" alt="after fillinitial" src="https://github.com/user-attachments/assets/f1c8aae0-df23-422b-98db-846bbe94fbc1" />


