### PR TITLE
feat: support linux-arm64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
         shell: pwsh
         env:
           STRATUM_VER: ${{ steps.ver.outputs.version }}
-        run: ./scripts/pack-release.ps1 -Rids linux-x64,win-x64 -OutDir release-out -Version "${{ steps.ver.outputs.version }}"
+        run: ./scripts/pack-release.ps1 -Rids linux-x64,linux-arm64,win-x64 -OutDir release-out -Version "${{ steps.ver.outputs.version }}"
 
       - name: Upload release artifacts
         uses: softprops/action-gh-release@v2

--- a/StratumServer/StratumServer.csproj
+++ b/StratumServer/StratumServer.csproj
@@ -24,6 +24,9 @@
 
   <ItemGroup>
     <Compile Include="$(StratumInfoPath)" Link="StratumInfo.cs" Condition="'$(StratumInfoPath)' != ''" />
+    <!-- Pinned arm64 native overlay releases (see forks.json's arm64NativeOverlays), read back at
+         runtime by VanillaBootstrap so arm64 asset resolution needs no GitHub API call. -->
+    <EmbeddedResource Include="..\forks.json" LogicalName="Stratum.forks.json" />
   </ItemGroup>
 
   <Target Name="ValidateStratumInfoPath" BeforeTargets="CoreCompile">

--- a/StratumServer/StratumServer.csproj
+++ b/StratumServer/StratumServer.csproj
@@ -4,7 +4,10 @@
     <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
     <OutputType>Exe</OutputType>
     <TargetFramework>$(FrameworkVersion)</TargetFramework>
-    <PlatformTarget>x64</PlatformTarget>
+    <!-- RID-less builds stay x64. When a RuntimeIdentifier is supplied (pack-release.ps1 publishes
+         per-RID), let the SDK infer the platform from it - an explicit x64 here fails NETSDK1032
+         against -r linux-arm64. -->
+    <PlatformTarget Condition="'$(RuntimeIdentifier)' == ''">x64</PlatformTarget>
     <RootNamespace>StratumServer</RootNamespace>
     <Configurations>Debug;Release;PerfTest</Configurations>
     <EmbedPatchedFiles Condition="'$(EmbedPatchedFiles)' == ''">false</EmbedPatchedFiles>

--- a/StratumServer/VanillaBootstrap.cs
+++ b/StratumServer/VanillaBootstrap.cs
@@ -2,7 +2,6 @@ using System;
 using System.IO;
 using System.IO.Compression;
 using System.Net.Http;
-using System.Net.Http.Headers;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Text.Json;
@@ -16,7 +15,9 @@ internal static class VanillaBootstrap
 	private const string VersionManifestUrl = "https://api.vintagestory.at/stable-unstable.json";
 
 	// Anego publishes the aarch64 natives as a standalone overlay; the main manifest is x64-only.
-	private const string Arm64ReleasesUrl = "https://api.github.com/repos/anegostudios/VintagestoryServerArm64/releases?per_page=50";
+	// Pinned in forks.json (arm64NativeOverlays), embedded into the assembly - resolving it needs
+	// no GitHub API call at runtime.
+	private const string Arm64CatalogResourceName = "Stratum.forks.json";
 
 	internal static void EnsureVanillaAssets(string baseGameVersion, bool refresh)
 	{
@@ -98,7 +99,7 @@ internal static class VanillaBootstrap
 		// Swap the handful of architecture-specific natives before PatchedFileOverlay runs.
 		if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && RuntimeInformation.ProcessArchitecture == Architecture.Arm64)
 		{
-			ApplyArm64NativeOverlay(installDir, cacheDir, baseGameVersion, overwriteExisting);
+			ApplyArm64NativeOverlay(installDir, cacheDir, baseGameVersion, refresh);
 		}
 
 		File.WriteAllText(markerPath, expectedMarker);
@@ -153,12 +154,12 @@ internal static class VanillaBootstrap
 	// patch release or two, so copying its managed/host files would risk a version mismatch against
 	// Stratum's patched assemblies. The natives are self-contained third-party libraries
 	// (SkiaSharp, e_sqlite3, zstd) whose ABI does not track Vintage Story patch releases.
-	private static void ApplyArm64NativeOverlay(string installDir, string cacheDir, string baseGameVersion, bool overwriteExisting)
+	private static void ApplyArm64NativeOverlay(string installDir, string cacheDir, string baseGameVersion, bool refresh)
 	{
 		string markerPath = Path.Combine(installDir, ".stratum-arm64-natives");
-		if (!overwriteExisting && File.Exists(markerPath))
+		if (!refresh && File.Exists(markerPath) && File.ReadAllText(markerPath).Trim() == baseGameVersion)
 		{
-			Console.WriteLine("Stratum: arm64 natives already in place; leaving them untouched");
+			Console.WriteLine("Stratum: arm64 natives already in place for " + baseGameVersion + "; leaving them untouched");
 			return;
 		}
 
@@ -224,7 +225,7 @@ internal static class VanillaBootstrap
 		}
 
 		Console.WriteLine($"Stratum: replaced {copied} native librar(ies) with aarch64 builds from {asset.Name}");
-		File.WriteAllText(markerPath, asset.Name);
+		File.WriteAllText(markerPath, baseGameVersion);
 	}
 
 	private static bool IsNativeLibrary(string path)
