### PR TITLE
Preserve Roles and DefaultRoleCode in serverconfig.json

### DIFF
--- a/patches/VSEssentials/Entity/Behavior/BehaviorSelectionBoxes.cs.patch
+++ b/patches/VSEssentials/Entity/Behavior/BehaviorSelectionBoxes.cs.patch
@@ -4,10 +4,10 @@ index 75cb94b..32a4977 100644
 +++ b/VSEssentials/Entity/Behavior/BehaviorSelectionBoxes.cs
 @@ -282,14 +282,16 @@ namespace Vintagestory.GameContent
              }
-
+ 
              return foundIndex;
          }
-
+ 
 -        public Vec3d GetCenterPosOfBox(int selectionBoxIndex)
 -        {
 -            if (selectionBoxIndex >= selectionBoxes.Length) return null;
@@ -20,15 +20,15 @@ index 75cb94b..32a4977 100644
 +			var apap = selectionBoxArray[selectionBoxIndex];
              mvmat.Identity();
              applyBoxTransform(mvmat, apap);
-
+ 
              var pe = apap.AttachPoint.ParentElement;
              Vec4d centerPos = new Vec4d((pe.To[0] - pe.From[0]) / 2/16, (pe.To[1] - pe.From[1]) / 2/16, (pe.To[2] - pe.From[2]) / 2/16, 1);
 @@ -355,21 +357,21 @@ namespace Vintagestory.GameContent
              return false;
          }
-
-
-
+ 
+ 
+ 
 -        public bool IsAPCode(EntitySelection es, string apcode)
 -        {
 -            var ebs = entity.GetBehavior<EntityBehaviorSelectionBoxes>();
@@ -53,6 +53,6 @@ index 75cb94b..32a4977 100644
 +					return apCode == apcode;
                  }
              }
-
+ 
              return false;
          }

--- a/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/1.GenTerra/GenTerra.cs.patch
+++ b/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/1.GenTerra/GenTerra.cs.patch
@@ -1,5 +1,5 @@
 diff --git a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/1.GenTerra/GenTerra.cs b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/1.GenTerra/GenTerra.cs
-index 5f759f1..afa24d6 100644
+index 5f759f1..2b97b95 100644
 --- a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/1.GenTerra/GenTerra.cs
 +++ b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/1.GenTerra/GenTerra.cs
 @@ -1,7 +1,8 @@

--- a/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/1.GenTerra/GenTerraPostProcess.cs.patch
+++ b/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/1.GenTerra/GenTerraPostProcess.cs.patch
@@ -2,14 +2,12 @@ diff --git a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/1.GenTerra/GenTerra
 index 79c481d..02503c7 100644
 --- a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/1.GenTerra/GenTerraPostProcess.cs
 +++ b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/1.GenTerra/GenTerraPostProcess.cs
-@@ -14,14 +14,45 @@ namespace Vintagestory.ServerMods
-     {
-         ICoreServerAPI api;
+@@ -16,10 +16,41 @@ namespace Vintagestory.ServerMods
          IWorldGenBlockAccessor blockAccessor;
-
+ 
          HashSet<int> chunkVisitedNodes = new HashSet<int>();
          List<int> solidNodes = new List<int>(40);
-
+ 
 +        // Stratum: isolate scratch collections while the stock handler processes columns concurrently.
 +        [ThreadStatic] private static HashSet<int> stratumChunkVisitedNodes;
 +        [ThreadStatic] private static List<int> stratumSolidNodes;
@@ -45,12 +43,8 @@ index 79c481d..02503c7 100644
          {
              return side == EnumAppSide.Server;
          }
-
-
-         public override double ExecuteOrder()
-@@ -54,14 +85,27 @@ namespace Vintagestory.ServerMods
-             blockAccessor.BeginColumn();
-             int seaLevel = TerraGenConfig.seaLevel - 1;
+ 
+@@ -56,10 +87,23 @@ namespace Vintagestory.ServerMods
              const int chunksize = GlobalConstants.ChunkSize;
              const int chunksizeSquared = chunksize * chunksize;
              int chunkY = seaLevel / chunksize;
@@ -70,15 +64,11 @@ index 79c481d..02503c7 100644
 +            HashSet<int> chunkVisitedNodes = stratumChunkVisitedNodes;
 +            this.chunkVisitedNodes = chunkVisitedNodes; // Stratum: publish the active set through the vanilla field.
              chunkVisitedNodes.Clear();
-
+ 
              for (int cy = chunkY; cy < cyMax; cy++)
              {
                  IChunkBlocks chunkdata = chunks[cy].Data;
-
-                 int yStart = cy == 0 ? 1 : 0;  // Prevents attempts to get a blockbelow with y == -1 - impossible unless seaLeavel is set to 0
-@@ -114,22 +158,33 @@ namespace Vintagestory.ServerMods
-         int iteration = 0;
-
+@@ -116,18 +160,29 @@ namespace Vintagestory.ServerMods
          /// <summary>
          /// Very similar to RoomRegistry room search code: we will search for contiguous islands of blocks, surrounded by air on all sides
          /// </summary>
@@ -100,23 +90,19 @@ index 79c481d..02503c7 100644
              int compressedPos = halfSize << 12 | halfSize << 6 | halfSize;
              bfsQueue.Enqueue(compressedPos);
              solidNodes.Add(compressedPos);
-
+ 
 -            int iteration = ++this.iteration;
 +            int iteration = useStratumState ? ++stratumIteration : ++this.iteration;
 +            if (useStratumState) this.iteration = iteration; // Stratum: publish the current counter through the vanilla field.
              int visitedIndex = (halfSize * ARRAYSIZE + halfSize) * ARRAYSIZE + halfSize; // Center node
              currentVisited[visitedIndex] = iteration;
-
+ 
              int baseX = X - halfSize;
              int baseY = Y - halfSize;
-             int baseZ = Z - halfSize;
-             BlockPos npos = new BlockPos(Dimensions.NormalWorld);
-@@ -223,15 +278,22 @@ namespace Vintagestory.ServerMods
-             const int chunkMask = ~(chunksize - 1);
-             if (((nposX ^ origX) & chunkMask) != 0) return;
+@@ -225,11 +280,18 @@ namespace Vintagestory.ServerMods
              if (((nposZ ^ origZ) & chunkMask) != 0) return;
              if (((nposY ^ origY) & chunkMask) != 0) return;
-
+ 
              const int inChunkMask = chunksize - 1;
              int index3d = ((nposY & inChunkMask) * chunksize + (nposZ & inChunkMask)) * chunksize + (nposX & inChunkMask);
 -            chunkVisitedNodes.Add(index3d);
@@ -129,9 +115,7 @@ index 79c481d..02503c7 100644
 +                chunkVisitedNodes.Add(index3d);
 +            }
          }
-
+ 
          //struct VisitNode : IEquatable<VisitNode>
          //{
          //    public int X, Y, Z;
-
-         //    public VisitNode(int x, int y, int z)

--- a/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves.cs.patch
+++ b/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves.cs.patch
@@ -2,34 +2,28 @@ diff --git a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves
 index 30f034d..827cc28 100644
 --- a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves.cs
 +++ b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves.cs
-@@ -10,17 +10,22 @@ namespace Vintagestory.ServerMods
- {
-     public class GenCaves : GenPartial
+@@ -12,13 +12,18 @@ namespace Vintagestory.ServerMods
      {
          protected override int chunkRange { get { return 5; } }
-
+ 
          public override double ExecuteOrder() { return 0.3; }
-
+ 
 +        // Stratum: plain field, vanilla shape, because mods look it up by name.
 +        // Each worldgen thread gets its own GenCaves, so two columns never share it.
          internal LCGRandom caveRand;
          IWorldGenBlockAccessor worldgenBlockAccessor;
-
+ 
 +        // Stratum: one GenCaves per worldgen thread, made on first use.
 +        StratumWorkerInstances<GenCaves> stratumWorkers;
 +
          NormalizedSimplexNoise basaltNoise;
          NormalizedSimplexNoise heightvarNoise;
          int regionsize;
-
+ 
          public override void StartServerSide(ICoreServerAPI api)
-         {
-             base.StartServerSide(api);
-@@ -28,35 +33,63 @@ namespace Vintagestory.ServerMods
-             if (TerraGenConfig.DoDecorationPass)
-             {
+@@ -30,18 +35,18 @@ namespace Vintagestory.ServerMods
                  api.Event.GetWorldgenBlockAccessor(OnWorldGenBlockAccessor);
-
+ 
                  api.ChatCommands.GetOrCreate("dev")
                      .BeginSubCommand("gencaves")
                      .WithDescription(
@@ -38,7 +32,7 @@ index 30f034d..827cc28 100644
                      .RequiresPrivilege(Privilege.controlserver)
                      .HandleWith(CmdCaveGenTest)
                      .EndSubCommand();
-
+ 
                  api.Event.MapChunkGeneration(OnMapChunkGen, "standard");
                  api.Event.MapChunkGeneration(OnMapChunkGen, "superflat");
 -                api.Event.ChunkColumnGeneration(GenChunkColumn, EnumWorldGenPass.Terrain, "standard");
@@ -46,15 +40,13 @@ index 30f034d..827cc28 100644
                  api.Event.InitWorldGenerator(initWorldGen, "superflat");
              }
          }
-
-
-         public override void initWorldGen()
-         {
-             base.initWorldGen();
+ 
+ 
+@@ -51,10 +56,38 @@ namespace Vintagestory.ServerMods
              caveRand = new LCGRandom(api.WorldManager.Seed + 123128);
              basaltNoise = NormalizedSimplexNoise.FromDefaultOctaves(2, 1f / 3.5f, 0.9f, api.World.Seed + 12);
              heightvarNoise = NormalizedSimplexNoise.FromDefaultOctaves(3, 1f / 20f, 0.9f, api.World.Seed + 12);
-
+ 
              regionsize = api.World.BlockAccessor.RegionSize;
 +            stratumWorkers = new StratumWorkerInstances<GenCaves>(StratumCreateWorker); // Stratum
 +        }
@@ -85,48 +77,42 @@ index 30f034d..827cc28 100644
 +            regionsize = origin.regionsize;
 +            caveRand = new LCGRandom(api.WorldManager.Seed + 123128);
          }
-
-
+ 
+ 
          private void OnMapChunkGen(IMapChunk mapChunk, int chunkX, int chunkZ)
          {
-             if (heightvarNoise == null) return;
-
-@@ -72,45 +105,51 @@ namespace Vintagestory.ServerMods
-                     mapChunk.CaveHeightDistort[dz * chunksize + dx] = (byte)(128 * val + 127);
-                 }
+@@ -74,19 +107,25 @@ namespace Vintagestory.ServerMods
              }
          }
-
+ 
          private TextCommandResult CmdCaveGenTest(TextCommandCallingArgs args)
          {
 -            caveRand = new LCGRandom(api.WorldManager.Seed + 123128);
 -            initWorldGen();
 +            initWorldGen(); // Stratum: this already reseeds caveRand with the same formula, no need to do it twice
-
+ 
 +            // Stratum start:
 +            // Adding light recalculation for caves
 +            // The cave generation command now works based on the player's coordinates.
-
+ 
 +            // replace the air block with granite to generate inverted caves
              airBlockId = api.World.GetBlock(new AssetLocation("rock-granite")).BlockId;
-
+ 
 -            int baseChunkX = api.World.BlockAccessor.MapSizeX / 2 / chunksize;
 -            int baseChunkZ = api.World.BlockAccessor.MapSizeZ / 2 / chunksize;
 +            // take the player as the center
 +            var player = args.Caller.Player as IServerPlayer;
 +            int baseChunkX = (int)player.Entity.Pos.X / chunksize;
 +            int baseChunkZ = (int)player.Entity.Pos.Z / chunksize;
-
+ 
 +            // first check that all chunks are loaded
              for (int dx = -5; dx <= 5; dx++)
              {
                  for (int dz = -5; dz <= 5; dz++)
                  {
                      int chunkX = baseChunkX + dx;
-                     int chunkZ = baseChunkZ + dz;
-
-                     IServerChunk[] chunks = GetChunkColumn(chunkX, chunkZ);
-
+@@ -96,19 +135,19 @@ namespace Vintagestory.ServerMods
+ 
                      for (int i = 0; i < chunks.Length; i++)
                      {
                          if (chunks[i] == null)
@@ -135,11 +121,11 @@ index 30f034d..827cc28 100644
 +                            return TextCommandResult.Success("Cannot generate 10x10 area of caves, chunks are not loaded that far yet.");
                          }
                      }
-
+ 
                      OnMapChunkGen(chunks[0].MapChunk, chunkX, chunkZ);
                  }
              }
-
+ 
 -
 +            // clear all chunks and start cave generation
              for (int dx = -5; dx <= 5; dx++)
@@ -147,16 +133,12 @@ index 30f034d..827cc28 100644
                  for (int dz = -5; dz <= 5; dz++)
                  {
                      int chunkX = baseChunkX + dx;
-                     int chunkZ = baseChunkZ + dz;
-
-@@ -123,19 +162,28 @@ namespace Vintagestory.ServerMods
-                         for (int gdz = -chunkRange; gdz <= chunkRange; gdz++)
-                         {
+@@ -125,15 +164,24 @@ namespace Vintagestory.ServerMods
                              chunkRand.InitPositionSeed(chunkX + gdx, chunkZ + gdz);
                              GeneratePartial(chunks, chunkX, chunkZ, gdx, gdz);
                          }
                      }
-
+ 
 +                    // Run lighting recalculation (like in GenLightSurvival)
 +                    worldgenBlockAccessor.BeginColumn();
 +                    api.WorldManager.SunFloodChunkColumnForWorldGen(chunks, chunkX, chunkZ);
@@ -166,24 +148,20 @@ index 30f034d..827cc28 100644
                      MarkDirty(chunkX, chunkZ, chunks);
                  }
              }
-
+ 
 +
 +            // restore the air block id back
              airBlockId = 0;
 +            // Stratum end
-
+ 
              return TextCommandResult.Success("Generated and chunks force resend flags set");
          }
-
+ 
          private IServerChunk[] GetChunkColumn(int chunkX, int chunkZ)
-         {
-             int size = api.World.BlockAccessor.MapSizeY / chunksize;
-@@ -504,164 +552,229 @@ namespace Vintagestory.ServerMods
-         }
-
-
-
-
+@@ -506,160 +554,225 @@ namespace Vintagestory.ServerMods
+ 
+ 
+ 
          private bool SetBlocks(IServerChunk[] chunks, float horRadius, float vertRadius, double centerX, double centerY, double centerZ, ushort[] terrainheightmap, ushort[] rainheightmap, int chunkX, int chunkZ, bool genHotSpring)
          {
 -            IMapChunk mapchunk = chunks[0].MapChunk;
@@ -195,7 +173,7 @@ index 30f034d..827cc28 100644
 +            // Fixing incorrect cave generation in the /dev gencaves command mode
 +            // We sped up the algorithm, filtered out blocks that weren't within the ellipsoid's dimensions,
 +            // and checked for liquid in the same cycle as everything else.
-
+ 
 -            int mindx = (int)GameMath.Clamp(centerX - horRadius, 0, chunksize - 1);
 -            int maxdx = (int)GameMath.Clamp(centerX + horRadius + 1, 0, chunksize - 1);
 -            int mindy = (int)GameMath.Clamp(centerY - vertRadius * 0.7f, 1, worldheight - 1);
@@ -238,15 +216,15 @@ index 30f034d..827cc28 100644
 -            }
 +            // Testing on 10,200 generation chunks:
 +            // Total method execution time: decreased from 9.2 s to 6.3 s;
-
+ 
 +            IMapChunk mapchunk = chunks[0].MapChunk;
-
+ 
 -            horRadius--;
 -            vertRadius-=2;
 +            // Regular generation radius
 +            float genHorRadius = horRadius;
 +            float genVertRadius = vertRadius;
-
+ 
 -            mindx = (int)GameMath.Clamp(centerX - horRadius, 0, chunksize - 1);
 -            maxdx = (int)GameMath.Clamp(centerX + horRadius + 1, 0, chunksize - 1);
 -            mindz = (int)GameMath.Clamp(centerZ - horRadius, 0, chunksize - 1);
@@ -254,7 +232,7 @@ index 30f034d..827cc28 100644
 +            // Increased radius for fluid checks
 +            float checkHorRadius = horRadius + 1;
 +            float checkVertRadius = vertRadius + 2;
-
+ 
 -            mindy = (int)GameMath.Clamp(centerY - vertRadius * 0.7f, 1, worldheight - 1);
 -            maxdy = (int)GameMath.Clamp(centerY + vertRadius + 1, 1, worldheight - 1);
 +            // Compute common bounds for both radii
@@ -262,23 +240,23 @@ index 30f034d..827cc28 100644
 +            int maxdx = (int)GameMath.Clamp(centerX + checkHorRadius + 1, 0, chunksize - 1);
 +            int mindz = (int)GameMath.Clamp(centerZ - checkHorRadius, 0, chunksize - 1);
 +            int maxdz = (int)GameMath.Clamp(centerZ + checkHorRadius + 1, 0, chunksize - 1);
-
+ 
 -            hRadiusSq = horRadius * horRadius;
 -            vRadiusSq = vertRadius * vertRadius;
 +            // For Y use the check radius because it is larger
 +            int mindy = (int)GameMath.Clamp(centerY - checkVertRadius * 0.7f, 1, worldheight - 1);
 +            int maxdy = (int)GameMath.Clamp(centerY + checkVertRadius + 1, 1, worldheight - 1);
-
+ 
 +            // Precompute squared radii for fast comparisons
 +            double genHorRadiusSq = genHorRadius * genHorRadius;
 +            double genVertRadiusSq = genVertRadius * genVertRadius;
 +            double checkHorRadiusSq = checkHorRadius * checkHorRadius;
 +            double checkVertRadiusSq = checkVertRadius * checkVertRadius;
-
+ 
 +            // Get geologic activity once
              int geoActivity = getGeologicActivity(chunkX * chunksize + (int)centerX, chunkZ * chunksize + (int)centerZ);
              genHotSpring &= geoActivity > 128;
-
+ 
              if (genHotSpring && centerX >= 0 && centerX < 32 && centerZ >= 0 && centerZ < 32)
              {
                  var data = mapchunk.GetModdata<Dictionary<Vec3i, HotSpringGenData>>("hotspringlocations");
@@ -287,10 +265,10 @@ index 30f034d..827cc28 100644
 +                data[new Vec3i((int)centerX, (int)centerY, (int)centerZ)] = new HotSpringGenData() { horRadius = genHorRadius };
                  mapchunk.SetModdata("hotspringlocations", data);
              }
-
+ 
              int yLavaStart = (geoActivity * 16) / 128;
 +            int chunksizeSq = chunksize * chunksize;
-
+ 
 -
 +            // Main loop - single pass
              for (int lx = mindx; lx <= maxdx; lx++)
@@ -298,17 +276,17 @@ index 30f034d..827cc28 100644
 -                xdistRel = (lx - centerX) * (lx - centerX) / hRadiusSq;
 +                double dx = lx - centerX;
 +                double dxSq = dx * dx;
-
+ 
                  for (int lz = mindz; lz <= maxdz; lz++)
                  {
 -                    zdistRel = (lz - centerZ) * (lz - centerZ) / hRadiusSq;
 +                    double dz = lz - centerZ;
 +                    double dzSq = dz * dz;
-
+ 
 -                    double heightrnd = (mapchunk.CaveHeightDistort[lz * chunksize + lx] - 127) * distortStrength;
 -                    int surfaceY = terrainheightmap[lz * chunksize + lx];
 +                    int idx2d = lz * chunksize + lx;
-
+ 
 -                    for (int y = maxdy + 10; y >= mindy; y--)
 -                    {
 -                        double yDist = y - centerY;
@@ -317,19 +295,19 @@ index 30f034d..827cc28 100644
 +                    double distortStrength = GameMath.Clamp(genVertRadius / 4.0, 0, 0.1);
 +                    double heightrnd = (mapchunk.CaveHeightDistort[idx2d] - 127) * distortStrength;
 +                    int surfaceY = terrainheightmap[idx2d];
-
+ 
 -                        ydistRel = yDist * yDist / (vRadiusSq + heightOffFac);
 +                    // Compute maximum XZ distance for the check radius
 +                    double checkXZDist = dxSq / checkHorRadiusSq + dzSq / checkHorRadiusSq;
 +                    if (checkXZDist > 1.0) continue;
-
+ 
 -                        if (y > worldheight - 1 || xdistRel + ydistRel + zdistRel > 1.0) continue;
 +                    // Compute Y range for the check radius
 +                    double maxCheckDist = 1.0 - checkXZDist;
 +                    double maxCheckYDist = Math.Sqrt(maxCheckDist * checkVertRadiusSq);
 +                    int checkMindy = (int)Math.Max(mindy, centerY - maxCheckYDist);
 +                    int checkMaxdy = (int)Math.Min(maxdy, centerY + maxCheckYDist);
-
+ 
 -                        if (terrainheightmap[lz * chunksize + lx] == y)
 -                        {
 -                            terrainheightmap[lz * chunksize + lx] = (ushort)(y - 1);
@@ -339,7 +317,7 @@ index 30f034d..827cc28 100644
 +                    bool hasLiquidInCheckRadius = false;
 +                    bool needsGenInGenRadius = false;
 +                    int firstGenY = -1;
-
+ 
 -                        IChunkBlocks chunkBlockData = chunks[y / chunksize].Data;
 -                        int index3d = ((y % chunksize) * chunksize + lz) * chunksize + lx;
 +                    // Walk Y once from top down
@@ -347,7 +325,7 @@ index 30f034d..827cc28 100644
 +                    {
 +                        double dy = y - centerY;
 +                        double dySq = dy * dy;
-
+ 
 -                        if (y == 11)
 +                        // Check inclusion in check radius (for fluids)
 +                        double checkYDistSq = dySq / checkVertRadiusSq;
@@ -386,7 +364,7 @@ index 30f034d..827cc28 100644
 +                        {
 +                            double heightOffFac = dy > 0 ? heightrnd * heightrnd * Math.Min(1, Math.Abs(y - surfaceY) / 10.0) : 0;
 +                            double genYDistSq = dySq / (genVertRadiusSq + heightOffFac);
-
+ 
 +                            if (dxSq / genHorRadiusSq + genYDistSq + dzSq / genHorRadiusSq <= 1.0 && y < worldheight)
 +                            {
 +                                needsGenInGenRadius = true;
@@ -497,14 +475,12 @@ index 30f034d..827cc28 100644
                      }
                  }
              }
-
+ 
              return true;
 +
 +            // Stratum end
          }
-
+ 
          private int getGeologicActivity(int posx, int posz)
          {
              var climateMap = worldgenBlockAccessor.GetMapRegion(posx / regionsize, posz / regionsize)?.ClimateMap;
-             if (climateMap == null) return 0;
-             int regionChunkSize = regionsize / chunksize;

--- a/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/4.GenBlockLayers/GenBlockLayers.cs.patch
+++ b/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/4.GenBlockLayers/GenBlockLayers.cs.patch
@@ -2,12 +2,10 @@ diff --git a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/4.GenBlockLayers/Ge
 index 55b134c..28229c8 100644
 --- a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/4.GenBlockLayers/GenBlockLayers.cs
 +++ b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/4.GenBlockLayers/GenBlockLayers.cs
-@@ -12,14 +12,18 @@ namespace Vintagestory.ServerMods
-
-     public class GenBlockLayers : ModStdWorldGen
+@@ -14,10 +14,14 @@ namespace Vintagestory.ServerMods
      {
          private ICoreServerAPI api;
-
+ 
          List<int> BlockLayersIds = new List<int>();
          LCGRandom rnd;
 +
@@ -18,24 +16,20 @@ index 55b134c..28229c8 100644
          ClampedSimplexNoise grassDensity;
          ClampedSimplexNoise grassHeight;
          int boilingWaterBlockId;
-
-         public int[] layersUnderWaterTmp = new int[1];
-         public int[] layersUnderWater = Array.Empty<int>();
-@@ -36,23 +40,24 @@ namespace Vintagestory.ServerMods
-         {
-             return 0.4;
+ 
+@@ -38,19 +42,20 @@ namespace Vintagestory.ServerMods
          }
-
+ 
          public override void StartServerSide(ICoreServerAPI api)
          {
              this.api = api;
 +            stratumWorkers = new StratumWorkerInstances<GenBlockLayers>(StratumCreateWorker); // Stratum: isolate mutable fields without changing their shape
-
+ 
              this.api.Event.InitWorldGenerator(InitWorldGen, "standard");
              this.api.Event.InitWorldGenerator(InitWorldGen, "superflat"); // Just the Init so that BlockSoil can grow grass; and both these are needed even if DecoPass is off
              //this.api.Event.MapRegionGeneration(OnMapRegionGen, "standard");   // 8.2.24 commented out because the method has no code
-
-
+ 
+ 
              if (TerraGenConfig.DoDecorationPass)
              {
 -                this.api.Event.ChunkColumnGeneration(OnChunkColumnGeneration, EnumWorldGenPass.Terrain, "standard");
@@ -44,17 +38,13 @@ index 55b134c..28229c8 100644
              distort2dx = new SimplexNoise(new double[] { 14, 9, 6, 3 }, new double[] { 1 / 100.0, 1 / 50.0, 1 / 25.0, 1 / 12.5 }, api.World.SeaLevel + 20980);
              distort2dz = new SimplexNoise(new double[] { 14, 9, 6, 3 }, new double[] { 1 / 100.0, 1 / 50.0, 1 / 25.0, 1 / 12.5 }, api.World.SeaLevel + 20981);
          }
-
-         private void OnMapRegionGen(IMapRegion mapRegion, int regionX, int regionZ, ITreeAttribute chunkGenParams = null)
-         {
-@@ -88,14 +93,44 @@ namespace Vintagestory.ServerMods
-             grassHeight = new ClampedSimplexNoise(new double[] { 1.5 }, new double[] { 0.5 }, rnd.NextInt());
-
+ 
+@@ -90,10 +95,40 @@ namespace Vintagestory.ServerMods
              mapheight = api.WorldManager.MapSizeY;
-
+ 
              boilingWaterBlockId = gcfg.boilingWaterBlockId;
          }
-
+ 
 +        private void StratumOnChunkColumnGeneration(IChunkColumnGenerateRequest request)
 +        {
 +            stratumWorkers.Current.OnChunkColumnGeneration(request);
@@ -90,14 +80,10 @@ index 55b134c..28229c8 100644
              var chunks = request.Chunks;
              int chunkX = request.ChunkX;
              int chunkZ = request.ChunkZ;
-
-             rnd.InitPositionSeed(chunkX, chunkZ);
-@@ -357,14 +392,21 @@ namespace Vintagestory.ServerMods
-                     }
-                 }
+@@ -359,10 +394,17 @@ namespace Vintagestory.ServerMods
              }
          }
-
+ 
          public void PlaceTallGrass(int x, int posY, int z, IServerChunk[] chunks, float rainRel, float tempRel, float temp, float forestRel, int biome)
          {
 +            // Stratum: external callers use the same per-thread generator as the registered handler.
@@ -108,9 +94,7 @@ index 55b134c..28229c8 100644
 +            }
 +
              double rndVal = blockLayerConfig.Tallgrass.RndWeight * rnd.NextDouble() + blockLayerConfig.Tallgrass.PerlinWeight * grassDensity.Noise(x, z, -0.5f);
-
+ 
              double extraGrass = Math.Max(0, rainRel * tempRel - 0.25);
-
+ 
              if (rndVal <= GameMath.Clamp(forestRel - extraGrass, 0.05, 0.99) || posY >= mapheight - 1 || posY < 1) return;
-
-             int blockId = chunks[posY / chunksize].Data[(chunksize * (posY % chunksize) + z) * chunksize + x];

--- a/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/5.GenDeposits/GenDeposits.cs.patch
+++ b/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/5.GenDeposits/GenDeposits.cs.patch
@@ -2,31 +2,25 @@ diff --git a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/5.GenDeposits/GenDe
 index b6ab588..4348e32 100644
 --- a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/5.GenDeposits/GenDeposits.cs
 +++ b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/5.GenDeposits/GenDeposits.cs
-@@ -24,14 +24,18 @@ namespace Vintagestory.ServerMods
-
-         float chanceMultiplier;
-
+@@ -26,10 +26,14 @@ namespace Vintagestory.ServerMods
+ 
          IBlockAccessor blockAccessor;
-
+ 
          public LCGRandom depositRand;
-
+ 
 +        // Stratum: DepositGeneratorBase instances capture depositRand by reference.
 +        // Serialize its RNG and scratch fields so concurrent columns cannot corrupt them.
 +        private readonly object stratumGenDepositsLock = new object();
 +
          BlockPos tmpPos = new BlockPos(API.Config.Dimensions.NormalWorld);
-
+ 
          NormalizedSimplexNoise depositShapeDistortNoise;
          Dictionary<BlockPos, DepositVariant> subDepositsToPlace = new Dictionary<BlockPos, DepositVariant>();
          MapLayerBase verticalDistortTop;
-         MapLayerBase verticalDistortBottom;
-         public bool addHandbookAttributes = true;
-@@ -199,58 +203,65 @@ namespace Vintagestory.ServerMods
-                 variant.OnMapRegionGen(mapRegion, regionX, regionZ);
-             }
+@@ -201,54 +205,61 @@ namespace Vintagestory.ServerMods
          }
