### PR TITLE
Microblock Optimization and GenRockStrataNew

### DIFF
--- a/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/2.GenRockStrata/GenRockStrata.cs.patch
+++ b/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/2.GenRockStrata/GenRockStrata.cs.patch
@@ -1,8 +1,8 @@
 diff --git a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/2.GenRockStrata/GenRockStrata.cs b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/2.GenRockStrata/GenRockStrata.cs
-index cb9eefa..3a5476e 100644
+index cb9eefa..3b30334 100644
 --- a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/2.GenRockStrata/GenRockStrata.cs
 +++ b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/2.GenRockStrata/GenRockStrata.cs
-@@ -1,8 +1,9 @@
+@@ -1,6 +1,7 @@
  using System;
 +using System.Collections.Concurrent;
  using System.Collections.Generic;
@@ -10,16 +10,12 @@ index cb9eefa..3a5476e 100644
  using Vintagestory.API.Datastructures;
  using Vintagestory.API.MathTools;
  using Vintagestory.API.Server;
- using Vintagestory.ServerMods.NoObf;
-
-@@ -24,14 +25,20 @@ namespace Vintagestory.ServerMods
-         internal SimplexNoise distort2dx;
-         internal SimplexNoise distort2dz;
+@@ -26,10 +27,16 @@ namespace Vintagestory.ServerMods
          internal MapLayerCustomPerlin[] strataNoises;
-
+ 
          int regionMapSize;
          Dictionary<int, LerpedWeightedIndex2DMap> ProvinceMapByRegion = new Dictionary<int, LerpedWeightedIndex2DMap>(10);
-
+ 
 +        // Stratum: each worldgen thread gets a complete generator so vanilla fields stay intact.
 +        StratumWorkerInstances<GenRockStrataNew> stratumWorkers;
 +
@@ -30,42 +26,69 @@ index cb9eefa..3a5476e 100644
          {
              return side == EnumAppSide.Server;
          }
-
-         public override double ExecuteOrder()
-         {
-@@ -42,17 +49,18 @@ namespace Vintagestory.ServerMods
-         {
-             this.api = api;
+ 
+@@ -44,13 +51,14 @@ namespace Vintagestory.ServerMods
          }
-
+ 
          public override void StartServerSide(ICoreServerAPI api)
          {
              this.api = api;
 +            stratumWorkers = new StratumWorkerInstances<GenRockStrataNew>(StratumCreateWorker); // Stratum: isolate mutable fields without changing their shape
-
+ 
              api.Event.InitWorldGenerator(initWorldGen, "standard");
 -            api.Event.ChunkColumnGeneration(GenChunkColumn, EnumWorldGenPass.Terrain, "standard");
 +            StratumTerrainSplit.Register(api, GenChunkColumn, StratumGenChunkColumn, "standard"); // Stratum: expose vanilla topology until the worker path is safe
-
+ 
              api.Event.MapRegionGeneration(OnMapRegionGen, "standard");
          }
-
-
-         public void initWorldGen()
-         {
-@@ -146,16 +154,59 @@ namespace Vintagestory.ServerMods
-
-         LerpedWeightedIndex2DMap map;
+ 
+ 
+@@ -69,10 +77,12 @@ namespace Vintagestory.ServerMods
+             regionSize = api.WorldManager.RegionSize;
+ 
+             // Unpadded region noise size in chunks
+             regionChunkSize = regionSize / chunksize;
+ 
++            chunksizeLog2 = System.Numerics.BitOperations.Log2((uint)chunksize);
++
+             // Unpadded region noise size in blocks
+             int geoProvRegionNoiseSize = regionSize / TerraGenConfig.geoProvMapScale;
+ 
+             // Amount of regions in all of the map
+             regionMapSize = api.WorldManager.MapSizeX / (chunksize * geoProvRegionNoiseSize);
+@@ -148,27 +158,146 @@ namespace Vintagestory.ServerMods
          float lerpMapInv;
          float chunkInRegionX;
          float chunkInRegionZ;
-
+ 
          GeologicProvinces provinces = NoiseGeoProvince.provinces;
 +
 +        // Stratum: reuse province weights to avoid one allocation per block column.
 +        float[] stratumIndicesBuf;
++
++        // Stratum: precomputed log2(chunksize) so genBlockColumn can use bit shifts
++        // instead of integer division/multiplication by chunksize on every Y step.
++        // chunksize is assumed to be a power of two (it always has been — 32).
++        int chunksizeLog2;
++
++        // Stratum: per-subchunk write buffers. Filled during genBlockColumn across
++        // the whole 32x32 column loop, flushed once per subchunk at the end of
++        // GenChunkColumn instead of taking stratumWriteLock on every block write.
++        // Lazily sized to the chunk column's height (chunks.Length) on first use
++        // and reused (Clear, not reallocated) on every subsequent call.
++        List<int>[] stratumPendingIndices;
++        List<int>[] stratumPendingValues;
++
++        // Stratum: per-subchunk block snapshots, refreshed once per chunk column instead of
++        // calling GetBlockIdUnsafe (interface dispatch + palette decode) once per replaced
++        // block. Correctness relies on writes being deferred until StratumFlushPendingWrites
++        // at the end of GenChunkColumn — the real data is untouched throughout the whole
++        // column loop, so one snapshot at the start sees exactly what every individual
++        // GetBlockIdUnsafe call would have seen.
++        int[][] stratumBlockSnapshot;
++
          #endregion
-
+ 
 +        private void StratumGenChunkColumn(IChunkColumnGenerateRequest request)
 +        {
 +            stratumWorkers.Current.GenChunkColumn(request);
@@ -78,6 +101,55 @@ index cb9eefa..3a5476e 100644
 +            return worker;
 +        }
 +
++        // Stratum: (re)allocates the per-subchunk buffer lists to match this
++        // column's chunk count. Cheap no-op after the first call for a given
++        // worker, since chunk column height doesn't change between calls.
++        private void StratumEnsureBuffers(int numSubchunks)
++        {
++            if (stratumPendingIndices != null && stratumPendingIndices.Length == numSubchunks)
++            {
++                return;
++            }
++            stratumPendingIndices = new List<int>[numSubchunks];
++            stratumPendingValues = new List<int>[numSubchunks];
++            stratumBlockSnapshot = new int[numSubchunks][];
++            for (int i = 0; i < numSubchunks; i++)
++            {
++                stratumPendingIndices[i] = new List<int>();
++                stratumPendingValues[i] = new List<int>();
++                stratumBlockSnapshot[i] = new int[chunksize * chunksize * chunksize]; // 32768
++            }
++        }
++
++        // Stratum: bulk-reads every subchunk's current block IDs once per chunk column.
++        // See stratumBlockSnapshot field comment for the correctness argument.
++        private void StratumSnapshotBlocks(IServerChunk[] chunks)
++        {
++            for (int cy = 0; cy < chunks.Length; cy++)
++            {
++                chunks[cy].Data.CopyBlocksToUnsafe(stratumBlockSnapshot[cy]);
++            }
++        }
++
++
++        // Stratum: flushes all buffered writes for this chunk column, one batched
++        // lock acquisition per subchunk instead of one per block. Clears the lists
++        // afterwards so they can be reused for the next chunk column.
++        private void StratumFlushPendingWrites(IServerChunk[] chunks)
++        {
++            for (int cy = 0; cy < stratumPendingIndices.Length; cy++)
++            {
++                List<int> indices = stratumPendingIndices[cy];
++                if (indices.Count == 0)
++                {
++                    continue;
++                }
++                chunks[cy].Data.SetBlocksUnsafe(indices, stratumPendingValues[cy]);
++                indices.Clear();
++                stratumPendingValues[cy].Clear();
++            }
++        }
++
 +        // Stratum: copy configured state and give mutable fields to one worldgen thread.
 +        private void StratumCopyStateFrom(GenRockStrataNew source)
 +        {
@@ -85,6 +157,7 @@ index cb9eefa..3a5476e 100644
 +            LoadGlobalConfig(api);
 +            regionSize = source.regionSize;
 +            regionChunkSize = source.regionChunkSize;
++            chunksizeLog2 = source.chunksizeLog2;
 +            rockBlockId = source.rockBlockId;
 +            strata = source.strata;
 +            distort2dx = source.distort2dx;
@@ -111,16 +184,31 @@ index cb9eefa..3a5476e 100644
              var chunks = request.Chunks;
              int chunkX = request.ChunkX;
              int chunkZ = request.ChunkZ;
-
+ 
              preLoad(chunks, chunkX, chunkZ);
-@@ -190,23 +241,29 @@ namespace Vintagestory.ServerMods
-             int ylower = 1;
-             int yupper = surfaceY;
++            StratumEnsureBuffers(chunks.Length);
++            StratumSnapshotBlocks(chunks); // Stratum: one bulk read per subchunk instead of per block
+ 
+             for (int x = 0; x < chunksize; x++)
+             {
+                 for (int z = 0; z < chunksize; z++)
+                 {
+                     genBlockColumn(chunks, chunkX, chunkZ, x, z);
+                 }
+             }
++
++            StratumFlushPendingWrites(chunks); // Stratum: one batched write per subchunk instead of per block
+         }
+ 
+         public void preLoad(IServerChunk[] chunks, int chunkX, int chunkZ)
+         {
+             mapChunk = chunks[0].MapChunk;
+@@ -192,19 +321,25 @@ namespace Vintagestory.ServerMods
              int rockBlockId = this.rockBlockId;
-
+ 
              rockGroupMaxThickness[0] = rockGroupMaxThickness[1] = rockGroupMaxThickness[2] = rockGroupMaxThickness[3] = 0;
              rockGroupCurrentThickness[0] = rockGroupCurrentThickness[1] = rockGroupCurrentThickness[2] = rockGroupCurrentThickness[3] = 0;
-
+ 
 -            float[] indices = new float[provinces.Variants.Length];
 +            // Stratum: keep the measured allocation reduction while each worker owns its buffer.
 +            if (stratumIndicesBuf == null || stratumIndicesBuf.Length != provinces.Variants.Length)
@@ -141,25 +229,70 @@ index cb9eefa..3a5476e 100644
 -                float w = indices[i];
 +                float w = stratumIndicesBuf[i];
                  if (w == 0) continue;
-
+ 
                  GeologicProvinceRockStrata[] localstrata = provinces.Variants[i].RockStrataIndexed;
-
+ 
                  rockGroupMaxThickness[0] += localstrata[0].ScaledMaxThickness * w;
-                 rockGroupMaxThickness[1] += localstrata[1].ScaledMaxThickness * w;
-                 rockGroupMaxThickness[2] += localstrata[2].ScaledMaxThickness * w;
-@@ -320,13 +377,14 @@ namespace Vintagestory.ServerMods
-             return CreateLerpedProvinceMap(mapchunk.MapRegion.GeologicProvinceMap, chunkX / regionChunkSize, chunkZ / regionChunkSize);
-         }
-
+@@ -277,34 +412,34 @@ namespace Vintagestory.ServerMods
+ 
+                 rockGroupCurrentThickness[grp]++;
+ 
+                 if (stratum.GenDir == EnumStratumGenDir.BottomUp)
+                 {
+-                    int chunkY = ylower / chunksize;
+-                    int lY = ylower - chunkY * chunksize;
+-                    int localIndex3D = (chunksize * lY + lz) * chunksize + lx;
++                    int chunkY = ylower >> chunksizeLog2;
++                    int lY = ylower - (chunkY << chunksizeLog2);
++                    int localIndex3D = (((lY << chunksizeLog2) + lz) << chunksizeLog2) + lx;
+ 
+-                    IChunkBlocks chunkBlockData = chunks[chunkY].Data;
+-                    if (chunkBlockData.GetBlockIdUnsafe(localIndex3D) == rockBlockId)
++                    // Stratum: read from the column's snapshot instead of calling GetBlockIdUnsafe.
++                    if (stratumBlockSnapshot[chunkY][localIndex3D] == rockBlockId)
+                     {
+-                        chunkBlockData.SetBlockUnsafe(localIndex3D, stratum.BlockId);
++                        stratumPendingIndices[chunkY].Add(localIndex3D);
++                        stratumPendingValues[chunkY].Add(stratum.BlockId);
+                     }
+ 
+                     ylower++;
+-
+                 }
+                 else
+                 {
++                    int chunkY = yupper >> chunksizeLog2;
++                    int lY = yupper - (chunkY << chunksizeLog2);
++                    int localIndex3D = (((lY << chunksizeLog2) + lz) << chunksizeLog2) + lx;
+ 
+-                    int chunkY = yupper / chunksize;
+-                    int lY = yupper - chunkY * chunksize;
+-                    int localIndex3D = (chunksize * lY + lz) * chunksize + lx;
+-
+-                    IChunkBlocks chunkBlockData = chunks[chunkY].Data;
+-                    if (chunkBlockData.GetBlockIdUnsafe(localIndex3D) == rockBlockId)      // Even if we found rock already in this column, it could be overhang or something, so have to keep checking
++                    // Stratum: read from the column's snapshot instead of calling GetBlockIdUnsafe.
++                    if (stratumBlockSnapshot[chunkY][localIndex3D] == rockBlockId)      // Even if we found rock already in this column, it could be overhang or something, so have to keep checking
+                     {
+-                        chunkBlockData.SetBlockUnsafe(localIndex3D, stratum.BlockId);
++                        stratumPendingIndices[chunkY].Add(localIndex3D);
++                        stratumPendingValues[chunkY].Add(stratum.BlockId);
+                     }
+ 
+                     yupper--;
+                 }
+             }
+@@ -322,11 +457,12 @@ namespace Vintagestory.ServerMods
+ 
          LerpedWeightedIndex2DMap CreateLerpedProvinceMap(IntDataMap2D geoMap, int regionX, int regionZ)
          {
              int index2d = regionZ * regionMapSize + regionX;
-
+ 
 -            return ProvinceMapByRegion[index2d] = new LerpedWeightedIndex2DMap(geoMap.Data, geoMap.Size, TerraGenConfig.geoProvSmoothingRadius, geoMap.TopLeftPadding, geoMap.BottomRightPadding);
 +            // Stratum: keep one expensive map across workers while preserving their vanilla cache field.
 +            return ProvinceMapByRegion[index2d] = stratumProvinceMapsByRegion.GetOrAdd(index2d, _ => new LerpedWeightedIndex2DMap(geoMap.Data, geoMap.Size, TerraGenConfig.geoProvSmoothingRadius, geoMap.TopLeftPadding, geoMap.BottomRightPadding));
          }
-
-
+ 
+ 
      }
  }