@@ -234,83 +235,37 @@ internal static class VanillaBootstrap
 			|| fileName.Contains(".so.", StringComparison.OrdinalIgnoreCase);
 	}
 
-	// Overlay releases are cut per minor version, so a 1.22.6 base resolves the 1.22.x overlay.
+	// Overlay releases are cut per minor version, so a 1.22.6 base resolves the pinned 1.22 entry.
+	// Pinned in forks.json rather than resolved from the GitHub API at runtime: it keeps every
+	// arm64 asset URL and digest reviewable in source control, and needs no network round-trip
+	// (or GITHUB_TOKEN, to dodge the anonymous rate limit) just to boot.
 	private static Arm64Asset ResolveArm64Asset(string baseGameVersion)
 	{
-		string preferredPrefix = "vs_server_linux-arm64_" + MajorMinor(baseGameVersion) + ".";
+		string majorMinor = MajorMinor(baseGameVersion);
 
-		using HttpClient client = CreateGitHubClient();
-		string json = client.GetStringAsync(Arm64ReleasesUrl).GetAwaiter().GetResult();
-		using JsonDocument document = JsonDocument.Parse(json);
+		using Stream resource = typeof(VanillaBootstrap).Assembly.GetManifestResourceStream(Arm64CatalogResourceName)
+			?? throw new InvalidOperationException("Embedded resource missing: " + Arm64CatalogResourceName);
+		using JsonDocument document = JsonDocument.Parse(resource);
 
-		Arm64Asset preferred = default;
-		Arm64Asset fallback = default;
-
-		foreach (JsonElement release in document.RootElement.EnumerateArray())
+		if (document.RootElement.TryGetProperty("arm64NativeOverlays", out JsonElement overlays))
 		{
-			if (release.TryGetProperty("draft", out JsonElement draft) && draft.GetBoolean())
+			foreach (JsonElement entry in overlays.EnumerateArray())
 			{
-				continue;
-			}
-			if (!release.TryGetProperty("assets", out JsonElement assets))
-			{
-				continue;
-			}
-
-			foreach (JsonElement assetElement in assets.EnumerateArray())
-			{
-				string name = OptionalString(assetElement, "name");
-				string url = OptionalString(assetElement, "browser_download_url");
-				if (name == null || url == null || !name.EndsWith(".tar.gz", StringComparison.OrdinalIgnoreCase))
-				{
-					continue;
-				}
-				if (!name.Contains("linux-arm64", StringComparison.OrdinalIgnoreCase))
+				if (!string.Equals(RequiredString(entry, "version"), majorMinor, StringComparison.OrdinalIgnoreCase))
 				{
 					continue;
 				}
 
-				Arm64Asset candidate = new(name, url, OptionalString(assetElement, "digest"));
-				if (fallback.Name == null)
-				{
-					fallback = candidate;
-				}
-				if (preferred.Name == null && name.StartsWith(preferredPrefix, StringComparison.OrdinalIgnoreCase))
-				{
-					preferred = candidate;
-				}
+				string name = RequiredString(entry, "name");
+				string url = RequiredString(entry, "url");
+				string sha256 = RequiredString(entry, "sha256");
+				return new Arm64Asset(name, url, "sha256:" + sha256);
 			}
 		}
 
-		if (preferred.Name != null)
-		{
-			return preferred;
-		}
-		if (fallback.Name != null)
-		{
-			Console.WriteLine($"Stratum: no arm64 overlay published for {MajorMinor(baseGameVersion)}.x; falling back to {fallback.Name}");
-			return fallback;
-		}
-
-		throw new InvalidOperationException("No linux-arm64 overlay asset found at " + Arm64ReleasesUrl + ". Stratum cannot run on arm64 without aarch64 natives.");
-	}
-
-	private static HttpClient CreateGitHubClient()
-	{
-		HttpClient client = new();
-		client.Timeout = TimeSpan.FromSeconds(30);
-		// The GitHub API rejects requests without a User-Agent.
-		client.DefaultRequestHeaders.UserAgent.ParseAdd("StratumServer");
-		client.DefaultRequestHeaders.Accept.ParseAdd("application/vnd.github+json");
-
-		// Anonymous callers get 60 requests/hour per IP, which a busy node can exhaust.
-		string token = Environment.GetEnvironmentVariable("GITHUB_TOKEN");
-		if (!string.IsNullOrWhiteSpace(token))
-		{
-			client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-		}
-
-		return client;
+		throw new InvalidOperationException(
+			"No pinned arm64 native overlay for Vintage Story " + majorMinor + ".x in forks.json. " +
+			"Add one under arm64NativeOverlays from https://github.com/anegostudios/VintagestoryServerArm64/releases.");
 	}
 
 	private static string MajorMinor(string version)