-
-
+ 
+ 
          protected override void GenChunkColumn(IChunkColumnGenerateRequest request)
          {
 -            if (blockAccessor is IWorldGenBlockAccessor wgba) wgba.BeginColumn();
@@ -38,7 +32,7 @@ index b6ab588..4348e32 100644
 +                base.GenChunkColumn(request);
 +            }
          }
-
+ 
          public override void GeneratePartial(IServerChunk[] chunks, int chunkX, int chunkZ, int chunkdX, int chunkdZ)
          {
 -            LCGRandom chunkRand = this.chunkRand;
@@ -49,18 +43,18 @@ index b6ab588..4348e32 100644
 +                LCGRandom chunkRand = this.chunkRand;
 +                int fromChunkx = chunkX + chunkdX;
 +                int fromChunkz = chunkZ + chunkdZ;
-
+ 
 -            int fromBaseX = fromChunkx * chunksize;
 -            int fromBaseZ = fromChunkz * chunksize;
 +                int fromBaseX = fromChunkx * chunksize;
 +                int fromBaseZ = fromChunkz * chunksize;
-
+ 
 -            subDepositsToPlace.Clear();
 +                subDepositsToPlace.Clear();
-
+ 
 -            float scaleAdjustMul = (float)api.WorldManager.MapSizeY / 256;
 +                float scaleAdjustMul = (float)api.WorldManager.MapSizeY / 256;
-
+ 
 -            for (int i = 0; i < Deposits.Length; i++)
 -            {
 -                DepositVariant variant = Deposits[i];
@@ -69,12 +63,12 @@ index b6ab588..4348e32 100644
 +                for (int i = 0; i < Deposits.Length; i++)
 +                {
 +                    DepositVariant variant = Deposits[i];
-
+ 
 -                float qModified = variant.TriesPerChunk * quantityFactor * chanceMultiplier * (variant.ScaleWithWorldheight ? scaleAdjustMul : 1);
 -                int quantity = (int)qModified;
 -                quantity += chunkRand.NextInt(100) < 100 * (qModified - quantity) ? 1 : 0;
 +                    float quantityFactor = variant.WithOreMap ? variant.GetOreMapFactor(fromChunkx, fromChunkz) : 1;
-
+ 
 -                while (quantity-- > 0)
 -                {
 -                    tmpPos.Set(fromBaseX + chunkRand.NextInt(chunksize), -99, fromBaseZ + chunkRand.NextInt(chunksize));
@@ -91,13 +85,13 @@ index b6ab588..4348e32 100644
 +                        long crseed = chunkRand.NextInt(10000000);
 +                        depositRand.SetWorldSeed(crseed);
 +                        depositRand.InitPositionSeed(fromChunkx, fromChunkz);
-
+ 
 -                    GenDeposit(chunks, chunkX, chunkZ, tmpPos, variant);
 +                        GenDeposit(chunks, chunkX, chunkZ, tmpPos, variant);
 +                    }
                  }
 -            }
-
+ 
 -            foreach (var val in subDepositsToPlace)
 -            {
 -                depositRand.SetWorldSeed(chunkRand.NextInt(10000000));
@@ -106,14 +100,12 @@ index b6ab588..4348e32 100644
 +                {
 +                    depositRand.SetWorldSeed(chunkRand.NextInt(10000000));
 +                    depositRand.InitPositionSeed(fromChunkx, fromChunkz);
-
+ 
 -                val.Value.GeneratorInst.GenDeposit(blockAccessor, chunks, chunkX, chunkZ, val.Key, ref subDepositsToPlace);
 +                    val.Value.GeneratorInst.GenDeposit(blockAccessor, chunks, chunkX, chunkZ, val.Key, ref subDepositsToPlace);
 +                }
              }
          }
-
-
-
-         public virtual void GenDeposit(IServerChunk[] chunks, int chunkX, int chunkZ, BlockPos depoCenterPos, DepositVariant variant)
-         {
+ 
+ 
+ 

--- a/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/6.GenStructures/GenStructures.cs.patch
+++ b/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/6.GenStructures/GenStructures.cs.patch
@@ -2,14 +2,12 @@ diff --git a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/6.GenStructures/Gen
 index 95025db..7c475dd 100644
 --- a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/6.GenStructures/GenStructures.cs
 +++ b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/6.GenStructures/GenStructures.cs
-@@ -44,23 +44,48 @@ namespace Vintagestory.ServerMods
-         int climateBotRight;
-
+@@ -46,19 +46,44 @@ namespace Vintagestory.ServerMods
          int forestUpLeft;
          int forestUpRight;
          int forestBotLeft;
          int forestBotRight;
-
+ 
 +        // Stratum: concurrent TerrainFeatures columns keep an isolated owner behind the vanilla fields.
 +        [ThreadStatic] private static ushort[] stratumHeightmap;
 +        [ThreadStatic] private static int stratumClimateUpLeft, stratumClimateUpRight, stratumClimateBotLeft, stratumClimateBotRight;
@@ -37,28 +35,24 @@ index 95025db..7c475dd 100644
 +        readonly object stratumStructurePlacementLock = new object();
 +
          public event PeventSchematicAtDelegate OnPreventSchematicPlaceAt;
-
+ 
          internal WorldGenStructuresConfig scfg;
-
+ 
          public WorldGenVillageConfig vcfg;
-
+ 
          LCGRandom strucRand; // Deterministic random
-
+ 
 -
          IWorldGenBlockAccessor worldgenBlockAccessor;
-
+ 
          WorldGenStructure[] shuffledStructures;
          private Dictionary<string, WorldGenStructure[]> StoryStructures;
-
-         public override double ExecuteOrder() { return 0.3; }
-
-@@ -236,14 +261,51 @@ namespace Vintagestory.ServerMods
-             var chunks = request.Chunks;
-             int chunkX = request.ChunkX;
+ 
+@@ -238,10 +263,47 @@ namespace Vintagestory.ServerMods
              int chunkZ = request.ChunkZ;
-
+ 
              worldgenBlockAccessor.BeginColumn();
-
+ 
              IMapRegion region = chunks[0].MapChunk.MapRegion;
 +            if (stratumHasColumnState(chunkX, chunkZ))
 +            {
@@ -97,20 +91,16 @@ index 95025db..7c475dd 100644
 +                stratumStateChunkX = chunkX;
 +                stratumStateChunkZ = chunkZ;
 +            }
-
+ 
              DoGenStructures(region, chunkX, chunkZ, true, structure?.Code, request.ChunkGenParams);
              TryGenVillages(region, chunkX, chunkZ, true, request.ChunkGenParams);
          }
-
-         private void OnChunkColumnGen(IChunkColumnGenerateRequest request)
-         {
-@@ -266,57 +328,63 @@ namespace Vintagestory.ServerMods
-             // A region has 16 chunks
-             // Size of the forest map is RegionSize / TerraGenConfig.forestMapScale  => 32*16 / 32  = 16 pixel
+ 
+@@ -268,24 +330,28 @@ namespace Vintagestory.ServerMods
              // rlX, rlZ goes from 0..16 pixel
              // facF = 16/16 = 1
              // Get 4 pixels for chunkx, chunkz, chunkx+1 and chunkz+1 inside the map
-
+ 
              float facC = (float)climateMap.InnerSize / regionChunkSize;
 -            climateUpLeft = climateMap.GetUnpaddedInt((int)(rlX * facC), (int)(rlZ * facC));
 -            climateUpRight = climateMap.GetUnpaddedInt((int)(rlX * facC + facC), (int)(rlZ * facC));
@@ -120,8 +110,8 @@ index 95025db..7c475dd 100644
 +            stratumClimateUpRight = climateUpRight = climateMap.GetUnpaddedInt((int)(rlX * facC + facC), (int)(rlZ * facC));
 +            stratumClimateBotLeft = climateBotLeft = climateMap.GetUnpaddedInt((int)(rlX * facC), (int)(rlZ * facC + facC));
 +            stratumClimateBotRight = climateBotRight = climateMap.GetUnpaddedInt((int)(rlX * facC + facC), (int)(rlZ * facC + facC));
-
-
+ 
+ 
              float facf = (float)forestMap.InnerSize / regionChunkSize;
 -            forestUpLeft = forestMap.GetUnpaddedInt((int)(rlX * facC), (int)(rlZ * facC));
 -            forestUpRight = forestMap.GetUnpaddedInt((int)(rlX * facC + facC), (int)(rlZ * facC));
@@ -131,22 +121,21 @@ index 95025db..7c475dd 100644
 +            stratumForestUpRight = forestUpRight = forestMap.GetUnpaddedInt((int)(rlX * facC + facC), (int)(rlZ * facC));
 +            stratumForestBotLeft = forestBotLeft = forestMap.GetUnpaddedInt((int)(rlX * facC), (int)(rlZ * facC + facC));
 +            stratumForestBotRight = forestBotRight = forestMap.GetUnpaddedInt((int)(rlX * facC + facC), (int)(rlZ * facC + facC));
-
-
+ 
+ 
 -            heightmap = chunks[0].MapChunk.WorldGenTerrainHeightMap;
 +            stratumHeightmap = heightmap = chunks[0].MapChunk.WorldGenTerrainHeightMap;
 +            if (stratumStateOwner != this) stratumStrucRand = null; // Stratum: a reused thread may now belong to another world
 +            stratumStateOwner = this;
 +            stratumStateChunkX = chunkX;
 +            stratumStateChunkZ = chunkZ;
-
+ 
              DoGenStructures(region, chunkX, chunkZ, false, structure?.Code, request.ChunkGenParams);
              if (structure == null)
              {
                  TryGenVillages(region, chunkX, chunkZ, false, request.ChunkGenParams);
-             }
-         }
-
+@@ -294,27 +360,29 @@ namespace Vintagestory.ServerMods
+ 
          private void DoGenStructures(IMapRegion region, int chunkX, int chunkZ, bool postPass, string locationCode, ITreeAttribute chunkGenParams = null)
          {
              // We need to make a copy each time to preserve determinism
@@ -175,20 +164,16 @@ index 95025db..7c475dd 100644
              }
 +            shuffledStructures = activeShuffledStructures; // Stratum: publish the active vanilla field for mod code
              BlockPos startPos = new BlockPos(Dimensions.NormalWorld);
-
+ 
              ITreeAttribute chanceModTree = null;
              ITreeAttribute maxQuantityModTree = null;
              StoryStructureLocation location = null;
-             if (chunkGenParams?["structureChanceModifier"] != null)
-             {
-@@ -324,21 +392,35 @@ namespace Vintagestory.ServerMods
-             }
-             if (chunkGenParams?["structureMaxCount"] != null)
+@@ -326,17 +394,31 @@ namespace Vintagestory.ServerMods
              {
                  maxQuantityModTree = chunkGenParams["structureMaxCount"] as TreeAttribute;
              }
-
-
+ 
+ 
 -            strucRand.InitPositionSeed(chunkX, chunkZ);
 -
 -            shuffledStructures.Shuffle(strucRand);
@@ -217,20 +202,16 @@ index 95025db..7c475dd 100644
 -                WorldGenStructure struc = shuffledStructures[i];
 +                WorldGenStructure struc = activeShuffledStructures[i];
                  if (struc.PostPass != postPass) continue;
-
+ 
                  float chance = struc.Chance * scfg.ChanceMultiplier;
                  int toGenerate = 9999;
                  if (chanceModTree != null)
-                 {
-                     chance *= chanceModTree.GetFloat(struc.Code, 0);
-@@ -346,30 +428,30 @@ namespace Vintagestory.ServerMods
-
-                 if (maxQuantityModTree != null)
+@@ -348,26 +430,26 @@ namespace Vintagestory.ServerMods
                  {
                      toGenerate = maxQuantityModTree.GetInt(struc.Code, 9999);
                  }
-
-
+ 
+ 
 -                while (chance-- > strucRand.NextFloat() && toGenerate > 0)
 +                while (chance-- > activeRand.NextFloat() && toGenerate > 0)
                  {
@@ -241,7 +222,7 @@ index 95025db..7c475dd 100644
 +                    int dz = activeRand.NextInt(chunksize);
 +                    int ySurface = activeHeightmap[dz * chunksize + dx];
                      if (ySurface <= 0 || ySurface >= worldheight - 15) continue;
-
+ 
                      if (struc.Placement == EnumStructurePlacement.Underground)
                      {
                          if (struc.Depth != null)
@@ -258,12 +239,8 @@ index 95025db..7c475dd 100644
                      else
                      {
                          startPos.Set(chunkX * chunksize + dx, ySurface, chunkZ * chunksize + dz);
-                     }
-
-@@ -380,155 +462,193 @@ namespace Vintagestory.ServerMods
-                         continue;
-                     }
-
+@@ -382,61 +464,69 @@ namespace Vintagestory.ServerMods
+ 
                      // check if in storylocation and if we can still generate this structure
                      if (locationCode != null)
                      {
@@ -274,7 +251,7 @@ index 95025db..7c475dd 100644
                              continue;
                          }
 +                    }
-
+ 
 -                        if (struc.StoryMaxFromCenter != 0 &&  !startPos.InRangeHorizontally(location.CenterPos.X, location.CenterPos.Z, struc.StoryMaxFromCenter))
 +                    int forest = GameMath.BiLerpRgbColor((float)(startPos.X % chunksize) / chunksize, (float)(startPos.Z % chunksize) / chunksize, activeForestUpLeft, activeForestUpRight, activeForestBotLeft, activeForestBotRight);
 +                    bool didGenerate;
@@ -286,7 +263,7 @@ index 95025db..7c475dd 100644
                              continue;
                          }
 -                    }
-
+ 
 -                    int forest = GameMath.BiLerpRgbColor((float)(startPos.X % chunksize) / chunksize, (float)(startPos.Z % chunksize) / chunksize, forestUpLeft, forestUpRight, forestBotLeft, forestBotRight);
 -                    if (struc.TryGenerate(worldgenBlockAccessor, api.World, startPos, climateUpLeft, climateUpRight, climateBotLeft, climateBotRight, forest, locationCode))
 -                    {
@@ -316,10 +293,10 @@ index 95025db..7c475dd 100644
 -                        }
 -                        Cuboidi loc = struc.LastPlacedSchematicLocation;
 +                            Cuboidi loc = struc.LastPlacedSchematicLocation;
-
+ 
 -                        string code = (struc.LastPlacedSchematic == null ? "" : struc.LastPlacedSchematic.FromFile.GetNameWithDomain()) + "/" + struc.Code;
 +                            string code = (struc.LastPlacedSchematic == null ? "" : struc.LastPlacedSchematic.FromFile.GetNameWithDomain()) + "/" + struc.Code;
-
+ 
 -                        region.AddGeneratedStructure(new GeneratedStructure() {
 -                            Code = code,
 -                            Group = struc.Group,
@@ -334,7 +311,7 @@ index 95025db..7c475dd 100644
 +                                SuppressTreesAndShrubs = struc.SuppressTrees,
 +                                SuppressRivulets = struc.SuppressWaterfalls
 +                            });
-
+ 
 -                        if (struc.BuildProtected)
 -                        {
 -                            api.World.Claims.Add(new LandClaim()
@@ -367,12 +344,12 @@ index 95025db..7c475dd 100644
                  }
              }
          }
-
-
-
-
-
-
+@@ -444,89 +534,119 @@ namespace Vintagestory.ServerMods
+ 
+ 
+ 
+ 
+ 
 +        private bool stratumHasColumnState(int chunkX, int chunkZ)
 +        {
 +            return stratumStateOwner == this && stratumStateChunkX == chunkX && stratumStateChunkZ == chunkZ;
@@ -386,7 +363,7 @@ index 95025db..7c475dd 100644
 +                : strucRand;
 +            activeRand.InitPositionSeed(chunkX, chunkZ);
 +            strucRand = activeRand; // Stratum: keep the exact field current even when ruins returned early
-
+ 
              for (int i = 0; i < vcfg.VillageTypes.Length; i++)
              {
                  WorldGenVillage struc = vcfg.VillageTypes[i];
@@ -399,7 +376,7 @@ index 95025db..7c475dd 100644
                  }
              }
          }
-
+ 
          public bool GenVillage(IBlockAccessor blockAccessor, IMapRegion region, WorldGenVillage struc, int chunkX, int chunkZ)
          {
 +            bool hasColumnState = stratumHasColumnState(chunkX, chunkZ);
@@ -409,15 +386,15 @@ index 95025db..7c475dd 100644
 +            int activeClimateBotLeft = hasColumnState ? stratumClimateBotLeft : climateBotLeft;
 +            int activeClimateBotRight = hasColumnState ? stratumClimateBotRight : climateBotRight;
              BlockPos pos = new BlockPos(Dimensions.NormalWorld);
-
+ 
              int dx = chunksize / 2;
              int dz = chunksize / 2;
 -            int ySurface = heightmap[dz * chunksize + dx];
 +            int ySurface = activeHeightmap[dz * chunksize + dx];
              if (ySurface <= 0 || ySurface >= worldheight - 15) return false;
-
+ 
              pos.Set(chunkX * chunksize + dx, ySurface, chunkZ * chunksize + dz);
-
+ 
 -            return struc.TryGenerate(blockAccessor, api.World, pos, climateUpLeft, climateUpRight, climateBotLeft, climateBotRight, (loc, schematic) =>
 +            // Stratum: same lock as the ruins loop in DoGenStructures. Villages and
 +            // ruins share the same region.GeneratedStructures overlap check, so they
@@ -428,10 +405,10 @@ index 95025db..7c475dd 100644
 +                return struc.TryGenerate(blockAccessor, api.World, pos, activeClimateUpLeft, activeClimateUpRight, activeClimateBotLeft, activeClimateBotRight, (loc, schematic) =>
 +                {
 +                    string code = (schematic == null ? "" : schematic.FromFile.GetNameWithDomain()) + "/" + struc.Code;
-
+ 
 -                region.AddGeneratedStructure(new GeneratedStructure() { Code = code, Group = struc.Group, Location = loc.Clone() });
 +                    region.AddGeneratedStructure(new GeneratedStructure() { Code = code, Group = struc.Group, Location = loc.Clone() });
-
+ 
 -                if (struc.BuildProtected)
 -                {
 -                    api.World.Claims.Add(new LandClaim()
@@ -459,18 +436,18 @@ index 95025db..7c475dd 100644
 +                }, spawnPos);
 +            }
          }
-
-
+ 
+ 
 +        // Stratum: protect the shared suppression list while serial Vegetation rebuilds and reads it.
 +        // A future concurrent Vegetation pass will need per-column suppression state as well.
 +        readonly object stratumTreeShrubSuppressLock = new object();
          List<Cuboidi> treeAndShrubSupressingStructures = new List<Cuboidi>();
          int chunkMapSizeY;
-
+ 
          public bool PreventPlacementAt(int x, int z, int category)
          {
              if (category != ShrubsHashCode && category != TreesHashCode) return false;
-
+ 
 -            for (int i = 0; i < treeAndShrubSupressingStructures.Count; i++)
 +            lock (stratumTreeShrubSuppressLock)
              {
@@ -480,15 +457,15 @@ index 95025db..7c475dd 100644
 +                    if (treeAndShrubSupressingStructures[i].Contains(x, z)) return true;
 +                }
              }
-
+ 
              return false;
          }
-
+ 
          public bool PreventPlacementBroadlyAt(int chunkX, int chunkZ)
          {
              BlockPos chunkStart = new BlockPos(Dimensions.NormalWorld);
              BlockPos chunkEnd = new BlockPos(Dimensions.NormalWorld);
-
+ 
 -            treeAndShrubSupressingStructures.Clear();
 -            api.World.BlockAccessor.WalkStructures(
 -                chunkStart.Set(chunkX * chunksize, 0, chunkZ * chunksize),
@@ -510,10 +487,8 @@ index 95025db..7c475dd 100644
 +                    }
 +                });
 +            }
-
+ 
              return false;
          }
-
+ 
          public BlockPatchConfig GetPatchProviderAt(int chunkX, int chunkZ, ref EnumHandling handling)
-         {
-             return null;

--- a/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/7.GenPonds/GenPonds.cs.patch
+++ b/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/7.GenPonds/GenPonds.cs.patch
@@ -2,14 +2,12 @@ diff --git a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/7.GenPonds/GenPonds
 index acfac74..fb99e05 100644
 --- a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/7.GenPonds/GenPonds.cs
 +++ b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/7.GenPonds/GenPonds.cs
-@@ -24,16 +24,48 @@ namespace Vintagestory.ServerMods
-         int climateUpLeft;
-         int climateUpRight;
+@@ -26,12 +26,44 @@ namespace Vintagestory.ServerMods
          int climateBotLeft;
          int climateBotRight;
          int[] didCheckPosition;
          int iteration;
-
+ 
 +        // Stratum: isolate the original scratch fields while the stock handler runs concurrently.
 +        [ThreadStatic] private static StratumWorldgenThreadGuard<LCGRandom> stratumRandGuard;
 +        [ThreadStatic] private static QueueOfInt stratumSearchPositionsDeltas;
@@ -22,7 +20,7 @@ index acfac74..fb99e05 100644
 +        [ThreadStatic] private static int stratumActiveDepth;
 +
          LakeBedLayerProperties lakebedLayerConfig;
-
+ 
 +        // Stratum: clear active TLS state on every handler exit without allocating on the hot path.
 +        private readonly struct StratumPondCallScope : IDisposable
 +        {
@@ -44,16 +42,12 @@ index acfac74..fb99e05 100644
 +            }
 +        }
 +