--- a/patches/VSSurvivalMod/Systems/Microblock/BEBehaviorMicroblockSnowCover.cs.patch
+++ b/patches/VSSurvivalMod/Systems/Microblock/BEBehaviorMicroblockSnowCover.cs.patch
@@ -1,0 +1,207 @@
+diff --git a/VSSurvivalMod/Systems/Microblock/BEBehaviorMicroblockSnowCover.cs b/VSSurvivalMod/Systems/Microblock/BEBehaviorMicroblockSnowCover.cs
+index 61d9053..a16a99f 100644
+--- a/VSSurvivalMod/Systems/Microblock/BEBehaviorMicroblockSnowCover.cs
++++ b/VSSurvivalMod/Systems/Microblock/BEBehaviorMicroblockSnowCover.cs
+@@ -2,10 +2,12 @@ using System;
+ using System.Collections.Generic;
+ using Vintagestory.API.Client;
+ using Vintagestory.API.Common;
+ using Vintagestory.API.Datastructures;
+ using Vintagestory.API.MathTools;
++using System.Runtime.CompilerServices;
++using System.Runtime.InteropServices;
+ 
+ #nullable disable
+ 
+ namespace Vintagestory.GameContent
+ {
+@@ -65,52 +67,51 @@ namespace Vintagestory.GameContent
+         }
+ 
+ 
+         CuboidWithMaterial[] aboveCuboids = null;
+ 
++        [MethodImpl(MethodImplOptions.AggressiveInlining)] // Stratum: added to hint compiler to inline the hot method
+         void buildSnowCuboids(BoolArray16x16x16 Voxels)
+         {
+             List<uint> snowCuboids = new List<uint>();
+             List<uint> groundSnowCuboids = new List<uint>();
+ 
+             var aboveBe = Api?.World.BlockAccessor.GetBlockEntity(Pos.UpCopy()) as BlockEntityMicroBlock;
+             CuboidWithMaterial[] newAboveCuboids = null;
+ 
+-           
+-            bool[,] snowVoxelVisited = new bool[16, 16];
++            // Stratum start: Replaced bool[16,16] heap allocation with stackalloc Span<bool> to avoid per-call GC pressure.
++            // Also flattened the 2D voxel/visited access into single-dimension indices for better cache locality.
++            Span<bool> snowVoxelVisited = stackalloc bool[256];
+ 
+             for (int dy = 15; dy >= 0; dy--)
+             {
++                int yOffset = dy * 16; // flat index base for the entire Y plane within Voxels
++
+                 for (int dx = 0; dx < 16; dx++)
+                 {
++                    int flatBase = dx * 256 + yOffset;     // base for Voxels.GetFlat(flatBase + dz)
++                    int visitedRowBase = dx * 16;           // base for snowVoxelVisited[dx*16+dz]
++
+                     for (int dz = 0; dz < 16; dz++)
+                     {
+-                        if (snowVoxelVisited[dx, dz]) continue;
+-                        bool ground = dy == 0 && !Voxels[dx, dy, dz];
+-                        bool search = ground || Voxels[dx, dy, dz];
++                        int visitedIdx = visitedRowBase + dz;
++                        if (snowVoxelVisited[visitedIdx]) continue;
++
++                        bool voxelHere = Voxels.GetFlat(flatBase + dz);
++                        bool ground = dy == 0 && !voxelHere;
++                        bool search = ground || voxelHere;
+ 
+                         if (!search) continue;
+ 
+-                        if (dy == 15)
++                        if (dy == 15 && aboveBe != null && newAboveCuboids == null)
+                         {
+-                            if (aboveBe != null)
++                            newAboveCuboids = new CuboidWithMaterial[aboveBe.VoxelCuboids.Count];
++                            for (int i = 0; i < newAboveCuboids.Length; i++)
+                             {
+-                                if (newAboveCuboids == null)
+-                                {
+-                                    newAboveCuboids = new CuboidWithMaterial[aboveBe.VoxelCuboids.Count];
+-                                    for (int i = 0; i < newAboveCuboids.Length; i++)
+-                                    {
+-                                        BlockEntityMicroBlock.FromUint(aboveBe.VoxelCuboids[i], newAboveCuboids[i] = new CuboidWithMaterial());
+-                                    }
+-                                }
+-
+-                                for (int i = 0; i < newAboveCuboids.Length; i++)
+-                                {
+-                                    if (newAboveCuboids[i].Contains(dx, dy, dz)) continue;
+-                                }
++                                BlockEntityMicroBlock.FromUint(aboveBe.VoxelCuboids[i], newAboveCuboids[i] = new CuboidWithMaterial());
+                             }
+-
++                            // Stratum: removed the now-empty loop that iterated aboveCuboids and called Contains() without using the result
+                         }
+ 
+                         CuboidWithMaterial cub = new CuboidWithMaterial()
+                         {
+                             Material = 0,
+@@ -120,11 +121,10 @@ namespace Vintagestory.GameContent
+                             X2 = dx + 0,
+                             Y2 = dy + 1,
+                             Z2 = dz + 0
+                         };
+ 
+-                        // Try grow this cuboid for as long as we can
+                         bool didGrowAny = true;
+                         while (didGrowAny)
+                         {
+                             didGrowAny = false;
+                             didGrowAny |= TrySnowableSurfaceGrowX(cub, Voxels, snowVoxelVisited, ground);
+@@ -135,11 +135,11 @@ namespace Vintagestory.GameContent
+ 
+                         for (int z = cub.Z1; z < cub.Z2; z++)
+                         {
+                             for (int x = cub.X1; x < cub.X2; x++)
+                             {
+-                                snowVoxelVisited[x, z] = true;
++                                snowVoxelVisited[x * 16 + z] = true; // Stratum: flat index instead of [x, z]
+                             }
+                         }
+ 
+                         if (ground)
+                         {
+@@ -152,10 +152,11 @@ namespace Vintagestory.GameContent
+ 
+                         break;
+                     }
+                 }
+             }
++            // Stratum end
+ 
+             this.aboveCuboids = newAboveCuboids;
+             this.GroundSnowCuboids = groundSnowCuboids;
+             this.SnowCuboids = snowCuboids;
+         }
+@@ -187,47 +188,69 @@ namespace Vintagestory.GameContent
+         }
+ 
+ 
+         #region Snowgrow
+ 
+-        protected bool TrySnowableSurfaceGrowX(CuboidWithMaterial cub, BoolArray16x16x16 voxels, bool[,] voxelVisited, bool ground)
++        // Stratum start: Replaced bool[,] voxelVisited with Span<bool> to match stackalloc allocation in buildSnowCuboids.
++        // Also switched from multi-dimensional Voxels[x,y,z] to flat GetFlat(idx) access for better memory layout.
++        protected bool TrySnowableSurfaceGrowX(CuboidWithMaterial cub, BoolArray16x16x16 voxels, Span<bool> voxelVisited, bool ground)
+         {
+             if (cub.X2 > 15) return false;
+ 
++            int x2 = cub.X2;
++            int xBase = x2 * 256;
++            int yOffset = cub.Y1 * 16;
++            int aboveLen = aboveCuboids?.Length ?? 0;
++
+             for (int z = cub.Z1; z < cub.Z2; z++)
+             {
+-                z = Math.Min(15, z);
+-                if (aboveCuboids != null)
++                int zz = Math.Min(15, z);
++
++                if (aboveLen > 0)
+                 {
+-                    for (int i = 0; i < aboveCuboids.Length; i++) if (aboveCuboids[i].Contains(cub.X2, 0, z)) return false;
++                    for (int i = 0; i < aboveLen; i++) if (aboveCuboids[i].Contains(x2, 0, zz)) return false;
+                 }
+ 
+-                if (voxels[cub.X2, cub.Y1, z] == ground || voxelVisited[cub.X2, z] || (cub.Y1 < 15 && voxels[cub.X2, cub.Y1 + 1, z])) return false;
++                int idx = xBase + yOffset + zz; // Stratum: flat index instead of voxels[x2, cub.Y1, z]
++                if (voxels.GetFlat(idx) == ground
++                    || voxelVisited[x2 * 16 + zz]       // Stratum: flat visited access
++                    || (cub.Y1 < 15 && voxels.GetFlat(idx + 16))) // Stratum: Y+1 is just +16 in flat layout
++                    return false;
+             }
+ 
+             cub.X2++;
+             return true;
+         }
+ 
+-        protected bool TrySnowableSurfaceGrowZ(CuboidWithMaterial cub, BoolArray16x16x16 voxels, bool[,] voxelVisited, bool ground)
++        protected bool TrySnowableSurfaceGrowZ(CuboidWithMaterial cub, BoolArray16x16x16 voxels, Span<bool> voxelVisited, bool ground) // Stratum: Span<bool> instead of bool[,]
+         {
+             if (cub.Z2 > 15) return false;
+ 
++            int z2 = cub.Z2;
++            int yOffset = cub.Y1 * 16;
++            int aboveLen = aboveCuboids?.Length ?? 0;
++
+             for (int x = cub.X1; x < cub.X2; x++)
+             {
+-                x = Math.Min(15, x);
+-                if (aboveCuboids != null)
++                int xx = Math.Min(15, x);
++
++                if (aboveLen > 0)
+                 {
+-                    for (int i = 0; i < aboveCuboids.Length; i++) if (aboveCuboids[i].Contains(x, 0, cub.Z2)) return false;
++                    for (int i = 0; i < aboveLen; i++) if (aboveCuboids[i].Contains(xx, 0, z2)) return false;
+                 }
+ 
+-                if (voxels[x, cub.Y1, cub.Z2] == ground || voxelVisited[x, cub.Z2] || (cub.Y1 < 15 && voxels[x, cub.Y1 + 1, cub.Z2])) return false;
++                int idx = xx * 256 + yOffset + z2; // Stratum: flat index instead of voxels[x, cub.Y1, cub.Z2]
++                if (voxels.GetFlat(idx) == ground
++                    || voxelVisited[xx * 16 + z2]       // Stratum: flat visited access
++                    || (cub.Y1 < 15 && voxels.GetFlat(idx + 16))) // Stratum: Y+1 is just +16 in flat layout
++                    return false;
+             }
+ 
+             cub.Z2++;
+             return true;
+         }
++        // Stratum end
+ 
+ 
+ 
+ 
+         #endregion

--- a/patches/VSSurvivalMod/Systems/Microblock/BEMicroBlock.cs.patch
+++ b/patches/VSSurvivalMod/Systems/Microblock/BEMicroBlock.cs.patch
@@ -1,8 +1,8 @@
 diff --git a/VSSurvivalMod/Systems/Microblock/BEMicroBlock.cs b/VSSurvivalMod/Systems/Microblock/BEMicroBlock.cs
-index 4e4704b..b29c91c 100644
+index 4e4704b..126d2ef 100644
 --- a/VSSurvivalMod/Systems/Microblock/BEMicroBlock.cs
 +++ b/VSSurvivalMod/Systems/Microblock/BEMicroBlock.cs
-@@ -86,10 +86,23 @@ namespace Vintagestory.GameContent
+@@ -86,10 +86,24 @@ namespace Vintagestory.GameContent
          // Set up two unmodifiable default values instead of spamming new objects
          private static Cuboidf[] noSelectionBox = Array.Empty<Cuboidf>();
          private static byte[] singleByte255 = new byte[] { 255 };
@@ -18,7 +18,8 @@ index 4e4704b..b29c91c 100644
 +            new ThreadLocal<BoolArray16x16x16>(() => new BoolArray16x16x16());
 +
 +        // Fixed buffer for cuboids (max 16*16*16 = 4096)
-+        private static readonly uint[] CuboidBuffer = new uint[4096];
++        protected static ThreadLocal<uint[]> cuboidBufferTL = new ThreadLocal<uint[]>(() => new uint[4096]);
++        protected static uint[] CuboidBuffer => cuboidBufferTL.Value;
 +        // Stratum end
 +
          // bits 0..3 = xmin
@@ -26,7 +27,7 @@ index 4e4704b..b29c91c 100644
          // bits 8..11 = ymin
          // bits 12..15 = ymax
          // bits 16..19 = zmin
-@@ -472,31 +485,50 @@ namespace Vintagestory.GameContent
+@@ -472,31 +486,51 @@ namespace Vintagestory.GameContent
          #region Voxel math
  
  
@@ -39,6 +40,7 @@ index 4e4704b..b29c91c 100644
 +            voxels = RebuildVoxelsTL.Value;
 +            voxels.Clear();
 +            materials = RebuildMaterialsTL.Value;
++            Array.Clear(materials, 0, 16 * 16 * 16); // clear stale data from previous block entities on this thread
 +
 +
 +            // byte[,,] in .NET is stored contiguously in memory (row-major),
@@ -86,7 +88,7 @@ index 4e4704b..b29c91c 100644
          {
              ConvertToVoxels(out BoolArray16x16x16 Voxels, out byte[,,] VoxelMaterial);
              RebuildCuboidList(Voxels, VoxelMaterial);
-@@ -768,110 +800,113 @@ namespace Vintagestory.GameContent
+@@ -768,110 +802,113 @@ namespace Vintagestory.GameContent
          {
              RebuildCuboidList();
              MarkDirty(true);
@@ -247,7 +249,7 @@ index 4e4704b..b29c91c 100644
              {
                  int preva = GetLightAbsorption();
                  absorbAnyLight = doEmitSideAo;
-@@ -886,15 +921,11 @@ namespace Vintagestory.GameContent
+@@ -886,15 +923,11 @@ namespace Vintagestory.GameContent
              for (int i = 0; i < 6; i++)
              {
                  sidecenterSolid[i] = edgeCenterVoxelsMissing[i] < 5;
@@ -264,7 +266,17 @@ index 4e4704b..b29c91c 100644
              if (BlockIds.Length == 1 && Api.World.GetBlock(BlockIds[0]).RenderPass == EnumChunkRenderPass.Meta)
              {
                  emitSideAo = 0;
-@@ -915,10 +946,11 @@ namespace Vintagestory.GameContent
+@@ -910,15 +943,21 @@ namespace Vintagestory.GameContent
+                 {
+                     bebhmicroblock.RebuildCuboidList(Voxels, VoxelMaterial);
+                 }
+             }
+ 
++            // sync rebuilt cuboids from fixed buffer back to instance list
++            VoxelCuboids = new List<uint>(cuboidCount);
++            for (int i = 0; i < cuboidCount; i++)
++                VoxelCuboids.Add(CuboidBuffer[i]);
++
              if (DisplacesLiquid())
              {
                  Api.World.BlockAccessor.SetBlock(0, Pos, BlockLayersAccess.Fluid);
@@ -276,7 +288,7 @@ index 4e4704b..b29c91c 100644
          {
              prevEmitSideAo ^= emitSideAo;  // This is now the changed bits
              if (prevEmitSideAo == 0) return;  // No change
-@@ -935,81 +967,96 @@ namespace Vintagestory.GameContent
+@@ -935,81 +974,96 @@ namespace Vintagestory.GameContent
              return sideAlmostSolid[0] && sideAlmostSolid[1] && sideAlmostSolid[2] && sideAlmostSolid[3] && sideAlmostSolid[5];
          }
  
@@ -388,7 +400,7 @@ index 4e4704b..b29c91c 100644
  
          public virtual void RegenSelectionBoxes(IWorldAccessor worldForResolve, IPlayer byPlayer)
          {
-@@ -2557,29 +2604,103 @@ namespace Vintagestory.GameContent
+@@ -2557,29 +2611,103 @@ namespace Vintagestory.GameContent
          {
              return GetEncompassingHitbox(VoxelCuboids);
          }

--- a/patches/VSSurvivalMod/Systems/Microblock/BEMicroBlock.cs.patch
+++ b/patches/VSSurvivalMod/Systems/Microblock/BEMicroBlock.cs.patch
@@ -1,8 +1,394 @@
 diff --git a/VSSurvivalMod/Systems/Microblock/BEMicroBlock.cs b/VSSurvivalMod/Systems/Microblock/BEMicroBlock.cs
-index 4e4704b..6ffea38 100644
+index 4e4704b..b29c91c 100644
 --- a/VSSurvivalMod/Systems/Microblock/BEMicroBlock.cs
 +++ b/VSSurvivalMod/Systems/Microblock/BEMicroBlock.cs
-@@ -2557,29 +2557,64 @@ namespace Vintagestory.GameContent
+@@ -86,10 +86,23 @@ namespace Vintagestory.GameContent
+         // Set up two unmodifiable default values instead of spamming new objects
+         private static Cuboidf[] noSelectionBox = Array.Empty<Cuboidf>();
+         private static byte[] singleByte255 = new byte[] { 255 };
+         private static Vec3f centerBase = new Vec3f(0.5f, 0, 0.5f);
+ 
++        // Stratum start:
++        // ThreadLocal for BoolArray, byte[,,] and VoxelVisited — avoid new on every RebuildCuboidList; fixed uint[] buffer 4096 for cuboids (max 16³)
++        protected static readonly ThreadLocal<BoolArray16x16x16> RebuildVoxelsTL =
++            new ThreadLocal<BoolArray16x16x16>(() => new BoolArray16x16x16());
++        protected static readonly ThreadLocal<byte[,,]> RebuildMaterialsTL =
++            new ThreadLocal<byte[,,]>(() => new byte[16, 16, 16]);
++        protected static readonly ThreadLocal<BoolArray16x16x16> VoxelVisitedTL =
++            new ThreadLocal<BoolArray16x16x16>(() => new BoolArray16x16x16());
++
++        // Fixed buffer for cuboids (max 16*16*16 = 4096)
++        private static readonly uint[] CuboidBuffer = new uint[4096];
++        // Stratum end
++
+         // bits 0..3 = xmin
+         // bits 4..7 = xmax
+         // bits 8..11 = ymin
+         // bits 12..15 = ymax
+         // bits 16..19 = zmin
+@@ -472,31 +485,50 @@ namespace Vintagestory.GameContent
+         #region Voxel math
+ 
+ 
+         public void ConvertToVoxels(out BoolArray16x16x16 voxels, out byte[,,] materials)
+         {
+-            voxels = new BoolArray16x16x16();
+-            materials = new byte[16, 16, 16];
++            // Stratum start:
++            // instead of new BoolArray/byte[][] we use ThreadLocal + Span<byte> for flat addressing of byte[,,]; SetRangeTrue/Fill instead of nested loops
++            voxels = RebuildVoxelsTL.Value;
++            voxels.Clear();
++            materials = RebuildMaterialsTL.Value;
++
++
++            // byte[,,] in .NET is stored contiguously in memory (row-major),
++            // so it's safe to get a flat Span and work with it as byte[4096].
++            // This removes 3D addressing (multiplications + 3 bounds checks) per element.
++            Span<byte> flatMaterials = MemoryMarshal.CreateSpan(ref materials[0, 0, 0], 16 * 16 * 16);
++
+             CuboidWithMaterial cwm = tmpCuboids[0];
+ 
+-            for (int i = 0; i < VoxelCuboids.Count; i++)
++            List<uint> list = VoxelCuboids;
++            int count = list.Count;
++
++            for (int i = 0; i < count; i++)
+             {
+-                FromUint(VoxelCuboids[i], cwm);
++                FromUint(list[i], cwm);
++
++                int lenZ = cwm.Z2 - cwm.Z1;
++                byte material = cwm.Material;
+ 
+                 for (int dx = cwm.X1; dx < cwm.X2; dx++)
+                 {
++                    int baseX = dx * 256; // 16*16
++
+                     for (int dy = cwm.Y1; dy < cwm.Y2; dy++)
+                     {
+-                        for (int dz = cwm.Z1; dz < cwm.Z2; dz++)
+-                        {
+-                            voxels[dx, dy, dz] = true;
+-                            materials[dx, dy, dz] = cwm.Material;
+-                        }
++                        int baseIndex = baseX + dy * 16 + cwm.Z1;
++
++                        // instead of lenZ individual assignments, one mass call for the entire Z-bar
++                        voxels.SetRangeTrue(baseIndex, lenZ);
++                        flatMaterials.Slice(baseIndex, lenZ).Fill(material);
+                     }
+                 }
+             }
+         }
++        // Stratum end
+ 
+         public void RebuildCuboidList()
+         {
+             ConvertToVoxels(out BoolArray16x16x16 Voxels, out byte[,,] VoxelMaterial);
+             RebuildCuboidList(Voxels, VoxelMaterial);
+@@ -768,110 +800,113 @@ namespace Vintagestory.GameContent
+         {
+             RebuildCuboidList();
+             MarkDirty(true);
+         }
+ 
++
++        [MethodImpl(MethodImplOptions.AggressiveInlining)]
++        // Stratum start: VoxelVisited from ThreadLocal instead of new; Span<byte> flatMat instead of 3D addressing of VoxelMaterial; GetFlat/SetFlatTrue instead of indexers; CuboidBuffer[cuboidCount++] instead of List.Add; optimized bounds checking (isWest/isEast/xCenter/yCenter)
+         protected void RebuildCuboidList(BoolArray16x16x16 Voxels, byte[,,] VoxelMaterial)
+         {
+-            BoolArray16x16x16 VoxelVisited = new BoolArray16x16x16();
++            BoolArray16x16x16 VoxelVisited = VoxelVisitedTL.Value;
++            VoxelVisited.Clear();
++
+             int prevEmitSideAo = emitSideAo;
+             emitSideAo = 0x3F;
+             sidecenterSolid = new SmallBoolArray(SmallBoolArray.OnAllSides);
+             float voxelCount = 0;
+-
+-            // And now let's rebuild the cuboids with some greedy search algo thing
+-            List<uint> voxelCuboids = new List<uint>();
++            int cuboidCount = 0;
++            CuboidWithMaterial cub = tmpCuboids[0];
+ 
+             int[] edgeVoxelsMissing = new int[6];
+             int[] edgeCenterVoxelsMissing = new int[6];
+ 
+             byte[] lightshv = GetLightHsv(Api.World.BlockAccessor);
+ 
++            // Flat Span instead of byte[,,] - removes 3-dimensional addressing for each voxel
++            Span<byte> flatMat = MemoryMarshal.CreateSpan(ref VoxelMaterial[0, 0, 0], 4096);
++
++            int idx = 0;
++
+             for (int dx = 0; dx < 16; dx++)
+             {
++                // Calculate dx once every 16 iterations, rather than dz every 4096 iterations
++                bool isWest = dx == 0;
++                bool isEast = dx == 15;
++                bool xCenter = dx >= 4 && dx <= 12;
++
+                 for (int dy = 0; dy < 16; dy++)
+                 {
+-                    for (int dz = 0; dz < 16; dz++)
++                    // Calculate once per 256 iterations (16 dx * 16 dy), not per 4096
++                    bool isDown = dy == 0;
++                    bool isUp = dy == 15;
++                    bool yCenter = dy >= 4 && dy <= 12;
++
++                    for (int dz = 0; dz < 16; dz++, idx++)
+                     {
+-                        bool isVoxel = Voxels[dx, dy, dz];
+-
+-                        // North: Negative Z
+-                        // East: Positive X
+-                        // South: Positive Z
+-                        // West: Negative X
+-                        // Up: Positive Y
+-                        // Down: Negative Y
++                        bool isVoxel = Voxels.GetFlat(idx);
++
+                         if (!isVoxel)
+                         {
+                             if (dz == 0)
+                             {
+                                 edgeVoxelsMissing[BlockFacing.NORTH.Index]++;
+-                                if (Math.Abs(dy - 8) < 5 && Math.Abs(dx - 8) < 5) edgeCenterVoxelsMissing[BlockFacing.NORTH.Index]++;
++                                if (yCenter && xCenter) edgeCenterVoxelsMissing[BlockFacing.NORTH.Index]++;
+                             }
+-                            if (dx == 15)
++                            if (isEast)
+                             {
+                                 edgeVoxelsMissing[BlockFacing.EAST.Index]++;
+-                                if (Math.Abs(dy - 8) < 5 && Math.Abs(dz - 8) < 5) edgeCenterVoxelsMissing[BlockFacing.EAST.Index]++;
++                                if (yCenter && dz >= 4 && dz <= 12) edgeCenterVoxelsMissing[BlockFacing.EAST.Index]++;
+                             }
+                             if (dz == 15)
+                             {
+                                 edgeVoxelsMissing[BlockFacing.SOUTH.Index]++;
+-                                if (Math.Abs(dy - 8) < 5 && Math.Abs(dx - 8) < 5) edgeCenterVoxelsMissing[BlockFacing.SOUTH.Index]++;
++                                if (yCenter && xCenter) edgeCenterVoxelsMissing[BlockFacing.SOUTH.Index]++;
+                             }
+-                            if (dx == 0)
++                            if (isWest)
+                             {
+                                 edgeVoxelsMissing[BlockFacing.WEST.Index]++;
+-                                if (Math.Abs(dy - 8) < 5 && Math.Abs(dz - 8) < 5) edgeCenterVoxelsMissing[BlockFacing.WEST.Index]++;
++                                if (yCenter && dz >= 4 && dz <= 12) edgeCenterVoxelsMissing[BlockFacing.WEST.Index]++;
+                             }
+-                            if (dy == 15)
++                            if (isUp)
+                             {
+                                 edgeVoxelsMissing[BlockFacing.UP.Index]++;
+-                                if (Math.Abs(dz - 8) < 5 && Math.Abs(dx - 8) < 5) edgeCenterVoxelsMissing[BlockFacing.UP.Index]++;
++                                if (dz >= 4 && dz <= 12 && xCenter) edgeCenterVoxelsMissing[BlockFacing.UP.Index]++;
+                             }
+-                            if (dy == 0)
++                            if (isDown)
+                             {
+                                 edgeVoxelsMissing[BlockFacing.DOWN.Index]++;
+-                                if (Math.Abs(dz - 8) < 5 && Math.Abs(dx - 8) < 5) edgeCenterVoxelsMissing[BlockFacing.DOWN.Index]++;
++                                if (dz >= 4 && dz <= 12 && xCenter) edgeCenterVoxelsMissing[BlockFacing.DOWN.Index]++;
+                             }
+                             continue;
+                         }
+-                        else
+-                        {
+-                            voxelCount++;
+-                        }
+ 
+-                        if (VoxelVisited[dx, dy, dz]) continue;
++                        voxelCount++;
++
++                        if (VoxelVisited.GetFlat(idx)) continue;
++
++                        cub.X1 = dx; cub.Y1 = dy; cub.Z1 = dz;
++                        cub.X2 = dx + 1; cub.Y2 = dy + 1; cub.Z2 = dz + 1;
++                        cub.Material = flatMat[idx];
+ 
+-                        CuboidWithMaterial cub = new CuboidWithMaterial()
+-                        {
+-                            Material = VoxelMaterial[dx, dy, dz],
+-                            X1 = dx,
+-                            Y1 = dy,
+-                            Z1 = dz,
+-                            X2 = dx + 1,
+-                            Y2 = dy + 1,
+-                            Z2 = dz + 1
+-                        };
+-
+-                        // Try grow this cuboid for as long as we can
+                         bool didGrowAny = true;
+                         while (didGrowAny)
+                         {
+                             didGrowAny = false;
+-                            didGrowAny |= TryGrowX(cub, Voxels, VoxelVisited, VoxelMaterial);
+-                            didGrowAny |= TryGrowY(cub, Voxels, VoxelVisited, VoxelMaterial);
+-                            didGrowAny |= TryGrowZ(cub, Voxels, VoxelVisited, VoxelMaterial);
++                            didGrowAny |= TryGrowX(cub, Voxels, VoxelVisited, flatMat);
++                            didGrowAny |= TryGrowY(cub, Voxels, VoxelVisited, flatMat);
++                            didGrowAny |= TryGrowZ(cub, Voxels, VoxelVisited, flatMat);
+                         }
+ 
+-                        voxelCuboids.Add(ToUint(cub));
++                        CuboidBuffer[cuboidCount++] = ToUint(cub);
+                     }
+                 }
+             }
+ 
+-            this.VoxelCuboids = voxelCuboids;
+-
+-            bool doEmitSideAo = edgeVoxelsMissing[0] < 64 || edgeVoxelsMissing[1] < 64 || edgeVoxelsMissing[2] < 64 || edgeVoxelsMissing[3] < 64 || edgeVoxelsMissing[4] < 64 || edgeVoxelsMissing[5] < 64;
++            bool doEmitSideAo = edgeVoxelsMissing[0] < 64 || edgeVoxelsMissing[1] < 64 ||
++                                edgeVoxelsMissing[2] < 64 || edgeVoxelsMissing[3] < 64 ||
++                                edgeVoxelsMissing[4] < 64 || edgeVoxelsMissing[5] < 64;
+ 
+             if (absorbAnyLight != doEmitSideAo)
+             {
+                 int preva = GetLightAbsorption();
+                 absorbAnyLight = doEmitSideAo;
+@@ -886,15 +921,11 @@ namespace Vintagestory.GameContent
+             for (int i = 0; i < 6; i++)
+             {
+                 sidecenterSolid[i] = edgeCenterVoxelsMissing[i] < 5;
+                 if ((sideAlmostSolid[i] = edgeVoxelsMissing[i] <= 32)) emitFlags += 1 << i;
+             }
+-            //if (emitFlags != 0x3F)
+-            //{
+-            //    if (emitFlags == 0x3E && emitFlags == 0x3D && emitFlags == 0x3B && emitFlags == 0x37) emitFlags = 0x3F;  // If only one side missing, treat as full cube
+-            //    else emitFlags &= 0x30;
+-            //}
++
+             emitSideAo = lightshv[2] < 10 && doEmitSideAo ? emitFlags : 0;
+ 
+             if (BlockIds.Length == 1 && Api.World.GetBlock(BlockIds[0]).RenderPass == EnumChunkRenderPass.Meta)
+             {
+                 emitSideAo = 0;
+@@ -915,10 +946,11 @@ namespace Vintagestory.GameContent
+             if (DisplacesLiquid())
+             {
+                 Api.World.BlockAccessor.SetBlock(0, Pos, BlockLayersAccess.Fluid);
+             }
+         }
++        // Stratum end
+ 
+         private void RedrawNeighbourChunkIfAoChanged(int prevEmitSideAo)
+         {
+             prevEmitSideAo ^= emitSideAo;  // This is now the changed bits
+             if (prevEmitSideAo == 0) return;  // No change
+@@ -935,81 +967,96 @@ namespace Vintagestory.GameContent
+             return sideAlmostSolid[0] && sideAlmostSolid[1] && sideAlmostSolid[2] && sideAlmostSolid[3] && sideAlmostSolid[5];
+         }
+ 
+ 
+ 
+-        protected bool TryGrowX(CuboidWithMaterial cub, BoolArray16x16x16 voxels, BoolArray16x16x16 voxelVisited, byte[,,] voxelMaterial)
++        // Stratum start: Span<byte> voxelMaterial instead of byte[,,], GetFlat/SetFlatTrue instead of indexers, calculate baseXY in advance
++        protected bool TryGrowX(CuboidWithMaterial cub, BoolArray16x16x16 voxels, BoolArray16x16x16 voxelVisited, Span<byte> voxelMaterial)
+         {
+             if (cub.X2 > 15) return false;
+ 
++            int baseX = cub.X2 * 256;
++
+             for (int y = cub.Y1; y < cub.Y2; y++)
+             {
++                int baseXY = baseX + y * 16;
+                 for (int z = cub.Z1; z < cub.Z2; z++)
+                 {
+-                    if (!voxels[cub.X2, y, z] || voxelVisited[cub.X2, y, z] || voxelMaterial[cub.X2, y, z] != cub.Material) return false;
++                    int idx = baseXY + z;
++                    if (!voxels.GetFlat(idx) || voxelVisited.GetFlat(idx) || voxelMaterial[idx] != cub.Material) return false;
+                 }
+             }
+ 
+             for (int y = cub.Y1; y < cub.Y2; y++)
+             {
++                int baseXY = baseX + y * 16;
+                 for (int z = cub.Z1; z < cub.Z2; z++)
+-                {
+-                    voxelVisited[cub.X2, y, z] = true;
+-                }
++                    voxelVisited.SetFlatTrue(baseXY + z);
+             }
+ 
+             cub.X2++;
+             return true;
+         }
++        // Stratum end
+ 
+-        protected bool TryGrowY(CuboidWithMaterial cub, BoolArray16x16x16 voxels, BoolArray16x16x16 voxelVisited, byte[,,] voxelMaterial)
++        // Stratum start: Span<byte> voxelMaterial instead of byte[,,], GetFlat/SetFlatTrue, baseY calculated once
++        protected bool TryGrowY(CuboidWithMaterial cub, BoolArray16x16x16 voxels, BoolArray16x16x16 voxelVisited, Span<byte> voxelMaterial)
+         {
+             if (cub.Y2 > 15) return false;
+ 
++            int baseY = cub.Y2 * 16;
++
+             for (int x = cub.X1; x < cub.X2; x++)
+             {
++                int baseXY = x * 256 + baseY;
+                 for (int z = cub.Z1; z < cub.Z2; z++)
+                 {
+-                    if (!voxels[x, cub.Y2, z] || voxelVisited[x, cub.Y2, z] || voxelMaterial[x, cub.Y2, z] != cub.Material) return false;
++                    int idx = baseXY + z;
++                    if (!voxels.GetFlat(idx) || voxelVisited.GetFlat(idx) || voxelMaterial[idx] != cub.Material) return false;
+                 }
+             }
+ 
+             for (int x = cub.X1; x < cub.X2; x++)
+             {
++                int baseXY = x * 256 + baseY;
+                 for (int z = cub.Z1; z < cub.Z2; z++)
+-                {
+-                    voxelVisited[x, cub.Y2, z] = true;
+-                }
++                    voxelVisited.SetFlatTrue(baseXY + z);
+             }
+ 
+             cub.Y2++;
+             return true;
+         }
++        // Stratum end
+ 
+-        protected bool TryGrowZ(CuboidWithMaterial cub, BoolArray16x16x16 voxels, BoolArray16x16x16 voxelVisited, byte[,,] voxelMaterial)
++        // Stratum start: Span<byte> voxelMaterial instead of byte[,,], GetFlat/SetFlatTrue, z2 moved outside the loop
++        protected bool TryGrowZ(CuboidWithMaterial cub, BoolArray16x16x16 voxels, BoolArray16x16x16 voxelVisited, Span<byte> voxelMaterial)
+         {
+             if (cub.Z2 > 15) return false;
+ 
++            int z2 = cub.Z2;
++
+             for (int x = cub.X1; x < cub.X2; x++)
+             {
++                int baseX = x * 256;
+                 for (int y = cub.Y1; y < cub.Y2; y++)
+                 {
+-                    if (!voxels[x, y, cub.Z2] || voxelVisited[x, y, cub.Z2] || voxelMaterial[x, y, cub.Z2] != cub.Material) return false;
++                    int idx = baseX + y * 16 + z2;
++                    if (!voxels.GetFlat(idx) || voxelVisited.GetFlat(idx) || voxelMaterial[idx] != cub.Material) return false;
+                 }
+             }
+ 
+             for (int x = cub.X1; x < cub.X2; x++)
+             {
++                int baseX = x * 256;
+                 for (int y = cub.Y1; y < cub.Y2; y++)
+-                {
+-                    voxelVisited[x, y, cub.Z2] = true;
+-                }
++                    voxelVisited.SetFlatTrue(baseX + y * 16 + z2);
+             }
+ 
+             cub.Z2++;
+             return true;
+         }
++        // Stratum end
+ 
+ 
+ 
+         public virtual void RegenSelectionBoxes(IWorldAccessor worldForResolve, IPlayer byPlayer)
+         {
+@@ -2557,29 +2604,103 @@ namespace Vintagestory.GameContent
          {
              return GetEncompassingHitbox(VoxelCuboids);
          }
@@ -22,24 +408,24 @@ index 4e4704b..6ffea38 100644
 -        BitArray voxels;   // Compact storage of boolean values in this nice high-performance class provided by System.Collections - note, suitable for large arrays of bools as we have here; in contrast, our own SmallBoolArray is more suitable for small arrays of bools especially length 6
 +        // Array of 64 ulong elements (64 * 64 bits = 4096 bits), allocated only once upon instantiation
 +        private readonly ulong[] voxels = new ulong[64];
++
++        [MethodImpl(MethodImplOptions.AggressiveInlining)]
++        public void Clear()
++        {
++            // Instantly zeroes out all 64 elements without creating a new object (zero allocations)
++            Array.Clear(voxels, 0, 64);
++        }
  
 -        public BoolArray16x16x16()
 +        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-+        public void Clear()
++        public bool Get(int x, int y, int z)
          {
 -            voxels = new BitArray(16 * 16 * 16);
-+            // Instantly zeroes out all 64 elements without creating a new object (zero allocations)
-+            Array.Clear(voxels, 0, 64);
-         }
- 
-+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-+        public bool Get(int x, int y, int z)
-+        {
 +            // Calculates flat index and checks the target bit using a fast bitwise AND
 +            int index = ((x * 16) + y) * 16 + z;
 +            return (voxels[index >> 6] & (1UL << (index & 63))) != 0;
-+        }
-+
+         }
+ 
 +        [MethodImpl(MethodImplOptions.AggressiveInlining)]
 +        public void Set(int x, int y, int z, bool value)
 +        {
@@ -59,6 +445,12 @@ index 4e4704b..6ffea38 100644
 +            voxels[index >> 6] |= (1UL << (index & 63));
 +        }
 +
++        [MethodImpl(MethodImplOptions.AggressiveInlining)]
++        public bool GetFlat(int index) => (voxels[index >> 6] & (1UL << (index & 63))) != 0;
++
++        [MethodImpl(MethodImplOptions.AggressiveInlining)]
++        public void SetFlatTrue(int index) => voxels[index >> 6] |= (1UL << (index & 63));
++
 +        // Indexer for full backward compatibility with the legacy array[x, y, z] syntax
          public bool this[int x, int y, int z]
          {
@@ -69,8 +461,41 @@ index 4e4704b..6ffea38 100644
              [MethodImpl(MethodImplOptions.AggressiveInlining)]
 -            set { voxels[((x * 16) + y) * 16 + z] = value; }
 +            set => Set(x, y, z, value);
++        }
++
++        [MethodImpl(MethodImplOptions.AggressiveInlining)]
++        public void SetRangeTrue(int startIndex, int length)
++        {
++            if (length <= 0) return;
++
++            int bitOffset = startIndex & 63;
++            int wordIndex = startIndex >> 6;
++
++            if (bitOffset + length <= 64)
++            {
++                ulong mask = length == 64 ? ulong.MaxValue : ((1UL << length) - 1) << bitOffset;
++                voxels[wordIndex] |= mask;
++                return;
++            }
++
++            // first (partial) word
++            voxels[wordIndex] |= ulong.MaxValue << bitOffset;
++            int remaining = length - (64 - bitOffset);
++            wordIndex++;
++
++            // full words
++            while (remaining >= 64)
++            {
++                voxels[wordIndex++] = ulong.MaxValue;
++                remaining -= 64;
++            }
++
++            // tail
++            if (remaining > 0)
++            {
++                voxels[wordIndex] |= (1UL << remaining) - 1;
++            }
          }
      }
-+
 +    // Startum end
  }

--- a/patches/VSSurvivalMod/Systems/Prospecting/ProPickWorkSpace.cs.patch
+++ b/patches/VSSurvivalMod/Systems/Prospecting/ProPickWorkSpace.cs.patch
@@ -1,0 +1,36 @@
+diff --git a/VSSurvivalMod/Systems/Prospecting/ProPickWorkSpace.cs b/VSSurvivalMod/Systems/Prospecting/ProPickWorkSpace.cs
+index 3fe5096..d75e6dc 100644
+--- a/VSSurvivalMod/Systems/Prospecting/ProPickWorkSpace.cs
++++ b/VSSurvivalMod/Systems/Prospecting/ProPickWorkSpace.cs
+@@ -216,10 +216,31 @@ namespace Vintagestory.GameContent
+                 public void SetBlockUnsafe(int index3d, int value)
+                 {
+                     this[index3d] = value;
+                 }
+ 
++                // Stratum: necessary interface overload
++                public void CopyBlocksToUnsafe(int[] blocksOut)
++                {
++                    Array.Copy(blocks, blocksOut, blocks.Length);
++                }
++
++                /// <summary>
++                /// Stratum: bulk variant of SetBlockUnsafe for interface compatibility. DummyChunkData
++                /// is a plain int[] with no locking, so there's no batching benefit here — just applies
++                /// each pair directly, same as calling SetBlockUnsafe in a loop.
++                /// </summary>
++                public void SetBlocksUnsafe(List<int> indices, List<int> values)
++                {
++                    int count = indices.Count;
++                    for (int i = 0; i < count; i++)
++                    {
++                        blocks[indices[i]] = values[i];
++                    }
++                }
++
++
+                 public void SetFluid(int index3d, int value)
+                 {
+ 
+                 }
+ 

--- a/patches/VintagestoryApi/Common/API/IWorldChunk.cs.patch
+++ b/patches/VintagestoryApi/Common/API/IWorldChunk.cs.patch
@@ -1,0 +1,47 @@
+diff --git a/VintagestoryApi/Common/API/IWorldChunk.cs b/VintagestoryApi/Common/API/IWorldChunk.cs
+index 1016d62..fccf531 100644
+--- a/VintagestoryApi/Common/API/IWorldChunk.cs
++++ b/VintagestoryApi/Common/API/IWorldChunk.cs
+@@ -32,10 +32,23 @@ namespace Vintagestory.API.Common
+         /// Not threadsafe, used only in cases where we know that the chunk already has a palette (e.g. in worldgen when replacing rock with other blocks)
+         /// </summary>
+         /// <param name="index3d"></param>
+         /// <param name="value"></param>
+         void SetBlockUnsafe(int index3d, int value);
++
++        /// <summary>
++        /// Bulk variant of <see cref="SetBlockUnsafe"/>. Not threadsafe for the same reasons.
++        /// Applies every (index3d, value) pair in indices/values (up to count entries) while
++        /// taking the underlying layer's write lock only once for the whole batch, instead of
++        /// once per block. Useful for worldgen code that already buffers many block writes for
++        /// one chunk before flushing (e.g. rock strata generation), to cut lock-acquisition
++        /// overhead and contention with other worldgen threads writing to the same chunk.
++        /// </summary>
++        /// <param name="indices">Buffered index3d values.</param>
++        /// <param name="values">Buffered block ids, parallel to indices.</param>
++        void SetBlocksUnsafe(List<int> indices, List<int> values);
++
+         void SetBlockAir(int index3d);
+         /// <summary>
+         /// Used to place blocks into the fluid layer instead of the solid blocks layer; calling code must do this
+         /// </summary>
+         /// <param name="index3d"></param>
+@@ -48,10 +61,18 @@ namespace Vintagestory.API.Common
+         /// Like get (i.e. this[]) but not threadsafe - only for use where setting and getting is guaranteed to be all on the same thread (e.g. during worldgen)
+         /// </summary>
+         /// <param name="index3d"></param>
+         int GetBlockIdUnsafe(int index3d);
+ 
++        /// <summary>
++        /// Not threadsafe, used only where a single thread has exclusive access to this chunk
++        /// (e.g. worldgen). Decodes every block ID in this chunk into blocksOut (must be at
++        /// least Length in size) in one pass, avoiding the per-position dispatch/decode cost of
++        /// calling GetBlockIdUnsafe once for every position that needs to be read.
++        /// </summary>
++        void CopyBlocksToUnsafe(int[] blocksOut);
++
+         /// <summary>
+         /// Enter a locked section for bulk block reads from this ChunkData, using Unsafe read methods
+         /// </summary>
+         void TakeBulkReadLock();
+ 

--- a/patches/VintagestoryLib/Vintagestory.Common/ChunkData.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Common/ChunkData.cs.patch
@@ -1,0 +1,56 @@
+diff --git a/VintagestoryLib/Vintagestory.Common/ChunkData.cs b/VintagestoryLib/Vintagestory.Common/ChunkData.cs
+index af79143..bb31aff 100644
+--- a/VintagestoryLib/Vintagestory.Common/ChunkData.cs
++++ b/VintagestoryLib/Vintagestory.Common/ChunkData.cs
+@@ -166,10 +166,21 @@ public class ChunkData : IChunkBlocks, IChunkLight, IEnumerable<int>, IEnumerabl
+ 	public int GetBlockIdUnsafe(int index3d)
+ 	{
+ 		return blocksLayer?.GetUnsafe(index3d) ?? 0;
+ 	}
+ 
++
++	public void CopyBlocksToUnsafe(int[] blocksOut)
++	{
++		if (blocksLayer == null || blocksLayer.palette == null)
++		{
++			Array.Clear(blocksOut, 0, blocksOut.Length);
++			return;
++		}
++		blocksLayer.CopyBlocksToUnsafe(blocksOut);
++	}
++
+ 	public int GetBlockIdUnsafe(int index3d, int layer)
+ 	{
+ 		switch (layer)
+ 		{
+ 		default:
+@@ -246,10 +257,29 @@ public class ChunkData : IChunkBlocks, IChunkLight, IEnumerable<int>, IEnumerabl
+ 			blocksLayer = new BlockChunkDataLayer(pool);
+ 		}
+ 		blocksLayer.SetUnsafe(index3d, value);
+ 	}
+ 
++	/// <summary>
++	/// Stratum: bulk variant of SetBlockUnsafe. Forwards a buffered batch of
++	/// (index3d, value) pairs to the blocks layer's SetManyUnsafe, taking the
++	/// layer's write lock once for the whole batch instead of once per block.
++	/// </summary>
++	public void SetBlocksUnsafe(List<int> indices, List<int> values)
++	{
++		if (indices.Count == 0)
++		{
++			return;
++		}
++		if (blocksLayer == null)
++		{
++			blocksLayer = new BlockChunkDataLayer(pool);
++		}
++		blocksLayer.SetManyUnsafe(indices, values);
++	}
++
++
+ 	public void SetBlockAir(int index3d)
+ 	{
+ 		blocksLayer?.SetZero(index3d);
+ 	}
+ 

--- a/patches/VintagestoryLib/Vintagestory.Common/ChunkDataLayer.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Common/ChunkDataLayer.cs.patch
@@ -1,5 +1,5 @@
 diff --git a/VintagestoryLib/Vintagestory.Common/ChunkDataLayer.cs b/VintagestoryLib/Vintagestory.Common/ChunkDataLayer.cs
-index 4d0bf91..db14432 100644
+index 4d0bf91..a5169d0 100644
 --- a/VintagestoryLib/Vintagestory.Common/ChunkDataLayer.cs
 +++ b/VintagestoryLib/Vintagestory.Common/ChunkDataLayer.cs
 @@ -1,9 +1,11 @@
@@ -515,8 +515,8 @@ index 4d0bf91..db14432 100644
 +		int b11 = (Unsafe.Add(ref base11, arrayIndex) >> shift) & 1;
 +		int b12 = (Unsafe.Add(ref base12, arrayIndex) >> shift) & 1;
 +		return palette[b0 | (b1 << 1) | (b2 << 2) | (b3 << 3) | (b4 << 4) | (b5 << 5) | (b6 << 6) | (b7 << 7) | (b8 << 8) | (b9 << 9) | (b10 << 10) | (b11 << 11) | (b12 << 12)];
- 	}
- 
++	}
++
 +	/// <summary>Fast-path read for bit depth of 14. Extracts the fourteen least significant bits from all available planes.</summary>
 +	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 +	private int GetFromBits14(int index3d)
@@ -552,8 +552,8 @@ index 4d0bf91..db14432 100644
 +		int b12 = (Unsafe.Add(ref base12, arrayIndex) >> shift) & 1;
 +		int b13 = (Unsafe.Add(ref base13, arrayIndex) >> shift) & 1;
 +		return palette[b0 | (b1 << 1) | (b2 << 2) | (b3 << 3) | (b4 << 4) | (b5 << 5) | (b6 << 6) | (b7 << 7) | (b8 << 8) | (b9 << 9) | (b10 << 10) | (b11 << 11) | (b12 << 12) | (b13 << 13)];
-+	}
-+
+ 	}
+ 
 +	// Stratum end.
 +
 +	/// <summary>Selects the optimal read delegate based on the current palette bit depth.</summary>
@@ -742,12 +742,43 @@ index 4d0bf91..db14432 100644
  		readWriteLock.AcquireReadLock();
  		int[][] array = new int[bitsize][];
  		try
-@@ -215,82 +683,94 @@ public class ChunkDataLayer
+@@ -215,82 +683,125 @@ public class ChunkDataLayer
  		{
  			readWriteLock.ReleaseReadLock();
  		}
  	}
  
++
++	/// <summary>
++	/// Stratum: unsafe bulk-read variant of CopyBlocksTo — decodes every block ID in this
++	/// layer into blocksOut without taking readWriteLock. Only safe where the caller
++	/// already guarantees exclusive single-threaded access to this ChunkDataLayer, the
++	/// same guarantee GetUnsafe/SetUnsafe already rely on.
++	/// </summary>
++	public void CopyBlocksToUnsafe(int[] blocksOut)
++	{
++		if (palette == null)
++		{
++			Array.Clear(blocksOut, 0, blocksOut.Length);
++			return;
++		}
++		int num = bitsize;
++		for (int i = 0; i < blocksOut.Length; i += 32)
++		{
++			int num2 = i / 32;
++			for (int j = 0; j < 32; j++)
++			{
++				int index = 0;
++				for (int k = 0; k < num; k++)
++				{
++					if (((dataBits[k][num2] >> j) & 1) != 0)
++						index |= (1 << k);
++				}
++				blocksOut[i + j] = palette[index];
++			}
++		}
++	}
++
 +	/// <summary>Gets the block value at a 3D index with palette null-check. Returns 0 if the palette is not initialized.</summary>
  	public int GetUnsafe_PaletteCheck(int index3d)
  	{
@@ -884,7 +915,7 @@ index 4d0bf91..db14432 100644
  		{
  			int num;
  			if (palette != null)
-@@ -314,19 +794,19 @@ public class ChunkDataLayer
+@@ -314,19 +825,19 @@ public class ChunkDataLayer
  									break;
  								}
  								num++;
@@ -911,7 +942,7 @@ index 4d0bf91..db14432 100644
  						setBlockIndexCached = num;
  						setBlockValueCached = value;
  					}
-@@ -376,11 +856,21 @@ public class ChunkDataLayer
+@@ -376,11 +887,44 @@ public class ChunkDataLayer
  			return;
  		}
  		throw new IndexOutOfRangeException("Chunk blocks index3d must be between 0 and " + 32767 + ", was " + index3d);
@@ -926,6 +957,29 @@ index 4d0bf91..db14432 100644
 +		}
 +	}
 +