@@ -321,17 +276,12 @@ internal static class VanillaBootstrap
 
 	private static bool VerifyArm64Digest(string path, string digest)
 	{
-		if (string.IsNullOrWhiteSpace(digest))
-		{
-			Console.WriteLine("Stratum: arm64 overlay asset publishes no digest; skipping checksum verification");
-			return true;
-		}
-
+		// digest is sourced from our own pinned forks.json, not a remote response, so a missing or
+		// malformed value is a config mistake - fail closed rather than silently trusting the file.
 		const string Sha256Prefix = "sha256:";
-		if (!digest.StartsWith(Sha256Prefix, StringComparison.OrdinalIgnoreCase))
+		if (string.IsNullOrWhiteSpace(digest) || !digest.StartsWith(Sha256Prefix, StringComparison.OrdinalIgnoreCase))
 		{
-			Console.WriteLine($"Stratum: unrecognised arm64 overlay digest format '{digest}'; skipping checksum verification");
-			return true;
+			throw new InvalidOperationException($"arm64 native overlay entry in forks.json has no usable sha256 digest: '{digest}'");
 		}
 
 		using FileStream stream = File.OpenRead(path);
@@ -435,27 +385,16 @@ internal static class VanillaBootstrap
 	{
 		if (!element.TryGetProperty(propertyName, out JsonElement property))
 		{
-			throw new InvalidOperationException("Anego manifest entry is missing property: " + propertyName);
+			throw new InvalidOperationException("JSON entry is missing property: " + propertyName);
 		}
 
 		string value = property.GetString();
 		if (string.IsNullOrWhiteSpace(value))
 		{
-			throw new InvalidOperationException("Anego manifest entry has empty property: " + propertyName);
+			throw new InvalidOperationException("JSON entry has empty property: " + propertyName);
 		}
 
 		return value;
-	}
-
-	private static string OptionalString(JsonElement element, string propertyName)
-	{
-		if (!element.TryGetProperty(propertyName, out JsonElement property) || property.ValueKind != JsonValueKind.String)
-		{
-			return null;
-		}
-
-		string value = property.GetString();
-		return string.IsNullOrWhiteSpace(value) ? null : value;
 	}
 
 	private static bool VerifyMd5(string path, string expectedMd5)

--- a/StratumServer/VanillaBootstrap.cs
+++ b/StratumServer/VanillaBootstrap.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.IO.Compression;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Text.Json;
@@ -13,6 +14,9 @@ namespace StratumServer;
 internal static class VanillaBootstrap
 {
 	private const string VersionManifestUrl = "https://api.vintagestory.at/stable-unstable.json";
+
+	// Anego publishes the aarch64 natives as a standalone overlay; the main manifest is x64-only.
+	private const string Arm64ReleasesUrl = "https://api.github.com/repos/anegostudios/VintagestoryServerArm64/releases?per_page=50";
 
 	internal static void EnsureVanillaAssets(string baseGameVersion, bool refresh)
 	{
@@ -90,6 +94,13 @@ internal static class VanillaBootstrap
 			Console.WriteLine($"Stratum: installed {copied} vanilla file(s) (existing files were preserved)");
 		}
 
+		// Anego ships no linux-arm64 server archive, so the files just laid down are x86-64.
+		// Swap the handful of architecture-specific natives before PatchedFileOverlay runs.
+		if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && RuntimeInformation.ProcessArchitecture == Architecture.Arm64)
+		{
+			ApplyArm64NativeOverlay(installDir, cacheDir, baseGameVersion, overwriteExisting);
+		}
+
 		File.WriteAllText(markerPath, expectedMarker);
 	}
 
@@ -134,6 +145,199 @@ internal static class VanillaBootstrap
 		}
 
 		return new ArchiveInfo(fileName, url, md5, isZip);