-
+ 
          public override double ExecuteOrder()
          {
              return 0.4;
          }
-
-         public override bool ShouldLoad(EnumAppSide side)
-@@ -85,35 +117,48 @@ namespace Vintagestory.ServerMods
-             var chunks = request.Chunks;
-             int chunkX = request.ChunkX;
+@@ -87,12 +119,25 @@ namespace Vintagestory.ServerMods
              int chunkZ = request.ChunkZ;
              if (GetIntersectingStructure(chunkX * chunksize + chunksize / 2, chunkZ * chunksize + chunksize / 2, PondsHashCode) != null)
              {
@@ -78,16 +72,14 @@ index acfac74..fb99e05 100644
              rand.InitPositionSeed(chunkX, chunkZ);
              int maxHeight = mapheight - 1;
              int pondYPos;
-
+ 
              ushort[] heightmap = chunks[0].MapChunk.RainHeightMap;
-             var mc = chunks[0].MapChunk;
-
-             IntDataMap2D climateMap = chunks[0].MapChunk.MapRegion.ClimateMap;
+@@ -102,16 +147,16 @@ namespace Vintagestory.ServerMods
              int regionChunkSize = api.WorldManager.RegionSize / chunksize;
              float fac = (float)climateMap.InnerSize / regionChunkSize;
              int rlX = chunkX % regionChunkSize;
              int rlZ = chunkZ % regionChunkSize;
-
+ 
 -            climateUpLeft = climateMap.GetUnpaddedInt((int)(rlX * fac), (int)(rlZ * fac));
 -            climateUpRight = climateMap.GetUnpaddedInt((int)(rlX * fac + fac), (int)(rlZ * fac));
 -            climateBotLeft = climateMap.GetUnpaddedInt((int)(rlX * fac), (int)(rlZ * fac + fac));
@@ -96,19 +88,15 @@ index acfac74..fb99e05 100644
 +            climateUpRight = stratumClimateUpRight = climateMap.GetUnpaddedInt((int)(rlX * fac + fac), (int)(rlZ * fac));
 +            climateBotLeft = stratumClimateBotLeft = climateMap.GetUnpaddedInt((int)(rlX * fac), (int)(rlZ * fac + fac));
 +            climateBotRight = stratumClimateBotRight = climateMap.GetUnpaddedInt((int)(rlX * fac + fac), (int)(rlZ * fac + fac));
-
+ 
 -            int climateMid = GameMath.BiLerpRgbColor(0.5f, 0.5f, climateUpLeft, climateUpRight, climateBotLeft, climateBotRight);
 +            int climateMid = GameMath.BiLerpRgbColor(0.5f, 0.5f, stratumClimateUpLeft, stratumClimateUpRight, stratumClimateBotLeft, stratumClimateBotRight);
-
+ 
              // 16-23 bits = Red = temperature
              // 8-15 bits = Green = rain
              // 0-7 bits = Blue = humidity
-
-             int rain = (climateMid >> 8) & 0xff;
-             int temp = (climateMid >> 16) & 0xff;
-@@ -182,26 +227,36 @@ namespace Vintagestory.ServerMods
-         {
-             int mapOffset = this.mapOffset;
+ 
+@@ -184,10 +229,19 @@ namespace Vintagestory.ServerMods
              int searchSize = this.searchSize;
              int minBoundary = this.minBoundary;
              int maxBoundary = this.maxBoundary;
@@ -125,11 +113,11 @@ index acfac74..fb99e05 100644
 +            int activeClimateBotRight = useStratumState ? stratumClimateBotRight : climateBotRight;
              searchPositionsDeltas.Clear();
              pondPositions.Clear();
-
+ 
              int basePosX = chunkX * chunksize;
              int basePosZ = chunkZ * chunksize;
-             Vec2i tmp = new Vec2i();
-
+@@ -195,11 +249,12 @@ namespace Vintagestory.ServerMods
+ 
              // The starting block is an air block
              int arrayIndex = (dz + mapOffset) * searchSize + dx + mapOffset;
              searchPositionsDeltas.Enqueue(arrayIndex);
@@ -138,32 +126,24 @@ index acfac74..fb99e05 100644
 +            int iteration = useStratumState ? ++stratumIteration : ++this.iteration;
 +            if (useStratumState) this.iteration = iteration; // Stratum: publish the current counter through the vanilla field.
              didCheckPosition[arrayIndex] = iteration;
-
+ 
              BlockPos tmpPos = new BlockPos(API.Config.Dimensions.NormalWorld);
-
+ 
              while (searchPositionsDeltas.Count > 0)
-             {
-                 int p = searchPositionsDeltas.Dequeue();
-@@ -260,15 +315,15 @@ namespace Vintagestory.ServerMods
-             int regionChunkSize = api.WorldManager.RegionSize / chunksize;
-             IMapChunk mapchunk=null;
+@@ -262,11 +317,11 @@ namespace Vintagestory.ServerMods
              IServerChunk chunk = null;
              IServerChunk chunkOneBlockBelow = null;
-
+ 
              int ly = GameMath.Mod(pondYPos, chunksize);
-
+ 
 -            bool extraPondDepth = rand.NextFloat() > 0.5f;
 +            bool extraPondDepth = activeRand.NextFloat() > 0.5f;
              bool withSeabed = extraPondDepth || pondPositions.Count > 16;
-
+ 
              while (pondPositions.Count > 0)
              {
                  int p = pondPositions.Dequeue();
-                 int px = p % searchSize - mapOffset + basePosX;
-                 int pz = p / searchSize - mapOffset + basePosZ;
-@@ -279,14 +334,16 @@ namespace Vintagestory.ServerMods
-                 int lz = GameMath.Mod(pz, chunksize);
-
+@@ -281,10 +336,12 @@ namespace Vintagestory.ServerMods
                  // Get correct chunk and correct climate data if we don't have it already
                  if (curChunkX != prevChunkX || curChunkZ != prevChunkZ)
                  {
@@ -172,20 +152,16 @@ index acfac74..fb99e05 100644
 +                    // Stratum: concurrent generation can observe an absent neighbour.
 +                    if (chunk == null) return;
                      chunk.Unpack();
-
+ 
                      if (ly == 0)
                      {
                          chunkOneBlockBelow = ((IServerChunk)blockAccessor.GetChunk(curChunkX, (pondYPos - 1) / chunksize, curChunkZ));
-                         if (chunkOneBlockBelow == null) return;
-                         chunkOneBlockBelow.Unpack();
-@@ -298,32 +355,44 @@ namespace Vintagestory.ServerMods
-                     mapchunk = chunk.MapChunk;
-                     IntDataMap2D climateMap = mapchunk.MapRegion.ClimateMap;
-
+@@ -300,14 +357,26 @@ namespace Vintagestory.ServerMods
+ 
                      float fac = (float)climateMap.InnerSize / regionChunkSize;
                      int rlX = curChunkX % regionChunkSize;
                      int rlZ = curChunkZ % regionChunkSize;
-
+ 
 -                    climateUpLeft = climateMap.GetUnpaddedInt((int)(rlX * fac), (int)(rlZ * fac));
 -                    climateUpRight = climateMap.GetUnpaddedInt((int)(rlX * fac + fac), (int)(rlZ * fac));
 -                    climateBotLeft = climateMap.GetUnpaddedInt((int)(rlX * fac), (int)(rlZ * fac + fac));
@@ -206,42 +182,34 @@ index acfac74..fb99e05 100644
 +                    climateUpRight = activeClimateUpRight;
 +                    climateBotLeft = activeClimateBotLeft;
 +                    climateBotRight = activeClimateBotRight;
-
+ 
                      prevChunkX = curChunkX;
                      prevChunkZ = curChunkZ;
-
+ 
                      chunkOneBlockBelow.MarkModified();
-                     chunk.MarkModified();
-                 }
-
-
+@@ -317,11 +386,11 @@ namespace Vintagestory.ServerMods
+ 
                  // Raise heightmap by 1 (only relevant for above-ground ponds)
                  if (mapchunk.RainHeightMap[lz * chunksize + lx] < pondYPos) mapchunk.RainHeightMap[lz * chunksize + lx] = (ushort)pondYPos;
-
+ 
                  // Identify correct climate at this position - could be optimised if we place water into ponds in columns instead of layers
 -                int climate = GameMath.BiLerpRgbColor((float)lx / chunksize, (float)lz / chunksize, climateUpLeft, climateUpRight, climateBotLeft, climateBotRight);
 +                int climate = GameMath.BiLerpRgbColor((float)lx / chunksize, (float)lz / chunksize, activeClimateUpLeft, activeClimateUpRight, activeClimateBotLeft, activeClimateBotRight);
                  float temp = Climate.GetScaledAdjustedTemperatureFloat((climate >> 16) & 0xff, pondYPos - TerraGenConfig.seaLevel);
-
-
+ 
+ 
                  // 1. Place water or ice block
                  int index3d = (ly * chunksize + lz) * chunksize + lx;
-                 Block existing = api.World.GetBlock(chunk.Data.GetBlockId(index3d, BlockLayersAccess.Solid));
-                 if (existing.BlockMaterial == EnumBlockMaterial.Plant)
-@@ -353,15 +422,15 @@ namespace Vintagestory.ServerMods
-                 // Water below? Seabed already placed
-                 if (belowBlock.IsLiquid()) continue;
-
+@@ -355,11 +424,11 @@ namespace Vintagestory.ServerMods
+ 
                  float rainRel = Climate.GetRainFall((climate >> 8) & 0xff, pondYPos) / 255f;
                  int rockBlockId = mapchunk.TopRockIdMap[lz * chunksize + lx];
                  if (rockBlockId == 0) continue;
-
+ 
 -                int lakebedId = lakebedLayerConfig.GetSuitable(temp, rainRel, (float)pondYPos / mapheight, rand, rockBlockId);
 +                int lakebedId = lakebedLayerConfig.GetSuitable(temp, rainRel, (float)pondYPos / mapheight, activeRand, rockBlockId);
                  if (lakebedId != 0) chunkOneBlockBelow.Data[index] = lakebedId;
              }
-
-
+ 
+ 
              if (extraPondDepth)
-             {
-                 TryPlacePondAt(dx, pondYPos+1, dz, chunkX, chunkZ, depth + 1);

--- a/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/8.GenVegetationAndPatches/GenVegetationAndPatches.cs.patch
+++ b/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/8.GenVegetationAndPatches/GenVegetationAndPatches.cs.patch
@@ -2,7 +2,8 @@ diff --git a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/8.GenVegetationAndP
 index aadf540..6f1c45c 100644
 --- a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/8.GenVegetationAndPatches/GenVegetationAndPatches.cs
 +++ b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/8.GenVegetationAndPatches/GenVegetationAndPatches.cs
-@@ -48,8 +48,15 @@ namespace Vintagestory.ServerMods
+@@ -47,10 +47,17 @@ namespace Vintagestory.ServerMods
+ 
          /// <summary>
          /// Vegetation and BlockPatch sub seed
          /// </summary>
@@ -18,38 +19,45 @@ index aadf540..6f1c45c 100644
          {
              return side == EnumAppSide.Server;
          }
-@@ -246,10 +253,10 @@ namespace Vintagestory.ServerMods
+ 
+@@ -245,12 +252,12 @@ namespace Vintagestory.ServerMods
+         {
              int dx, dz, x, z;
              Block liquidBlock;
              int mapsizeY = blockAccessor.MapSizeY;
-
+ 
 -            var patchIterRandom = new LCGRandom();
 -            var blockPatchRandom = new LCGRandom();
 +            var patchIterRandom = stratumPatchIterRandom ??= new LCGRandom();
 +            var blockPatchRandom = stratumBlockPatchRandom ??= new LCGRandom();
-
+ 
              // get temp pos to check if we need a story location patch or a regular one
              patchIterRandom.SetWorldSeed(sapi.WorldManager.Seed - subSeed);
              patchIterRandom.InitPositionSeed(chunkX, chunkZ);
-@@ -367,9 +374,9 @@ namespace Vintagestory.ServerMods
+ 
+@@ -366,11 +373,11 @@ namespace Vintagestory.ServerMods
+         {
              rnd.InitPositionSeed(chunkX, chunkZ);
              int triesShrubs = (int)treeSupplier.treeGenProps.shrubsPerChunk.nextFloat(1f, rnd);
              int dx, dz, x, z;
              Block block;
 -            var shrubTryRandom = new LCGRandom();
 +            var shrubTryRandom = stratumShrubTryRandom ??= new LCGRandom();
-
+ 
              while (triesShrubs > 0)
              {
                  shrubTryRandom.SetWorldSeed(sapi.World.Seed - subSeed + triesShrubs);
-@@ -430,9 +437,9 @@ namespace Vintagestory.ServerMods
+                 shrubTryRandom.InitPositionSeed(chunkX, chunkZ);
+@@ -429,11 +436,11 @@ namespace Vintagestory.ServerMods
+             Block block;
              int treesGenerated = 0;
-
+ 
              EnumHemisphere hemisphere = sapi.World.Calendar.GetHemisphere(new BlockPos(chunkX * chunksize + chunksize / 2, 0, chunkZ * chunksize + chunksize / 2));
-
+ 
 -            var treeTryRandom = new LCGRandom();
 +            var treeTryRandom = stratumTreeTryRandom ??= new LCGRandom();
              while (triesTrees > 0)
              {
                  treeTryRandom.SetWorldSeed(sapi.World.Seed - subSeed + triesTrees);
                  treeTryRandom.InitPositionSeed(chunkX, chunkZ);
+                 triesTrees--;

--- a/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/93.GenCreatures.cs.patch
+++ b/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/93.GenCreatures.cs.patch
@@ -2,31 +2,40 @@ diff --git a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/93.GenCreatures.cs 
 index 647310c..540409d 100644
 --- a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/93.GenCreatures.cs
 +++ b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/93.GenCreatures.cs
-@@ -48,6 +48,9 @@ namespace Vintagestory.ServerMods
+@@ -46,22 +46,26 @@ namespace Vintagestory.ServerMods
+         protected int shrubsUpRight;
+         protected int shrubsBotLeft;
          protected int shrubsBotRight;
          protected List<SpawnOppurtunity> spawnPositions = new List<SpawnOppurtunity>();
-
+ 
 +        // Stratum: each worldgen thread gets a complete generator so protected fields stay mod-visible.
 +        StratumWorkerInstances<GenCreatures> stratumWorkers;
 +
-
+ 
          public override bool ShouldLoad(EnumAppSide side) => side == EnumAppSide.Server;
          public override double ExecuteOrder() => 0.1;
-@@ -58,8 +61,9 @@ namespace Vintagestory.ServerMods
-
+ 
+         public override void StartServerSide(ICoreServerAPI api)
+         {
+             this.api = api;
+ 
              if (TerraGenConfig.DoDecorationPass)
              {
 +                stratumWorkers = new StratumWorkerInstances<GenCreatures>(StratumCreateWorker); // Stratum: isolate per-column state without changing vanilla fields
                  api.Event.InitWorldGenerator(initWorldGen, "standard");
 -                api.Event.ChunkColumnGeneration(OnChunkColumnGen, EnumWorldGenPass.PreDone, "standard");
 +                api.Event.ChunkColumnGeneration(StratumOnChunkColumnGen, EnumWorldGenPass.PreDone, "standard"); // Stratum: run the handler on this thread's worker
-
+ 
                  api.Event.MapRegionGeneration(OnMapRegionGen, "standard");
                  api.Event.MapRegionGeneration(OnMapRegionGen, "superflat");
-@@ -141,6 +145,33 @@ namespace Vintagestory.ServerMods
+ 
+                 api.Event.GetWorldgenBlockAccessor(OnWorldGenBlockAccessor);
+@@ -139,10 +143,37 @@ namespace Vintagestory.ServerMods
+             }
+ 
              loadAnimalMaps();
          }
-
+ 
 +        private void StratumOnChunkColumnGen(IChunkColumnGenerateRequest request)
 +        {
 +            stratumWorkers.Current.OnChunkColumnGen(request);
@@ -57,7 +66,11 @@ index 647310c..540409d 100644
          protected void loadAnimalMaps()
          {
              regionSize = api.WorldManager.RegionSize;
-@@ -182,6 +213,9 @@ namespace Vintagestory.ServerMods
+             noiseSizeDensityMap = regionSize / TerraGenConfig.animalMapScale;
+ 
+@@ -180,10 +211,13 @@ namespace Vintagestory.ServerMods
+ 
+             if (GetIntersectingStructure(chunkX * chunksize + chunksize / 2, chunkZ * chunksize + chunksize / 2, CreaturesHashCode) != null)
              {
                  return;
              }
@@ -67,14 +80,20 @@ index 647310c..540409d 100644
              wgenBlockAccessor.BeginColumn();
              IntDataMap2D climateMap = chunks[0].MapChunk.MapRegion.ClimateMap;
              ushort[] heightMap = chunks[0].MapChunk.WorldGenTerrainHeightMap;
-@@ -220,7 +254,10 @@ namespace Vintagestory.ServerMods
+ 
+             int regionChunkSize = api.WorldManager.RegionSize / chunksize;
+@@ -218,11 +252,14 @@ namespace Vintagestory.ServerMods
+                 EntityProperties entitytype = val.Key;
+                 float tries = entitytype.Server.SpawnConditions.Worldgen.TriesPerChunk.nextFloat(1, rnd);
                  if (tries == 0f) continue;
-
+ 
                  var scRuntime = entitytype.Server.SpawnConditions.Runtime;   // the Group ("hostile"/"neutral"/"passive") is only held in the Runtime spawn conditions
 +                float stratumSpawnMultiplier = StratumMobSpawningHook.GetNaturalSpawnMultiplier(scRuntime?.Group); // Stratum: issue #216 natural worldgen control
 +                if (stratumSpawnMultiplier <= 0f) continue;
                  if (scRuntime == null || scRuntime.Group != "hostile") tries *= gcfg.neutralCreatureSpawnMultiplier;
 +                tries *= stratumSpawnMultiplier; // Stratum: issue #216 lower natural worldgen volume
-
+ 
                  while (tries-- > rnd.NextDouble())
                  {
+                     int dx = rnd.Next(chunksize);
+                     int dz = rnd.Next(chunksize);

--- a/patches/VSEssentials/Systems/WorldGen/Standard/Datastructures/BlockSchematicStructure.cs.patch
+++ b/patches/VSEssentials/Systems/WorldGen/Standard/Datastructures/BlockSchematicStructure.cs.patch
@@ -2,11 +2,12 @@ diff --git a/VSEssentials/Systems/WorldGen/Standard/Datastructures/BlockSchemati
 index 7573f32..7b9e3e9 100644
 --- a/VSEssentials/Systems/WorldGen/Standard/Datastructures/BlockSchematicStructure.cs
 +++ b/VSEssentials/Systems/WorldGen/Standard/Datastructures/BlockSchematicStructure.cs
-@@ -15,8 +15,15 @@ namespace Vintagestory.ServerMods
+@@ -14,10 +14,17 @@ namespace Vintagestory.ServerMods
+ {
      public class BlockSchematicStructure : BlockSchematic
      {
          public Dictionary<int, AssetLocation> BlockCodesTmpForRemap = new();
-
+ 
 +        // Stratum: reuse remap storage without clearing any schematic's permanent BlockCodes.
 +        [ThreadStatic]
 +        private static Dictionary<int, AssetLocation> stratumBlockCodesRemapScratch;
@@ -15,14 +16,16 @@ index 7573f32..7b9e3e9 100644
 +        private readonly object stratumRemapLock = new object();
 +
          public AssetLocation FromFile;
-
+ 
          public Block[,,] blocksByPos;
          public Dictionary<int, Block> FluidBlocksByPos;
-@@ -126,9 +133,14 @@ namespace Vintagestory.ServerMods
+         public BlockLayerConfig blockLayerConfig;
+@@ -125,11 +132,16 @@ namespace Vintagestory.ServerMods
+             IMapChunk mapchunk = blockAccessor.GetMapChunkAtBlockPos(curPos);
              int centerrockblockid = mapchunk.TopRockIdMap[(curPos.Z % chunksize) * chunksize + curPos.X % chunksize];
-
+ 
              IWorldAccessor worldgenWorldAccessor = blockAccessor is IWorldGenBlockAccessor wgba ? wgba.WorldgenWorldAccessor : worldForCollectibleResolve;
-
+ 
 -            resolveReplaceRemapsForBlockEntities(blockAccessor, worldForCollectibleResolve, replaceBlocks, centerrockblockid);
 +            Dictionary<int, AssetLocation> blockCodesForRemap;
 +            lock (stratumRemapLock)
@@ -30,26 +33,30 @@ index 7573f32..7b9e3e9 100644
 +                resolveReplaceRemapsForBlockEntities(blockAccessor, worldForCollectibleResolve, replaceBlocks, centerrockblockid);
 +                blockCodesForRemap = BlockCodesTmpForRemap;
 +            }
-
+ 
              Dictionary<BlockPos, Block> layerBlockForBlockEntities = new Dictionary<BlockPos, Block>();
-
+ 
              for (int x = 0; x < SizeX; x++)
-@@ -307,9 +319,9 @@ namespace Vintagestory.ServerMods
+             {
+@@ -306,11 +318,11 @@ namespace Vintagestory.ServerMods
+                     }
                  }
              }
-
+ 
              PlaceDecors(blockAccessor, startPos);
 -            PlaceEntitiesAndBlockEntities(blockAccessor, worldForCollectibleResolve, startPos, BlockCodesTmpForRemap, ItemCodes, replaceBlockEntities, replaceBlocks, centerrockblockid, layerBlockForBlockEntities, replaceMetaBlocks);
 +            PlaceEntitiesAndBlockEntities(blockAccessor, worldForCollectibleResolve, startPos, blockCodesForRemap, ItemCodes, replaceBlockEntities, replaceBlocks, centerrockblockid, layerBlockForBlockEntities, replaceMetaBlocks);
-
+ 
              return placed;
          }
-
-@@ -320,23 +332,28 @@ namespace Vintagestory.ServerMods
+ 
+         private void resolveReplaceRemapsForBlockEntities(IBlockAccessor blockAccessor, IWorldAccessor worldForCollectibleResolve, Dictionary<int, Dictionary<int, int>> replaceBlocks, int centerrockblockid)
+@@ -319,25 +331,30 @@ namespace Vintagestory.ServerMods
+             {
                  BlockCodesTmpForRemap = BlockCodes;
                  return;
              }
-
+ 
 +            if (stratumBlockCodesRemapScratch == null) stratumBlockCodesRemapScratch = new Dictionary<int, AssetLocation>();
 +            else stratumBlockCodesRemapScratch.Clear();
 +
@@ -57,10 +64,10 @@ index 7573f32..7b9e3e9 100644
              {
                  Block origBlock = worldForCollectibleResolve.GetBlock(val.Value);
                  if (origBlock == null) continue; // Invalid blocks
-
+ 
 -                BlockCodesTmpForRemap[val.Key] = val.Value;
 +                stratumBlockCodesRemapScratch[val.Key] = val.Value;
-
+ 
                  if (replaceBlocks.TryGetValue(origBlock.Id, out var replaceByBlock))
                  {
                      if (replaceByBlock.TryGetValue(centerrockblockid, out int newBlockId))
@@ -73,10 +80,12 @@ index 7573f32..7b9e3e9 100644
 +
 +            BlockCodesTmpForRemap = stratumBlockCodesRemapScratch;
          }
-
-
-
-@@ -359,9 +376,14 @@ namespace Vintagestory.ServerMods
+ 
+ 
+ 
+ 
+@@ -358,11 +375,16 @@ namespace Vintagestory.ServerMods
+ 
              const int chunksize = GlobalConstants.ChunkSize;
              curPos.Set(SizeX / 2 + startPos.X, startPos.Y, SizeZ / 2 + startPos.Z);
              IMapChunk mapchunk = blockAccessor.GetMapChunkAtBlockPos(curPos);
@@ -88,26 +97,30 @@ index 7573f32..7b9e3e9 100644
 +                resolveReplaceRemapsForBlockEntities(blockAccessor, worldForCollectibleResolve, replaceBlocks, centerrockblockid);
 +                blockCodesForRemap = BlockCodesTmpForRemap;
 +            }
-
-
+ 
+ 
              PlaceBlockDelegate handler = null;
              switch (ReplaceMode)
-@@ -427,9 +449,9 @@ namespace Vintagestory.ServerMods
-
+             {
+@@ -426,11 +448,11 @@ namespace Vintagestory.ServerMods
+             }
+ 
              if (!(blockAccessor is IBlockAccessorRevertable))
              {
                  PlaceDecors(blockAccessor, startPos);
 -                PlaceEntitiesAndBlockEntities(blockAccessor, worldForCollectibleResolve, startPos, BlockCodesTmpForRemap, ItemCodes, false, null, centerrockblockid, null, GlobalConfig.ReplaceMetaBlocks);
 +                PlaceEntitiesAndBlockEntities(blockAccessor, worldForCollectibleResolve, startPos, blockCodesForRemap, ItemCodes, false, null, centerrockblockid, null, GlobalConfig.ReplaceMetaBlocks);
              }
-
+ 
              return placed;
          }
-@@ -513,27 +535,50 @@ namespace Vintagestory.ServerMods
-
+ 
+@@ -512,29 +534,52 @@ namespace Vintagestory.ServerMods
+             cloned.OriginalPos = OriginalPos;
+ 
              return cloned;
          }
-
+ 
 +        // Stratum: guards the lazy unpack below. schematicDatas entries (see WorldGenStructure)
 +        // are cached objects reused by every column that draws this schematic, and worldgen has
 +        // always let different columns run in different pipeline stages at the same time,
@@ -141,7 +154,7 @@ index 7573f32..7b9e3e9 100644
 +                }
              }
          }
-
+ 
          public void Unpack(ICoreAPI api, int orientation)
          {
 -            if (orientation > 0 && blocksByPos == null)
@@ -159,3 +172,4 @@ index 7573f32..7b9e3e9 100644
              Unpack(api);
          }
      }
+ }

--- a/patches/VSEssentials/Systems/WorldGen/Standard/GenPartial.cs.patch
+++ b/patches/VSEssentials/Systems/WorldGen/Standard/GenPartial.cs.patch
@@ -1,7 +1,10 @@
 diff --git a/VSEssentials/Systems/WorldGen/Standard/GenPartial.cs b/VSEssentials/Systems/WorldGen/Standard/GenPartial.cs
+index 58aa710..ccaa47a 100644
 --- a/VSEssentials/Systems/WorldGen/Standard/GenPartial.cs
 +++ b/VSEssentials/Systems/WorldGen/Standard/GenPartial.cs
-@@ -30,6 +30,23 @@
+@@ -28,10 +28,27 @@ namespace Vintagestory.ServerMods
+ 
+             worldheight = api.WorldManager.MapSizeY;
              chunkRand = new LCGRandom(api.WorldManager.Seed);
          }
  
@@ -25,3 +28,5 @@ diff --git a/VSEssentials/Systems/WorldGen/Standard/GenPartial.cs b/VSEssentials
  
          protected virtual void GenChunkColumn(IChunkColumnGenerateRequest request)
          {
+             var chunks = request.Chunks;
+             int chunkX = request.ChunkX;

--- a/patches/VSEssentials/Systems/WorldGen/Standard/ModStdWorldGen.cs.patch
+++ b/patches/VSEssentials/Systems/WorldGen/Standard/ModStdWorldGen.cs.patch
@@ -2,7 +2,9 @@ diff --git a/VSEssentials/Systems/WorldGen/Standard/ModStdWorldGen.cs b/VSEssent
 index 1bd4340..3d6d3f6 100644
 --- a/VSEssentials/Systems/WorldGen/Standard/ModStdWorldGen.cs
 +++ b/VSEssentials/Systems/WorldGen/Standard/ModStdWorldGen.cs
-@@ -44,6 +44,8 @@ namespace Vintagestory.ServerMods
+@@ -42,21 +42,26 @@ namespace Vintagestory.ServerMods
+         /// </summary>
+         public event Action<int, int> OnRegenFinalized;
  
          public void TriggerRegenFinalized(int chunkX, int chunkZ) => OnRegenFinalized?.Invoke(chunkX, chunkZ);
          protected IStructureProvider[] providers;
@@ -11,7 +13,10 @@ index 1bd4340..3d6d3f6 100644
          public override bool ShouldLoad(EnumAppSide forSide) => true;
  
  
-@@ -54,7 +56,10 @@ namespace Vintagestory.ServerMods
+         public override void StartPre(ICoreAPI api)
+         {
+             providers = Array.Empty<IStructureProvider>();
+         }
  
          public void RegisterProvider(IStructureProvider provider)
          {
@@ -23,7 +28,11 @@ index 1bd4340..3d6d3f6 100644
          }
  
          /// <summary>
-@@ -68,13 +73,16 @@ namespace Vintagestory.ServerMods
+         /// Checks weather the provided position is inside a story structures schematics for the specified skipCategory, or it's radius.
+         /// If the Radius for the storystrcuture should be also checked is defined in the json as int as part of the skipGenerationCategories. Does only check 2D from story locations center.
+@@ -66,17 +71,20 @@ namespace Vintagestory.ServerMods
+         /// <param name="z"></param>
+         /// <param name="category">The hashcode of the string category from storystructure.json skipGenerationCategories. The strings from storystructure.json are first converted to lowercase before getting the hash code.</param>
          /// <returns></returns>
          public IStructureLocation GetIntersectingStructure(int x, int z, int category)
          {
@@ -45,3 +54,5 @@ index 1bd4340..3d6d3f6 100644
          }
  
      }
+ 
+     public abstract class ModStdWorldGen : ModSystem

--- a/patches/VSSurvivalMod/Entity/Behavior/BehaviorAttachable.cs.patch
+++ b/patches/VSSurvivalMod/Entity/Behavior/BehaviorAttachable.cs.patch
@@ -7,7 +7,7 @@ index ca7d5e3..69e50ea 100644
          {
              int seleBox = (byEntity as EntityPlayer).EntitySelection?.SelectionBoxIndex ?? -1;
              if (seleBox <= 0) return;
-
+ 
 -            var index = GetSlotIndexFromSelectionBoxIndex(seleBox - 1);
 -            var slot = index >= 0 ? inv[index] : null;
 +            // Stratum: reject stale selection boxes before indexing attachments.
@@ -15,20 +15,20 @@ index ca7d5e3..69e50ea 100644
 +			var slot = index >= 0 && index < inv.Count ? inv[index] : null;
              if (slot == null) return;
              handled = EnumHandling.PreventSubsequent;
-
+ 
              var controls = byEntity.MountedOn?.Controls ?? byEntity.Controls;
              var attachKey = UseShiftAttach ? controls.ShiftKey : controls.CtrlKey;
 @@ -374,20 +375,24 @@ namespace Vintagestory.GameContent
          }
-
+ 
          private bool TryRemoveAttachment(EntityAgent byEntity, int selectionBoxIndex)
          {
              int slotIndex = GetSlotIndexFromSelectionBoxIndex(selectionBoxIndex);
 +            if (slotIndex < 0) return false;
              ItemSlot slot = inv[slotIndex];
-
+ 
              if (slot.Empty) return false;
-
+ 
              // Don't allow removal of seats where somebody sits on
 -            var ebh = entity.GetBehavior<EntityBehaviorSeatable>();
 -            if (ebh != null)
@@ -52,48 +52,48 @@ index ca7d5e3..69e50ea 100644
          {
              var iatta = IAttachableToEntity.FromCollectible(itemslot.Itemstack.Collectible);
              if (iatta == null || !iatta.IsAttachable(entity, itemslot.Itemstack)) return false;
-
+ 
              int slotIndex = GetSlotIndexFromSelectionBoxIndex(selectionBoxIndex);
 +            if (slotIndex < 0) return false;
              ItemSlot targetSlot = inv[slotIndex];
              string code = iatta.GetCategoryCode(itemslot.Itemstack);
              WearableSlotConfig slotConfig = wearableSlots[slotIndex];
-
+ 
              var ebhs = entity.GetBehavior<EntityBehaviorSeatable>();
 @@ -530,21 +536,23 @@ namespace Vintagestory.GameContent
              var index = GetSlotIndexFromSelectionBoxIndex(boxIndex);
              if (index == -1) return null;
              return inv[index];
          }
-
+ 
 -        public int GetSlotIndexFromSelectionBoxIndex(int boxIndex)
 -        {
 -            if (boxIndex < 0) return -1;
 +		public int GetSlotIndexFromSelectionBoxIndex(int boxIndex)
 +		{
 +			if (boxIndex < 0) return -1;
-
+ 
 -            var selectionBehavior = entity.GetBehavior<EntityBehaviorSelectionBoxes>();
 -            ArgumentNullException.ThrowIfNull(selectionBehavior);
 +            // Stratum: bound selection-box and inventory indices before lookup.
 +			var selectionBehavior = entity.GetBehavior<EntityBehaviorSelectionBoxes>();
 +			var selectionBoxes = selectionBehavior?.selectionBoxes;
 +			if (selectionBoxes == null || (uint)boxIndex >= (uint)selectionBoxes.Length) return -1;
-
+ 
 -            // Allow throwing if the index is out of bounds, since that shouldn't be happening
 -            string apCode = selectionBehavior.selectionBoxes[boxIndex].AttachPoint.Code;
 +			string apCode = selectionBoxes[boxIndex].AttachPoint.Code;
-
+ 
 -            return wearableSlots.IndexOf(elem => elem.AttachmentPointCode == apCode);
 +			int slotIndex = wearableSlots.IndexOf(elem => elem.AttachmentPointCode == apCode);
 +			return slotIndex >= 0 && slotIndex < inv.Count ? slotIndex : -1;
          }
-
+ 
          public ItemSlot GetSlotConfigFromAPName(string apCode)
          {
              var seleBoxes = entity.GetBehavior<EntityBehaviorSelectionBoxes>().selectionBoxes;
 @@ -590,11 +598,13 @@ namespace Vintagestory.GameContent
-
+ 
          public override WorldInteraction[] GetInteractionHelp(IClientWorldAccessor world, EntitySelection es, IClientPlayer player, ref EnumHandling handled)
          {
              if (es.SelectionBoxIndex > 0)
@@ -103,16 +103,16 @@ index ca7d5e3..69e50ea 100644
 +                if (slot == null) return base.GetInteractionHelp(world, es, player, ref handled);
 +                return AttachableInteractionHelp.GetOrCreateInteractionHelp(world.Api, this, wearableSlots, es.SelectionBoxIndex - 1, slot);
              }
-
+ 
              return base.GetInteractionHelp(world, es, player, ref handled);
          }
-
+ 
 @@ -608,11 +618,15 @@ namespace Vintagestory.GameContent
              if (capi.World.Player.CurrentEntitySelection == null) return null;
-
+ 
              var selebox = capi.World.Player.CurrentEntitySelection.SelectionBoxIndex - 1;
              if (selebox < 0) return null;
-
+ 
 -            return entity.GetBehavior<EntityBehaviorSelectionBoxes>().GetCenterPosOfBox(selebox)?.Add(0, 0.5, 0);
 +			var selectionBoxes = entity.GetBehavior<EntityBehaviorSelectionBoxes>();
 +			var selectionBoxArray = selectionBoxes?.selectionBoxes;
@@ -120,7 +120,7 @@ index ca7d5e3..69e50ea 100644
 +
 +            return selectionBoxes.GetCenterPosOfBox(selebox)?.Add(0, 0.5, 0);
          }
-
+ 
          public override void OnEntityDeath(DamageSource damageSourceForDeath)
          {
              int i = 0;

--- a/patches/VSSurvivalMod/Systems/Boats/EntityBehaviorSeatable.cs.patch
+++ b/patches/VSSurvivalMod/Systems/Boats/EntityBehaviorSeatable.cs.patch
@@ -1,5 +1,5 @@
 diff --git a/VSSurvivalMod/Systems/Boats/EntityBehaviorSeatable.cs b/VSSurvivalMod/Systems/Boats/EntityBehaviorSeatable.cs
-index e0e3ce5..fc566a2 100644
+index e0e3ce5..77f664e 100644
 --- a/VSSurvivalMod/Systems/Boats/EntityBehaviorSeatable.cs
 +++ b/VSSurvivalMod/Systems/Boats/EntityBehaviorSeatable.cs
 @@ -133,16 +133,20 @@ namespace Vintagestory.GameContent
@@ -7,7 +7,7 @@ index e0e3ce5..fc566a2 100644
              if (mode != EnumInteractMode.Interact || !entity.Alive || !byEntity.Alive) return;
              if (!allowSit(byEntity)) return;
              if (itemslot.Itemstack?.Collectible is ItemRope) return;
-
+ 
 -            int seleBox = (byEntity as EntityPlayer).EntitySelection?.SelectionBoxIndex ?? -1;
 -            var bhs = entity.GetBehavior<EntityBehaviorSelectionBoxes>();
 -
@@ -29,12 +29,12 @@ index e0e3ce5..fc566a2 100644
                  if (seat != null && seat.Passenger != null && seat.Passenger.HasBehavior<EntityBehaviorRopeTieable>())
                  {
                      (seat.Passenger as EntityAgent).TryUnmount();
-@@ -154,14 +157,14 @@ namespace Vintagestory.GameContent
+@@ -154,14 +158,14 @@ namespace Vintagestory.GameContent
              if (byEntity.Controls.CtrlKey)
              {
                  return;
              }
-
+ 
 -            // If we have the selection boxes behavior, use that
 -            if (seleBox > 0 && bhs != null)
 -            {
@@ -44,14 +44,14 @@ index e0e3ce5..fc566a2 100644
 +			{
 +				var apap = selectionBoxes[selectionBoxIndex];
                  string apname = apap.AttachPoint.Code;
-
+ 
                  var seat = Seats.FirstOrDefault((seat) => seat.Config.APName == apname || seat.Config.SelectionBox == apname);
                  if (seat != null && CanSitOn(seat) && byEntity.TryMount(seat))
                  {
-@@ -367,18 +370,25 @@ namespace Vintagestory.GameContent
-
-
-
+@@ -367,18 +371,25 @@ namespace Vintagestory.GameContent
+ 
+ 
+ 
          public override WorldInteraction[] GetInteractionHelp(IClientWorldAccessor world, EntitySelection es, IClientPlayer player, ref EnumHandling handled)
          {
 -            if (es.SelectionBoxIndex > 0)
@@ -61,10 +61,10 @@ index e0e3ce5..fc566a2 100644
 -                return SeatableInteractionHelp.GetOrCreateInteractionHelp(world.Api, this, Seats, es.SelectionBoxIndex - 1);
 +                return SeatableInteractionHelp.GetOrCreateInteractionHelp(world.Api, this, Seats, selectionBoxIndex);
              }
-
+ 
              return base.GetInteractionHelp(world, es, player, ref handled);
          }
-
+ 
 +		public bool HasSelectionBox(int selectionBoxIndex)
 +		{
 +			var selectionBoxes = entity.GetBehavior<EntityBehaviorSelectionBoxes>()?.selectionBoxes;
@@ -74,14 +74,14 @@ index e0e3ce5..fc566a2 100644
          public override void OnEntityDeath(DamageSource damageSourceForDeath)
          {
              base.OnEntityDeath(damageSourceForDeath);
-
+ 
              foreach (var seat in Seats) {
-@@ -444,16 +454,16 @@ namespace Vintagestory.GameContent
+@@ -444,16 +455,16 @@ namespace Vintagestory.GameContent
              }
-
+ 
              return null;
          }
-
+ 
 -        private static IMountableSeat getSeat(EntityBehaviorSeatable eba, IMountableSeat[] seats, int slotIndex)
 -        {
 -            var bhs = eba.entity.GetBehavior<EntityBehaviorSelectionBoxes>();
@@ -90,11 +90,11 @@ index e0e3ce5..fc566a2 100644
 +		{
 +			var selectionBoxes = eba.entity.GetBehavior<EntityBehaviorSelectionBoxes>()?.selectionBoxes;
 +			if (selectionBoxes == null || (uint)slotIndex >= (uint)selectionBoxes.Length) return null;
-
+ 
 -            var apap = bhs.selectionBoxes[slotIndex];
 +			var apap = selectionBoxes[slotIndex];
              string apname = apap.AttachPoint.Code;
-
+ 
              return seats.FirstOrDefault((seat) => seat.Config.APName == apname || seat.Config.SelectionBox == apname);
          }
      }

--- a/patches/VSSurvivalMod/Systems/WorldGen/Standard/ChunkGen/6.GenStructures/GenDungeons.cs.patch
+++ b/patches/VSSurvivalMod/Systems/WorldGen/Standard/ChunkGen/6.GenStructures/GenDungeons.cs.patch
@@ -2,26 +2,20 @@ diff --git a/VSSurvivalMod/Systems/WorldGen/Standard/ChunkGen/6.GenStructures/Ge
 index dfdae53..7ddb048 100644
 --- a/VSSurvivalMod/Systems/WorldGen/Standard/ChunkGen/6.GenStructures/GenDungeons.cs
 +++ b/VSSurvivalMod/Systems/WorldGen/Standard/ChunkGen/6.GenStructures/GenDungeons.cs
-@@ -48,14 +48,16 @@ namespace Vintagestory.ServerMods
-     public class GenDungeons : ModStdWorldGen
-     {
+@@ -50,10 +50,12 @@ namespace Vintagestory.ServerMods
          private ModSystemTiledDungeons tiledDungeonsSys = null!;
          private IWorldGenBlockAccessor worldgenBlockAccessor = null!;
          private ICoreServerAPI sapi = null!;
          private LCGRandom rand = null!;
-
+ 
 +        // Stratum: protect persistent dungeon tasks and locations while TerrainFeatures runs concurrently.
 +        private readonly object stratumDungeonStateLock = new object();
          private Dictionary<long, List<DungeonPlaceTask>> dungeonPlaceTasksByRegion = new Dictionary<long, List<DungeonPlaceTask>>();
-
+ 
          private int regionSize;
          private BlockPos spawnPos = null!;
          private GenStoryStructures storyStructSys = null!;
-         private GenBlockLayers genBlockLayers = null!;
-         private LCGRandom grassRand = null!;
-@@ -116,110 +118,126 @@ namespace Vintagestory.ServerMods
-         private void Event_MapRegionLoaded(Vec2i mapCoord, IMapRegion region)
-         {
+@@ -118,42 +120,54 @@ namespace Vintagestory.ServerMods
              try
              {
                  var tasks = region.GetModdata<List<DungeonPlaceTask>>("dungeonPlaceTasks");
@@ -36,10 +30,10 @@ index dfdae53..7ddb048 100644
              }
              catch
              {
-
+ 
              }
          }
-
+ 
          private void Event_GameWorldSave()
          {
 -            if (DungeonsDirty)
@@ -54,7 +48,7 @@ index dfdae53..7ddb048 100644
 +                }
              }
          }
-
+ 
          private void Event_SaveGameLoaded()
          {
              var strucs = sapi.WorldManager.SaveGame.GetData<List<DungeonLocation>>("dungeonLocations");
@@ -67,7 +61,7 @@ index dfdae53..7ddb048 100644
 +                }
              }
          }
-
+ 
          private void Event_MapRegionUnloaded(Vec2i mapCoord, IMapRegion region)
          {
 -            if (dungeonPlaceTasksByRegion.TryGetValue(MapRegionIndex2D(mapCoord.X, mapCoord.Y), out var list) && list.Any(d => d.IsDirty))
@@ -80,15 +74,15 @@ index dfdae53..7ddb048 100644
 +                }
              }
          }
-
+ 
          private void onMapRegionGen(IMapRegion mapRegion, int regionX, int regionZ, ITreeAttribute? chunkGenParams = null)
          {
-             int size = sapi.WorldManager.RegionSize;
+@@ -161,63 +175,67 @@ namespace Vintagestory.ServerMods
              var mapRand = new LCGRandom(sapi.WorldManager.Seed ^ 8991827198);
              mapRand.InitPositionSeed(regionX * size, regionZ * size);
-
+ 
              long mapRegionIndex = MapRegionIndex2D(regionX, regionZ);
-
+ 
 -            if (dungeonPlaceTasksByRegion.ContainsKey(mapRegionIndex))
 +            // Stratum: region generation replaces shared dungeon state as one operation.
 +            lock (stratumDungeonStateLock)
@@ -101,14 +95,14 @@ index dfdae53..7ddb048 100644
 +                {
 +                    Dungeons.RemoveAll(d => d.Position.X / regionSize == regionX && d.Position.Z / regionSize == regionZ);
 +                }
-
+ 
 -            var dungeons = tiledDungeonsSys.Tcfg.Dungeons.Where(d => d.Worldgen).ToList();
 +                dungeonPlaceTasksByRegion[mapRegionIndex] = new List<DungeonPlaceTask>();
-
+ 
 -            var dungeIndices = new int[dungeons.Count];
 -            for (int l = 0; l < dungeIndices.Length; l++) dungeIndices[l] = l;
 +                var dungeons = tiledDungeonsSys.Tcfg.Dungeons.Where(d => d.Worldgen).ToList();
-
+ 
 -            var seaLevel = sapi.World.SeaLevel;
 -            for (int i = 0; i < 12; i++)
 -            {
@@ -116,40 +110,40 @@ index dfdae53..7ddb048 100644
 -                int posz = regionZ * size + mapRand.NextInt(size);
 +                var dungeIndices = new int[dungeons.Count];
 +                for (int l = 0; l < dungeIndices.Length; l++) dungeIndices[l] = l;
-
+ 
 -                if(!SatisfiesMinDistance(posx, seaLevel, posz)) continue;
 +                var seaLevel = sapi.World.SeaLevel;
 +                for (int i = 0; i < 12; i++)
 +                {
 +                    int posx = regionX * size + mapRand.NextInt(size);
 +                    int posz = regionZ * size + mapRand.NextInt(size);
-
+ 
 -                if(storyStructSys.Structures.values.Values.Any(storyLoc =>
 -                       storyLoc.CenterPos.HorDistanceSqTo(posx, posz) < tiledDungeonsSys.Tcfg.StoryStructMinDistanceSq)) continue;
 +                    if(!SatisfiesMinDistance(posx, seaLevel, posz)) continue;
-
+ 
 -                var dungeon = pickDungeon(dungeIndices, mapRand, dungeons);
 +                    if(storyStructSys.Structures.values.Values.Any(storyLoc =>
 +                           storyLoc.CenterPos.HorDistanceSqTo(posx, posz) < tiledDungeonsSys.Tcfg.StoryStructMinDistanceSq)) continue;
-
+ 
 -                if (spawnPos.HorDistanceSqTo(posx, posz) < dungeon.MinSpawnDistance * dungeon.MinSpawnDistance) continue;
 +                    var dungeon = pickDungeon(dungeIndices, mapRand, dungeons);
-
+ 
 -                if (IsInOcean(mapRegion, posx, posz)) continue;
 +                    if (spawnPos.HorDistanceSqTo(posx, posz) < dungeon.MinSpawnDistance * dungeon.MinSpawnDistance) continue;
-
+ 
 -                if (!HasSuitableLandforms(dungeon, mapRegion, posx, posz)) continue;
 +                    if (IsInOcean(mapRegion, posx, posz)) continue;
-
+ 
 +                    if (!HasSuitableLandforms(dungeon, mapRegion, posx, posz)) continue;
-
+ 
 -                int posy = seaLevel-dungeon.MaxDepth + mapRand.NextInt(dungeon.MaxDepth-dungeon.MinDepth);
 -                var dungeonStartPos = new BlockPos(posx, posy, posz);
 -                var didGen = false;
 -                for (int j = 0; j < 5; j++)
 -                {
 -                    var placeTask = tiledDungeonsSys.TryPregenerateTiledDungeon(mapRand, dungeon, mapRegion.GeneratedStructures, dungeonStartPos, dungeon.MinTiles, dungeon.MaxTiles);
-
+ 
 -                    if (placeTask != null)
 +                    int posy = seaLevel-dungeon.MaxDepth + mapRand.NextInt(dungeon.MaxDepth-dungeon.MinDepth);
 +                    var dungeonStartPos = new BlockPos(posx, posy, posz);
@@ -179,20 +173,16 @@ index dfdae53..7ddb048 100644
 +                        }
                      }
 -                }
-
+ 
 -                if (didGen) break;
 +                    if (didGen) break;
 +                }
              }
          }
-
+ 
          private static TiledDungeon pickDungeon(int[] dungeIndices, LCGRandom mapRand, List<TiledDungeon> dungeons)
          {
-             TiledDungeon dungeon = null!;
-             dungeIndices.Shuffle(mapRand);
-@@ -356,19 +374,28 @@ namespace Vintagestory.ServerMods
-             IMapRegion region = request.Chunks[0].MapChunk.MapRegion;
-
+@@ -358,15 +376,24 @@ namespace Vintagestory.ServerMods
              for (int dx = -1; dx <= 1; dx++)
              {
                  for (int dz = -1; dz <= 1; dz++)
@@ -204,7 +194,7 @@ index dfdae53..7ddb048 100644
 +                    {
 +                        if (!dungeonPlaceTasksByRegion.TryGetValue(mapRegionIndex2D, out dungePlaceTasks)) continue;
 +                    }
-
+ 
                      foreach (var placeTask in dungePlaceTasks)
                      {
                          if (!placeTask.DungeonBoundaries.Intersects(cuboid)) continue;
@@ -214,16 +204,12 @@ index dfdae53..7ddb048 100644
 +                            // Stratum: do not place tasks from a list replaced by region regeneration.
 +                            if (!dungeonPlaceTasksByRegion.TryGetValue(mapRegionIndex2D, out var activeTasks) || activeTasks != dungePlaceTasks) break;
                          if (!tiledDungeonsSys.Tcfg.DungeonsByCode.TryGetValue(placeTask.Code, out var dungeon)) return; // Ignore dungeons that no longer exist in assets
-
+ 
                          Block? rockBlock = null;
                          // get the rockblock for the first generating chunk and reuse that for each room
                          if (placeTask.RockBlockCode == null)
-                         {
-                             var posY = placeTask.TilePlaceTasks[0].Pos.Y;
-@@ -498,14 +525,15 @@ namespace Vintagestory.ServerMods
-                             placeTask.IsDirty = true;
-                         }
-
+@@ -500,10 +527,11 @@ namespace Vintagestory.ServerMods
+ 
                          if (placeTask.SurfacePlaceTasks != null)
                          {
                              generateDungeonSurfacePartial(request ,region, dungeon, placeTask.SurfacePlaceTasks, request.Chunks, request.ChunkX, request.ChunkZ, rockBlock);
@@ -233,6 +219,4 @@ index dfdae53..7ddb048 100644
                  }
              }
          }
-
-
-         private bool pickStairTile(DungeonGenWorkspace dgd, ConnectorMetaData connector, int[] tileIndices, [NotNullWhen(true)] ref BlockSchematicPartial? schematic, [NotNullWhen(true)] ref DungeonTile? tile, [NotNullWhen(true)] ref FastVec3i? offsetPos)
+ 

--- a/patches/VintagestoryApi/Common/Entity/Entity.cs.patch
+++ b/patches/VintagestoryApi/Common/Entity/Entity.cs.patch
@@ -1,5 +1,5 @@
 diff --git a/VintagestoryApi/Common/Entity/Entity.cs b/VintagestoryApi/Common/Entity/Entity.cs
-index aafb4f0..735ca4b 100644
+index 3a55cef..35c1c8c 100644
 --- a/VintagestoryApi/Common/Entity/Entity.cs
 +++ b/VintagestoryApi/Common/Entity/Entity.cs
 @@ -577,12 +577,16 @@ namespace Vintagestory.API.Common.Entities

--- a/patches/VintagestoryApi/Server/PathfinderTask.cs.patch
+++ b/patches/VintagestoryApi/Server/PathfinderTask.cs.patch
@@ -2,7 +2,9 @@ diff --git a/VintagestoryApi/Server/PathfinderTask.cs b/VintagestoryApi/Server/P
 index cc21075..6051161 100644
 --- a/VintagestoryApi/Server/PathfinderTask.cs
 +++ b/VintagestoryApi/Server/PathfinderTask.cs
-@@ -18,10 +18,20 @@ namespace Vintagestory.API.Server
+@@ -16,22 +16,34 @@ namespace Vintagestory.API.Server
+         public int searchDepth;
+         public int mhdistanceTolerance = 0;
          public List<Vec3d> waypoints;
          public EnumAICreatureType CreatureType;
          public float modeMinFleeDistance;
@@ -23,7 +25,10 @@ index cc21075..6051161 100644
          {
              this.startBlockPos = startBlockPos;
              this.targetBlockPos = targetBlockPos;
-@@ -32,6 +42,8 @@ namespace Vintagestory.API.Server
+             this.maxFallHeight = maxFallHeight;
+             this.stepHeight = stepHeight;
+             this.collisionBox = collisionBox;
+             this.searchDepth = searchDepth;
              this.mhdistanceTolerance = mhdistanceTolerance;
              this.modeMinFleeDistance = modeMinFleeDistance;
              this.CreatureType = creatureType;

--- a/patches/VintagestoryLib/Properties/AssemblyInfo.cs.patch
+++ b/patches/VintagestoryLib/Properties/AssemblyInfo.cs.patch
@@ -1,7 +1,10 @@
 diff --git a/VintagestoryLib/Properties/AssemblyInfo.cs b/VintagestoryLib/Properties/AssemblyInfo.cs
+index 8e6aec1..ce2093c 100644
 --- a/VintagestoryLib/Properties/AssemblyInfo.cs
 +++ b/VintagestoryLib/Properties/AssemblyInfo.cs
-@@ -14,4 +14,4 @@
+@@ -12,6 +12,6 @@ using System.Security.Permissions;
+ [assembly: AssemblyProduct("Vintage Story")]
+ [assembly: AssemblyCopyright("Copyright © 2016-2026 Anego Studios")]
  [assembly: ComVisible(false)]
  [assembly: Guid("8495b9b8-6974-45de-b896-87f195304ede")]
  [assembly: AssemblyFileVersion("1.22.7")]

--- a/patches/VintagestoryLib/SaveGame.cs.patch
+++ b/patches/VintagestoryLib/SaveGame.cs.patch
@@ -1,5 +1,5 @@
 diff --git a/VintagestoryLib/SaveGame.cs b/VintagestoryLib/SaveGame.cs
-index 81e18d3..935d6cf 100644
+index 52050d7..016dfa6 100644
 --- a/VintagestoryLib/SaveGame.cs
 +++ b/VintagestoryLib/SaveGame.cs
 @@ -254,11 +254,11 @@ public class SaveGame : ISaveGame

--- a/patches/VintagestoryLib/Vintagestory.Client.NoObf/ClientPlatformWindows.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Client.NoObf/ClientPlatformWindows.cs.patch
@@ -1,5 +1,5 @@
 diff --git a/VintagestoryLib/Vintagestory.Client.NoObf/ClientPlatformWindows.cs b/VintagestoryLib/Vintagestory.Client.NoObf/ClientPlatformWindows.cs
-index 7c0bb2c..bd48f3f 100644
+index 3fd1a2c..109f02f 100644
 --- a/VintagestoryLib/Vintagestory.Client.NoObf/ClientPlatformWindows.cs
 +++ b/VintagestoryLib/Vintagestory.Client.NoObf/ClientPlatformWindows.cs
 @@ -362,11 +362,11 @@ public sealed class ClientPlatformWindows : ClientPlatformAbstract

--- a/patches/VintagestoryLib/Vintagestory.Client.NoObf/ClientSettings.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Client.NoObf/ClientSettings.cs.patch
@@ -1,5 +1,5 @@
 diff --git a/VintagestoryLib/Vintagestory.Client.NoObf/ClientSettings.cs b/VintagestoryLib/Vintagestory.Client.NoObf/ClientSettings.cs
-index 9786197..c1e2c75 100644
+index 6b6ece9..bdaa84a 100644
 --- a/VintagestoryLib/Vintagestory.Client.NoObf/ClientSettings.cs
 +++ b/VintagestoryLib/Vintagestory.Client.NoObf/ClientSettings.cs
 @@ -7,11 +7,11 @@ using Vintagestory.API.Config;

--- a/patches/VintagestoryLib/Vintagestory.Client.NoObf/GuiElementModCell.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Client.NoObf/GuiElementModCell.cs.patch
@@ -1,5 +1,5 @@
 diff --git a/VintagestoryLib/Vintagestory.Client.NoObf/GuiElementModCell.cs b/VintagestoryLib/Vintagestory.Client.NoObf/GuiElementModCell.cs
-index 5c17bca..905f143 100644
+index 7229af8..34a3ba9 100644
 --- a/VintagestoryLib/Vintagestory.Client.NoObf/GuiElementModCell.cs
 +++ b/VintagestoryLib/Vintagestory.Client.NoObf/GuiElementModCell.cs
 @@ -112,11 +112,11 @@ public class GuiElementModCell : GuiElementTextBase, IGuiElementCell, IDisposabl

--- a/patches/VintagestoryLib/Vintagestory.Client/ClientProgram.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Client/ClientProgram.cs.patch
@@ -1,5 +1,5 @@
 diff --git a/VintagestoryLib/Vintagestory.Client/ClientProgram.cs b/VintagestoryLib/Vintagestory.Client/ClientProgram.cs
-index d273390..d70969e 100644
+index 26724c7..afa4d5f 100644
 --- a/VintagestoryLib/Vintagestory.Client/ClientProgram.cs
 +++ b/VintagestoryLib/Vintagestory.Client/ClientProgram.cs
 @@ -8,10 +8,11 @@ using System.Threading;

--- a/patches/VintagestoryLib/Vintagestory.Client/GuiScreenDownloadMods.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Client/GuiScreenDownloadMods.cs.patch
@@ -1,7 +1,10 @@
 diff --git a/VintagestoryLib/Vintagestory.Client/GuiScreenDownloadMods.cs b/VintagestoryLib/Vintagestory.Client/GuiScreenDownloadMods.cs
+index 7c15866..a9767f7 100644
 --- a/VintagestoryLib/Vintagestory.Client/GuiScreenDownloadMods.cs
 +++ b/VintagestoryLib/Vintagestory.Client/GuiScreenDownloadMods.cs
-@@ -71,7 +71,7 @@
+@@ -69,11 +69,11 @@ public class GuiScreenDownloadMods : GuiScreen
+ 			title = Lang.Get("downloadmods-title-dependencyinstall");
+ 			text = Lang.Get("downloadmods-dependencyinstall", string.Join(", ", modsToDownload));
  		}
  		else
  		{
@@ -10,7 +13,11 @@ diff --git a/VintagestoryLib/Vintagestory.Client/GuiScreenDownloadMods.cs b/Vint
  			title = Lang.Get("downloadmods-title-serverinstall");
  			text = Lang.Get("downloadmods-serverinstall", modsToDownload.Count);
  		}
-@@ -432,10 +432,8 @@
+ 		return new GuiScreenDownloadMods(sourceServer, serverArgs, installPath, modsToDownload, title, text, screenManager, parentScreen);
+ 	}
+@@ -430,12 +430,10 @@ public class GuiScreenDownloadMods : GuiScreen
+ 			FocusedMouseCursor = ScreenManager.mainMenuComposer.MouseOverCursor;
+ 		}
  		ElementComposer.PostRender(dt);
  	}
  