++
++	/// <summary>
++	/// Stratum: bulk write for a whole batch of (index3d, value) pairs. Takes
++	/// stratumWriteLock ONCE for the entire batch instead of once per block —
++	/// meant for callers that buffer many writes for one layer before flushing,
++	/// e.g. GenRockStrataNew accumulating a subchunk's worth of strata blocks.
++	/// Correctness matches calling SetUnsafe once per pair in order: each
++	/// SetUnsafeCore reads/updates setBlockIndexCached/setBlockValueCached and
++	/// the palette exactly as the single-call path does, just without releasing
++	/// the lock between entries.
++	/// </summary>
++	public void SetManyUnsafe(List<int> indices, List<int> values)
++	{
++		lock (stratumWriteLock)
++		{
++			int count = indices.Count;
++			for (int i = 0; i < count; i++)
++			{
++				SetUnsafeCore(indices[i], values[i]);
++			}
++		}
++	}
++
 +	/// <summary>SetUnsafe core. Executes under the held stratumWriteLock.</summary>
 +	private void SetUnsafeCore(int index3d, int value)
  	{
@@ -933,7 +987,7 @@ index 4d0bf91..db14432 100644
  		index3d /= 32;
  		int num2 = ~num;
  		if (value != 0)
-@@ -449,11 +939,21 @@ public class ChunkDataLayer
+@@ -449,11 +993,21 @@ public class ChunkDataLayer
  				dataBits[j][index3d] &= num2;
  			}
  		}