+	}
+
+	// Replaces the x86-64 natives from the official archive with the aarch64 builds Anego publishes
+	// as a separate overlay release. Only *.so files are taken: everything else in that overlay is
+	// either portable IL or VintagestoryServer host files, and the overlay lags the base game by a
+	// patch release or two, so copying its managed/host files would risk a version mismatch against
+	// Stratum's patched assemblies. The natives are self-contained third-party libraries
+	// (SkiaSharp, e_sqlite3, zstd) whose ABI does not track Vintage Story patch releases.
+	private static void ApplyArm64NativeOverlay(string installDir, string cacheDir, string baseGameVersion, bool overwriteExisting)
+	{
+		string markerPath = Path.Combine(installDir, ".stratum-arm64-natives");
+		if (!overwriteExisting && File.Exists(markerPath))
+		{
+			Console.WriteLine("Stratum: arm64 natives already in place; leaving them untouched");
+			return;
+		}
+
+		Arm64Asset asset = ResolveArm64Asset(baseGameVersion);
+		Console.WriteLine($"Stratum: arm64 node detected; fetching native overlay {asset.Name}");
+
+		string archivePath = Path.Combine(cacheDir, asset.Name);
+		if (File.Exists(archivePath) && !VerifyArm64Digest(archivePath, asset.Digest))
+		{
+			Console.WriteLine($"Stratum: cached {asset.Name} failed checksum; downloading a fresh copy");
+			File.Delete(archivePath);
+		}
+
+		if (!File.Exists(archivePath))
+		{
+			DownloadFile(asset.Url, archivePath);
+			if (!VerifyArm64Digest(archivePath, asset.Digest))
+			{
+				File.Delete(archivePath);
+				throw new InvalidOperationException("Downloaded arm64 native overlay failed SHA256 verification: " + asset.Name);
+			}
+		}
+		else
+		{
+			Console.WriteLine($"Stratum: using cached {archivePath}");
+		}
+
+		string extractDir = Path.Combine(cacheDir, "extract-arm64");
+		if (Directory.Exists(extractDir))
+		{
+			Directory.Delete(extractDir, recursive: true);
+		}
+		Directory.CreateDirectory(extractDir);
+
+		Console.WriteLine($"Stratum: unpacking {asset.Name}");
+		ExtractTarGz(archivePath, extractDir);
+
+		string sourceRoot = FindContentRoot(extractDir);
+		int copied = 0;
+		foreach (string sourcePath in Directory.EnumerateFiles(sourceRoot, "*", SearchOption.AllDirectories))
+		{
+			if (!IsNativeLibrary(sourcePath))
+			{
+				continue;
+			}
+
+			string rel = Path.GetRelativePath(sourceRoot, sourcePath);
+			string destPath = Path.Combine(installDir, rel);
+			string destDir = Path.GetDirectoryName(destPath);
+			if (destDir != null)
+			{
+				Directory.CreateDirectory(destDir);
+			}
+			File.Copy(sourcePath, destPath, overwrite: true);
+			copied++;
+		}
+
+		Directory.Delete(extractDir, recursive: true);
+
+		if (copied == 0)
+		{
+			throw new InvalidOperationException("arm64 native overlay " + asset.Name + " contained no shared libraries; refusing to run against x86-64 natives.");
+		}
+
+		Console.WriteLine($"Stratum: replaced {copied} native librar(ies) with aarch64 builds from {asset.Name}");
+		File.WriteAllText(markerPath, asset.Name);
+	}
+
+	private static bool IsNativeLibrary(string path)
+	{
+		string fileName = Path.GetFileName(path);
+		return fileName.EndsWith(".so", StringComparison.OrdinalIgnoreCase)
+			|| fileName.Contains(".so.", StringComparison.OrdinalIgnoreCase);
+	}
+
+	// Overlay releases are cut per minor version, so a 1.22.6 base resolves the 1.22.x overlay.
+	private static Arm64Asset ResolveArm64Asset(string baseGameVersion)
+	{
+		string preferredPrefix = "vs_server_linux-arm64_" + MajorMinor(baseGameVersion) + ".";
+
+		using HttpClient client = CreateGitHubClient();
+		string json = client.GetStringAsync(Arm64ReleasesUrl).GetAwaiter().GetResult();
+		using JsonDocument document = JsonDocument.Parse(json);
+
+		Arm64Asset preferred = default;
+		Arm64Asset fallback = default;
+
+		foreach (JsonElement release in document.RootElement.EnumerateArray())
+		{
+			if (release.TryGetProperty("draft", out JsonElement draft) && draft.GetBoolean())
+			{
+				continue;
+			}
+			if (!release.TryGetProperty("assets", out JsonElement assets))
+			{
+				continue;
+			}
+
+			foreach (JsonElement assetElement in assets.EnumerateArray())
+			{
+				string name = OptionalString(assetElement, "name");
+				string url = OptionalString(assetElement, "browser_download_url");
+				if (name == null || url == null || !name.EndsWith(".tar.gz", StringComparison.OrdinalIgnoreCase))
+				{
+					continue;
+				}
+				if (!name.Contains("linux-arm64", StringComparison.OrdinalIgnoreCase))
+				{
+					continue;
+				}
+
+				Arm64Asset candidate = new(name, url, OptionalString(assetElement, "digest"));
+				if (fallback.Name == null)
+				{
+					fallback = candidate;
+				}
+				if (preferred.Name == null && name.StartsWith(preferredPrefix, StringComparison.OrdinalIgnoreCase))
+				{
+					preferred = candidate;
+				}
+			}
+		}
+
+		if (preferred.Name != null)
+		{
+			return preferred;
+		}
+		if (fallback.Name != null)
+		{
+			Console.WriteLine($"Stratum: no arm64 overlay published for {MajorMinor(baseGameVersion)}.x; falling back to {fallback.Name}");
+			return fallback;
+		}
+
+		throw new InvalidOperationException("No linux-arm64 overlay asset found at " + Arm64ReleasesUrl + ". Stratum cannot run on arm64 without aarch64 natives.");
+	}
+
+	private static HttpClient CreateGitHubClient()
+	{
+		HttpClient client = new();
+		client.Timeout = TimeSpan.FromSeconds(30);
+		// The GitHub API rejects requests without a User-Agent.
+		client.DefaultRequestHeaders.UserAgent.ParseAdd("StratumServer");
+		client.DefaultRequestHeaders.Accept.ParseAdd("application/vnd.github+json");
+
+		// Anonymous callers get 60 requests/hour per IP, which a busy node can exhaust.
+		string token = Environment.GetEnvironmentVariable("GITHUB_TOKEN");
+		if (!string.IsNullOrWhiteSpace(token))
+		{
+			client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+		}
+
+		return client;
+	}
+
+	private static string MajorMinor(string version)
+	{
+		string[] parts = version.Split('.');
+		return parts.Length >= 2 ? parts[0] + "." + parts[1] : version;
+	}
+
+	private static bool VerifyArm64Digest(string path, string digest)
+	{
+		if (string.IsNullOrWhiteSpace(digest))
+		{
+			Console.WriteLine("Stratum: arm64 overlay asset publishes no digest; skipping checksum verification");
+			return true;
+		}
+
+		const string Sha256Prefix = "sha256:";
+		if (!digest.StartsWith(Sha256Prefix, StringComparison.OrdinalIgnoreCase))
+		{
+			Console.WriteLine($"Stratum: unrecognised arm64 overlay digest format '{digest}'; skipping checksum verification");
+			return true;
+		}
+
+		using FileStream stream = File.OpenRead(path);
+		using SHA256 sha = SHA256.Create();
+		string actual = Convert.ToHexString(sha.ComputeHash(stream));
+		return string.Equals(actual, digest.Substring(Sha256Prefix.Length), StringComparison.OrdinalIgnoreCase);
 	}
 
 	private static void DownloadFile(string url, string destination)