--- a/patches/VintagestoryLib/Vintagestory.Client/GuiScreenServerDashboard.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Client/GuiScreenServerDashboard.cs.patch
@@ -1,5 +1,5 @@
 diff --git a/VintagestoryLib/Vintagestory.Client/GuiScreenServerDashboard.cs b/VintagestoryLib/Vintagestory.Client/GuiScreenServerDashboard.cs
-index 6c40846..b1cc47d 100644
+index 1148683..2515735 100644
 --- a/VintagestoryLib/Vintagestory.Client/GuiScreenServerDashboard.cs
 +++ b/VintagestoryLib/Vintagestory.Client/GuiScreenServerDashboard.cs
 @@ -588,12 +588,12 @@ public class GuiScreenServerDashboard : GuiScreen

--- a/patches/VintagestoryLib/Vintagestory.Client/ScreenManager.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Client/ScreenManager.cs.patch
@@ -1,5 +1,5 @@
 diff --git a/VintagestoryLib/Vintagestory.Client/ScreenManager.cs b/VintagestoryLib/Vintagestory.Client/ScreenManager.cs
-index 244b371..433cbdc 100644
+index d1951ec..b5000e7 100644
 --- a/VintagestoryLib/Vintagestory.Client/ScreenManager.cs
 +++ b/VintagestoryLib/Vintagestory.Client/ScreenManager.cs
 @@ -601,11 +601,11 @@ public class ScreenManager : KeyEventHandler, MouseEventHandler, NewFrameHandler