@@ -955,7 +1009,7 @@ index 4d0bf91..db14432 100644
  		{
  			int num = 1 << index3d;
  			index3d /= 32;
-@@ -464,65 +964,64 @@ public class ChunkDataLayer
+@@ -464,65 +1018,64 @@ public class ChunkDataLayer
  				dataBits[i][index3d] &= num2;
  			}
  		}
@@ -1054,7 +1108,7 @@ index 4d0bf91..db14432 100644
  		if (dataBits == null)
  		{
  			dataBits = new int[15][];
-@@ -535,10 +1034,11 @@ public class ChunkDataLayer
+@@ -535,10 +1088,11 @@ public class ChunkDataLayer
  		palette[1] = value;
  		Get = GetFromBits1;
  		bitsize = 1;
@@ -1066,7 +1120,7 @@ index 4d0bf91..db14432 100644
  		if (bitsize > 6 && CleanUpPalette())
  		{
  			return paletteCount;
-@@ -555,10 +1055,11 @@ public class ChunkDataLayer
+@@ -555,10 +1109,11 @@ public class ChunkDataLayer
  		Get = selectDelegate(bitsize + 1);
  		bitsize++;
  		return num;
@@ -1078,7 +1132,7 @@ index 4d0bf91..db14432 100644
  		if (pool.server == null)
  		{
  			if (bitsize < 14)
-@@ -653,10 +1154,11 @@ public class ChunkDataLayer
+@@ -653,10 +1208,11 @@ public class ChunkDataLayer
  			}
  		}
  		return true;
@@ -1090,7 +1144,7 @@ index 4d0bf91..db14432 100644
  		if (paletteCount == 0)
  		{
  			return 0;
-@@ -668,10 +1170,11 @@ public class ChunkDataLayer
+@@ -668,10 +1224,11 @@ public class ChunkDataLayer
  			num2++;
  		}
  		return num2;
@@ -1102,7 +1156,7 @@ index 4d0bf91..db14432 100644
  		int num = paletteCount - 1;
  		for (int num2 = num / 32; num2 >= 0; num2--)
  		{
-@@ -698,23 +1201,18 @@ public class ChunkDataLayer
+@@ -698,23 +1255,18 @@ public class ChunkDataLayer
  				}
  			}
  		}