@@ -243,6 +447,17 @@ internal static class VanillaBootstrap
 		return value;
 	}
 
+	private static string OptionalString(JsonElement element, string propertyName)
+	{
+		if (!element.TryGetProperty(propertyName, out JsonElement property) || property.ValueKind != JsonValueKind.String)
+		{
+			return null;
+		}
+
+		string value = property.GetString();
+		return string.IsNullOrWhiteSpace(value) ? null : value;
+	}
+
 	private static bool VerifyMd5(string path, string expectedMd5)
 	{
 		using FileStream stream = File.OpenRead(path);
@@ -265,5 +480,19 @@ internal static class VanillaBootstrap
 		public string Url { get; }
 		public string Md5 { get; }
 		public bool IsZip { get; }
+	}
+
+	private readonly struct Arm64Asset
+	{
+		public Arm64Asset(string name, string url, string digest)
+		{
+			Name = name;
+			Url = url;
+			Digest = digest;
+		}
+
+		public string Name { get; }
+		public string Url { get; }
+		public string Digest { get; }
 	}
 }

--- a/StratumServer/VanillaBootstrap.cs
+++ b/StratumServer/VanillaBootstrap.cs
@@ -18,6 +18,12 @@ internal static class VanillaBootstrap
 	// Pinned in forks.json (arm64NativeOverlays), embedded into the assembly - resolving it needs
 	// no GitHub API call at runtime.
 	private const string Arm64CatalogResourceName = "Stratum.forks.json";