--- a/patches/VintagestoryLib/Vintagestory.Common/EventManager.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Common/EventManager.cs.patch
@@ -1,5 +1,5 @@
 diff --git a/VintagestoryLib/Vintagestory.Common/EventManager.cs b/VintagestoryLib/Vintagestory.Common/EventManager.cs
-index 842d31f..2db0d99 100644
+index 842d31f..21dfb24 100644
 --- a/VintagestoryLib/Vintagestory.Common/EventManager.cs
 +++ b/VintagestoryLib/Vintagestory.Common/EventManager.cs
 @@ -1,11 +1,13 @@
@@ -121,7 +121,7 @@ index 842d31f..2db0d99 100644
  			{
 -				gameTickListener.OnTriggered(ellapsedMilliseconds);
 +				continue;
- 			}
++			}
 +			int stratumEffectiveInterval = gameTickListener.Millisecondinterval;
 +			if (stratumAdaptiveThrottle && stratumEffectiveInterval > stratumAdaptiveCritMs)
 +			{
@@ -143,7 +143,7 @@ index 842d31f..2db0d99 100644
 +				{
 +					gameTickListener.OnTriggered(ellapsedMilliseconds);
 +				}
-+			}
+ 			}
 +			else if (stratumAdaptiveThrottle && stratumEffectiveInterval != gameTickListener.Millisecondinterval)
 +			{
 +				stratumEntityListenersThrottled++;
@@ -323,27 +323,29 @@ index 842d31f..2db0d99 100644
  	public virtual long AddGameTickListener(Action<float> handler, int millisecondInterval, int initialDelayOffsetMs = 0)
  	{
  		return AddGameTickListener(handler, null, millisecondInterval, initialDelayOffsetMs);
-@@ -303,6 +453,8 @@ public abstract class EventManager
+@@ -301,21 +451,44 @@ public abstract class EventManager
+ 	}
+ 
  	public virtual long AddGameTickListener(Action<float> handler, BlockPos pos, Action<Exception> errorHandler, int millisecondInterval, int initialDelayOffsetMs = 0)
  	{
  		long newListenerId = ++listenerId;
-+		// Stratum: stagger default block entity listeners by position.
 -		GameTickListenerBlock listener = new GameTickListenerBlock(newListenerId, millisecondInterval, InWorldEllapsedMs + initialDelayOffsetMs, pos.Copy(), handler, errorHandler);
++		// Stratum: stagger default block entity listeners by position.
 +		int stratumInitialDelayOffsetMs = GetStratumBlockEntityInitialDelay(pos, millisecondInterval, initialDelayOffsetMs);
 +		GameTickListenerBlock listener = new GameTickListenerBlock(newListenerId, millisecondInterval, InWorldEllapsedMs + stratumInitialDelayOffsetMs, pos.Copy(), handler, errorHandler);
  		return AddGameTickListenerBlockInternal(listener, newListenerId);
  	}
-@@ -310,6 +460,8 @@ public abstract class EventManager
+ 
  	public virtual long AddGameTickListener(Action<IWorldAccessor, BlockPos, float> handler, BlockPos pos, Action<Exception> errorHandler, int millisecondInterval, int initialDelayOffsetMs = 0)
  	{
  		long newListenerId = ++listenerId;
+-		GameTickListenerBlock listener = new GameTickListenerBlock(newListenerId, millisecondInterval, InWorldEllapsedMs + initialDelayOffsetMs, pos.Copy(), handler, errorHandler);
 +		// Stratum: stagger default block entity listeners by position.
 +		int stratumInitialDelayOffsetMs = GetStratumBlockEntityInitialDelay(pos, millisecondInterval, initialDelayOffsetMs);
--		GameTickListenerBlock listener = new GameTickListenerBlock(newListenerId, millisecondInterval, InWorldEllapsedMs + initialDelayOffsetMs, pos.Copy(), handler, errorHandler);
 +		GameTickListenerBlock listener = new GameTickListenerBlock(newListenerId, millisecondInterval, InWorldEllapsedMs + stratumInitialDelayOffsetMs, pos.Copy(), handler, errorHandler);
  		return AddGameTickListenerBlockInternal(listener, newListenerId);
  	}
-@@ -317,2 +467,21 @@ public abstract class EventManager
+ 
 +	private static int GetStratumBlockEntityInitialDelay(BlockPos pos, int millisecondInterval, int initialDelayOffsetMs)
 +	{
 +		// Stratum: stagger default block entity listeners by position.
@@ -365,3 +367,6 @@ index 842d31f..2db0d99 100644
 +
  	private long AddGameTickListenerBlockInternal(GameTickListenerBlock listener, long newListenerId)
  	{
+ 		List<GameTickListenerBlock> gameTickListenersBlock = GameTickListenersBlock;
+ 		for (int i = 0; i < gameTickListenersBlock.Count; i++)
+ 		{

--- a/patches/VintagestoryLib/Vintagestory.ModDb/ModDbUtil.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.ModDb/ModDbUtil.cs.patch
@@ -1,5 +1,5 @@
 diff --git a/VintagestoryLib/Vintagestory.ModDb/ModDbUtil.cs b/VintagestoryLib/Vintagestory.ModDb/ModDbUtil.cs
-index 496706f..0334c93 100644
+index 00c2c32..2f82bb3 100644
 --- a/VintagestoryLib/Vintagestory.ModDb/ModDbUtil.cs
 +++ b/VintagestoryLib/Vintagestory.ModDb/ModDbUtil.cs
 @@ -12,11 +12,10 @@ using System.Threading.Tasks;

--- a/patches/VintagestoryLib/Vintagestory.Server/CmdPlayer.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/CmdPlayer.cs.patch
@@ -2,7 +2,8 @@ diff --git a/VintagestoryLib/Vintagestory.Server/CmdPlayer.cs b/VintagestoryLib/
 index 8af710f..88910a9 100644
 --- a/VintagestoryLib/Vintagestory.Server/CmdPlayer.cs
 +++ b/VintagestoryLib/Vintagestory.Server/CmdPlayer.cs
-@@ -334,12 +334,18 @@ public class CmdPlayer : ServerSystem
+@@ -333,28 +333,40 @@ public class CmdPlayer : ServerSystem
+ 
  	private TextCommandResult OnRevokeCmd(TextCommandCallingArgs args)
  	{
  		IPlayerRole playerRole = (IPlayerRole)args.Parsers[0].GetValue();
@@ -21,7 +22,7 @@ index 8af710f..88910a9 100644
  		server.ConfigNeedsSaving = true;
  		return TextCommandResult.Success(Lang.Get("Ok, privilege '{0}' now revoked", text));
  	}
-@@ -347,12 +347,18 @@ public class CmdPlayer : ServerSystem
+ 
  	private TextCommandResult OnGrantCmd(TextCommandCallingArgs args)
  	{
  		IPlayerRole playerRole = (IPlayerRole)args.Parsers[0].GetValue();
@@ -40,7 +41,9 @@ index 8af710f..88910a9 100644
  		server.ConfigNeedsSaving = true;
  		return TextCommandResult.Success(Lang.Get("Ok, privilege '{0}' now granted", text));
  	}
-@@ -821,8 +821,15 @@ public class CmdPlayer : ServerSystem
+ 
+ 	private TextCommandResult OnPrivilegeCmd(TextCommandCallingArgs args)
+@@ -821,10 +833,17 @@ public class CmdPlayer : ServerSystem
  		{
  			server.SendOwnPlayerData(clientByPlayername.Player, sendInventory: false, sendPrivileges: true);
  			string message = ((playerRole.PrivilegeLevel > playerRole2.PrivilegeLevel) ? Lang.Get("You've been promoted to role {0}", playerRole.Name) : Lang.Get("You've been demoted to role {0}", playerRole.Name));
@@ -56,3 +59,5 @@ index 8af710f..88910a9 100644
  		}
  		return TextCommandResult.Success(Lang.Get("Ok, role {0} assigned to {1}", playerRole.Name, targetPlayer.Name));
  	}
+ 
+ 	private TextCommandResult removeDenyPrivilege(PlayerUidName targetPlayer, TextCommandCallingArgs args)

--- a/patches/VintagestoryLib/Vintagestory.Server/ServerConfig.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/ServerConfig.cs.patch
@@ -1,5 +1,5 @@
 diff --git a/VintagestoryLib/Vintagestory.Server/ServerConfig.cs b/VintagestoryLib/Vintagestory.Server/ServerConfig.cs
-index 93750fa..6b4edf8 100644
+index 9dc87af..75698ea 100644
 --- a/VintagestoryLib/Vintagestory.Server/ServerConfig.cs
 +++ b/VintagestoryLib/Vintagestory.Server/ServerConfig.cs
 @@ -4,46 +4,57 @@ using System.Drawing;
@@ -82,7 +82,7 @@ index 93750fa..6b4edf8 100644
  
  	[JsonProperty]
  	public EnumProtectionLevel AntiAbuse { get; set; }
-@@ -262,11 +283,11 @@ public class ServerConfig : IServerConfig
+@@ -274,11 +295,11 @@ public class ServerConfig : IServerConfig
  	public bool CorruptionProtection { get; set; }
  
  	[JsonProperty]
@@ -95,7 +95,7 @@ index 93750fa..6b4edf8 100644
  	public int ChatRateLimitMs { get; set; }
  
  	[JsonProperty]
-@@ -331,12 +352,13 @@ public class ServerConfig : IServerConfig
+@@ -343,12 +364,13 @@ public class ServerConfig : IServerConfig
  	}
  
  	public ServerConfig()
@@ -111,11 +111,7 @@ index 93750fa..6b4edf8 100644
  		ModDbUrl = "https://mods.vintagestory.at/";
  		VerifyPlayerAuth = true;
  		AdvertiseServer = false;
-@@ -402,15 +424,15 @@ public class ServerConfig : IServerConfig
- 		DisableModSafetyCheck = false;
- 		DisableAutoRemap = false;
- 		AntiAbuseBufferSize = 100;
- 		AntiAbuseTriggerOnBlockBreakCount = 40;
+@@ -406,11 +428,11 @@ public class ServerConfig : IServerConfig
  		AntiAbuseTriggerOnDurationMs = 2000;
  		AntiAbuseBlockBurstAbuseBanDays = 14.0;
  		WorldConfig = new StartServerArgs
@@ -128,7 +124,7 @@ index 93750fa..6b4edf8 100644
  			PlayStyleLangCode = "surviveandbuild-bands",
  			WorldType = "standard"
  		};
-@@ -433,39 +455,77 @@ public class ServerConfig : IServerConfig
+@@ -449,39 +471,77 @@ public class ServerConfig : IServerConfig
  		{
  			value.GrantPrivilege(privilege);
  		}
@@ -152,14 +148,14 @@ index 93750fa..6b4edf8 100644
 +	{
 +		RolesByCode.Clear();
 +		if (Roles == null)
-+		{
+ 		{
+-			RolesByCode.Clear();
+-			foreach (PlayerRole role in Roles)
 +			return;
 +		}
 +
 +		foreach (PlayerRole role in Roles)
- 		{
--			RolesByCode.Clear();
--			foreach (PlayerRole role in Roles)
++		{
 +			if (role == null || string.IsNullOrWhiteSpace(role.Code))
 +			{
 +				continue;
@@ -170,6 +166,10 @@ index 93750fa..6b4edf8 100644
 -				RolesByCode[role.Code] = role;
 -				if (role.AutoGrant)
 +				if (role.Privileges != null)
++				{
++					role.Privileges = role.Privileges.Union(Privilege.AllCodes()).ToList();
++				}
++				else
  				{
 -					if (role.Privileges != null)
 -					{
@@ -179,10 +179,6 @@ index 93750fa..6b4edf8 100644
 -					{
 -						role.Privileges = Privilege.AllCodes().ToList();
 -					}
-+					role.Privileges = role.Privileges.Union(Privilege.AllCodes()).ToList();
-+				}
-+				else
-+				{
 +					role.Privileges = Privilege.AllCodes().ToList();
  				}
  			}
@@ -223,7 +219,7 @@ index 93750fa..6b4edf8 100644
  		{
  			foreach (KeyValuePair<string, PlayerRole> item in RolesByCode)
  			{
-@@ -515,21 +575,15 @@ public class ServerConfig : IServerConfig
+@@ -531,21 +591,15 @@ public class ServerConfig : IServerConfig
  		if (GameVersion.IsLowerVersionThan(ConfigVersion, "1.10"))
  		{
  			TryGrantPrivilege("sumod", Privilege.manageotherplayergroups);
@@ -246,7 +242,7 @@ index 93750fa..6b4edf8 100644
  		if (LoadedConfigVersion != ConfigVersion)
  		{
  			Save();
-@@ -576,10 +630,11 @@ public class ServerConfig : IServerConfig
+@@ -592,10 +646,11 @@ public class ServerConfig : IServerConfig
  	}
  
  	public void InitializeRoles()
@@ -258,7 +254,7 @@ index 93750fa..6b4edf8 100644
  			Code = "suvisitor",
  			Name = "Survival Visitor",
  			Description = "Can only visit this world and chat but not use/place/break anything",
-@@ -762,32 +817,116 @@ public class ServerConfig : IServerConfig
+@@ -778,32 +833,125 @@ public class ServerConfig : IServerConfig
  			Color = Color.LightBlue,
  			DefaultGameMode = EnumGameMode.Survival,
  			AutoGrant = true
@@ -348,19 +344,19 @@ index 93750fa..6b4edf8 100644
 -					role.Privileges = Privilege.AllCodes().ToList();
 -				}
 +				TryGrantPrivilege(roleCode, privilege);
- 			}
- 		}
--		foreach (PlayerRole role2 in Roles)
++			}
++		}
 +		foreach (string roleCode in StratumStaffRoleCodes)
- 		{
--			RolesByCode[role2.Code] = role2;
++		{
 +			foreach (string privilege in StratumStaffPrivileges)
 +			{
 +				TryGrantPrivilege(roleCode, privilege);
-+			}
-+		}
+ 			}
+ 		}
+-		foreach (PlayerRole role2 in Roles)
 +		foreach (string roleCode in StratumAdminRoleCodes)
-+		{
+ 		{
+-			RolesByCode[role2.Code] = role2;
 +			foreach (string privilege in StratumAdminPrivileges)
 +			{
 +				TryGrantPrivilege(roleCode, privilege);
@@ -380,11 +376,20 @@ index 93750fa..6b4edf8 100644
 +		config.Remove(nameof(LoadedConfigVersion));
 +		config.Remove(nameof(RuntimeUpnp));
 +		config.Remove(nameof(DefaultRole));
-+		config.Remove(nameof(Roles));
 +		config.Remove(nameof(RolesByCode));
 +		config.Remove(nameof(RuntimePrivileveCodes));
-+		config.Remove(nameof(DefaultRoleCode));
 +		config.Remove(nameof(FileEditWarning));
++		// Stratum: write Roles and DefaultRoleCode back so vanilla can still boot from this config
++		config.Remove(nameof(Roles));
++		config.Remove(nameof(DefaultRoleCode));
++		if (Roles != null && Roles.Count > 0)
++		{
++			config[nameof(Roles)] = JToken.FromObject(Roles, serializer);
++		}
++		if (!string.IsNullOrWhiteSpace(DefaultRoleCode))
++		{
++			config[nameof(DefaultRoleCode)] = DefaultRoleCode;
++		}
 +		string contents = config.ToString((Formatting)1);
  		File.WriteAllText(Path.Combine(GamePaths.Config, "serverconfig.json"), contents);
  	}

--- a/patches/VintagestoryLib/Vintagestory.Server/ServerEventAPI.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/ServerEventAPI.cs.patch
@@ -1,7 +1,10 @@
 diff --git a/VintagestoryLib/Vintagestory.Server/ServerEventAPI.cs b/VintagestoryLib/Vintagestory.Server/ServerEventAPI.cs
+index fba8acc..d7e922b 100644
 --- a/VintagestoryLib/Vintagestory.Server/ServerEventAPI.cs
 +++ b/VintagestoryLib/Vintagestory.Server/ServerEventAPI.cs
-@@ -451,6 +451,10 @@
+@@ -449,10 +449,14 @@ internal class ServerEventAPI : ServerAPIComponentBase, IServerEventAPI, IEventA
+ 	}
+ 
  	public ServerEventAPI(ServerMain server)
  		: base(server)
  	{
@@ -12,7 +15,11 @@ diff --git a/VintagestoryLib/Vintagestory.Server/ServerEventAPI.cs b/Vintagestor
  	}
  
  	public void Trigger<T>(Delegate[] delegates, string eventName, Action<T> onDele, Action onException = null) where T : Delegate
-@@ -677,6 +681,9 @@
+ 	{
+ 		if (delegates == null)
+@@ -675,10 +679,13 @@ internal class ServerEventAPI : ServerAPIComponentBase, IServerEventAPI, IEventA
+ 				server.api.Logger.Error("Error during Init worldgen for " + item.Target.GetType().FullName);
+ 				server.api.Logger.Error(e);
  			}
  		}
  		server.api.Logger.VerboseDebug("Done all worldgens");
@@ -22,3 +29,5 @@ diff --git a/VintagestoryLib/Vintagestory.Server/ServerEventAPI.cs b/Vintagestor
  		return value;
  	}
  
+ 	public void WorldgenHook(WorldGenHookDelegate handler, string worldType, string hook)
+ 	{

--- a/patches/VintagestoryLib/Vintagestory.Server/ServerMain.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/ServerMain.cs.patch
@@ -1,5 +1,5 @@
 diff --git a/VintagestoryLib/Vintagestory.Server/ServerMain.cs b/VintagestoryLib/Vintagestory.Server/ServerMain.cs
-index 1103a72..1bf6ac3 100644
+index 6f69cd3..4b70fc3 100644
 --- a/VintagestoryLib/Vintagestory.Server/ServerMain.cs
 +++ b/VintagestoryLib/Vintagestory.Server/ServerMain.cs
 @@ -27,10 +27,13 @@ using VintagestoryLib.Server.Systems;
@@ -409,7 +409,7 @@ index 1103a72..1bf6ac3 100644
  	}
  
  	public ServerMain(StartServerArgs serverargs, string[] cmdlineArgsRaw, ServerProgramArgs progArgs, bool isDedicatedServer = true)
-@@ -1173,16 +1356,18 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -1173,15 +1358,17 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  		if (HeartbeatSystem == null)
  		{
  			HeartbeatSystem = new ServerSystemHeartbeat(this);
@@ -428,8 +428,7 @@ index 1103a72..1bf6ac3 100644
  			new PlayerAntiAbuseMonitor(this),
  			serverSystemModHandler,
  			new ServerySystemPlayerGroups(this),
- 			new ServerSystemEntitySimulation(this),
-@@ -1213,14 +1400,15 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -1214,14 +1401,15 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  		if (xPlatInterface == null)
  		{
  			xPlatInterface = XPlatformInterfaces.GetInterface();
@@ -447,7 +446,7 @@ index 1103a72..1bf6ac3 100644
  		if (progArgs.AddOrigin != null)
  		{
  			foreach (string item in progArgs.AddOrigin)
-@@ -1280,11 +1468,20 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -1281,11 +1469,20 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  		EnterRunPhase(EnumServerRunPhase.WorldReady);
  		if (exitState.Exit)
  		{
@@ -469,7 +468,7 @@ index 1103a72..1bf6ac3 100644
  		ModEventManager.TriggerWorldgenStartup();
  		if (exitState.Exit)
  		{
-@@ -1453,10 +1650,11 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -1454,10 +1651,11 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  		UdpSockets[1]?.Start();
  	}
  
@@ -481,7 +480,7 @@ index 1103a72..1bf6ac3 100644
  		{
  			Thread.Sleep(2);
  			return;
-@@ -1482,17 +1680,19 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -1483,17 +1681,19 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  					ServerSystem serverSystem = Systems[i];
  					long num = elapsedMilliseconds - serverSystem.millisecondsSinceStart;
  					if (num > serverSystem.GetUpdateInterval())
@@ -502,7 +501,7 @@ index 1103a72..1bf6ac3 100644
  				int num2 = 0;
  				while (!FrameProfilerUtil.offThreadProfiles.IsEmpty && num2++ < 25)
  				{
-@@ -1507,18 +1707,22 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -1508,18 +1708,22 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  					ServerSystem serverSystem2 = Systems[j];
  					long num = elapsedMilliseconds - serverSystem2.millisecondsSinceStart;
  					if (num > serverSystem2.GetUpdateInterval())
@@ -526,7 +525,7 @@ index 1103a72..1bf6ac3 100644
  			{
  				processConnectionQueue();
  				statsupdate = DateTime.UtcNow;
-@@ -1533,24 +1737,31 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -1534,24 +1738,31 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  				{
  					StatsCollector[StatsCollectorIndex].tickTimes[k] = 0L;
  				}
@@ -562,7 +561,7 @@ index 1103a72..1bf6ac3 100644
  			TickPosition++;
  		}
  		catch (Exception e)
-@@ -1558,24 +1769,113 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -1559,24 +1770,113 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  			Logger.Fatal(e);
  		}
  		FrameProfiler.End();
@@ -676,7 +675,7 @@ index 1103a72..1bf6ac3 100644
  			try
  			{
  				HandleClientPacket_mainthread(result);
-@@ -1588,10 +1888,13 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -1589,10 +1889,13 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  					DisconnectPlayer(result.client, "Threw an exception at the server", "An action you (or your client) did caused an unhandled exception");
  				}
  				Logger.Error(e);
@@ -690,7 +689,7 @@ index 1103a72..1bf6ac3 100644
  		TickPosition++;
  		foreach (KeyValuePair<Timer, Timer.Tick> timer in Timers)
  		{
-@@ -1882,10 +2185,15 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -1883,10 +2186,15 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  	}
  
  	public void Dispose()
@@ -706,7 +705,7 @@ index 1103a72..1bf6ac3 100644
  		if (Systems != null)
  		{
  			ServerSystem[] systems = Systems;
-@@ -1946,11 +2254,11 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -1947,11 +2255,11 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  				}
  			});
  		}
@@ -719,7 +718,7 @@ index 1103a72..1bf6ac3 100644
  	}
  
  	public string GetSaveFilepath()
-@@ -1971,10 +2279,20 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -1972,10 +2280,20 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  		return nextClientID++;
  	}
  
@@ -740,7 +739,7 @@ index 1103a72..1bf6ac3 100644
  			return;
  		}
  		if (client.State == EnumClientState.Queued)
-@@ -1982,17 +2300,23 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -1983,17 +2301,23 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  			lock (ConnectionQueue)
  			{
  				ConnectionQueue.RemoveAll((QueuedClient e) => e.Client.Id == client.Id);
@@ -765,7 +764,7 @@ index 1103a72..1bf6ac3 100644
  			{
  			}
  			Logger.Notification($"Client {client.Id} disconnected: {hisKickMessage}");
-@@ -2004,10 +2328,11 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -2005,10 +2329,11 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  			Clients.Remove(client.Id);
  			client.CloseConnection();
  		}
@@ -777,7 +776,7 @@ index 1103a72..1bf6ac3 100644
  				Logger.Audit("Client {0} got removed: '{1}' ({2})", client.PlayerName, othersKickmessage, hisKickMessage);
  			}
  			else