@@ -1129,7 +1183,7 @@ index 4d0bf91..db14432 100644
  		Get = GetFromBits0;
  		int num = bitsize;
  		bitsize = 0;
-@@ -731,10 +1229,11 @@ public class ChunkDataLayer
+@@ -731,10 +1283,11 @@ public class ChunkDataLayer
  		}
  		setBlockIndexCached = 0;
  		setBlockValueCached = 0;
@@ -1141,7 +1195,7 @@ index 4d0bf91..db14432 100644
  		if (dataBits == null)
  		{
  			dataBits = new int[15][];
-@@ -746,19 +1245,21 @@ public class ChunkDataLayer
+@@ -746,19 +1299,21 @@ public class ChunkDataLayer
  		paletteCount = 1;
  		Get = GetFromBits1;
  		bitsize = 1;
@@ -1163,7 +1217,7 @@ index 4d0bf91..db14432 100644
  		int num = 0;
  		readWriteLock.AcquireReadLock();
  		try
-@@ -774,10 +1275,11 @@ public class ChunkDataLayer
+@@ -774,10 +1329,11 @@ public class ChunkDataLayer
  			readWriteLock.ReleaseReadLock();
  		}
  		return Compression.CompressAndCombine(arrayStatic, palette, paletteCount);
@@ -1175,7 +1229,7 @@ index 4d0bf91..db14432 100644
  		int num = 0;
  		lock (palette ?? ((object)readWriteLock))
  		{
-@@ -806,10 +1308,11 @@ public class ChunkDataLayer
+@@ -806,10 +1362,11 @@ public class ChunkDataLayer
  			paletteCompressed = Compression.Compress(palette, paletteCount, chunkdataVersion);
  		}
  		return Compression.Compress(arrayStatic, num, chunkdataVersion);