+	private static readonly string[] RequiredArm64NativeLibraries =
+	{
+		"libe_sqlite3.so",
+		"libSkiaSharp.so",
+		"libzstd.so"
+	};
 
 	internal static void EnsureVanillaAssets(string baseGameVersion, bool refresh)
 	{
@@ -27,9 +33,25 @@ internal static class VanillaBootstrap
 		bool markerExists = File.Exists(markerPath);
 		string currentMarker = markerExists ? File.ReadAllText(markerPath).Trim() : string.Empty;
 		bool markerMatches = markerExists && currentMarker == expectedMarker;
+		bool isLinuxArm64 = IsLinuxArm64();
+		Arm64Asset arm64Asset = default;
+		if (isLinuxArm64)
+		{
+			// Resolve from the embedded catalog before the base-marker fast path. An install
+			// created on x64 still needs the arm64 overlay when it moves to an arm64 host.
+			arm64Asset = ResolveArm64Asset(baseGameVersion);
+		}
 
 		if (!refresh && markerMatches)
 		{
+			if (!isLinuxArm64)
+			{
+				return;
+			}
+
+			string existingCacheDir = Path.Combine(installDir, ".vanilla-cache");
+			Directory.CreateDirectory(existingCacheDir);
+			ApplyArm64NativeOverlay(installDir, existingCacheDir, baseGameVersion, arm64Asset, refresh);
 			return;
 		}
 
@@ -97,9 +119,9 @@ internal static class VanillaBootstrap
 
 		// Anego ships no linux-arm64 server archive, so the files just laid down are x86-64.
 		// Swap the handful of architecture-specific natives before PatchedFileOverlay runs.
-		if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && RuntimeInformation.ProcessArchitecture == Architecture.Arm64)
+		if (isLinuxArm64)
 		{
-			ApplyArm64NativeOverlay(installDir, cacheDir, baseGameVersion, refresh);
+			ApplyArm64NativeOverlay(installDir, cacheDir, baseGameVersion, arm64Asset, refresh);
 		}
 
 		File.WriteAllText(markerPath, expectedMarker);
@@ -154,17 +176,25 @@ internal static class VanillaBootstrap
 	// patch release or two, so copying its managed/host files would risk a version mismatch against
 	// Stratum's patched assemblies. The natives are self-contained third-party libraries
 	// (SkiaSharp, e_sqlite3, zstd) whose ABI does not track Vintage Story patch releases.
-	private static void ApplyArm64NativeOverlay(string installDir, string cacheDir, string baseGameVersion, bool refresh)
+	private static void ApplyArm64NativeOverlay(string installDir, string cacheDir, string baseGameVersion, Arm64Asset asset, bool refresh)
 	{
 		string markerPath = Path.Combine(installDir, ".stratum-arm64-natives");
-		if (!refresh && File.Exists(markerPath) && File.ReadAllText(markerPath).Trim() == baseGameVersion)
+		string expectedMarker = BuildArm64Marker(baseGameVersion, asset);
+		if (!refresh && File.Exists(markerPath) && File.ReadAllText(markerPath).Trim() == expectedMarker)
 		{
-			Console.WriteLine("Stratum: arm64 natives already in place for " + baseGameVersion + "; leaving them untouched");
-			return;
+			try
+			{
+				ValidateArm64NativeLibraries(installDir);
+				Console.WriteLine("Stratum: arm64 natives already in place for " + baseGameVersion + "; leaving them untouched");
+				return;
+			}
+			catch (InvalidOperationException exception)
+			{
+				Console.WriteLine("Stratum: arm64 native layout is stale; reapplying the overlay: " + exception.Message);
+			}
 		}
 
-		Arm64Asset asset = ResolveArm64Asset(baseGameVersion);
-		Console.WriteLine($"Stratum: arm64 node detected; fetching native overlay {asset.Name}");
+		Console.WriteLine($"Stratum: linux-arm64 host detected; fetching native overlay {asset.Name}");
 
 		string archivePath = Path.Combine(cacheDir, asset.Name);
 		if (File.Exists(archivePath) && !VerifyArm64Digest(archivePath, asset.Digest))
@@ -224,8 +254,79 @@ internal static class VanillaBootstrap
 			throw new InvalidOperationException("arm64 native overlay " + asset.Name + " contained no shared libraries; refusing to run against x86-64 natives.");
 		}
 
+		RemoveUnusedArm64NativeLibraries(installDir);
+		ValidateArm64NativeLibraries(installDir);
 		Console.WriteLine($"Stratum: replaced {copied} native librar(ies) with aarch64 builds from {asset.Name}");