-@@ -2041,13 +2366,18 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -2042,13 +2367,18 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  			string playerName = client.PlayerName;
  			Clients.Remove(client.Id);
  			player.client = null;
@@ -799,7 +798,7 @@ index 1103a72..1bf6ac3 100644
  		}
  		else
  		{
-@@ -2070,10 +2400,15 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -2071,10 +2401,15 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  		{
  			SendMessageToGeneral(message, chatType, (chatType == EnumChatType.JoinLeave) ? player : null);
  		}
@@ -815,7 +814,7 @@ index 1103a72..1bf6ac3 100644
  		if (Config.MaxClientsInQueue <= 0 || stopped)
  		{
  			if (debugProcessConnectionQueue)
-@@ -2095,19 +2430,25 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -2096,19 +2431,25 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  			if (count > 0)
  			{
  				int maxClients = Config.MaxClients;
@@ -844,7 +843,7 @@ index 1103a72..1bf6ac3 100644
  					}
  					if (debugProcessConnectionQueue)
  					{
-@@ -2154,17 +2495,43 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -2155,17 +2496,43 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  		}
  	}
  
@@ -890,7 +889,7 @@ index 1103a72..1bf6ac3 100644
  			return num;
  		}
  		return result;
-@@ -2994,11 +3361,62 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -2995,11 +3362,62 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  		return WorldMap.GetServerChunk(entity.InChunkIndex3d)?.RemoveEntity(entity.EntityId) ?? false;
  	}
  
@@ -954,7 +953,7 @@ index 1103a72..1bf6ac3 100644
  	public Entity GetEntityById(long entityId)
  	{
  		LoadedEntities.TryGetValue(entityId, out var value);
-@@ -3289,20 +3707,38 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -3290,20 +3708,38 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  		return result;
  	}
  
@@ -998,7 +997,7 @@ index 1103a72..1bf6ac3 100644
  	public IPlayer PlayerByUid(string playerUid)
  	{
  		if (playerUid == null)
-@@ -3427,11 +3863,11 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -3428,11 +3864,11 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  			{
  				Socket = senderConnection
  			});
@@ -1011,7 +1010,7 @@ index 1103a72..1bf6ac3 100644
  		case NetworkMessageType.Data:
  		{
  			ConnectedClient client2 = msg.SenderConnection.client;
-@@ -3446,11 +3882,11 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -3447,11 +3883,11 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  		{
  			ConnectedClient client = msg.SenderConnection.client;
  			if (client != null)
@@ -1024,7 +1023,7 @@ index 1103a72..1bf6ac3 100644
  		}
  		}
  	}
-@@ -3472,13 +3908,54 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -3473,13 +3909,54 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  			DisconnectedClientsThisTick.Add(client.Id);
  			item = new ReceivedClientPacket(client, (client.Player == null) ? "" : "Network error: invalid client packet");
  		}
@@ -1081,7 +1080,7 @@ index 1103a72..1bf6ac3 100644
  	private void HandleClientPacket_mainthread(ReceivedClientPacket cpk)
  	{
  		ConnectedClient client = cpk.client;
-@@ -3500,15 +3977,67 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -3501,15 +3978,67 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  			{
  				Logger.Event("Client " + client.Id + " disconnected.");
  				EventManager.TriggerPlayerLeave(client.Player);
@@ -1150,7 +1149,7 @@ index 1103a72..1bf6ac3 100644
  				FrameProfiler.Mark("net-read-", packet.Id);
  			}
  			return;
-@@ -3516,11 +4045,36 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -3517,11 +4046,36 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  		ClientPacketHandler<Packet_Client, ConnectedClient> clientPacketHandler = PacketHandlers[packet.Id];
  		if (clientPacketHandler != null && (client.Player != null || PacketHandlingOnConnectingAllowed[packet.Id]))
  		{
@@ -1188,7 +1187,7 @@ index 1103a72..1bf6ac3 100644
  					FrameProfiler.Mark("net-read-", packet.Id);
  				}
  			}
-@@ -3533,10 +4087,18 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -3534,10 +4088,18 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  				FrameProfiler.Mark("net-readerror-", packet.Id);
  			}
  		}
@@ -1207,7 +1206,7 @@ index 1103a72..1bf6ac3 100644
  		Logger.Debug("Client uid {0}, mp token {1}: Verifying with auth server", packet.PlayerUID, packet.MpToken);
  		AuthServerComm.ValidatePlayerWithServer(packet.MpToken, packet.Playername, packet.PlayerUID, client.LoginToken, delegate(EnumServerResponse result, string entitlements, string errorReason)
  		{
-@@ -3557,30 +4119,30 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -3558,30 +4120,30 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  						case "missingmptokenv2":
  						case "missingaccount":
  						case "banned":
@@ -1242,7 +1241,7 @@ index 1103a72..1bf6ac3 100644
  			if (!orCreateServerPlayerData.HasPrivilege(Privilege.controlserver, Config.RolesByCode) && !orCreateServerPlayerData.HasPrivilege("ignoremaxclients", Config.RolesByCode))
  			{
  				tryEnqueuePlayer(packet, client, entitlements, maxClients);
-@@ -3635,16 +4197,17 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -3636,16 +4198,17 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  				Logger.Notification($"Player {packet.Playername} was put into the connection queue at position {count2}");
  				SendPacket(client.Id, packet2);
  				return;
@@ -1261,7 +1260,7 @@ index 1103a72..1bf6ac3 100644
  			return;
  		}
  		if (client.Socket is TcpNetConnection tcpNetConnection)
-@@ -3704,11 +4267,16 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -3705,11 +4268,16 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  					{
  						Id = 78
  					};
@@ -1279,7 +1278,7 @@ index 1103a72..1bf6ac3 100644
  				{
  					Logger.Debug($"UDP: Client {client.Id} did send UDP");
  				}
-@@ -3773,10 +4341,20 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -3774,10 +4342,20 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  			SendServerIdentification(client.Player);
  			SpawnPlayerRandomlyAround(client, playername, entityPos, 15);
  			client.IsNewClient = false;
@@ -1300,7 +1299,7 @@ index 1103a72..1bf6ac3 100644
  			SendServerIdentification(client.Player);
  			client.Entityplayer.Pos.SetFrom(entityPos);
  			SpawnEntity(client.Entityplayer);
-@@ -3851,10 +4429,21 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -3852,10 +4430,21 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  	}
  
  	private void SpawnPlayerRandomlyAround(ConnectedClient client, string playername, EntityPos centerPos, int tries)
@@ -1322,7 +1321,7 @@ index 1103a72..1bf6ac3 100644
  			EntityPos entityPos = centerPos.Copy();
  			if (pos == null)
  			{
-@@ -3869,10 +4458,38 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -3870,10 +4459,38 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  			}
  			SpawnPlayerHere(client, playername, entityPos);
  		});
@@ -1361,7 +1360,7 @@ index 1103a72..1bf6ac3 100644
  		Clients.TryGetValue(client.Id, out var value);
  		if (value != null)
  		{
-@@ -4244,11 +4861,11 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -4245,11 +4862,11 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  
  	internal void BroadcastArbitraryPacket(byte[] data, params IServerPlayer[] skipPlayers)
  	{
@@ -1374,7 +1373,7 @@ index 1103a72..1bf6ac3 100644
  			}
  		}
  	}
-@@ -4258,11 +4875,11 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -4259,11 +4876,11 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  		Serialize_(packet);
  		byte[] array = null;
  		bool compressed = false;
@@ -1387,7 +1386,7 @@ index 1103a72..1bf6ac3 100644
  				{
  					array = client.Socket.PreparePacketForSending(reusableBuffer, Config.CompressPackets, out compressed);
  				}
-@@ -4277,17 +4894,42 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -4278,17 +4895,42 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  
  	internal void BroadcastArbitraryUdpPacket(Packet_UdpPacket data, params IServerPlayer[] skipPlayers)
  	{
@@ -1431,7 +1430,7 @@ index 1103a72..1bf6ac3 100644
  		if (packetBenchmark.ContainsKey(packetId))
  		{
  			packetBenchmark[packetId]++;
-@@ -4694,15 +5336,40 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -4695,15 +5337,40 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  	}
  
  	private void SendWorldMetaData(IServerPlayer player)
@@ -1472,7 +1471,7 @@ index 1103a72..1bf6ac3 100644
  		float[] array = blockLightLevels;
  		Packet_WorldMetaData packet_WorldMetaData = new Packet_WorldMetaData();
  		int[] array2 = new int[array.Length];
-@@ -4755,14 +5422,53 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -4756,14 +5423,53 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  		{
  			((DummyUdpNetServer)UdpSockets[0]).Client.Player = player;
  		}
@@ -1527,7 +1526,7 @@ index 1103a72..1bf6ac3 100644
  		List<Packet_ModId> list = (from mod in api.ModLoader.Mods
  			where mod.Info.Side.IsUniversal()
  			select new Packet_ModId
-@@ -4791,15 +5497,20 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -4792,15 +5498,20 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  			RequireRemapping = ((controlServerPrivilege && requiresRemaps) ? 1 : 0)
  		};
  		Logger.Notification((Config.DisableAutoRemap ? ("Sending server identification with remap " + requiresRemaps) : "Sending server identification") + ". Server control privilege is " + controlServerPrivilege);
@@ -1550,7 +1549,7 @@ index 1103a72..1bf6ac3 100644
  		}
  		return new Packet_Server
  		{
-@@ -4843,12 +5554,12 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -4844,12 +5555,12 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  				array[num] = item.Id;
  				array2[num] = (int)(1000f * item.Player.Ping);
  				num++;
@@ -1565,7 +1564,7 @@ index 1103a72..1bf6ac3 100644
  			Id = 3,
  			PlayerPing = packet_ServerPlayerPing
  		};
-@@ -5140,11 +5851,11 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
+@@ -5141,11 +5852,11 @@ public sealed class ServerMain : GameMain, IServerWorldAccessor, IWorldAccessor,
  		}
  	}
  

--- a/patches/VintagestoryLib/Vintagestory.Server/ServerMapRegion.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/ServerMapRegion.cs.patch
@@ -1,5 +1,5 @@
 diff --git a/VintagestoryLib/Vintagestory.Server/ServerMapRegion.cs b/VintagestoryLib/Vintagestory.Server/ServerMapRegion.cs
-index d06a399..b56c20c 100644
+index 10bf95f..d95b0e1 100644
 --- a/VintagestoryLib/Vintagestory.Server/ServerMapRegion.cs
 +++ b/VintagestoryLib/Vintagestory.Server/ServerMapRegion.cs
 @@ -272,27 +272,46 @@ public class ServerMapRegion : IMapRegion

--- a/patches/VintagestoryLib/Vintagestory.Server/ServerProgram.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/ServerProgram.cs.patch
@@ -1,5 +1,5 @@
 diff --git a/VintagestoryLib/Vintagestory.Server/ServerProgram.cs b/VintagestoryLib/Vintagestory.Server/ServerProgram.cs
-index b5942fe..9cbd88d 100644
+index 173a626..9cbd88d 100644
 --- a/VintagestoryLib/Vintagestory.Server/ServerProgram.cs
 +++ b/VintagestoryLib/Vintagestory.Server/ServerProgram.cs
 @@ -4,11 +4,10 @@ using System.Runtime.InteropServices;

--- a/patches/VintagestoryLib/Vintagestory.Server/ServerProgramArgs.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/ServerProgramArgs.cs.patch
@@ -1,5 +1,5 @@
 diff --git a/VintagestoryLib/Vintagestory.Server/ServerProgramArgs.cs b/VintagestoryLib/Vintagestory.Server/ServerProgramArgs.cs
-index 08bc6af..d129b0a 100644
+index d8a57c4..23d37a2 100644
 --- a/VintagestoryLib/Vintagestory.Server/ServerProgramArgs.cs
 +++ b/VintagestoryLib/Vintagestory.Server/ServerProgramArgs.cs
 @@ -5,11 +5,11 @@ using CommandLine.Text;
@@ -39,10 +39,7 @@ index 08bc6af..d129b0a 100644
  	[Option("logPath", HelpText = "Default logs folder is in dataPath/Logs/. This option can only set an absolute path.")]
  	public string LogPath { get; set; }
  
-@@ -62,12 +62,13 @@ public class ServerProgramArgs
- 	public int ArchiveLogFileMaxSizeMb { get; set; } = 1024;
- 
- 	[Option("restoreLogsFolder", HelpText = "Used to revert removed blocks from server-build log files. You have to put a names.txt into the restoreLogsFolder, in there put the a name on each line. Further you may also put a optional blocks.txt with line separated block codes like game:soil-low-normal to filter only for specific blocks if needed. The server will not fully start and shutdown once finished.")]
+@@ -65,9 +65,10 @@ public class ServerProgramArgs
  	public string RestoreLogsFolder { get; set; }
  
  	public string GetUsage(ParserResult<ServerProgramArgs> parser)

--- a/patches/VintagestoryLib/Vintagestory.Server/ServerSystemEntitySimulation.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/ServerSystemEntitySimulation.cs.patch
@@ -1,5 +1,5 @@
 diff --git a/VintagestoryLib/Vintagestory.Server/ServerSystemEntitySimulation.cs b/VintagestoryLib/Vintagestory.Server/ServerSystemEntitySimulation.cs
-index ea1d5c0..42aa2eb 100644
+index ea1d5c0..204d7d7 100644
 --- a/VintagestoryLib/Vintagestory.Server/ServerSystemEntitySimulation.cs
 +++ b/VintagestoryLib/Vintagestory.Server/ServerSystemEntitySimulation.cs
 @@ -1,8 +1,13 @@
@@ -18,11 +18,11 @@ index ea1d5c0..42aa2eb 100644
  using Vintagestory.API.Config;
  using Vintagestory.API.Datastructures;
 @@ -22,13 +27,152 @@ public class ServerSystemEntitySimulation : ServerSystem
-
+ 
  	private Dictionary<string, List<string>> deathMessagesCache;
-
+ 
  	private int skippedDespawnTicks;
-
+ 
 +	private ConcurrentDictionary<long, StratumEntityTickState> stratumEntityTickStates = new ConcurrentDictionary<long, StratumEntityTickState>();
 +	private int stratumTicksSinceTickStateReconcile; // Stratum: periodic orphan eviction
 +
@@ -173,7 +173,7 @@ index ea1d5c0..42aa2eb 100644
 @@ -43,26 +187,33 @@ public class ServerSystemEntitySimulation : ServerSystem
  		player.Player.ItemCollectMode = packet.RuntimeSetting.ItemCollectMode;
  	}
-
+ 
  	private void EventManager_OnPlayerChat(IServerPlayer byPlayer, int channelId, ref string message, ref string data, BoolRef consumed)
  	{
 +		string messageBody = StratumChatFormatter.FormatMessageBody(message);
@@ -203,13 +203,13 @@ index ea1d5c0..42aa2eb 100644
 -		message = $"<strong>{byPlayer.PlayerName}:</strong> {message}";
 +		message = $"<strong>{byPlayer.PlayerName}:</strong> {messageBody}";
  	}
-
+ 
  	private void EventManager_OnGameWorldBeingSaved()
  	{
  		if (server.RunPhase != EnumServerRunPhase.Shutdown)
 @@ -77,66 +228,257 @@ public class ServerSystemEntitySimulation : ServerSystem
  	}
-
+ 
  	public override void OnBeginModsAndConfigReady()
  	{
  		server.EventManager.OnPlayerRespawn += OnPlayerRespawn;
@@ -221,7 +221,7 @@ index ea1d5c0..42aa2eb 100644
 +			ServerMain.Logger.Warning("[Stratum] Region ticking is ENABLED (experimental). Not all entity behaviors are thread-safe. Monitor with /stratum regions.");
 +		}
  	}