@@ -1187,7 +1241,7 @@ index 4d0bf91..db14432 100644
  		paletteCount = 0;
  		palette = Compression.DecompressCombined(layerCompressed, ref dataBits, ref paletteCount, pool.NewData);
  		if (palette != null)
-@@ -827,10 +1330,11 @@ public class ChunkDataLayer
+@@ -827,10 +1384,11 @@ public class ChunkDataLayer
  		{
  			bitsize = 0;
  		}
@@ -1199,7 +1253,7 @@ index 4d0bf91..db14432 100644
  		palette = Compression.DecompressToInts(paletteCompressed, ref paletteCount);
  		if (palette != null)
  		{
-@@ -872,10 +1376,11 @@ public class ChunkDataLayer
+@@ -872,10 +1430,11 @@ public class ChunkDataLayer
  			Get = GetFromBits0;
  			bitsize = 0;
  		}
@@ -1211,7 +1265,7 @@ index 4d0bf91..db14432 100644
  		if (dataBits == null)
  		{
  			dataBits = new int[15][];
-@@ -910,39 +1415,29 @@ public class ChunkDataLayer
+@@ -910,39 +1469,29 @@ public class ChunkDataLayer
  		{
  			pool.FreeArrays(this);
  		}
@@ -1239,12 +1293,12 @@ index 4d0bf91..db14432 100644
 -				}
 -				if (array[j + 2] != 0)
 -				{
--					return true;
++				if ((array[j] | array[j + 1] | array[j + 2] | array[j + 3]) != 0)
+ 					return true;
 -				}
 -				if (array[j + 3] != 0)
 -				{
-+				if ((array[j] | array[j + 1] | array[j + 2] | array[j + 3]) != 0)
- 					return true;
+-					return true;
 -				}
  			}
  		}