-		File.WriteAllText(markerPath, baseGameVersion);
+		File.WriteAllText(markerPath, expectedMarker);
+	}
+
+	private static bool IsLinuxArm64()
+	{
+		return RuntimeInformation.IsOSPlatform(OSPlatform.Linux)
+			&& RuntimeInformation.ProcessArchitecture == Architecture.Arm64;
+	}
+
+	private static string BuildArm64Marker(string baseGameVersion, Arm64Asset asset)
+	{
+		return "version=" + baseGameVersion + "\nasset=" + asset.Name + "\ndigest=" + asset.Digest;
+	}
+
+	private static void RemoveUnusedArm64NativeLibraries(string installDir)
+	{
+		// The official x64 archive includes OpenAL for the client, but the dedicated server
+		// never loads it and the archive has no arm64 replacement. Do not leave an x64 ELF
+		// in an arm64 install where a mod or future code could load it accidentally.
+		string openAlPath = Path.Combine(installDir, "Lib", "libopenal.so.1");
+		if (File.Exists(openAlPath))
+		{
+			File.Delete(openAlPath);
+			Console.WriteLine("Stratum: removed unused x86-64 libopenal.so.1 from arm64 install");
+		}
+	}
+
+	private static void ValidateArm64NativeLibraries(string installDir)
+	{
+		string libDir = Path.Combine(installDir, "Lib");
+		if (!Directory.Exists(libDir))
+		{
+			throw new InvalidOperationException("arm64 native directory is missing: Lib");
+		}
+
+		foreach (string name in RequiredArm64NativeLibraries)
+		{
+			string path = Path.Combine(libDir, name);
+			if (!File.Exists(path))
+			{
+				throw new InvalidOperationException("required arm64 native library is missing: Lib/" + name);
+			}
+		}
+
+		foreach (string path in Directory.EnumerateFiles(libDir, "*", SearchOption.TopDirectoryOnly))
+		{
+			if (!IsNativeLibrary(path))
+			{
+				continue;
+			}
+
+			if (!IsArm64Elf(path))
+			{
+				throw new InvalidOperationException("native library is not an AArch64 ELF: " + Path.GetRelativePath(installDir, path));
+			}
+		}
+	}
+
+	private static bool IsArm64Elf(string path)
+	{
+		byte[] header = new byte[20];
+		using FileStream stream = File.OpenRead(path);
+		stream.ReadExactly(header);
+		if (header[0] != 0x7f || header[1] != (byte)'E' || header[2] != (byte)'L' || header[3] != (byte)'F')
+		{
+			return false;
+		}
+
+		// Linux arm64 uses ELF64 little-endian and e_machine EM_AARCH64 (183).
+		return header[4] == 2 && header[5] == 1 && header[18] == 183 && header[19] == 0;
 	}
 
 	private static bool IsNativeLibrary(string path)

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -100,6 +100,10 @@ aarch64 builds from
 Only `*.so` files are taken from that overlay: its managed and `VintagestoryServer` host files
 lag the base game by a patch release or two, and Stratum ships its own apphost anyway.
 