-
+ 
  	public override void OnPlayerJoin(ServerPlayer player)
  	{
 +		// Stratum: reconnect only player animators. Mob/global server animators remain deferred
@@ -229,7 +229,7 @@ index ea1d5c0..42aa2eb 100644
 +		StratumEnsurePlayerAnimator(player?.Entity);
  		physicsManager.ForceClientUpdateTick(player.client);
  	}
-
+ 
 +	private void StratumLoadPlayerEntityShapes()
 +	{
 +		List<EntityProperties> playerTypes = new List<EntityProperties>(1);
@@ -328,12 +328,12 @@ index ea1d5c0..42aa2eb 100644
  		physicsManager.ForceClientUpdateTick(player.client);
 +		stratumSelectionState.Remove(player.client.Id);
  	}
-
+ 
  	private void OnPlayerLeaveChunk(ClientStatistics clientStats)
  	{
  		physicsManager.ForceClientUpdateTick(clientStats.client);
  	}
-
+ 
  	public override void OnServerTick(float dt)
  	{
 +		long stratumSelectionTimingStart = StratumRuntime.Timings.GetTimestamp();
@@ -430,7 +430,7 @@ index ea1d5c0..42aa2eb 100644
  		TickEntities(dt);
  		SendPlayerEntityDeaths();
  	}
-
+ 
 +	// Stratum: per-client raytrace throttle state.
 +	private sealed class StratumSelectionState
 +	{
@@ -488,7 +488,7 @@ index ea1d5c0..42aa2eb 100644
 @@ -185,19 +527,150 @@ public class ServerSystemEntitySimulation : ServerSystem
  		}
  	}
-
+ 
  	private void TickEntities(float dt)
  	{
 -		List<KeyValuePair<Entity, EntityDespawnData>> list = new List<KeyValuePair<Entity, EntityDespawnData>>();
@@ -1475,7 +1475,7 @@ index ea1d5c0..42aa2eb 100644
 +		}
 +		return false;
  	}
-
+ 
  	private void HandleEntityInteraction(Packet_Client packet, ConnectedClient client)
  	{
  		ServerPlayer player = client.Player;
@@ -1541,7 +1541,7 @@ index ea1d5c0..42aa2eb 100644
  			entity.OnInteract(player.Entity, player.InventoryManager.ActiveHotbarSlot, vec3d, (p.MouseButton != 0) ? EnumInteractMode.Interact : EnumInteractMode.Attack);
  		}
  	}
-
+ 
 +	private static bool StratumHasValidSelectionBox(Entity entity, int selectionBoxIndex)
 +	{
 +		if (selectionBoxIndex == 0)
@@ -1612,7 +1612,7 @@ index ea1d5c0..42aa2eb 100644
  			item.Entityplayer.DeadNotify = false;
  			item.WorldData.Deaths++;
  			server.EventManager.TriggerPlayerDeath(item.Player, item.Entityplayer.DeathReason);
-@@ -401,11 +1755,15 @@ public class ServerSystemEntitySimulation : ServerSystem
+@@ -401,13 +1755,17 @@ public class ServerSystemEntitySimulation : ServerSystem
  			{
  				Id = 45,
  				PlayerDeath = new Packet_PlayerDeath
@@ -1629,7 +1629,9 @@ index ea1d5c0..42aa2eb 100644
  			DamageSource deathReason = item.Entityplayer.DeathReason;
  			bool num2 = !server.api.World.Config.GetBool("disableDeathMessages");
  			string text = "";
-@@ -422,10 +1776,11 @@ public class ServerSystemEntitySimulation : ServerSystem
+ 			if (num2)
+ 			{
+@@ -422,10 +1780,11 @@ public class ServerSystemEntitySimulation : ServerSystem
  			else
  			{
  				ServerMain.Logger.Audit(Lang.Get("{0} died. Death message: {1}", item.PlayerName, text));
@@ -1637,7 +1639,7 @@ index ea1d5c0..42aa2eb 100644
  		}
 +		list.Clear();
  	}
-
+ 
  	private string GetDeathMessage(ConnectedClient client, DamageSource src)
  	{
  		if (src == null)

--- a/patches/VintagestoryLib/Vintagestory.Server/ServerSystemEntitySpawner.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/ServerSystemEntitySpawner.cs.patch
@@ -1,5 +1,5 @@
 diff --git a/VintagestoryLib/Vintagestory.Server/ServerSystemEntitySpawner.cs b/VintagestoryLib/Vintagestory.Server/ServerSystemEntitySpawner.cs
-index 52a073b..87610a6 100644
+index 52a073b..34b2679 100644
 --- a/VintagestoryLib/Vintagestory.Server/ServerSystemEntitySpawner.cs
 +++ b/VintagestoryLib/Vintagestory.Server/ServerSystemEntitySpawner.cs
 @@ -65,10 +65,19 @@ public class ServerSystemEntitySpawner : ServerSystem

--- a/patches/VintagestoryLib/Vintagestory.Server/ServerSystemLoadAndSaveGame.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/ServerSystemLoadAndSaveGame.cs.patch
@@ -1,7 +1,10 @@
 diff --git a/VintagestoryLib/Vintagestory.Server/ServerSystemLoadAndSaveGame.cs b/VintagestoryLib/Vintagestory.Server/ServerSystemLoadAndSaveGame.cs
+index 43dace8..b047996 100644
 --- a/VintagestoryLib/Vintagestory.Server/ServerSystemLoadAndSaveGame.cs
 +++ b/VintagestoryLib/Vintagestory.Server/ServerSystemLoadAndSaveGame.cs
-@@ -30,6 +30,20 @@
+@@ -28,10 +28,24 @@ internal class ServerSystemLoadAndSaveGame : ServerSystem, IChunkProviderThread
+ 
+ 	private BlockAccessorWorldGenUpdateHeightmap blockAccessorWGUpdateHeightMap;
  
  	private Dictionary<long, ServerChunk> chunksCopy = new Dictionary<long, ServerChunk>();
  
@@ -22,7 +25,11 @@ diff --git a/VintagestoryLib/Vintagestory.Server/ServerSystemLoadAndSaveGame.cs 
  	private bool ignoreSave;
  
  	internal static PlayerSpawnPos SetDefaultSpawnOnce;
-@@ -47,6 +61,7 @@
+ 
+ 	private FastMemoryStream reusableStream => reusableMemoryStream ?? (reusableMemoryStream = new FastMemoryStream());
+@@ -45,10 +59,11 @@ internal class ServerSystemLoadAndSaveGame : ServerSystem, IChunkProviderThread
+ 
+ 	public override void OnSeparateThreadTick()
  	{
  		if (!chunkthread.runOffThreadSaveNow)
  		{
@@ -30,7 +37,11 @@ diff --git a/VintagestoryLib/Vintagestory.Server/ServerSystemLoadAndSaveGame.cs 
  			return;
  		}
  		lock (savingLock)
-@@ -67,6 +82,192 @@
+ 		{
+ 			if (chunkthread.runOffThreadSaveNow)
+@@ -65,10 +80,196 @@ internal class ServerSystemLoadAndSaveGame : ServerSystem, IChunkProviderThread
+ 				chunkthread.runOffThreadSaveNow = false;
+ 			}
  		}
  	}
  
@@ -223,7 +234,11 @@ diff --git a/VintagestoryLib/Vintagestory.Server/ServerSystemLoadAndSaveGame.cs 
  	public override void OnFinalizeAssets()
  	{
  		server.SaveGameData.WillSave(reusableStream);
-@@ -155,6 +356,7 @@
+ 		server.SaveGameData.UpdateLandClaims(server.WorldMap.All);
+ 		chunkthread.gameDatabase.StoreSaveGame(server.SaveGameData, reusableStream);
+@@ -153,18 +354,41 @@ internal class ServerSystemLoadAndSaveGame : ServerSystem, IChunkProviderThread
+ 				ServerMain.Logger.Event("Failed upgrading old savegame, giving up, sorry.");
+ 				throw new InvalidDataException("Failed upgrading savegame {0}", innerException);
  			}
  		}
  		chunkthread.gameDatabase.UpgradeToWriteAccess();
@@ -231,7 +246,8 @@ diff --git a/VintagestoryLib/Vintagestory.Server/ServerSystemLoadAndSaveGame.cs 
  		server.ModEventManager.OnWorldgenStartup += OnWorldgenStartup;
  		if (!string.IsNullOrWhiteSpace(server.progArgs.RestoreLogsFolder))
  		{
-@@ -163,6 +365,28 @@
+ 			server.ModEventManager.RegisterOnServerRunPhase(EnumServerRunPhase.RunGame, OnRestoreFromBuildLog);
+ 		}
  		LoadSaveGame();
  	}
  
@@ -260,7 +276,11 @@ diff --git a/VintagestoryLib/Vintagestory.Server/ServerSystemLoadAndSaveGame.cs 
  	public override void OnBeginModsAndConfigReady()
  	{
  		if (server.SaveGameData.IsNewWorld)
-@@ -209,6 +433,8 @@
+ 		{
+ 			server.ModEventManager.TriggerSaveGameCreated();
+@@ -207,10 +431,12 @@ internal class ServerSystemLoadAndSaveGame : ServerSystem, IChunkProviderThread
+ 		}
+ 	}
  
  	public override void OnSeperateThreadShutDown()
  	{
@@ -269,7 +289,11 @@ diff --git a/VintagestoryLib/Vintagestory.Server/ServerSystemLoadAndSaveGame.cs 
  		chunkthread.gameDatabase.Dispose();
  	}
  
-@@ -400,7 +626,8 @@
+ 	public void OnWorldBeingSaved()
+ 	{
+@@ -398,11 +624,12 @@ internal class ServerSystemLoadAndSaveGame : ServerSystem, IChunkProviderThread
+ 	}
+ 
  	private int SaveAllDirtyMapRegions(FastMemoryStream ms)
  	{
  		int num = 0;
@@ -279,7 +303,11 @@ diff --git a/VintagestoryLib/Vintagestory.Server/ServerSystemLoadAndSaveGame.cs 
  		foreach (KeyValuePair<long, ServerMapRegion> loadedMapRegion in server.loadedMapRegions)
  		{
  			if (loadedMapRegion.Value.DirtyForSaving)
-@@ -421,7 +648,8 @@
+ 			{
+ 				loadedMapRegion.Value.DirtyForSaving = false;
+@@ -419,11 +646,12 @@ internal class ServerSystemLoadAndSaveGame : ServerSystem, IChunkProviderThread
+ 	}
+ 
  	private int SaveAllDirtyMapChunks(FastMemoryStream ms)
  	{
  		int num = 0;
@@ -289,7 +317,11 @@ diff --git a/VintagestoryLib/Vintagestory.Server/ServerSystemLoadAndSaveGame.cs 
  		foreach (KeyValuePair<long, ServerMapChunk> loadedMapChunk in server.loadedMapChunks)
  		{
  			if (loadedMapChunk.Value.DirtyForSaving)
-@@ -448,7 +676,8 @@
+ 			{
+ 				loadedMapChunk.Value.DirtyForSaving = false;
+@@ -446,11 +674,12 @@ internal class ServerSystemLoadAndSaveGame : ServerSystem, IChunkProviderThread
+ 	}
+ 
  	internal int SaveAllDirtyLoadedChunks(bool isSaveLater, FastMemoryStream ms)
  	{
  		int num = 0;
@@ -299,7 +331,11 @@ diff --git a/VintagestoryLib/Vintagestory.Server/ServerSystemLoadAndSaveGame.cs 
  		if (!isSaveLater)
  		{
  			PopulateChunksCopy();
-@@ -506,7 +735,8 @@
+ 		}
+ 		foreach (KeyValuePair<long, ServerChunk> item in chunksCopy)
+@@ -504,11 +733,12 @@ internal class ServerSystemLoadAndSaveGame : ServerSystem, IChunkProviderThread
+ 	internal int SaveAllDirtyGeneratingChunks(FastMemoryStream ms)
+ 	{
  		int num = 0;
  		if (chunkthread.requestedChunkColumns.Count > 0)
  		{
@@ -309,3 +345,5 @@ diff --git a/VintagestoryLib/Vintagestory.Server/ServerSystemLoadAndSaveGame.cs 
  			List<DbChunk> list2 = new List<DbChunk>();
  			foreach (ChunkColumnLoadRequest item in chunkthread.requestedChunkColumns.Snapshot())
  			{
+ 				if (item.Chunks == null || item.Disposed || item.CurrentIncompletePass <= EnumWorldGenPass.Terrain)
+ 				{

--- a/patches/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs.patch
@@ -1,8 +1,8 @@
 diff --git a/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs b/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs
-index 707d78e..534b43d 100644
+index 159b06c..ac6145a 100644
 --- a/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs
 +++ b/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs
-@@ -1,195 +1,1170 @@
+@@ -1,139 +1,1094 @@
  using System;
  using System.Collections.Generic;
  using System.Linq;
@@ -22,30 +22,30 @@ index 707d78e..534b43d 100644
 +using System.Diagnostics;
 +using System.Collections.Concurrent;
  namespace Vintagestory.Server;
-
+ 
 +
  internal class ServerSystemSupplyChunks : ServerSystem
  {
 +	// World generation handler (generation pass callbacks)
  	private WorldGenHandler worldgenHandler;
-
+ 
 +	// Chunk load/save thread
  	private ChunkServerThread chunkthread;
-
+ 
 +	// Flag: 8+ CPU cores — enable multithreaded generation
  	private bool is8Core = Environment.ProcessorCount >= 8;
-
+ 
 +	// Whether chunk border smoothing is required (for worlds created before version 3)
  	private bool requiresChunkBorderSmoothing;
-
+ 
 +	// Whether the "empty chunk" flag needs to be set (for worlds before 1.12-dev.1)
  	private bool requiresSetEmptyFlag;
-
+ 
 +	// Pause request flag for all worldgen threads (0 = run, 1 = pause requested).
 +	// Acknowledgements live in pauseAckState, so a late or raced acknowledgement
 +	// can never leave this flag above zero with no pauser active.
  	private volatile int pauseAllWorldgenThreads;
-
+ 
 +	// Packed pause acknowledgement state: the upper bits carry the pause epoch,
 +	// the low 16 bits count workers parked for that epoch. The epoch moves on
 +	// every pause start, cancel, and resume, so an acknowledgement from a worker
@@ -59,19 +59,19 @@ index 707d78e..534b43d 100644
 +	// Thread-local stream for chunk serialization during saving
  	[ThreadStatic]
  	private static FastMemoryStream saveChunksStream;
-
+ 
 +	// List of entity IDs to remove when unloading a chunk
  	private List<long> entitiesToRemove = new List<long>();
-
+ 
 +	// Counter of "story" messages printed during spawn loading
  	private int storyEventPrints;
-
+ 
 +	// Array of "story" messages displayed during spawn loading
  	private string[] storyChunkSpawnEvents;
-
+ 
 +	// Number of remaining blocking requests (for loadChunkAreaBlocking)
  	private int blockingRequestsRemaining;
-
+ 
 +	// Stratum start:
 +
 +
@@ -329,7 +329,7 @@ index 707d78e..534b43d 100644
 +		stratumStageMaxConcurrent[StratumWorldGenStages.Terrain] = Math.Max(1, chunkthread.additionalWorldGenThreadsCount);
 +		stratumStageMaxConcurrent[StratumWorldGenStages.TerrainFeatures] = Math.Max(1, chunkthread.additionalWorldGenThreadsCount);
  	}
-
+ 
 +	/// <summary>
 +	/// Returns the system update interval (in ms).
 +	/// When requests exist and 8+ cores are available — minimal interval for maximum throughput.
@@ -343,7 +343,7 @@ index 707d78e..534b43d 100644
 -		return chunkthread.additionalWorldGenThreadsCount - 1;
 +		return Math.Max(1, chunkthread.additionalWorldGenThreadsCount - 1); // protection against negative and zero values
  	}
-
+ 
 +	/// <summary>
 +	/// Called when the game is ready. Initializes version flags and starts generation threads.
 +	/// </summary>
@@ -984,7 +984,7 @@ index 707d78e..534b43d 100644
 +		Volatile.Write(ref stratumPriorityListPublished, list);
 +		return list;
  	}
-
+ 
 +
 +
 +	/// <summary>
@@ -1119,14 +1119,12 @@ index 707d78e..534b43d 100644
  			if (!tryLoadOrGenerateChunkColumnsInQueue())
  			{
  				break;
- 			}
- 			if (server.Suspended)
- 			{
+@@ -143,39 +1098,59 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				break;
  			}
  		}
  	}
-
+ 
 +
 +
 +
@@ -1183,7 +1181,7 @@ index 707d78e..534b43d 100644
  				ServerChunk serverChunk = (ServerChunk)server.WorldMap.GetChunk(x, i, z);
  				if (serverChunk != null)
  				{
- 					Entity[] entities = serverChunk.Entities;
+@@ -183,11 +1158,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					for (int j = 0; j < entities.Length; j++)
  					{
  						Entity entity = entities[j];
@@ -1196,11 +1194,7 @@ index 707d78e..534b43d 100644
  						{
  							if (j >= serverChunk.EntitiesCount)
  							{
- 								break;
- 							}
-@@ -209,23 +1184,27 @@ internal class ServerSystemSupplyChunks : ServerSystem
- 					Y = i,
- 					Z = z
+@@ -211,19 +1186,23 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				});
  			}
  			list2.Add(item);
@@ -1225,16 +1219,12 @@ index 707d78e..534b43d 100644
  		{
  			ChunkPos item2 = server.WorldMap.MapRegionPosFromIndex2D(result2);
  			if (hashSet == null)
- 			{
- 				hashSet = new HashSet<ChunkPos>();
-@@ -235,162 +1214,300 @@ internal class ServerSystemSupplyChunks : ServerSystem
- 		}
- 		if (hashSet != null && hashSet.Count > 0)
+@@ -237,28 +1216,46 @@ internal class ServerSystemSupplyChunks : ServerSystem
  		{
  			chunkthread.gameDatabase.DeleteMapRegions(hashSet);
  		}
  	}
-
+ 
 +	/// <summary>
 +	/// Moves requests from the main queue (server.requestedChunkColumns)
 +	/// to the generation queue (chunkthread.requestedChunkColumns) with capacity limiting.
@@ -1271,7 +1261,7 @@ index 707d78e..534b43d 100644
 +		}
 +		// Stratum end
  	}
-
+ 
 +	/// <summary>
 +	/// Simple load of a chunk column from the database (without generation).
 +	/// Returns true on successful load.
@@ -1281,8 +1271,7 @@ index 707d78e..534b43d 100644
  		ServerMapChunk orCreateMapChunk = chunkthread.loadsavechunks.GetOrCreateMapChunk(request);
  		if (orCreateMapChunk == null)
  		{
- 			return false;
- 		}
+@@ -267,94 +1264,203 @@ internal class ServerSystemSupplyChunks : ServerSystem
  		ServerChunk[] array = chunkthread.loadsavechunks.TryLoadChunkColumn(request);
  		if (array == null)
  		{
@@ -1305,7 +1294,7 @@ index 707d78e..534b43d 100644
  		});
  		return true;
  	}
-
+ 
 +	/// <summary>
 +	/// Attempts to load or generate chunks from the queue.
 +	/// Uses the priority list (Stratum) or FIFO as a fallback.
@@ -1432,7 +1421,7 @@ index 707d78e..534b43d 100644
  		}
  		return false;
  	}
-
+ 
 +
 +
 +	/// <summary>
@@ -1466,7 +1455,7 @@ index 707d78e..534b43d 100644
  		}
  		return num;
  	}
-
+ 
 +	/// <summary>
 +	/// Loads or generates a chunk column on the chunk thread.
 +	/// Handles loading from DB, generation, finalization (Done), and stage transitions.
@@ -1492,9 +1481,7 @@ index 707d78e..534b43d 100644
  				chunkRequest.Chunks = TryLoadChunkColumn(chunkRequest);
  				if (chunkRequest.Chunks != null)
  				{
- 					for (int i = 0; i < chunkRequest.Chunks.Length; i++)
- 					{
- 						ServerChunk obj = chunkRequest.Chunks[i];
+@@ -364,31 +1470,42 @@ internal class ServerSystemSupplyChunks : ServerSystem
  						obj.serverMapChunk = orCreateMapChunk;
  						obj.MarkFresh();
  					}
@@ -1537,11 +1524,7 @@ index 707d78e..534b43d 100644
  				ServerEventAPI eventapi = server.api.eventapi;
  				ServerMapChunk mapChunk = orCreateMapChunk;
  				int chunkX = chunkRequest.chunkX;
- 				int chunkZ = chunkRequest.chunkZ;
- 				IWorldChunk[] chunks = chunkRequest.Chunks;
-@@ -402,121 +1519,109 @@ internal class ServerSystemSupplyChunks : ServerSystem
- 				if (server.Config.RepairMode)
- 				{
+@@ -404,117 +1521,105 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					ServerMain.Logger.Error("Repair mode is enabled so will delete the entire chunk column.");
  					GenerateNewChunkColumn(orCreateMapChunk, chunkRequest);
  					return false;
@@ -1582,7 +1565,7 @@ index 707d78e..534b43d 100644
  		}
  		return num;
  	}
-
+ 
 -	public int GenerateChunkColumns_OnSeparateThread(int stageStart, int stageEnd)
 -	{
 -		ChunkColumnLoadRequest chunkColumnLoadRequest = null;
@@ -1622,7 +1605,7 @@ index 707d78e..534b43d 100644
 -		}
 -		return 0;
 -	}
-
+ 
 +
 +
 +	/// <summary>
@@ -1637,7 +1620,7 @@ index 707d78e..534b43d 100644
  		}
  		return true;
  	}
-
+ 
 +	/// <summary>
 +	/// Finalizes chunk column loading on the main thread.
 +	/// Registers chunks, loads entities, initializes BlockEntities, triggers events.
@@ -1689,11 +1672,7 @@ index 707d78e..534b43d 100644
  				try
  				{
  					serverChunk.Unpack();
- 				}
- 				catch (Exception ex)
-@@ -527,14 +1632,16 @@ internal class ServerSystemSupplyChunks : ServerSystem
- 						ServerMain.Logger.Error("Repair mode is enabled so will delete the entire chunk column.");
- 						server.api.worldapi.DeleteChunkColumn(chunkRequest.chunkX, chunkRequest.chunkZ);
+@@ -529,10 +1634,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
  						ServerMain.FrameProfiler.Leave();
  						return;
  					}
@@ -1706,11 +1685,7 @@ index 707d78e..534b43d 100644
  			{
  				for (int j = 0; j < serverChunk.Entities.Length; j++)
  				{
- 					Entity entity = serverChunk.Entities[j];
- 					if (entity == null)
-@@ -546,14 +1653,15 @@ internal class ServerSystemSupplyChunks : ServerSystem
- 					}
- 					else
+@@ -548,10 +1655,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					{
  						if (server.LoadEntity(entity, num2))
  						{
@@ -1722,11 +1697,7 @@ index 707d78e..534b43d 100644
  						{
  							string text = "-";
  							try
- 							{
- 								text = entity.WatchedAttributes.GetTreeAttribute("nametag")?.GetString("name") ?? "-";
-@@ -562,57 +1670,81 @@ internal class ServerSystemSupplyChunks : ServerSystem
- 							{
- 							}
+@@ -564,14 +1672,18 @@ internal class ServerSystemSupplyChunks : ServerSystem
  							ServerMain.Logger.Log(EnumLogType.Worldgen, "In " + server.WorldName + ", villager " + text + " removed at " + entity.Pos.AsBlockPos?.ToString() + " due to an exception on loading");
  						}
  					}
@@ -1745,8 +1716,7 @@ index 707d78e..534b43d 100644
  			{
  				BlockEntity value = blockEntity.Value;
  				if (value == null)
- 				{
- 					continue;
+@@ -580,13 +1692,23 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				}
  				try
  				{
@@ -1772,7 +1742,7 @@ index 707d78e..534b43d 100644
  					ServerMain.FrameProfiler.Leave();
  				}
  				catch (Exception ex3)
- 				{
+@@ -594,23 +1716,33 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					ServerMain.Logger.Notification("Exception thrown when trying to initialize a block entity @{0}: {1}", value.Pos, ex3);
  					value.UnregisterAllTickListeners();
  				}
@@ -1797,7 +1767,7 @@ index 707d78e..534b43d 100644
  		ServerMain.FrameProfiler.Mark("MTT-ChunkLoaded-Pack");
  		ServerMain.FrameProfiler.Leave();
  	}
-
+ 
 +	/// <summary>
 +	/// Updates neighbour loaded flags for the given MapChunk.
 +	/// </summary>
@@ -1806,16 +1776,12 @@ index 707d78e..534b43d 100644
  		mapChunk.NeighboursLoaded = default(SmallBoolArray);
  		mapChunk.SelfLoaded = true;
  		for (int i = 0; i < Cardinal.ALL.Length; i++)
- 		{
- 			Cardinal cardinal = Cardinal.ALL[i];
-@@ -621,24 +1753,30 @@ internal class ServerSystemSupplyChunks : ServerSystem
- 			{
- 				mapChunk.NeighboursLoaded[i] = serverMapChunk.SelfLoaded;
+@@ -623,20 +1755,26 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				serverMapChunk.NeighboursLoaded[cardinal.Opposite.Index] = true;
  			}
  		}
  	}
-
+ 
 +	/// <summary>
 +	/// Resets neighbour loaded flags when a chunk is deleted.
 +	/// Iterates 8 neighbouring positions and clears the corresponding flags.
@@ -1837,16 +1803,12 @@ index 707d78e..534b43d 100644
  			serverMapChunk.NeighboursLoaded[4] = false;
  		}
  		if (serverMapChunk2 != null)
- 		{
- 			serverMapChunk2.NeighboursLoaded[5] = false;
-@@ -665,38 +1803,48 @@ internal class ServerSystemSupplyChunks : ServerSystem
- 		}
- 		if (serverMapChunk8 != null)
+@@ -667,12 +1805,17 @@ internal class ServerSystemSupplyChunks : ServerSystem
  		{
  			serverMapChunk8.NeighboursLoaded[3] = false;
  		}
  	}