@@ -1257,7 +1311,7 @@ index 4d0bf91..db14432 100644
  		readWriteLock.AcquireReadLock();
  		try
  		{
-@@ -950,54 +1445,47 @@ public class ChunkDataLayer
+@@ -950,54 +1499,47 @@ public class ChunkDataLayer
  			for (int i = 0; i < blocksOut.Length; i += 32)
  			{
  				int num2 = i / 32;
@@ -1324,7 +1378,7 @@ index 4d0bf91..db14432 100644
  	{
  		int num = -1;
  		for (int i = 0; i < bitsize; i++)
-@@ -1005,10 +1493,11 @@ public class ChunkDataLayer
+@@ -1005,10 +1547,11 @@ public class ChunkDataLayer
  			num &= (((needle & (1 << i)) != 0) ? dataBits[i][intIndex] : (~dataBits[i][intIndex]));
  		}
  		return num;
@@ -1336,7 +1390,7 @@ index 4d0bf91..db14432 100644
  		for (int i = 0; i < paletteCount; i++)
  		{
  			if (palette[i] != id)
-@@ -1025,18 +1514,20 @@ public class ChunkDataLayer
+@@ -1025,18 +1568,20 @@ public class ChunkDataLayer
  			return false;
  		}
  		return false;
@@ -1357,7 +1411,7 @@ index 4d0bf91..db14432 100644
  		int num = ~mask;
  		readWriteLock.AcquireWriteLock();
  		for (int i = 0; i < bitsize; i++)
-@@ -1051,10 +1542,11 @@ public class ChunkDataLayer
+@@ -1051,10 +1596,11 @@ public class ChunkDataLayer
  			}
  		}
  		readWriteLock.ReleaseWriteLock();