-The overlay is resolved per minor version, so a 1.22.6 base picks the newest `1.22.x` overlay.
-Set `GITHUB_TOKEN` in the environment if the anonymous GitHub API limit (60 requests/hour per IP)
-becomes a problem. The resolved asset name is recorded in `.stratum-arm64-natives`.
+The overlay asset for each Vintage Story minor version is pinned in `forks.json`
+(`arm64NativeOverlays`), embedded into the assembly at build time, and verified against its
+sha256 digest on download - resolving it needs no GitHub API call, and there is no
+unauthenticated-fallback path that skips verification. Add an entry there (name, url, sha256 from
+the release asset's `digest` field) when overlaying a new Vintage Story minor version; boot on
+arm64 without one and the launcher fails with a clear error instead of guessing. The base game
+version this overlay was applied for is recorded in `.stratum-arm64-natives`.

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -78,10 +78,28 @@ Commit the updated `patches/` and `sources/` files.
 ## Release Zips
 
 ```powershell
-.\scripts\pack-release.ps1 -Rids win-x64,linux-x64 -OutDir release-out
+.\scripts\pack-release.ps1 -Rids win-x64,linux-x64,linux-arm64 -OutDir release-out
 ```
 
 Release zips contain `StratumServer` plus Stratum patched managed files. They do
 not contain the full official Vintage Story server archive or files. On first run, the
 launcher downloads and verifies the official archive, extracts it, writes the
 patched files, and then starts the server.
+
+Every project except `StratumServer` builds AnyCPU, and the launcher is published
+framework-dependent, so the only architecture-specific artifact is the apphost. The SDK
+cross-targets it from an x64 host - `linux-arm64` needs no arm64 build machine.
+
+## arm64
+
+Anego publishes no `linux-arm64` server archive, so on an arm64 host the launcher still
+downloads the official `linux-x64` archive for its assets and IL, then replaces the
+architecture-specific natives (`libe_sqlite3.so`, `libSkiaSharp.so`, `libzstd.so`) with the
+aarch64 builds from
+[anegostudios/VintagestoryServerArm64](https://github.com/anegostudios/VintagestoryServerArm64).
+Only `*.so` files are taken from that overlay: its managed and `VintagestoryServer` host files
+lag the base game by a patch release or two, and Stratum ships its own apphost anyway.
+
+The overlay is resolved per minor version, so a 1.22.6 base picks the newest `1.22.x` overlay.
+Set `GITHUB_TOKEN` in the environment if the anonymous GitHub API limit (60 requests/hour per IP)
+becomes a problem. The resolved asset name is recorded in `.stratum-arm64-natives`.

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -105,5 +105,7 @@ The overlay asset for each Vintage Story minor version is pinned in `forks.json`
 sha256 digest on download - resolving it needs no GitHub API call, and there is no
 unauthenticated-fallback path that skips verification. Add an entry there (name, url, sha256 from
 the release asset's `digest` field) when overlaying a new Vintage Story minor version; boot on
-arm64 without one and the launcher fails with a clear error instead of guessing. The base game
-version this overlay was applied for is recorded in `.stratum-arm64-natives`.
+arm64 without one and the launcher fails with a clear error instead of guessing. The marker in
+`.stratum-arm64-natives` records the base version, asset name, and digest. If an existing install
+was prepared on x64 and later runs on arm64, the launcher still applies the native overlay before
+starting the server.

--- a/forks.json
+++ b/forks.json
@@ -27,5 +27,20 @@
       "url": "https://github.com/anegostudios/vssurvivalmod.git",
       "ref": "849fa8cad9e392368566efc7474e73db6404a145"
     }
+  ],
+  "_arm64NativeOverlaysComment": "Pinned anegostudios/VintagestoryServerArm64 releases, keyed by Vintage Story major.minor. VanillaBootstrap overlays these *.so files onto the official linux-x64 archive on arm64 hosts. Bump/add an entry when overlaying a new Vintage Story minor version; the sha256 comes from the release asset's 'digest' field.",
+  "arm64NativeOverlays": [
+    {
+      "version": "1.22",
+      "name": "vs_server_linux-arm64_1.22.0.tar.gz",
+      "url": "https://github.com/anegostudios/VintagestoryServerArm64/releases/download/1.22.0/vs_server_linux-arm64_1.22.0.tar.gz",
+      "sha256": "191c7f3a58a89a47843e7ab8d1fb16d51f3030f7a6cead639c7c48a907679bfa"
+    },
+    {
+      "version": "1.21",
+      "name": "vs_server_linux-arm64_1.21.0.tar.gz",
+      "url": "https://github.com/anegostudios/VintagestoryServerArm64/releases/download/1.21.0/vs_server_linux-arm64_1.21.0.tar.gz",
+      "sha256": "a0f26b3999410559f1fa2b0f3c270367ff59d5a289d990419d5f3e31d1af59d1"
+    }
   ]
 }


### PR DESCRIPTION
## Summary

Adds Linux ARM64 support to the Stratum launcher while keeping the existing x64 and Windows paths unchanged.

## Changes

- Publishes a Linux ARM64 apphost from the release workflow.
- Downloads the official Linux x64 server archive for the managed server files and portable assets.
- Pins the ARM64 native overlay by Vintage Story major and minor version in `forks.json`.
- Embeds the pinned catalog in the launcher, so startup does not depend on the GitHub API or an unauthenticated fallback.
- Verifies the overlay archive with its pinned SHA256 digest before extraction.
- Copies only native shared libraries from the overlay. Managed files and the overlay host executable are not copied because they can lag the selected base patch.
- Applies the native overlay even when the base install marker already exists, including an install moved from x64 to ARM64.
- Records the base version, asset name, and digest in `.stratum-arm64-natives`.
- Removes the unused x86-64 `libopenal.so.1` from ARM64 installs.
- Verifies that all required native libraries exist and that every top-level native library in `Lib` is an AArch64 ELF.
- Rebases the branch onto the current `indev` branch.

## Checklist

- [x] Linux ARM64 apphost cross-publish
- [x] Pinned overlay URLs and SHA256 digests
- [x] Missing overlay mapping fails closed
- [x] Missing or malformed digest fails closed
- [x] Existing-install and marker refresh paths handled
- [x] No managed files copied from the overlay
- [x] Documentation updated

## Verification

- `bash scripts/bootstrap.sh`
- `dotnet build VintageStory.slnx -c Release`
- `dotnet build VintageStory.slnx -c Release -p:EmbedPatchedFiles=true`
- `bash scripts/smoke-test.sh`, reached `RunGame` without fatal errors
- `scripts/pack-release.ps1` cross-publish for `linux-arm64`
- Published launcher inspected as an ARM AArch64 ELF
- Pinned 1.21 and 1.22 overlay archives matched their SHA256 values and contained the expected AArch64 libraries
- Official 1.22.7 Linux x64 archive inspected to confirm the x86-64 natives replaced by the launcher

## Related issues

Closes #258