-
+ 
 +	/// <summary>
 +	/// Executes deferred block updates for a chunk and its neighbours
 +	/// if all neighbours are loaded and generation is complete.
@@ -1859,9 +1821,7 @@ index 707d78e..534b43d 100644
  			for (int j = -1; j <= 1; j++)
  			{
  				bool flag = false;
- 				if (server.loadedMapChunks.TryGetValue(server.WorldMap.MapChunkIndex2D(chunkRequest.chunkX + j, chunkRequest.chunkZ + i), out var value) && value.CurrentIncompletePass == EnumWorldGenPass.Done && value.ScheduledBlockUpdates.Count > 0 && areAllChunkNeighboursLoaded(value, chunkRequest.chunkX + j, chunkRequest.chunkZ + i))
- 				{
- 					flag = true;
+@@ -682,19 +1825,24 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				}
  				if (!flag)
  				{
@@ -1877,7 +1837,7 @@ index 707d78e..534b43d 100644
  			}
  		}
  	}
-
+ 
 +	/// <summary>
 +	/// Checks whether all 8 neighbours of a chunk are loaded (generation complete).
 +	/// </summary>
@@ -1886,16 +1846,12 @@ index 707d78e..534b43d 100644
  		int num = 0;
  		for (int i = -1; i <= 1; i++)
  		{
- 			for (int j = -1; j <= 1; j++)
- 			{
-@@ -705,79 +1853,99 @@ internal class ServerSystemSupplyChunks : ServerSystem
- 					num++;
- 				}
+@@ -707,60 +1855,78 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			}
  		}
  		return num == 8;
  	}
-
+ 
 +	/// <summary>
 +	/// Gets or creates a map region, ensuring neighbouring regions are loaded.
 +	/// On first neighbour load, triggers OnMapRegionNeighborsLoaded callbacks.
@@ -1930,7 +1886,7 @@ index 707d78e..534b43d 100644
  		}
  		return orCreateMapRegion;
  	}
-
+ 
 +	/// <summary>
 +	/// Gets or creates a map region without storing it in the global registry.
 +	/// Updates outdated generation version if necessary, preserving existing data.
@@ -1970,9 +1926,7 @@ index 707d78e..534b43d 100644
  				dictionary = value.ModData;
  				dictionary2 = value.OreMaps;
  				intDataMap2D = value.GeologicProvinceMap;
- 				array = value.RockStrata;
- 			}
- 			else
+@@ -770,12 +1936,14 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			{
  				flag = false;
  				value.loadedTotalMs = server.ElapsedMilliseconds;
@@ -1987,16 +1941,12 @@ index 707d78e..534b43d 100644
  			if (list != null)
  			{
  				value.GeneratedStructures = list;
- 			}
- 			if (dictionary != null)
-@@ -796,118 +1964,158 @@ internal class ServerSystemSupplyChunks : ServerSystem
- 			{
- 				value.RockStrata = array;
+@@ -798,35 +1966,48 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			}
  		}
  		return value;
  	}
-
+ 
 +	/// <summary>
 +	/// Gets or creates a map region with storage in the global registry.
 +	/// Triggers the MapRegionLoaded event on the main thread.
@@ -2017,7 +1967,7 @@ index 707d78e..534b43d 100644
  		});
  		return mapRegion;
  	}
-
+ 
 +	/// <summary>
 +	/// Creates a new map region, invoking all region generation callbacks.
 +	/// </summary>
@@ -2030,7 +1980,7 @@ index 707d78e..534b43d 100644
  		}
  		return serverMapRegion;
  	}
-
+ 
 +	/// <summary>
 +	/// Restores generated structures from chunk generation parameters.
 +	/// Stratum: uses HashSet for O(N+M) instead of O(N*M) nested scanning.
@@ -2040,9 +1990,7 @@ index 707d78e..534b43d 100644
  		byte[] array = chunkGenParams?.GetBytes("GeneratedStructures");
  		if (array == null)
  		{
- 			return;
- 		}
- 		Dictionary<long, List<GeneratedStructure>> dictionary = SerializerUtil.Deserialize<Dictionary<long, List<GeneratedStructure>>>(array);
+@@ -836,44 +2017,60 @@ internal class ServerSystemSupplyChunks : ServerSystem
  		long key = server.api.WorldManager.MapRegionIndex2D(regionX, regionZ);
  		if (!dictionary.TryGetValue(key, out var value) || value == null)
  		{
@@ -2054,7 +2002,7 @@ index 707d78e..534b43d 100644
 +		List<GeneratedStructure> generatedStructure = [.. value.Where(structure => !existingStarts.Contains(structure.Location.Start))];
  		mapRegion.AddGeneratedStructures(generatedStructure);
  	}
-
+ 
 +	/// <summary>
 +	/// Gets or creates a MapChunk for the request. Searches memory first,
 +	/// then the database, creates a new one if necessary.
@@ -2094,7 +2042,7 @@ index 707d78e..534b43d 100644
  		server.loadedMapChunks[key] = value;
  		return value;
  	}
-
+ 
 +	/// <summary>
 +	/// Quickly gets a MapChunk from memory or the database without creating a new one.
 +	/// </summary>
@@ -2104,12 +2052,12 @@ index 707d78e..534b43d 100644
  		long key = server.WorldMap.MapChunkIndex2D(chunkX, chunkZ);
  		server.loadedMapChunks.TryGetValue(key, out var value);
  		if (value != null)
- 		{
+@@ -881,31 +2078,42 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			return value;
  		}
  		return TryLoadMapChunk(chunkX, chunkZ);
  	}
-
+ 
 +	/// <summary>
 +	/// Creates a new MapChunk, invoking all MapChunk generation callbacks.
 +	/// </summary>
@@ -2122,7 +2070,7 @@ index 707d78e..534b43d 100644
  		}
  		return serverMapChunk;
  	}
-
+ 
 +	/// <summary>
 +	/// Creates a new chunk column for generation.
 +	/// Prepares border smoothing data if necessary.
@@ -2147,11 +2095,7 @@ index 707d78e..534b43d 100644
  			for (int j = 0; j < Cardinal.ALL.Length; j++)
  			{
  				Cardinal cardinal = Cardinal.ALL[j];
- 				ServerMapChunk serverMapChunk = PeekMapChunk(chunkRequest.chunkX + cardinal.Normali.X, chunkRequest.chunkZ + cardinal.Normali.Z);
- 				if (serverMapChunk != null && serverMapChunk.CurrentIncompletePass >= EnumWorldGenPass.Done && serverMapChunk.WorldGenVersion != 3)
-@@ -916,83 +2124,153 @@ internal class ServerSystemSupplyChunks : ServerSystem
- 					{
- 						chunkRequest.NeighbourTerrainHeight = new ushort[8][];
+@@ -918,47 +2126,111 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					}
  					chunkRequest.NeighbourTerrainHeight[j] = serverMapChunk.WorldGenTerrainHeightMap;
  				}
@@ -2168,7 +2112,7 @@ index 707d78e..534b43d 100644
 +		// Set the initial generation stage
  		chunkRequest.CurrentIncompletePass = EnumWorldGenPass.Terrain;
  	}
-
+ 
 +	/// <summary>
 +	/// Attempts to load a chunk column from the database.
 +	/// Supports parallel loading via StratumChunkReadPool.
@@ -2279,8 +2223,7 @@ index 707d78e..534b43d 100644
  			foreach (ServerChunk serverChunk in array)
  			{
  				if (serverChunk != null)
- 				{
- 					serverChunk.Unpack();
+@@ -967,10 +2239,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					serverChunk.MarkModified();
  					serverChunk.TryPackAndCommit();
  				}
@@ -2293,13 +2236,12 @@ index 707d78e..534b43d 100644
  			ServerMain.Logger.Error("Loaded some but not all chunks of a column? Discarding whole column.");
  			return null;
  		}
- 		if (num != chunkMapSizeY)
- 		{
+@@ -979,18 +2253,22 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			return null;
  		}
  		return array;
  	}
-
+ 
 +	/// <summary>
 +	/// Attempts to load a MapChunk from the database. Returns null if absent or on error.
 +	/// </summary>
@@ -2317,16 +2259,12 @@ index 707d78e..534b43d 100644
  					serverMapChunk.YMax = (ushort)(server.SaveGameData.MapSizeY - 1);
  				}
  				return serverMapChunk;
- 			}
- 			catch (Exception ex)
-@@ -1009,14 +2287,17 @@ internal class ServerSystemSupplyChunks : ServerSystem
- 				ServerMain.Logger.Error("Failed deserializing a map chunk, we are in repair mode, so will initialize empty one. Exception: {0}", ex);
- 				return null;
+@@ -1011,10 +2289,13 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			}
  		}
  		return null;
  	}
-
+ 
 +	/// <summary>
 +	/// Attempts to load a map region from the database. Returns null if absent or on error.
 +	/// </summary>
@@ -2335,16 +2273,12 @@ index 707d78e..534b43d 100644
  		byte[] mapRegion = chunkthread.gameDatabase.GetMapRegion(regionX, regionZ);
  		try
  		{
- 			if (mapRegion != null)
- 			{
-@@ -1033,18 +2314,37 @@ internal class ServerSystemSupplyChunks : ServerSystem
- 			}
- 			ServerMain.Logger.Error("Failed deserializing a map region. Not in repair mode, will exit.");
+@@ -1035,14 +2316,33 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			throw;
  		}
  		return null;
  	}
-
+ 
 +	/// <summary>
 +	/// Initializes world generation and loads spawn chunks.
 +	/// For old worlds, searches for a suitable spawn point; for new ones, loads the map center.
@@ -2373,11 +2307,7 @@ index 707d78e..534b43d 100644
  			storyChunkSpawnEvents = new string[15]
  			{
  				Lang.Get("...the carved mountains"),
- 				Lang.Get("...the rolling hills"),
- 				Lang.Get("...the vertical cliffs"),
-@@ -1058,27 +2358,31 @@ internal class ServerSystemSupplyChunks : ServerSystem
- 				Lang.Get("...the roaming creatures"),
- 				Lang.Get("with their offspring..."),
+@@ -1060,23 +2360,27 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				Lang.Get("...a misty sunrise"),
  				Lang.Get("...dew drops on a blade of grass"),
  				Lang.Get("...a soft breeze")
@@ -2405,11 +2335,7 @@ index 707d78e..534b43d 100644
  					double value = random.NextDouble() * 6.2831854820251465;
  					double num7 = num6 * GameMath.Sin(value);
  					double num8 = num6 * GameMath.Cos(value);
- 					num = (int)num7;
- 					num2 = (int)num8;
-@@ -1094,114 +2398,139 @@ internal class ServerSystemSupplyChunks : ServerSystem
- 				if (i + 1 < num3)
- 				{
+@@ -1096,10 +2400,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					server.api.Logger.Notification("Trying another spawn location ({0}/{1})...", i + 2, num3);
  				}
  			}
@@ -2421,7 +2347,7 @@ index 707d78e..534b43d 100644
  				if (!server.blockAccessor.GetBlock(blockPos).SideSolid[BlockFacing.UP.Index])
  				{
  					server.blockAccessor.SetBlock(server.blockAccessor.GetBlock(new AssetLocation("planks-oak-we")).Id, blockPos);
- 				}
+@@ -1107,13 +2412,16 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				blockPos.Y++;
  			}
  		}
@@ -2438,14 +2364,12 @@ index 707d78e..534b43d 100644
  			x = blockPos.X,
  			y = blockPos.Y,
  			z = blockPos.Z
- 		};
- 		if (blockPos.Y < 0)
- 		{
+@@ -1123,10 +2431,14 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			server.mapMiddleSpawnPos.y = null;
  		}
  		server.api.Logger.VerboseDebug("Done spawn chunk");
  	}
-
+ 
 +	/// <summary>
 +	/// Adjusts the spawn position: searches for a safe spot (not liquid, no solid block above,
 +	/// not blocked by a land claim). Up to 60 attempts with random offset.
@@ -2455,10 +2379,7 @@ index 707d78e..534b43d 100644
  		int num = 60;
  		int num2 = 0;
  		int num3 = 0;
- 		int num4 = 0;
- 		int num5 = 0;
- 		int num6 = 0;
- 		while (num-- > 0)
+@@ -1137,36 +2449,47 @@ internal class ServerSystemSupplyChunks : ServerSystem
  		{
  			num4 = GameMath.Clamp(num2 + pos.X, 0, server.WorldMap.MapSizeX - 1);
  			num6 = GameMath.Clamp(num3 + pos.Z, 0, server.WorldMap.MapSizeZ - 1);
@@ -2485,7 +2406,7 @@ index 707d78e..534b43d 100644
  		}
  		return false;
  	}
-
+ 
 +	/// <summary>
 +	/// Generates a chunk area in "peek" mode without saving.
 +	/// Used for preview purposes (e.g., cartography).
@@ -2507,7 +2428,7 @@ index 707d78e..534b43d 100644
  		{
  			for (int k = -num2; k <= num2; k++)
  			{
- 				if (server.WorldMap.IsValidChunkPos(x + j, 0, y + k))
+@@ -1174,18 +2497,22 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				{
  					long index2d = server.WorldMap.MapChunkIndex2D(x + j, y + k);
  					int regionX = (x + j) / MagicNum.ChunkRegionSizeInChunks;
@@ -2531,10 +2452,7 @@ index 707d78e..534b43d 100644
  					};
  					chunkColumnLoadRequest.MapChunk = mapChunk;
  					GenerateNewChunkColumn(mapChunk, chunkColumnLoadRequest);
- 					chunkColumnLoadRequest.Unpack();
- 					array[j + num2, k + num2] = chunkColumnLoadRequest;
- 					lock (chunkthread.peekingChunkColumns)
- 					{
+@@ -1196,10 +2523,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
  						chunkthread.peekingChunkColumns.Enqueue(chunkColumnLoadRequest);
  					}
  				}
@@ -2547,11 +2465,7 @@ index 707d78e..534b43d 100644
  		{
  			num4 = num - i;
  			for (int l = -num4; l <= num4; l++)
- 			{
- 				for (int m = -num4; m <= num4; m++)
-@@ -1210,14 +2539,16 @@ internal class ServerSystemSupplyChunks : ServerSystem
- 					{
- 						ChunkColumnLoadRequest chunkRequest = array[l + num2, m + num2];
+@@ -1212,10 +2541,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
  						runGenerators(chunkRequest, i);
  					}
  				}
@@ -2564,11 +2478,7 @@ index 707d78e..534b43d 100644
  		{
  			for (int n = -num2; n <= num2; n++)
  			{
- 				for (int num5 = -num2; num5 <= num2; num5++)
- 				{
-@@ -1230,65 +2561,115 @@ internal class ServerSystemSupplyChunks : ServerSystem
- 						Vec2i key = new Vec2i(x + n, y + num5);
- 						IServerChunk[] chunks = chunkColumnLoadRequest2.Chunks;
+@@ -1232,61 +2563,111 @@ internal class ServerSystemSupplyChunks : ServerSystem
  						dictionary2[key] = chunks;
  					}
  				}
@@ -2589,7 +2499,7 @@ index 707d78e..534b43d 100644
  			ServerMain.FrameProfiler.Mark("MTT-PeekChunk");
  		});
  	}
-
+ 
 +	/// <summary>
 +	/// Blocking load/generation of a rectangular chunk area.
 +	/// Throttles request submission to avoid queue overflow.
@@ -2682,11 +2592,7 @@ index 707d78e..534b43d 100644
  				millisecondsSinceStart = server.totalUnpausedTime.ElapsedMilliseconds;
  				float num4 = 100f * ((float)server.loadedChunks.Count / (float)server.WorldMap.ChunkMapSizeY - (float)num) / (float)num2;
  				ServerMain.Logger.Event(num4.ToString("0.#") + "% ({0} in queue)", chunkthread.requestedChunkColumns.Count);
- 				if (storyEventPrints < storyChunkSpawnEvents.Length)
- 				{
-@@ -1296,41 +2677,88 @@ internal class ServerSystemSupplyChunks : ServerSystem
- 				}
- 				else
+@@ -1298,37 +2679,84 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				{
  					ServerMain.Logger.StoryEvent("...");
  				}
@@ -2774,16 +2680,12 @@ index 707d78e..534b43d 100644
  				foreach (ChunkColumnLoadRequest requestedChunkColumn3 in chunkthread.requestedChunkColumns)
  				{
  					if (requestedChunkColumn3 != null)
- 					{
- 						string text = ((requestedChunkColumn3.chunkX >= chunkX1 && requestedChunkColumn3.chunkX <= chunkX2 && requestedChunkColumn3.chunkZ >= chunkZ1 && requestedChunkColumn3.chunkZ <= chunkZ2) ? " (in original req)" : "");
-@@ -1338,55 +2766,94 @@ internal class ServerSystemSupplyChunks : ServerSystem
- 					}
- 				}
+@@ -1340,16 +2768,25 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				throw new Exception("Somehow worldgen has become stuck in an endless loop, please report this as a bug!  Additional data in the server-main log");
  			}
  		}
  	}
-
+ 
 +	/// <summary>
 +	/// Executes one generation stage for a chunk (PopulateChunk).
 +	/// Invokes generators for the current pass, marks chunks as modified,
@@ -2804,9 +2706,7 @@ index 707d78e..534b43d 100644
  				if (chunkRequest.CurrentIncompletePass == EnumWorldGenPass.Terrain)
  				{
  					ushort sunLight = (ushort)server.sunBrightness;
- 					for (int i = 0; i < chunkRequest.Chunks.Length; i++)
- 					{
- 						chunkRequest.Chunks[i].Lighting.ClearWithSunlight(sunLight);
+@@ -1359,32 +2796,62 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					}
  				}
  			}
@@ -2852,7 +2752,7 @@ index 707d78e..534b43d 100644
  			chunkRequest.generatingLock.ReleaseWriteLock();
  		}
  	}
-
+ 
 +	/// <summary>
 +	/// Runs all registered generators for the specified pass.
 +	/// On error at Terrain stage or below — aborts generation.
@@ -2871,11 +2771,7 @@ index 707d78e..534b43d 100644
  			return;
  		}
  		for (int i = 0; i < list.Count; i++)
- 		{
- 			try
-@@ -1394,93 +2861,123 @@ internal class ServerSystemSupplyChunks : ServerSystem
- 				list[i](chunkRequest);
- 			}
+@@ -1396,89 +2863,119 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			catch (Exception ex)
  			{
  				ServerMain.Logger.Worldgen("An error was thrown in pass {5} when generating chunk column X={0},Z={1} in world '{3}' with seed {4}\nException {2}\n\n", chunkRequest.chunkX, chunkRequest.chunkZ, ex, server.SaveGameData.WorldName, server.SaveGameData.Seed, chunkRequest.CurrentIncompletePass.ToString());
@@ -2887,7 +2783,7 @@ index 707d78e..534b43d 100644
  			}
  		}
  	}
-
+ 
 +	/// <summary>
 +	/// Checks that chunk neighbours are sufficiently generated for the current stage.
 +	/// For stages up to and including Terrain2, no check is required.
@@ -2956,7 +2852,7 @@ index 707d78e..534b43d 100644
 +		if (!result) Interlocked.Increment(ref stratumGateBlockedCounts[currentIncompletePass_AsInt]);
  		return result;
  	}
-
+ 
 -	private EnumWorldGenPass getLoadedOrQueuedChunkPass(long index2d)
 -	{
 -		server.loadedMapChunks.TryGetValue(index2d, out var value);
@@ -2966,7 +2862,7 @@ index 707d78e..534b43d 100644
 -		}
 -		return EnumWorldGenPass.Done;
 -	}
-
+ 
 +
 +	/// <summary>
 +	/// Checks if there is space in the request queue. On overflow:
@@ -3012,16 +2908,12 @@ index 707d78e..534b43d 100644
  			chunkthread.requestedChunkColumns.Enqueue(curRequest);
  			return true;
  		}
- 		finally
- 		{
-@@ -1488,121 +2985,204 @@ internal class ServerSystemSupplyChunks : ServerSystem
- 			if (chunkthread.additionalWorldGenThreadsCount > 0)
- 			{
+@@ -1490,13 +2987,19 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				ServerMain.Logger.VerboseDebug("Un-pausing all worldgen threads.");
  			}
  		}
  	}
-
+ 
 +	/// <summary>
 +	/// Fully clears the generation queue, saving incomplete chunks beforehand.
 +	/// </summary>
@@ -3036,13 +2928,12 @@ index 707d78e..534b43d 100644
  			if (requestedChunkColumn != null && !requestedChunkColumn.Disposed)
  			{
  				server.loadedMapChunks.Remove(requestedChunkColumn.mapIndex2d);
- 				server.ChunkColumnRequested.Remove(requestedChunkColumn.mapIndex2d);
- 			}
+@@ -1505,104 +3008,181 @@ internal class ServerSystemSupplyChunks : ServerSystem
  		}
  		chunkthread.requestedChunkColumns.Clear();
  		ServerMain.Logger.VerboseDebug("Incomplete chunks stored and wiped.");
  	}
-
+ 
 -	private Thread CreateAdditionalWorldGenThread(int stageStart, int stageEnd, int threadnum)
 +
 +	/// <summary>
@@ -3058,7 +2949,7 @@ index 707d78e..534b43d 100644
  		thread.Start();
  		return thread;
  	}
-
+ 
 -	public void GeneratorThreadLoop(int stageStart, int stageEnd)
 +
 +
@@ -3104,7 +2995,7 @@ index 707d78e..534b43d 100644
 +		readyTasksQueue.CompleteAdding(); // Stratum: Close the channel for workers
  		BlockAccessorWorldGen.ThreadDispose();
  	}
-
+ 
 -	public override void OnSeperateThreadShutDown()
 +	/// <summary>
 +	/// Resource disposal. Duplicates shutdown logic to guarantee correct shutdown.
@@ -3123,7 +3014,7 @@ index 707d78e..534b43d 100644
 +
  		BlockAccessorWorldGen.ThreadDispose();
  	}
-
+ 
 -	public override void Dispose()
 +	/// <summary>
 +	/// Retires the current pause epoch: bumps the epoch bits and zeroes the
@@ -3142,7 +3033,7 @@ index 707d78e..534b43d 100644
 +			}
 +		}
  	}
-
+ 
 +	/// <summary>
 +	/// Pauses all worldgen threads. Waits until all workers acknowledge the pause.
 +	/// Returns false on timeout (cancels the request to prevent deadlock).
@@ -3184,7 +3075,7 @@ index 707d78e..534b43d 100644
  		}
  		return true;
  	}
-
+ 
 +	/// <summary>
 +	/// Resumes all worldgen threads and wakes the dispatcher.
 +	/// </summary>
@@ -3194,7 +3085,7 @@ index 707d78e..534b43d 100644
  		pauseAllWorldgenThreads = 0;
 +		SignalDispatcher(); // Stratum: wake the dispatcher — time to work
  	}
-
+ 
 +	/// <summary>
 +	/// Called by a worker to acknowledge the pause.
 +	/// Registers the acknowledgement against the current epoch and waits for

--- a/patches/VintagestoryLib/Vintagestory/Logger.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory/Logger.cs.patch
@@ -1,5 +1,5 @@
 diff --git a/VintagestoryLib/Vintagestory/Logger.cs b/VintagestoryLib/Vintagestory/Logger.cs
-index f06bc69..8f9c105 100644
+index 8c1f523..c8c90a2 100644
 --- a/VintagestoryLib/Vintagestory/Logger.cs
 +++ b/VintagestoryLib/Vintagestory/Logger.cs
 @@ -6,10 +6,11 @@ using System.Globalization;

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumPregenManager.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumPregenManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;


### PR DESCRIPTION
ServerConfig.Save() strips Roles and DefaultRoleCode from the JSON. Vanilla reads that file at boot and fatals when the role table is empty. This writes both keys back into the JObject before serializing, so vanilla can still boot from the same serverconfig.json while Stratum loads from serverroles.json as its authoritative source.

Fixes #264