@@ -1369,7 +1423,7 @@ index 4d0bf91..db14432 100644
  		int num = paletteCount - 1;
  		readWriteLock.AcquireWriteLock();
  		int num2 = bitsize;
-@@ -1088,10 +1580,11 @@ public class ChunkDataLayer
+@@ -1088,10 +1634,11 @@ public class ChunkDataLayer
  		palette[deletePosition] = palette[num];
  		paletteCount--;
  		readWriteLock.ReleaseWriteLock();
@@ -1381,7 +1435,7 @@ index 4d0bf91..db14432 100644
  		int[] array = palette;
  		if (array == null)
  		{
-@@ -1104,6 +1597,6 @@ public class ChunkDataLayer
+@@ -1104,6 +1651,6 @@ public class ChunkDataLayer
  			{
  				array[i] = 0;
  			}

--- a/patches/VintagestoryLib/Vintagestory.Common/NoChunkData.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Common/NoChunkData.cs.patch
@@ -1,0 +1,27 @@
+diff --git a/VintagestoryLib/Vintagestory.Common/NoChunkData.cs b/VintagestoryLib/Vintagestory.Common/NoChunkData.cs
+index db9ffef..a72ce6a 100644
+--- a/VintagestoryLib/Vintagestory.Common/NoChunkData.cs
++++ b/VintagestoryLib/Vintagestory.Common/NoChunkData.cs
+@@ -41,10 +41,22 @@ public class NoChunkData : IChunkBlocks
+ 
+ 	public void SetBlockUnsafe(int index3d, int blockId)
+ 	{
+ 	}
+ 
++
++	// Stratum: necessary interface overload
++	public void SetBlocksUnsafe(List<int> indices, List<int> values)
++	{
++	}
++
++	// Stratum: necessary interface overload
++	public void CopyBlocksToUnsafe(int[] blocksOut)
++	{
++
++	}
++
+ 	public void SetBlockAir(int index3d)
+ 	{
+ 	}
+ 
+ 	public int GetBlockId(int index, int layer)


### PR DESCRIPTION
## Summary

### `Microblock optimization`

### BlockEntityMicroBlock

**ConvertToVoxels:**
- ThreadLocal caches for `BoolArray16x16x16` and `byte[,,]` — eliminated per-call object allocations.
- `Span<byte>` replaces 3D indexing of `byte[,,]` (removed multiplications + 3 bounds checks per element).
- `SetRangeTrue` / `Fill` instead of nested Z-loop assignments.

**RebuildCuboidList:**
- `VoxelVisited` from ThreadLocal — zero allocations during rebuild.
- `Span<byte> flatMat` + `GetFlat`/`SetFlatTrue` replaces 3D access to `VoxelMaterial`.
- Fixed buffer `uint[4096]` with `cuboidCount++` instead of `List.Add`.
- Precomputed flags (`isWest`, `isEast`, `xCenter`, `yCenter`) hoisted out of inner loops.

**TryGrowX / TryGrowY / TryGrowZ:**
- Switched to `Span<byte>` and flat indexing.
- Base offsets (`baseX`/`baseXY`/`baseY`) computed once before nested loops.

> **Summary:** eliminated GC allocations during voxel rebuild, improved memory locality via flat access and `Span<T>`.

---

### BoolArray16x16x16 (new class)
- Stores 4096 bits in an array of 64 `ulong`s (512 bytes).
- `GetFlat`, `SetFlatTrue`, `SetRangeTrue` — fast bitwise ops without branch checks.
- `[x,y,z]` indexer preserved for backward compatibility.

> **Summary:** compact storage + O(1) bitwise operations instead of bool array.

---

### BEBehaviorMicroblockSnowCover

**buildSnowCuboids:**
- `Span<bool>` (stackalloc 256) replaces heap-allocated `bool[16,16]` — removed GC pressure per call.
- Flat indexing for visited and voxel access (`dx * 256 + yOffset + dz`).
- Removed unused iteration over `aboveCuboids.Contains()`.

**TrySnowableSurfaceGrowX / TrySnowableSurfaceGrowZ:**
- `Span<bool>` replaces `bool[,]` for visited.
- Flat indexing for voxels (`idx + 16` for Y+1).

> **Summary:** eliminated heap allocations in the hot snow-cover path

---

### `GenRockStrataNew optimization`

Implemented batch reading and writing of data in chunks. Why? This reduces the number of write locks and reduces the overhead of block-by-block access to palette data. Corresponding methods have also been added to `ChunkData` and `ChunkDataLayer` to implement this functionality. They may also be useful elsewhere.
Added corresponding overloads for the `IChunkBlocks` interface.

## Type

- [ ] Bug fix
- [x] Performance
- [ ] New feature
- [ ] Refactor or cleanup
- [ ] Docs or build

## Checklist

- [x] `.\scripts\extract-patches.ps1` ran clean.
- [x] `dotnet build VintageStory.slnx -c Release` is green.
- [x] Every vanilla edit has a `// Stratum` marker.
- [x] No vanilla source committed.
- [x] Tested on a real server start, not just compilation.

## Performance numbers

### `Microblock optimization`

Tested on the generation of 31417 chunk columns (6 threads):
- BlockEntityMicroBlock.FromTreeAttributes method execution time: reduced from 9904 ms to 5228 ms;
- BlockEntityMicroBlock GC memory allocations: reduced from 2.47 Gb to 1.57 GB.


**Before (vanilla)**
<img width="986" height="605" alt="microblock before trace" src="https://github.com/user-attachments/assets/183bd3ad-a236-4276-86b8-e07be9c1cedf" />
<img width="1687" height="674" alt="microblock before mem" src="https://github.com/user-attachments/assets/5ad612ff-1679-445c-b487-67a44ef27f2c" />




**After**
<img width="975" height="634" alt="microblock after trace" src="https://github.com/user-attachments/assets/de00e446-8a99-4485-b316-691fcd78ce9e" />
<img width="1686" height="642" alt="microblock after mem" src="https://github.com/user-attachments/assets/c47cceb0-a9fc-4b69-97ce-c0fe425cb6df" />


### `GenRockStrataNew optimization`

Tested on the generation of 31417 chunk columns (6 threads):
- GenRockStrataNew.StratumGenChunkColumn method execution time: reduced from 113547 ms to 96604 ms;
- GenRockStrataNew.genBlockColumn method execution time: reduced from 113426 ms to 57765 ms;



**Before**
<img width="977" height="567" alt="image" src="https://github.com/user-attachments/assets/f0db6e33-7209-4e49-8656-c3c9cc20ef41" />


**After**
<img width="946" height="639" alt="image" src="https://github.com/user-attachments/assets/3a78e8d4-8688-4fa8-b603-ee684a150958" />

