### PR TITLE
Read and write batching for lighting calculations and more

### DIFF
--- a/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/2.GenRockStrata/GenRockStrata.cs.patch
+++ b/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/2.GenRockStrata/GenRockStrata.cs.patch
@@ -1,5 +1,5 @@
 diff --git a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/2.GenRockStrata/GenRockStrata.cs b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/2.GenRockStrata/GenRockStrata.cs
-index cb9eefa..3b30334 100644
+index cb9eefa..574c98e 100644
 --- a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/2.GenRockStrata/GenRockStrata.cs
 +++ b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/2.GenRockStrata/GenRockStrata.cs
 @@ -1,6 +1,7 @@
@@ -10,90 +10,82 @@ index cb9eefa..3b30334 100644
  using Vintagestory.API.Datastructures;
  using Vintagestory.API.MathTools;
  using Vintagestory.API.Server;
-@@ -26,10 +27,16 @@ namespace Vintagestory.ServerMods
+@@ -26,10 +27,18 @@ namespace Vintagestory.ServerMods
          internal MapLayerCustomPerlin[] strataNoises;
  
          int regionMapSize;
          Dictionary<int, LerpedWeightedIndex2DMap> ProvinceMapByRegion = new Dictionary<int, LerpedWeightedIndex2DMap>(10);
  
-+        // Stratum: each worldgen thread gets a complete generator so vanilla fields stay intact.
++        // Stratum start: thread-local worker instances so each worldgen thread gets its own mutable state without interfering with other threads.
 +        StratumWorkerInstances<GenRockStrataNew> stratumWorkers;
++        // Stratum end
 +
-+        // Stratum: workers keep vanilla dictionaries while sharing the expensive cached maps.
++        // Stratum start: concurrent dictionary shared across workers for expensive cached province maps, avoiding per-worker duplication of the same LerpedWeightedIndex2DMap instances.
 +        ConcurrentDictionary<int, LerpedWeightedIndex2DMap> stratumProvinceMapsByRegion = new ConcurrentDictionary<int, LerpedWeightedIndex2DMap>();
++        // Stratum end
 +
          public override bool ShouldLoad(EnumAppSide side)
          {
              return side == EnumAppSide.Server;
          }
  
-@@ -44,13 +51,14 @@ namespace Vintagestory.ServerMods
+@@ -44,13 +53,14 @@ namespace Vintagestory.ServerMods
          }
  
          public override void StartServerSide(ICoreServerAPI api)
          {
              this.api = api;
-+            stratumWorkers = new StratumWorkerInstances<GenRockStrataNew>(StratumCreateWorker); // Stratum: isolate mutable fields without changing their shape
++            stratumWorkers = new StratumWorkerInstances<GenRockStrataNew>(StratumCreateWorker); // Stratum: initialize thread-local workers with their own mutable state copies.
  
              api.Event.InitWorldGenerator(initWorldGen, "standard");
 -            api.Event.ChunkColumnGeneration(GenChunkColumn, EnumWorldGenPass.Terrain, "standard");
-+            StratumTerrainSplit.Register(api, GenChunkColumn, StratumGenChunkColumn, "standard"); // Stratum: expose vanilla topology until the worker path is safe
++            StratumTerrainSplit.Register(api, GenChunkColumn, StratumGenChunkColumn, "standard"); // Stratum: register vanilla and stratum chunk generation paths for terrain pass.
  
              api.Event.MapRegionGeneration(OnMapRegionGen, "standard");
          }
  
  
-@@ -69,10 +77,12 @@ namespace Vintagestory.ServerMods
+@@ -69,10 +79,12 @@ namespace Vintagestory.ServerMods
              regionSize = api.WorldManager.RegionSize;
  
              // Unpadded region noise size in chunks
              regionChunkSize = regionSize / chunksize;
  
-+            chunksizeLog2 = System.Numerics.BitOperations.Log2((uint)chunksize);
++            chunksizeLog2 = System.Numerics.BitOperations.Log2((uint)chunksize); // Stratum: precompute log2(chunksize) for bit-shift operations instead of division/multiplication on every Y step.
 +
              // Unpadded region noise size in blocks
              int geoProvRegionNoiseSize = regionSize / TerraGenConfig.geoProvMapScale;
  
              // Amount of regions in all of the map
              regionMapSize = api.WorldManager.MapSizeX / (chunksize * geoProvRegionNoiseSize);
-@@ -148,27 +158,146 @@ namespace Vintagestory.ServerMods
+@@ -148,27 +160,120 @@ namespace Vintagestory.ServerMods
          float lerpMapInv;
          float chunkInRegionX;
          float chunkInRegionZ;
  
          GeologicProvinces provinces = NoiseGeoProvince.provinces;
 +
-+        // Stratum: reuse province weights to avoid one allocation per block column.
++        // Stratum start: reusable province weights buffer to avoid allocation per block column. Reallocated only when provinces.Variants.Length changes.
 +        float[] stratumIndicesBuf;
++        // Stratum end
 +
-+        // Stratum: precomputed log2(chunksize) so genBlockColumn can use bit shifts
-+        // instead of integer division/multiplication by chunksize on every Y step.
-+        // chunksize is assumed to be a power of two (it always has been — 32).
++        // Stratum start: precomputed log2(chunksize) for bit-shift operations instead of division/multiplication on every Y step. chunksize is assumed to be a power of two (it always has been — 32).
 +        int chunksizeLog2;
++        // Stratum end
 +
-+        // Stratum: per-subchunk write buffers. Filled during genBlockColumn across
-+        // the whole 32x32 column loop, flushed once per subchunk at the end of
-+        // GenChunkColumn instead of taking stratumWriteLock on every block write.
-+        // Lazily sized to the chunk column's height (chunks.Length) on first use
-+        // and reused (Clear, not reallocated) on every subsequent call.
-+        List<int>[] stratumPendingIndices;
-+        List<int>[] stratumPendingValues;
-+
-+        // Stratum: per-subchunk block snapshots, refreshed once per chunk column instead of
-+        // calling GetBlockIdUnsafe (interface dispatch + palette decode) once per replaced
-+        // block. Correctness relies on writes being deferred until StratumFlushPendingWrites
-+        // at the end of GenChunkColumn — the real data is untouched throughout the whole
-+        // column loop, so one snapshot at the start sees exactly what every individual
-+        // GetBlockIdUnsafe call would have seen.
++        // Stratum start: per-subchunk block snapshots, refreshed once per chunk column instead of calling GetBlockIdUnsafe (interface dispatch + palette decode) once per replaced block. Correctness relies on writes being deferred until StratumFlushPendingWrites at the end of GenChunkColumn — the real data is untouched throughout the whole column loop, so one snapshot at the start sees exactly what every individual GetBlockIdUnsafe call would have seen. We mutate this array directly during genBlockColumn and bulk-write it back to the chunk in one pass via SetBlocksBulkUnsafe, completely bypassing per-block list allocations and per-block palette encoding overhead.
 +        int[][] stratumBlockSnapshot;
++        // Stratum end
 +
          #endregion
  
++        /// <summary>Stratum: delegates chunk column generation to the current thread-local worker instance.</summary>
 +        private void StratumGenChunkColumn(IChunkColumnGenerateRequest request)
 +        {
 +            stratumWorkers.Current.GenChunkColumn(request);
 +        }
 +
++        /// <summary>Stratum: factory method that creates a new GenRockStrataNew worker and copies the configured state from this instance.</summary>
 +        private GenRockStrataNew StratumCreateWorker()
 +        {
 +            GenRockStrataNew worker = new GenRockStrataNew();
@@ -101,28 +93,21 @@ index cb9eefa..3b30334 100644
 +            return worker;
 +        }
 +
-+        // Stratum: (re)allocates the per-subchunk buffer lists to match this
-+        // column's chunk count. Cheap no-op after the first call for a given
-+        // worker, since chunk column height doesn't change between calls.
++        /// <summary>Stratum: (re)allocates the per-subchunk buffer arrays to match this column's chunk count. Cheap no-op after the first call for a given worker, since chunk column height doesn't change between calls.</summary>
 +        private void StratumEnsureBuffers(int numSubchunks)
 +        {
-+            if (stratumPendingIndices != null && stratumPendingIndices.Length == numSubchunks)
++            if (stratumBlockSnapshot != null && stratumBlockSnapshot.Length == numSubchunks)
 +            {
 +                return;
 +            }
-+            stratumPendingIndices = new List<int>[numSubchunks];
-+            stratumPendingValues = new List<int>[numSubchunks];
 +            stratumBlockSnapshot = new int[numSubchunks][];
 +            for (int i = 0; i < numSubchunks; i++)
 +            {
-+                stratumPendingIndices[i] = new List<int>();
-+                stratumPendingValues[i] = new List<int>();
 +                stratumBlockSnapshot[i] = new int[chunksize * chunksize * chunksize]; // 32768
 +            }
 +        }
 +
-+        // Stratum: bulk-reads every subchunk's current block IDs once per chunk column.
-+        // See stratumBlockSnapshot field comment for the correctness argument.
++        /// <summary>Stratum: bulk-reads every subchunk's current block IDs once per chunk column. See stratumBlockSnapshot field comment for the correctness argument.</summary>
 +        private void StratumSnapshotBlocks(IServerChunk[] chunks)
 +        {
 +            for (int cy = 0; cy < chunks.Length; cy++)
@@ -131,26 +116,17 @@ index cb9eefa..3b30334 100644
 +            }
 +        }
 +
-+
-+        // Stratum: flushes all buffered writes for this chunk column, one batched
-+        // lock acquisition per subchunk instead of one per block. Clears the lists
-+        // afterwards so they can be reused for the next chunk column.
++        /// <summary>Stratum: bulk-write the mutated snapshot back to each subchunk in one pass.</summary>
 +        private void StratumFlushPendingWrites(IServerChunk[] chunks)
 +        {
-+            for (int cy = 0; cy < stratumPendingIndices.Length; cy++)
++            for (int cy = 0; cy < stratumBlockSnapshot.Length; cy++)
 +            {
-+                List<int> indices = stratumPendingIndices[cy];
-+                if (indices.Count == 0)
-+                {
-+                    continue;
-+                }
-+                chunks[cy].Data.SetBlocksUnsafe(indices, stratumPendingValues[cy]);
-+                indices.Clear();
-+                stratumPendingValues[cy].Clear();
++                // Stratum: single bulk write per subchunk. The engine handles palette encoding for the entire array in one optimized pass, which is vastly faster than per-block SetBlockUnsafe calls and avoids all list allocations.
++                chunks[cy].Data.SetBlocksBulkUnsafe(stratumBlockSnapshot[cy]);
 +            }
 +        }
 +
-+        // Stratum: copy configured state and give mutable fields to one worldgen thread.
++        /// <summary>Stratum: copy configured state from source to this worker instance. Copies immutable references (strata, distort2dx/dz, strataNoises) and clones mutable arrays/fields so each thread has its own isolated state.</summary>
 +        private void StratumCopyStateFrom(GenRockStrataNew source)
 +        {
 +            api = source.api;
@@ -164,8 +140,8 @@ index cb9eefa..3b30334 100644
 +            distort2dz = source.distort2dz;
 +            strataNoises = source.strataNoises;
 +            regionMapSize = source.regionMapSize;
-+            ProvinceMapByRegion = new Dictionary<int, LerpedWeightedIndex2DMap>(source.ProvinceMapByRegion);
-+            stratumProvinceMapsByRegion = source.stratumProvinceMapsByRegion;
++            ProvinceMapByRegion = new Dictionary<int, LerpedWeightedIndex2DMap>(source.ProvinceMapByRegion); // Stratum: clone the dictionary so each worker has its own cache.
++            stratumProvinceMapsByRegion = source.stratumProvinceMapsByRegion; // Reference shared ConcurrentDictionary for expensive cached maps.
 +            rockGroupMaxThickness = (float[])source.rockGroupMaxThickness.Clone();
 +            rockGroupCurrentThickness = (int[])source.rockGroupCurrentThickness.Clone();
 +            mapChunk = source.mapChunk;
@@ -186,8 +162,8 @@ index cb9eefa..3b30334 100644
              int chunkZ = request.ChunkZ;
  
              preLoad(chunks, chunkX, chunkZ);
-+            StratumEnsureBuffers(chunks.Length);
-+            StratumSnapshotBlocks(chunks); // Stratum: one bulk read per subchunk instead of per block
++            StratumEnsureBuffers(chunks.Length); // Stratum: ensure per-subchunk buffers are allocated.
++            StratumSnapshotBlocks(chunks); // Stratum: one bulk read per subchunk instead of per block.
  
              for (int x = 0; x < chunksize; x++)
              {
@@ -197,20 +173,20 @@ index cb9eefa..3b30334 100644
                  }
              }
 +
-+            StratumFlushPendingWrites(chunks); // Stratum: one batched write per subchunk instead of per block
++            StratumFlushPendingWrites(chunks); // Stratum: one batched write per subchunk instead of per block.
          }
  
          public void preLoad(IServerChunk[] chunks, int chunkX, int chunkZ)
          {
              mapChunk = chunks[0].MapChunk;
-@@ -192,19 +321,25 @@ namespace Vintagestory.ServerMods
+@@ -192,19 +297,25 @@ namespace Vintagestory.ServerMods
              int rockBlockId = this.rockBlockId;
  
              rockGroupMaxThickness[0] = rockGroupMaxThickness[1] = rockGroupMaxThickness[2] = rockGroupMaxThickness[3] = 0;
              rockGroupCurrentThickness[0] = rockGroupCurrentThickness[1] = rockGroupCurrentThickness[2] = rockGroupCurrentThickness[3] = 0;
  
 -            float[] indices = new float[provinces.Variants.Length];
-+            // Stratum: keep the measured allocation reduction while each worker owns its buffer.
++            // Stratum: reuse stratumIndicesBuf instead of allocating new float[] per block column. Reallocated only when provinces.Variants.Length changes.
 +            if (stratumIndicesBuf == null || stratumIndicesBuf.Length != provinces.Variants.Length)
 +            {
 +                stratumIndicesBuf = new float[provinces.Variants.Length];
@@ -220,50 +196,51 @@ index cb9eefa..3b30334 100644
                  chunkInRegionX + lx * lerpMapInv,
                  chunkInRegionZ + lz * lerpMapInv,
 -                indices
-+                stratumIndicesBuf
++                stratumIndicesBuf // Stratum: write into pre-allocated buffer instead of new allocation.
              );
 -            for (int i = 0; i < indices.Length; i++)
 +
-+            for (int i = 0; i < stratumIndicesBuf.Length; i++)
++            for (int i = 0; i < stratumIndicesBuf.Length; i++) // Stratum: iterate over reused buffer.
              {
 -                float w = indices[i];
-+                float w = stratumIndicesBuf[i];
++                float w = stratumIndicesBuf[i]; // Stratum: read from reused buffer.
                  if (w == 0) continue;
  
                  GeologicProvinceRockStrata[] localstrata = provinces.Variants[i].RockStrataIndexed;
  
                  rockGroupMaxThickness[0] += localstrata[0].ScaledMaxThickness * w;
-@@ -277,34 +412,34 @@ namespace Vintagestory.ServerMods
+@@ -273,45 +384,35 @@ namespace Vintagestory.ServerMods
+                         }
+                         continue;
+                     }
+                 }
  
-                 rockGroupCurrentThickness[grp]++;
+-                rockGroupCurrentThickness[grp]++;
++                // Stratum start: direct mutation of the snapshot array instead of per-block GetBlockIdUnsafe/SetBlockUnsafe calls. Uses chunksizeLog2 for bit-shift operations (equivalent to division/multiplication by 32).
++                int chunkY = (stratum.GenDir == EnumStratumGenDir.BottomUp) ? (ylower >> chunksizeLog2) : (yupper >> chunksizeLog2); // Stratum: right shift instead of division by chunksize.
++                int localY = (stratum.GenDir == EnumStratumGenDir.BottomUp) ? (ylower - (chunkY << chunksizeLog2)) : (yupper - (chunkY << chunksizeLog2)); // Stratum: left shift and subtract instead of modulo operation.
++                int localIndex3D = (((localY << chunksizeLog2) + lz) << chunksizeLog2) + lx; // Stratum: bit-shift based index calculation.
  
-                 if (stratum.GenDir == EnumStratumGenDir.BottomUp)
+-                if (stratum.GenDir == EnumStratumGenDir.BottomUp)
++                if (stratumBlockSnapshot[chunkY][localIndex3D] == rockBlockId) // Stratum: check snapshot instead of calling GetBlockIdUnsafe.
                  {
 -                    int chunkY = ylower / chunksize;
 -                    int lY = ylower - chunkY * chunksize;
 -                    int localIndex3D = (chunksize * lY + lz) * chunksize + lx;
-+                    int chunkY = ylower >> chunksizeLog2;
-+                    int lY = ylower - (chunkY << chunksizeLog2);
-+                    int localIndex3D = (((lY << chunksizeLog2) + lz) << chunksizeLog2) + lx;
- 
+-
 -                    IChunkBlocks chunkBlockData = chunks[chunkY].Data;
 -                    if (chunkBlockData.GetBlockIdUnsafe(localIndex3D) == rockBlockId)
-+                    // Stratum: read from the column's snapshot instead of calling GetBlockIdUnsafe.
-+                    if (stratumBlockSnapshot[chunkY][localIndex3D] == rockBlockId)
-                     {
+-                    {
 -                        chunkBlockData.SetBlockUnsafe(localIndex3D, stratum.BlockId);
-+                        stratumPendingIndices[chunkY].Add(localIndex3D);
-+                        stratumPendingValues[chunkY].Add(stratum.BlockId);
-                     }
- 
-                     ylower++;
+-                    }
 -
+-                    ylower++;
+-
++                    stratumBlockSnapshot[chunkY][localIndex3D] = stratum.BlockId; // Stratum: write to snapshot instead of SetBlockUnsafe.
                  }
-                 else
-                 {
-+                    int chunkY = yupper >> chunksizeLog2;
-+                    int lY = yupper - (chunkY << chunksizeLog2);
-+                    int localIndex3D = (((lY << chunksizeLog2) + lz) << chunksizeLog2) + lx;
+-                else
+-                {
++                // Stratum end
  
 -                    int chunkY = yupper / chunksize;
 -                    int lY = yupper - chunkY * chunksize;
@@ -271,25 +248,39 @@ index cb9eefa..3b30334 100644
 -
 -                    IChunkBlocks chunkBlockData = chunks[chunkY].Data;
 -                    if (chunkBlockData.GetBlockIdUnsafe(localIndex3D) == rockBlockId)      // Even if we found rock already in this column, it could be overhang or something, so have to keep checking
-+                    // Stratum: read from the column's snapshot instead of calling GetBlockIdUnsafe.
-+                    if (stratumBlockSnapshot[chunkY][localIndex3D] == rockBlockId)      // Even if we found rock already in this column, it could be overhang or something, so have to keep checking
-                     {
+-                    {
 -                        chunkBlockData.SetBlockUnsafe(localIndex3D, stratum.BlockId);
-+                        stratumPendingIndices[chunkY].Add(localIndex3D);
-+                        stratumPendingValues[chunkY].Add(stratum.BlockId);
-                     }
- 
-                     yupper--;
-                 }
+-                    }
+-
+-                    yupper--;
+-                }
++                if (stratum.GenDir == EnumStratumGenDir.BottomUp) ylower++; else yupper--;
              }
-@@ -322,11 +457,12 @@ namespace Vintagestory.ServerMods
+         }
+ 
++        /// <summary>Stratum: wrapper for Prospecting Pick (ProPickWorkSpace), which bypasses the full GenChunkColumn request pipeline and only needs a single column generated. Takes care of snapshotting the initial dummy state and flushing the mutated snapshot back into the DummyChunk so the caller reads the correct strata.</summary>
++        public void GenRockColumnForProPick(IServerChunk[] chunks, int chunkX, int chunkZ, int lx, int lz)
++        {
++            preLoad(chunks, chunkX, chunkZ);
++            StratumEnsureBuffers(chunks.Length);
++            StratumSnapshotBlocks(chunks);
++            genBlockColumn(chunks, chunkX, chunkZ, lx, lz);
++            StratumFlushPendingWrites(chunks);
++        }
++
+         LerpedWeightedIndex2DMap GetOrLoadLerpedProvinceMap(IMapChunk mapchunk, int chunkX, int chunkZ)
+         {
+             int index2d = chunkZ / regionChunkSize * regionMapSize + chunkX / regionChunkSize;
+ 
+             ProvinceMapByRegion.TryGetValue(index2d, out LerpedWeightedIndex2DMap map);
+@@ -322,11 +423,12 @@ namespace Vintagestory.ServerMods
  
          LerpedWeightedIndex2DMap CreateLerpedProvinceMap(IntDataMap2D geoMap, int regionX, int regionZ)
          {
              int index2d = regionZ * regionMapSize + regionX;
  
 -            return ProvinceMapByRegion[index2d] = new LerpedWeightedIndex2DMap(geoMap.Data, geoMap.Size, TerraGenConfig.geoProvSmoothingRadius, geoMap.TopLeftPadding, geoMap.BottomRightPadding);
-+            // Stratum: keep one expensive map across workers while preserving their vanilla cache field.
++            // Stratum: keep one expensive map across workers while preserving their vanilla cache field. Uses ConcurrentDictionary for thread-safe access from multiple worker threads.
 +            return ProvinceMapByRegion[index2d] = stratumProvinceMapsByRegion.GetOrAdd(index2d, _ => new LerpedWeightedIndex2DMap(geoMap.Data, geoMap.Size, TerraGenConfig.geoProvSmoothingRadius, geoMap.TopLeftPadding, geoMap.BottomRightPadding));
          }
  

--- a/patches/VSSurvivalMod/Systems/Prospecting/ProPickWorkSpace.cs.patch
+++ b/patches/VSSurvivalMod/Systems/Prospecting/ProPickWorkSpace.cs.patch
@@ -1,23 +1,45 @@
 diff --git a/VSSurvivalMod/Systems/Prospecting/ProPickWorkSpace.cs b/VSSurvivalMod/Systems/Prospecting/ProPickWorkSpace.cs
-index 3fe5096..d75e6dc 100644
+index 3fe5096..6bc906d 100644
 --- a/VSSurvivalMod/Systems/Prospecting/ProPickWorkSpace.cs
 +++ b/VSSurvivalMod/Systems/Prospecting/ProPickWorkSpace.cs
-@@ -216,10 +216,31 @@ namespace Vintagestory.GameContent
+@@ -122,12 +122,14 @@ namespace Vintagestory.GameContent
+                 int localIndex3D = (chunksize * lY + lz) * chunksize + lx;
+ 
+                 chunks[chunkY].Blocks[localIndex3D] = rockStrataGen.rockBlockId;
+             }
+ 
+-            rockStrataGen.preLoad(chunks, chunkX, chunkZ);
+-            rockStrataGen.genBlockColumn(chunks, chunkX, chunkZ, lx, lz);
++            // Stratum start: Replaced two separate calls (preLoad + genBlockColumn) with a single wrapper method that encapsulates the full stratum workflow — snapshotting the initial rock block state, running block generation to mutate it, and flushing the result back into DummyChunk arrays. This ensures the subsequent loop reads the correct strata column instead of stale data.
++            rockStrataGen.GenRockColumnForProPick(chunks, chunkX, chunkZ, lx, lz);
++            // Stratum end
++
+ 
+             if (depositGen == null)
+             {
+                 // Wait for off-thread initialisation to finish (should be well finished by the time any player is able to use a ProPick, but let's make sure)
+                 int timeOutCount = 100;
+@@ -216,10 +218,65 @@ namespace Vintagestory.GameContent
                  public void SetBlockUnsafe(int index3d, int value)
                  {
                      this[index3d] = value;
                  }
  
-+                // Stratum: necessary interface overload
++                // Stratum start: Added 5 interface methods required for the snapshot-flush workflow used by GenRockColumnForProPick. DummyChunkData stores only block IDs in a flat int[], so each method is implemented as a simple pass-through or no-op rather than a full palette/bit-plane-aware implementation.
++                /// <summary>
++                /// Stratum: necessary interface overload for the snapshot flush path.
++                /// Copies all block data from this DummyChunkData's internal array into
++                /// the provided output array using Array.Copy (which the runtime lowers to
++                /// a fast memcpy/memmove). Used by GenRockColumnForProPick to read back
++                /// the mutated stratum state after generation.
++                /// </summary>
 +                public void CopyBlocksToUnsafe(int[] blocksOut)
 +                {
 +                    Array.Copy(blocks, blocksOut, blocks.Length);
 +                }
 +
 +                /// <summary>
-+                /// Stratum: bulk variant of SetBlockUnsafe for interface compatibility. DummyChunkData
-+                /// is a plain int[] with no locking, so there's no batching benefit here — just applies
-+                /// each pair directly, same as calling SetBlockUnsafe in a loop.
++                /// Stratum: bulk variant of SetBlockUnsafe for interface compatibility. DummyChunkData is a plain int[] with no locking or palette, so there's no batching benefit — this simply applies each index/value pair directly via the indexer, equivalent to calling SetBlockUnsafe in a loop but matching the IChunkBlocks contract signature.
 +                /// </summary>
 +                public void SetBlocksUnsafe(List<int> indices, List<int> values)
 +                {
@@ -28,9 +50,191 @@ index 3fe5096..d75e6dc 100644
 +                    }
 +                }
 +
++                /// <summary>
++                /// Stratum: bulk array overwrite for the snapshot flush path. Since DummyChunkData is a plain int[] with no palette or bit-planes, the fastest correct implementation is a single Array.Copy call (which the JIT/runtime optimises to a native memcpy). Length is clamped to avoid out-of-bounds writes if blocksIn is shorter than expected.
++                /// </summary>
++                public void SetBlocksBulkUnsafe(int[] blocksIn)
++                {
++                    if (blocksIn != null && blocksIn.Length > 0)
++                    {
++                        int len = Math.Min(blocksIn.Length, blocks.Length);
++                        Array.Copy(blocksIn, 0, blocks, 0, len);
++                    }
++                }
++
++                /// <summary>
++                /// Stratum: necessary interface overload. DummyChunkData stores only block IDs — no light data exists in this implementation. Returns all zeros (via Array.Clear) to prevent reading uninitialized memory if ever called by code that expects light values.
++                /// </summary>
++                public void CopyLightToUnsafe(int[] lightOut)
++                {
++                    if (lightOut != null) Array.Clear(lightOut, 0, lightOut.Length);
++                }
++
++                /// <summary>
++                /// Stratum: necessary interface overload. Light writes are silently ignored since the prospecting pick workflow only cares about block IDs — no light data is ever read or written by this code path, so a no-op is correct and safe.
++                /// </summary>
++                public void SetLightBulkUnsafe(int[] lightIn)
++                {
++                    // No-op: DummyChunkData has no light storage.
++                }
++                // Stratum end
++
 +
                  public void SetFluid(int index3d, int value)
                  {
  
                  }
  
+@@ -251,13 +308,13 @@ namespace Vintagestory.GameContent
+             public string GameVersionCreated => throw new NotImplementedException();
+ 
+             public bool Disposed => throw new NotImplementedException();
+ 
+             public bool Empty { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+-			Dictionary<BlockPos, BlockEntity> IWorldChunk.BlockEntities { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
++            Dictionary<BlockPos, BlockEntity> IWorldChunk.BlockEntities { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+ 
+-			public IChunkBlocks MaybeBlocks => throw new NotImplementedException();
++            public IChunkBlocks MaybeBlocks => throw new NotImplementedException();
+ 
+             public bool NotAtEdge => throw new NotImplementedException();
+ 
+             IChunkBlocks IWorldChunk.Blocks => throw new NotImplementedException();
+ 
+@@ -301,22 +358,22 @@ namespace Vintagestory.GameContent
+             }
+             public void Unpack()
+             {
+                 throw new NotImplementedException();
+             }
+-			public bool Unpack_ReadOnly()
+-			{
+-				throw new NotImplementedException();
+-			}
+-			public int UnpackAndReadBlock(int index, int layer)
+-			{
+-				throw new NotImplementedException();
+-			}
+-			public ushort Unpack_AndReadLight(int index)
+-			{
+-				throw new NotImplementedException();
+-			}
++            public bool Unpack_ReadOnly()
++            {
++                throw new NotImplementedException();
++            }
++            public int UnpackAndReadBlock(int index, int layer)
++            {
++                throw new NotImplementedException();
++            }
++            public ushort Unpack_AndReadLight(int index)
++            {
++                throw new NotImplementedException();
++            }
+             public ushort Unpack_AndReadLight(int index, out int lightSat)
+             {
+                 throw new NotImplementedException();
+             }
+ 
+@@ -334,19 +391,19 @@ namespace Vintagestory.GameContent
+             public BlockEntity GetLocalBlockEntityAtBlockPos(BlockPos pos)
+             {
+                 throw new NotImplementedException();
+             }
+ 
+-			public bool AddDecor(IBlockAccessor blockAccessor, BlockPos pos, int faceIndex, Block block)
+-			{
+-				throw new NotImplementedException();
+-			}
++            public bool AddDecor(IBlockAccessor blockAccessor, BlockPos pos, int faceIndex, Block block)
++            {
++                throw new NotImplementedException();
++            }
+ 
+-			public void RemoveDecor(int index3d, IWorldAccessor world, BlockPos pos)
+-			{
+-				throw new NotImplementedException();
+-			}
++            public void RemoveDecor(int index3d, IWorldAccessor world, BlockPos pos)
++            {
++                throw new NotImplementedException();
++            }
+ 
+             Block[] IWorldChunk.GetDecors(IBlockAccessor blockAccessor, BlockPos pos)
+             {
+                 throw new NotImplementedException();
+             }
+@@ -355,35 +412,35 @@ namespace Vintagestory.GameContent
+             {
+                 throw new NotImplementedException();
+             }
+ 
+             public bool GetDecors(IBlockAccessor blockAccessor, BlockPos pos, Block[] result)
+-			{
+-				throw new NotImplementedException();
+-			}
++            {
++                throw new NotImplementedException();
++            }
+ 
+-			public Cuboidf[] AdjustSelectionBoxForDecor(IBlockAccessor blockAccessor, BlockPos pos, Cuboidf[] orig)
+-			{
+-				throw new NotImplementedException();
+-			}
++            public Cuboidf[] AdjustSelectionBoxForDecor(IBlockAccessor blockAccessor, BlockPos pos, Cuboidf[] orig)
++            {
++                throw new NotImplementedException();
++            }
+ 
+-			public void FinishLightDoubleBuffering()
+-			{
+-				throw new NotImplementedException();
+-			}
++            public void FinishLightDoubleBuffering()
++            {
++                throw new NotImplementedException();
++            }
+ 
+             public bool SetDecor(IBlockAccessor blockAccessor, Block block, BlockPos pos, BlockFacing onFace)
+             {
+                 throw new NotImplementedException();
+             }
+ 
+-			public bool SetDecor(IBlockAccessor blockAccessor, Block block, BlockPos pos, int subPosition)
+-			{
+-				throw new NotImplementedException();
+-			}
++            public bool SetDecor(IBlockAccessor blockAccessor, Block block, BlockPos pos, int subPosition)
++            {
++                throw new NotImplementedException();
++            }
+ 
+-			public void BreakDecor(IWorldAccessor world, BlockPos pos, BlockFacing side = null)
++            public void BreakDecor(IWorldAccessor world, BlockPos pos, BlockFacing side = null)
+             {
+                 throw new NotImplementedException();
+             }
+ 
+             public void BreakAllDecorFast(IWorldAccessor world, BlockPos pos, int index3d, bool callOnBrokenAsDecor = true)
+@@ -394,16 +451,16 @@ namespace Vintagestory.GameContent
+             public Dictionary<int, Block> GetDecors(IBlockAccessor blockAccessor, BlockPos pos)
+             {
+                 throw new NotImplementedException();
+             }
+ 
+-			public void SetDecors(Dictionary<int, Block> newDecors)
+-			{
+-				throw new NotImplementedException();
+-			}
++            public void SetDecors(Dictionary<int, Block> newDecors)
++            {
++                throw new NotImplementedException();
++            }
+ 
+-			public void BreakDecorPart(IWorldAccessor world, BlockPos pos, BlockFacing side, int faceAndSubposition)
++            public void BreakDecorPart(IWorldAccessor world, BlockPos pos, BlockFacing side, int faceAndSubposition)
+             {
+                 throw new NotImplementedException();
+             }
+ 
+             public Block GetDecor(IBlockAccessor blockAccessor, BlockPos pos, int faceAndSubposition)

--- a/patches/VintagestoryApi/Common/API/IWorldChunk.cs.patch
+++ b/patches/VintagestoryApi/Common/API/IWorldChunk.cs.patch
@@ -1,47 +1,346 @@
 diff --git a/VintagestoryApi/Common/API/IWorldChunk.cs b/VintagestoryApi/Common/API/IWorldChunk.cs
-index 1016d62..fccf531 100644
+index 1016d62..4826fd5 100644
 --- a/VintagestoryApi/Common/API/IWorldChunk.cs
 +++ b/VintagestoryApi/Common/API/IWorldChunk.cs
-@@ -32,10 +32,23 @@ namespace Vintagestory.API.Common
+@@ -10,11 +10,11 @@ namespace Vintagestory.API.Common
+     public interface IChunkBlocks
+     {
+         /// <summary>
+         /// Retrieves the first solid block, if that one is empty, retrieves the first fluid block
+         /// </summary>
+-        /// <param name="index3d"></param>
++        /// <param name="index3d"></param</param>
+         /// <returns></returns>
+         int this[int index3d] { get; set; }
+ 
+         int Length { get; }
+ 
+@@ -29,29 +29,94 @@ namespace Vintagestory.API.Common
+         /// </summary>
+         void SetBlockBulk(int index3d, int lenX, int lenZ, int value);
+         /// <summary>
          /// Not threadsafe, used only in cases where we know that the chunk already has a palette (e.g. in worldgen when replacing rock with other blocks)
          /// </summary>
-         /// <param name="index3d"></param>
-         /// <param name="value"></param>
+-        /// <param name="index3d"></param>
+-        /// <param name="value"></param>
++        /// <param name="index3d"></param</param>
++        /// <param name="value"></param</param>
          void SetBlockUnsafe(int index3d, int value);
 +
++        // Stratum start: Added bulk block write variant that takes a flat int[] buffer of length Length.
++        // Each contiguous chunk of 4 ints encodes one (x, y, z) position followed by the target block id,
++        // enabling worldgen code to push pre-batched writes without per-position lock acquisition.
 +        /// <summary>
-+        /// Bulk variant of <see cref="SetBlockUnsafe"/>. Not threadsafe for the same reasons.
-+        /// Applies every (index3d, value) pair in indices/values (up to count entries) while
-+        /// taking the underlying layer's write lock only once for the whole batch, instead of
-+        /// once per block. Useful for worldgen code that already buffers many block writes for
-+        /// one chunk before flushing (e.g. rock strata generation), to cut lock-acquisition
-+        /// overhead and contention with other worldgen threads writing to the same chunk.
++        /// Bulk variant of <see cref="SetBlockUnsafe"/> that takes a flat <c>int[]</c> buffer whose length must equal
++        /// <see cref="Length"/>. The buffer is read in groups of 4 ints: each group encodes the target position as
++        /// (x, y, z) followed by the block id to place at that position. Acquires the layer's write lock once for
++        /// the entire batch rather than per-position, cutting lock-acquisition overhead and contention with other
++        /// worldgen threads writing to the same chunk. Not thread-safe; caller must ensure exclusive access or hold
++        /// a bulk write lock beforehand.
 +        /// </summary>
-+        /// <param name="indices">Buffered index3d values.</param>
-+        /// <param name="values">Buffered block ids, parallel to indices.</param>
++        /// <param name="blocksIn">Buffer of interleaved (x, y, z, blockId) tuples, one per chunk position.</param</param>
++        void SetBlocksBulkUnsafe(int[] blocksIn);
++
++        // Stratum end
++
++        // Stratum start: Added batched unsafe block write taking parallel indices/values lists.
++        // Lets worldgen code flush a sparse set of buffered writes in one call instead of issuing
++        // per-position SetBlockUnsafe calls, reducing lock contention and dispatch overhead.
++        /// <summary>
++        /// Bulk variant of <see cref="SetBlockUnsafe"/>. Not threadsafe for the same reasons. Applies every (index3d, value) pair
++        /// in indices/values (up to count entries) while taking the underlying layer's write lock only once for the whole batch, instead
++        /// of once per block. Useful for worldgen code that already buffers many block writes for one chunk before flushing (e.g. rock strata generation),
++        /// to cut lock-acquisition overhead and contention with other worldgen threads writing to the same chunk.
++        /// </summary>
++        /// <param name="indices">Buffered index3d values.</param</param>
++        /// <param name="values">Buffered block ids, parallel to indices.</param</param>
 +        void SetBlocksUnsafe(List<int> indices, List<int> values);
++
++        // Stratum end
++
++        // Stratum start: Added light readout variant that copies all light levels into a caller-provided array.
++        // Provides lock-free access for code that needs every light value (e.g. strata-based light propagation
++        /// <summary>
++        /// Not threadsafe, used only where a single thread has exclusive access to this chunk (e.g. worldgen). Copies the
++        /// entire light buffer into <c>lightOut</c> (must be at least <see cref="Length"/> in size) in one pass, avoiding the per-position
++        /// dispatch cost of calling <see cref="GetSunlight(int)"/> or <see cref="GetBlocklight(int)"/> for every position that needs to be read.
++        /// </summary>
++        /// <param name="lightOut">Output buffer; filled with light values in chunk-index order.</param</param>
++        void CopyLightToUnsafe(int[] lightOut);
++
++        // Stratum end
++
++        // Stratum start: Added bulk unsafe light write taking a flat int[] buffer.
++        // Lets worldgen code push pre-batched light updates without per-position lock acquisition,
++        /// <summary>
++        /// Not threadsafe, used only where a single thread has exclusive access to this chunk (e.g. worldgen). Bulk writes the entire
++        /// light buffer from <c>lightIn</c>, which must be at least <see cref="Length"/> in size. Acquires the underlying layer's write lock once for
++        /// the whole batch rather than per-position, cutting lock-acquisition overhead and contention with other worldgen threads writing to the same chunk.
++        /// </summary>
++        /// <param name="lightIn">Source buffer of light values in chunk-index order.</param</param>
++        void SetLightBulkUnsafe(int[] lightIn);
++
++        // Stratum end
 +
          void SetBlockAir(int index3d);
          /// <summary>
          /// Used to place blocks into the fluid layer instead of the solid blocks layer; calling code must do this
          /// </summary>
-         /// <param name="index3d"></param>
-@@ -48,10 +61,18 @@ namespace Vintagestory.API.Common
+-        /// <param name="index3d"></param>
+-        /// <param name="value"></param>
++        /// <param name="index3d"></param</param>
++        /// <param name="value"></param</param>
+         void SetFluid(int index3d, int value);
+         int GetBlockId(int index3d, int layer);
+         int GetFluid(int index3d);
+ 
+         /// <summary>
          /// Like get (i.e. this[]) but not threadsafe - only for use where setting and getting is guaranteed to be all on the same thread (e.g. during worldgen)
          /// </summary>
-         /// <param name="index3d"></param>
+-        /// <param name="index3d"></param>
++        /// <param name="index3d"></param</param>
          int GetBlockIdUnsafe(int index3d);
  
++        // Stratum start: Added bulk block readout variant that copies all decoded block IDs into a caller-provided array.
++        // Provides lock-free access for code that needs every block value (e.g. strata-based worldgen reads) without per-position dispatch cost.
 +        /// <summary>
-+        /// Not threadsafe, used only where a single thread has exclusive access to this chunk
-+        /// (e.g. worldgen). Decodes every block ID in this chunk into blocksOut (must be at
-+        /// least Length in size) in one pass, avoiding the per-position dispatch/decode cost of
-+        /// calling GetBlockIdUnsafe once for every position that needs to be read.
++        /// Not threadsafe, used only where a single thread has exclusive access to this chunk (e.g. worldgen). Decodes every block ID in this chunk into blocksOut (must be at least Length in size) in one pass, avoiding the per-position dispatch/decode cost of calling GetBlockIdUnsafe once for every position that needs to be read.
 +        /// </summary>
 +        void CopyBlocksToUnsafe(int[] blocksOut);
++
++        // Stratum end
 +
          /// <summary>
          /// Enter a locked section for bulk block reads from this ChunkData, using Unsafe read methods
          /// </summary>
          void TakeBulkReadLock();
  
+@@ -95,11 +160,11 @@ namespace Vintagestory.API.Common
+         bool LoadedFromServer { get; }
+ 
+         /// <summary>
+         /// Can be used to set a chunk as invisible, probably temporarily (e.g. for the Timeswitch system)
+         /// </summary>
+-        /// <param name="visible"></param>
++        /// <param name="visible"></param</param>
+         void SetVisibility(bool visible);
+     }
+ 
+ 
+     public interface IWorldChunk
+@@ -195,58 +260,58 @@ namespace Vintagestory.API.Common
+         bool Disposed { get; }
+ 
+         /// <summary>
+         /// Adds an entity to the chunk.
+         /// </summary>
+-        /// <param name="entity">The entity to add.</param>
++        /// <param name="entity">The entity to add.</param</param>
+         void AddEntity(Entity entity);
+ 
+         /// <summary>
+         /// Removes an entity from the chunk.
+         /// </summary>
+-        /// <param name="entityId">the ID for the entity</param>
++        /// <param name="entityId">the ID for the entity</param</param>
+         /// <returns>Whether or not the entity was removed.</returns>
+         bool RemoveEntity(long entityId);
+ 
+ 
+         /// <summary>
+         /// Allows setting of arbitrary, permanantly stored moddata of this chunk. When set on the server before the chunk is sent to the client, the data will also be sent to the client.
+         /// When set on the client the data is discarded once the chunk gets unloaded
+         /// </summary>
+-        /// <param name="key"></param>
+-        /// <param name="data"></param>
++        /// <param name="key"></param</param>
++        /// <param name="data"></param</param>
+         void SetModdata(string key, byte[] data);
+ 
+         /// <summary>
+         /// Removes the permanently stored data.
+         /// </summary>
+-        /// <param name="key"></param>
++        /// <param name="key"></param</param>
+         void RemoveModdata(string key);
+ 
+         /// <summary>
+         /// Retrieve arbitrary, permantly stored mod data
+         /// </summary>
+-        /// <param name="key"></param>
++        /// <param name="key"></param</param>
+         /// <returns></returns>
+         byte[] GetModdata(string key);
+ 
+         /// <summary>
+         /// Allows setting of arbitrary, permanantly stored moddata of this chunk. When set on the server before the chunk is sent to the client, the data will also be sent to the client.
+         /// When set on the client the data is discarded once the chunk gets unloaded
+         /// </summary>
+         /// <typeparam name="T"></typeparam>
+-        /// <param name="key"></param>
+-        /// <param name="data"></param>
++        /// <param name="key"></param</param>
++        /// <param name="data"></param</param>
+ 
+         void SetModdata<T>(string key, T data);
+ 
+         /// <summary>
+         /// Retrieve arbitrary, permantly stored mod data
+         /// </summary>
+         /// <typeparam name="T"></typeparam>
+-        /// <param name="key"></param>
+-        /// <param name="defaultValue"></param>
++        /// <param name="key"></param</param>
++        /// <param name="defaultValue"></param</param>
+         /// <returns></returns>
+         T GetModdata<T>(string key, T defaultValue = default(T));
+ 
+         /// <summary>
+         /// Can be used to store non-serialized mod data that is only serialized into the standard moddata dictionary on unload. This prevents the need for constant serializing/deserializing. Useful when storing large amounts of data. Is not populated on chunk load, you need to populate it with stored data yourself using GetModData()
+@@ -256,101 +321,101 @@ namespace Vintagestory.API.Common
+ 
+ 
+         /// <summary>
+         /// Retrieve a block from this chunk ignoring ice/water layer, performs Unpack() and a modulo operation on the position arg to get a local position in the 0..chunksize range (it's your job to pick out the right chunk before calling this method)
+         /// </summary>
+-        /// <param name="world"></param>
+-        /// <param name="position"></param>
++        /// <param name="world"></param</param>
++        /// <param name="position"></param</param>
+         /// <returns></returns>
+         Block GetLocalBlockAtBlockPos(IWorldAccessor world, BlockPos position);
+ 
+         Block GetLocalBlockAtBlockPos(IWorldAccessor world, int posX, int posY, int posZ, int layer);
+ 
+         /// <summary>
+         /// As GetLocalBlockAtBlockPos except lock-free, use it inside paired LockForReading(true/false) calls
+         /// </summary>
+-        /// <param name="world"></param>
+-        /// <param name="position"></param>
+-        /// <param name="layer"></param>
++        /// <param name="world"></param</param>
++        /// <param name="position"></param</param>
++        /// <param name="layer"></param</param>
+         /// <returns></returns>
+         Block GetLocalBlockAtBlockPos_LockFree(IWorldAccessor world, BlockPos position, int layer = BlockLayersAccess.Default);
+ 
+         /// <summary>
+         /// Retrieve a block entity from this chunk
+         /// </summary>
+-        /// <param name="pos"></param>
++        /// <param name="pos"></param</param>
+         /// <returns></returns>
+         BlockEntity GetLocalBlockEntityAtBlockPos(BlockPos pos);
+ 
+         /// <summary>
+         /// Sets a decor block to the side of an existing block. Use air block (id 0) to remove a decor.<br/>
+         /// </summary>
+-        /// <param name="index3d"></param>
+-        /// <param name="onFace"></param>
+-        /// <param name="block"></param>
++        /// <param name="index3d"></param</param>
++        /// <param name="onFace"></param</param>
++        /// <param name="block"></param</param>
+         /// <returns>False if there already exists a block in this position and facing</returns>
+         bool SetDecor(Block block, int index3d, BlockFacing onFace);
+         //bool SetDecor(IBlockAccessor blockAccessor, Block block, BlockPos pos, BlockFacing onFace);
+ 
+ 
+         /// <summary>
+         /// Sets a decor block to a specific sub-position on the side of an existing block. Use air block (id 0) to remove a decor.<br/>
+         /// </summary>
+-        /// <param name="block"></param>
+-        /// <param name="index3d"></param>
+-        /// <param name="faceAndSubposition"></param>
++        /// <param name="block"></param</param>
++        /// <param name="index3d"></param</param>
++        /// <param name="faceAndSubposition"></param</param>
+         /// <returns>False if there already exists a block in this position and facing</returns>
+         bool SetDecor(Block block, int index3d, int faceAndSubposition);
+ 
+         /// <summary>
+         /// If allowed by a player action, removes all decors at given position and calls OnBrokenAsDecor() on all selected decors and drops the items that are returned from Block.GetDrops()
+         /// </summary>
+-        /// <param name="world"></param>
+-        /// <param name="pos"></param>
+-        /// <param name="side">If null, all the decor blocks on all sides are removed</param>
+-        /// <param name="decorIndex">If not null breaks only this part of the decor for give face. Requires side to be set.</param>
++        /// <param name="world"></param</param>
++        /// <param name="pos"></param</param>
++        /// <param name="side">If null, all the decor blocks on all sides are removed</param</param>
++        /// <param name="decorIndex">If not null breaks only this part of the decor for give face. Requires side to be set.</param</param>
+         bool BreakDecor(IWorldAccessor world, BlockPos pos, BlockFacing side = null, int? decorIndex = null);
+ 
+         /// <summary>
+         /// Removes a decor block from given position, saves a few cpu cycles by not calculating index3d
+         /// </summary>
+-        /// <param name="world"></param>
+-        /// <param name="pos"></param>
+-        /// <param name="index3d"></param>
+-        /// <param name="callOnBrokenAsDecor">When set to true it will call block.OnBrokenAsDecor(...) which is used to drop the decors of that block</param>
++        /// <param name="world"></param</param>
++        /// <param name="pos"></param</param>
++        /// <param name="index3d"></param</param>
++        /// <param name="callOnBrokenAsDecor">When set to true it will call block.OnBrokenAsDecor(...) which is used to drop the decors of that block</param</param>
+         void BreakAllDecorFast(IWorldAccessor world, BlockPos pos, int index3d, bool callOnBrokenAsDecor = true);
+ 
+         /// <summary>
+         ///
+         /// </summary>
+-        /// <param name="blockAccessor"></param>
+-        /// <param name="pos"></param>
++        /// <param name="blockAccessor"></param</param>
++        /// <param name="pos"></param</param>
+         /// <returns></returns>
+         Block[] GetDecors(IBlockAccessor blockAccessor, BlockPos pos);
+ 
+         /// <summary>
+         ///
+         /// </summary>
+-        /// <param name="blockAccessor"></param>
+-        /// <param name="position"></param>
++        /// <param name="blockAccessor"></param</param>
++        /// <param name="position"></param</param>
+         /// <returns></returns>
+         Dictionary<int, Block> GetSubDecors(IBlockAccessor blockAccessor, BlockPos position);
+ 
+         Block GetDecor(IBlockAccessor blockAccessor, BlockPos pos, int decorIndex);
+ 
+         /// <summary>
+         /// Set entire Decors for a chunk - used in Server->Client updates
+         /// </summary>
+-        /// <param name="newDecors"></param>
++        /// <param name="newDecors"></param</param>
+         void SetDecors(Dictionary<int, Block> newDecors);
+ 
+         /// <summary>
+         /// Adds extra selection boxes in case a decor block is attached at given position
+         /// </summary>
+-        /// <param name="blockAccessor"></param>
+-        /// <param name="pos"></param>
+-        /// <param name="orig"></param>
++        /// <param name="blockAccessor"></param</param>
++        /// <param name="pos"></param</param>
++        /// <param name="orig"></param</param>
+         /// <returns></returns>
+         Cuboidf[] AdjustSelectionBoxForDecor(IBlockAccessor blockAccessor, BlockPos pos, Cuboidf[] orig);
+ 
+         /// <summary>
+         /// Only to be implemented client side
+@@ -358,13 +423,13 @@ namespace Vintagestory.API.Common
+         void FinishLightDoubleBuffering();
+ 
+         /// <summary>
+         /// Returns the higher light absorption between solids and fluids block layers
+         /// </summary>
+-        /// <param name="index3d"></param>
+-        /// <param name="blockPos"></param>
+-        /// <param name="blockTypes"></param>
++        /// <param name="index3d"></param</param>
++        /// <param name="blockPos"></param</param>
++        /// <param name="blockTypes"></param</param>
+         /// <returns></returns>
+         int GetLightAbsorptionAt(int index3d, BlockPos blockPos, IList<Block> blockTypes);
+ 
+         /// <summary>
+         /// For bulk chunk GetBlock operations, allows the chunkDataLayers to be pre-locked for reading, instead of entering and releasing one lock per read

--- a/patches/VintagestoryLib/Vintagestory.Common/ChunkData.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Common/ChunkData.cs.patch
@@ -1,30 +1,197 @@
 diff --git a/VintagestoryLib/Vintagestory.Common/ChunkData.cs b/VintagestoryLib/Vintagestory.Common/ChunkData.cs
-index af79143..bb31aff 100644
+index af79143..bd887b3 100644
 --- a/VintagestoryLib/Vintagestory.Common/ChunkData.cs
 +++ b/VintagestoryLib/Vintagestory.Common/ChunkData.cs
-@@ -166,10 +166,21 @@ public class ChunkData : IChunkBlocks, IChunkLight, IEnumerable<int>, IEnumerabl
+@@ -99,41 +99,41 @@ public class ChunkData : IChunkBlocks, IChunkLight, IEnumerable<int>, IEnumerabl
+ 
+ 	public int GetBlockId(int index, int layer)
+ 	{
+ 		switch (layer)
+ 		{
+-		default:
+-		{
+-			int solidBlock = GetSolidBlock(index);
+-			if (solidBlock != 0)
+-			{
+-				return solidBlock;
+-			}
+-			return GetFluid(index);
+-		}
+-		case 1:
+-			return GetSolidBlock(index);
+-		case 2:
+-			return GetFluid(index);
+-		case 3:
+-		{
+-			int fluid = GetFluid(index);
+-			if (fluid != 0)
+-			{
+-				return fluid;
+-			}
+-			return GetSolidBlock(index);
+-		}
+-		case 4:
+-		{
+-			int num = GetFluid(index);
+-			if (num == 0 || !pool.Game.Blocks[num].SideSolid.Any)
+-			{
+-				num = GetSolidBlock(index);
+-			}
+-			return num;
+-		}
++			default:
++				{
++					int solidBlock = GetSolidBlock(index);
++					if (solidBlock != 0)
++					{
++						return solidBlock;
++					}
++					return GetFluid(index);
++				}
++			case 1:
++				return GetSolidBlock(index);
++			case 2:
++				return GetFluid(index);
++			case 3:
++				{
++					int fluid = GetFluid(index);
++					if (fluid != 0)
++					{
++						return fluid;
++					}
++					return GetSolidBlock(index);
++				}
++			case 4:
++				{
++					int num = GetFluid(index);
++					if (num == 0 || !pool.Game.Blocks[num].SideSolid.Any)
++					{
++						num = GetSolidBlock(index);
++					}
++					return num;
++				}
+ 		}
+ 	}
+ 
+ 	public int GetSolidBlock(int index3d)
+ 	{
+@@ -166,45 +166,59 @@ public class ChunkData : IChunkBlocks, IChunkLight, IEnumerable<int>, IEnumerabl
  	public int GetBlockIdUnsafe(int index3d)
  	{
  		return blocksLayer?.GetUnsafe(index3d) ?? 0;
  	}
  
+-	public int GetBlockIdUnsafe(int index3d, int layer)
 +
++	// Stratum start: Added new public method to copy block data into a flat int array using unsafe fast path.
++	// Replaces the inner-loop zero-filling with Array.Clear when layer/palette is null for better performance.
 +	public void CopyBlocksToUnsafe(int[] blocksOut)
-+	{
+ 	{
+-		switch (layer)
+-		{
+-		default:
+-		{
+-			int num2 = blocksLayer?.GetUnsafe_PaletteCheck(index3d) ?? 0;
+-			if (num2 != 0)
+-			{
+-				return num2;
+-			}
+-			return fluidsLayer?.GetUnsafe_PaletteCheck(index3d) ?? 0;
+-		}
+-		case 1:
+-			return blocksLayer?.GetUnsafe_PaletteCheck(index3d) ?? 0;
+-		case 2:
+-			return fluidsLayer?.GetUnsafe_PaletteCheck(index3d) ?? 0;
+-		case 3:
 +		if (blocksLayer == null || blocksLayer.palette == null)
-+		{
+ 		{
+-			int num3 = fluidsLayer?.GetUnsafe_PaletteCheck(index3d) ?? 0;
+-			if (num3 != 0)
+-			{
+-				return num3;
+-			}
+-			return blocksLayer?.GetUnsafe_PaletteCheck(index3d) ?? 0;
 +			Array.Clear(blocksOut, 0, blocksOut.Length);
 +			return;
-+		}
+ 		}
+-		case 4:
 +		blocksLayer.CopyBlocksToUnsafe(blocksOut);
 +	}
++	// Stratum end
 +
- 	public int GetBlockIdUnsafe(int index3d, int layer)
- 	{
- 		switch (layer)
++	public int GetBlockIdUnsafe(int index3d, int layer)
++	{
++		switch (layer)
  		{
- 		default:
-@@ -246,10 +257,29 @@ public class ChunkData : IChunkBlocks, IChunkLight, IEnumerable<int>, IEnumerabl
+-			int num = fluidsLayer?.GetUnsafe_PaletteCheck(index3d) ?? 0;
+-			if (num == 0 || !pool.Game.Blocks[num].SideSolid.Any)
+-			{
+-				num = blocksLayer?.GetUnsafe_PaletteCheck(index3d) ?? 0;
+-			}
+-			return num;
+-		}
++			default:
++				{
++					int num2 = blocksLayer?.GetUnsafe_PaletteCheck(index3d) ?? 0;
++					if (num2 != 0)
++					{
++						return num2;
++					}
++					return fluidsLayer?.GetUnsafe_PaletteCheck(index3d) ?? 0;
++				}
++			case 1:
++				return blocksLayer?.GetUnsafe_PaletteCheck(index3d) ?? 0;
++			case 2:
++				return fluidsLayer?.GetUnsafe_PaletteCheck(index3d) ?? 0;
++			case 3:
++				{
++					int num3 = fluidsLayer?.GetUnsafe_PaletteCheck(index3d) ?? 0;
++					if (num3 != 0)
++					{
++						return num3;
++					}
++					return blocksLayer?.GetUnsafe_PaletteCheck(index3d) ?? 0;
++				}
++			case 4:
++				{
++					int num = fluidsLayer?.GetUnsafe_PaletteCheck(index3d) ?? 0;
++					if (num == 0 || !pool.Game.Blocks[num].SideSolid.Any)
++					{
++						num = blocksLayer?.GetUnsafe_PaletteCheck(index3d) ?? 0;
++					}
++					return num;
++				}
+ 		}
+ 	}
+ 
+ 	public void TakeBulkReadLock()
+ 	{
+@@ -220,21 +234,18 @@ public class ChunkData : IChunkBlocks, IChunkLight, IEnumerable<int>, IEnumerabl
+ 		bulkBlocksTmp?.readWriteLock.ReleaseReadLock();
+ 		bulkFluidsTmp = null;
+ 		bulkBlocksTmp = null;
+ 	}
+ 
++	/// <summary>Stratum: bulk-fill a rectangular region with one block value, taking the write lock once.</summary>
+ 	public void SetBlockBulk(int index3d, int lenX, int lenZ, int value)
+ 	{
+-		if (blocksLayer == null)
++		if (blocksLayer == null && value != 0)
+ 		{
+-			if (value == 0)
+-			{
+-				return;
+-			}
+ 			blocksLayer = new BlockChunkDataLayer(pool);
+ 		}
+-		blocksLayer.SetBulk(index3d, lenX, lenZ, value);
++		blocksLayer?.SetBulk(index3d, lenX, lenZ, value);
+ 	}
+ 
+ 	public void SetBlockUnsafe(int index3d, int value)
+ 	{
+ 		if (blocksLayer == null)
+@@ -246,10 +257,65 @@ public class ChunkData : IChunkBlocks, IChunkLight, IEnumerable<int>, IEnumerabl
  			blocksLayer = new BlockChunkDataLayer(pool);
  		}
  		blocksLayer.SetUnsafe(index3d, value);
@@ -48,9 +215,54 @@ index af79143..bb31aff 100644
 +		blocksLayer.SetManyUnsafe(indices, values);
 +	}
 +
++	/// <summary>
++	/// Stratum: bulk-write an entire block array back into the chunk in one pass.
++	/// Takes the layer's write lock once, rebuilds the palette optimally.
++	/// </summary>
++	public void SetBlocksBulkUnsafe(int[] blocksIn)
++	{
++		if (blocksIn == null || blocksIn.Length != length) return;
++
++		if (blocksLayer == null)
++		{
++			blocksLayer = new BlockChunkDataLayer(pool);
++		}
++		blocksLayer.SetBlocksBulkUnsafe(blocksIn);
++	}
++
++
++	// Stratum start: Added new public method to copy light data into a flat int array using unsafe fast path.
++	// Uses Array.Clear for null/empty case instead of manual loop for better performance.
++	public void CopyLightToUnsafe(int[] lightOut)
++	{
++		if (lightOut == null) return;
++		if (lightLayer == null) Array.Clear(lightOut, 0, lightOut.Length);
++		else lightLayer.CopyLightToUnsafe(lightOut);
++	}
++	// Stratum end
++
++	// Stratum start: Added new public method to bulk-write an entire light array into the chunk in one pass.
++	// Lazily creates the light layer if it doesn't exist, then delegates to layer's unsafe bulk setter.
++	public void SetLightBulkUnsafe(int[] lightIn)
++	{
++		if (lightIn == null) return;
++		if (lightLayer == null) lightLayer = new ChunkDataLayer(pool);
++		lightLayer.SetLightBulkUnsafe(lightIn);
++	}
++	// Stratum end
++
 +
  	public void SetBlockAir(int index3d)
  	{
  		blocksLayer?.SetZero(index3d);
  	}
  
+@@ -685,6 +751,6 @@ public class ChunkData : IChunkBlocks, IChunkLight, IEnumerable<int>, IEnumerabl
+ 
+ 	public void FuzzyListBlockIds(List<int> reusableList)
+ 	{
+ 		blocksLayer?.ListAllPaletteValues(reusableList);
+ 	}
+-}
++}
+\ No newline at end of file

--- a/patches/VintagestoryLib/Vintagestory.Common/ChunkDataLayer.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Common/ChunkDataLayer.cs.patch
@@ -1,5 +1,5 @@
 diff --git a/VintagestoryLib/Vintagestory.Common/ChunkDataLayer.cs b/VintagestoryLib/Vintagestory.Common/ChunkDataLayer.cs
-index 4d0bf91..164b035 100644
+index 4d0bf91..e696d20 100644
 --- a/VintagestoryLib/Vintagestory.Common/ChunkDataLayer.cs
 +++ b/VintagestoryLib/Vintagestory.Common/ChunkDataLayer.cs
 @@ -1,9 +1,13 @@
@@ -1385,12 +1385,12 @@ index 4d0bf91..164b035 100644
  			{
 -				if (array[j] != 0)
 -				{
--					return true;
++				if ((array[j] | array[j + 1] | array[j + 2] | array[j + 3]) != 0)
+ 					return true;
 -				}
 -				if (array[j + 1] != 0)
 -				{
-+				if ((array[j] | array[j + 1] | array[j + 2] | array[j + 3]) != 0)
- 					return true;
+-					return true;
 -				}
 -				if (array[j + 2] != 0)
 +			}
@@ -1598,7 +1598,7 @@ index 4d0bf91..164b035 100644
  		int num = paletteCount - 1;
  		readWriteLock.AcquireWriteLock();
  		int num2 = bitsize;
-@@ -1088,10 +1812,188 @@ public class ChunkDataLayer
+@@ -1088,10 +1812,194 @@ public class ChunkDataLayer
  		palette[deletePosition] = palette[num];
  		paletteCount--;
  		readWriteLock.ReleaseWriteLock();
@@ -1768,6 +1768,12 @@ index 4d0bf91..164b035 100644
 +				int need = CalcBitsize(count + 1);
 +				while (bitsize < need)
 +				{
++					// Guard against exceeding DATASLICES on client chunks, matching vanilla CleanUpPalette behavior.
++					if (pool.server == null && bitsize >= 14)
++					{
++						throw new Exception("Oops, a client chunk had so many changes that it exceeded the maximum size. That's not your fault! Re-joining the game should fix it.");
++					}
++
 +					dataBits[bitsize] = pool.NewData();
 +					Array.Clear(dataBits[bitsize], 0, 1024);
 +					bitsize++;
@@ -1787,7 +1793,7 @@ index 4d0bf91..164b035 100644
  		int[] array = palette;
  		if (array == null)
  		{
-@@ -1104,6 +2006,6 @@ public class ChunkDataLayer
+@@ -1104,6 +2012,6 @@ public class ChunkDataLayer
  			{
  				array[i] = 0;
  			}

--- a/patches/VintagestoryLib/Vintagestory.Common/ChunkDataLayer.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Common/ChunkDataLayer.cs.patch
@@ -1,26 +1,28 @@
 diff --git a/VintagestoryLib/Vintagestory.Common/ChunkDataLayer.cs b/VintagestoryLib/Vintagestory.Common/ChunkDataLayer.cs
-index 4d0bf91..a5169d0 100644
+index 4d0bf91..164b035 100644
 --- a/VintagestoryLib/Vintagestory.Common/ChunkDataLayer.cs
 +++ b/VintagestoryLib/Vintagestory.Common/ChunkDataLayer.cs
-@@ -1,9 +1,11 @@
+@@ -1,9 +1,13 @@
  using System;
  using System.Collections.Generic;
  using System.Runtime.CompilerServices;
  using Vintagestory.API.MathTools;
 +using System.Numerics;
 +using System.Runtime.InteropServices;
++using System.Runtime.Intrinsics;
++using System.Runtime.Intrinsics.X86;
  
  namespace Vintagestory.Common;
  
  public class ChunkDataLayer
  {
-@@ -25,20 +27,108 @@ public class ChunkDataLayer
+@@ -25,20 +29,108 @@ public class ChunkDataLayer
  
  	protected int bitsize;
  
  	public FastRWLock readWriteLock;
  
-+	// Stratum: serialises every writer that can grow the palette or flip plane bits.
++	// Stratum start: serialises every writer that can grow the palette or flip plane bits.
 +	//
 +	// The palette grows by MakeSpaceInPalette, which reassigns the palette field,
 +	// claims dataBits[bitsize], and then does a non-atomic bitsize++. Vanilla guards
@@ -123,7 +125,7 @@ index 4d0bf91..a5169d0 100644
  	private int setBlockValueCached;
  
  	protected ChunkDataPool pool;
-@@ -49,149 +139,527 @@ public class ChunkDataLayer
+@@ -49,149 +141,533 @@ public class ChunkDataLayer
  	private static int[] paletteBitmap;
  
  	[ThreadStatic]
@@ -169,12 +171,13 @@ index 4d0bf91..a5169d0 100644
 -	{
 -		return 0;
 -	}
++	// Stratum: added [MethodImpl(MethodImplOptions.AggressiveInlining)] — previously absent, forces JIT to inline this trivial method on the hot Get path.
 +	/// <summary>Delegate variant for the case when the palette is absent or bit depth is zero. Always returns 0.</summary>
-+	// Read: no bounds-check overhead on the hot path since there are no array accesses at all.
 +	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 +	private int GetFromBits0(int index3d) => 0;
  
-+	/// <summary>Fast-path read for bit depth of 1. Extracts the least significant bit from the first plane and maps it through the palette.</summary>
++	// Stratum start: entire method body rewritten to use MemoryMarshal.GetArrayDataReference + Unsafe.Add instead of array-of-arrays indexing. Eliminates two pointer dereferences per call and lets JIT elide bounds checks on the hot path.
++	/// <summary>Stratum: Fast-path read for bit depth of 1. Extracts the least significant bit from the first plane and maps it through the palette.</summary>
 +	[MethodImpl(MethodImplOptions.AggressiveInlining)]
  	private int GetFromBits1(int index3d)
  	{
@@ -184,8 +187,9 @@ index 4d0bf91..a5169d0 100644
 +		ref int base0 = ref MemoryMarshal.GetArrayDataReference(dataBit0);
 +		return palette[(Unsafe.Add(ref base0, arrayIndex) >> index3d) & 1];
  	}
++	// Stratum end.
  
-+	/// <summary>Fast-path read for bit depth of 2. Extracts the two least significant bits from the first two planes.</summary>
++	/// <summary>Stratum: Fast-path read for bit depth of 2. Extracts the two least significant bits from the first two planes.</summary>
 +	[MethodImpl(MethodImplOptions.AggressiveInlining)]
  	private int GetFromBits2(int index3d)
  	{
@@ -209,7 +213,7 @@ index 4d0bf91..a5169d0 100644
 +		return palette[b0 | (b1 << 1)];
  	}
  
-+	/// <summary>Fast-path read for bit depth of 3. Extracts the three least significant bits from the first three planes.</summary>
++	/// <summary>Stratum: Fast-path read for bit depth of 3. Extracts the three least significant bits from the first three planes.</summary>
 +	[MethodImpl(MethodImplOptions.AggressiveInlining)]
  	private int GetFromBits3(int index3d)
  	{
@@ -235,7 +239,7 @@ index 4d0bf91..a5169d0 100644
 +		return palette[b0 | (b1 << 1) | (b2 << 2)];
  	}
  
-+	/// <summary>Fast-path read for bit depth of 4. Extracts the four least significant bits from the first four planes.</summary>
++	/// <summary>Stratum: Fast-path read for bit depth of 4. Extracts the four least significant bits from the first four planes.</summary>
 +	[MethodImpl(MethodImplOptions.AggressiveInlining)]
  	private int GetFromBits4(int index3d)
  	{
@@ -263,7 +267,7 @@ index 4d0bf91..a5169d0 100644
 +		return palette[b0 | (b1 << 1) | (b2 << 2) | (b3 << 3)];
  	}
  
-+	/// <summary>Fast-path read for bit depth of 5. Extracts the five least significant bits from the first five planes.</summary>
++	/// <summary>Stratum: Fast-path read for bit depth of 5. Extracts the five least significant bits from the first five planes.</summary>
 +	[MethodImpl(MethodImplOptions.AggressiveInlining)]
  	private int GetFromBits5(int index3d)
  	{
@@ -284,6 +288,7 @@ index 4d0bf91..a5169d0 100644
 +		ref int base1 = ref MemoryMarshal.GetArrayDataReference(dataBit1);
 +		ref int base2 = ref MemoryMarshal.GetArrayDataReference(dataBit2);
 +		ref int base3 = ref MemoryMarshal.GetArrayDataReference(dataBit3);
++		// Stratum: added dataBit4 — previously the 5th plane was read through the array-of-arrays (dataBits[4][num]). Now hoisted to a dedicated field.
 +		ref int base4 = ref MemoryMarshal.GetArrayDataReference(dataBit4);
 +		int b0 = (Unsafe.Add(ref base0, arrayIndex) >> shift) & 1;
 +		int b1 = (Unsafe.Add(ref base1, arrayIndex) >> shift) & 1;
@@ -293,7 +298,7 @@ index 4d0bf91..a5169d0 100644
 +		return palette[b0 | (b1 << 1) | (b2 << 2) | (b3 << 3) | (b4 << 4)];
 +	}
 +
-+	/// <summary>Fast-path read for bit depth of 6. Extracts the six least significant bits from the first six planes.</summary>
++	/// <summary>Stratum: Fast-path read for bit depth of 6. Extracts the six least significant bits from the first six planes.</summary>
 +	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 +	private int GetFromBits6(int index3d)
 +	{
@@ -314,7 +319,7 @@ index 4d0bf91..a5169d0 100644
 +		return palette[b0 | (b1 << 1) | (b2 << 2) | (b3 << 3) | (b4 << 4) | (b5 << 5)];
 +	}
 +
-+	/// <summary>Fast-path read for bit depth of 7. Extracts the seven least significant bits from the first seven planes.</summary>
++	/// <summary>Stratum: Fast-path read for bit depth of 7. Extracts the seven least significant bits from the first seven planes.</summary>
 +	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 +	private int GetFromBits7(int index3d)
 +	{
@@ -337,7 +342,7 @@ index 4d0bf91..a5169d0 100644
 +		return palette[b0 | (b1 << 1) | (b2 << 2) | (b3 << 3) | (b4 << 4) | (b5 << 5) | (b6 << 6)];
 +	}
 +
-+	/// <summary>Fast-path read for bit depth of 8. Extracts the eight least significant bits from the first eight planes.</summary>
++	/// <summary>Stratum: Fast-path read for bit depth of 8. Extracts the eight least significant bits from the first eight planes.</summary>
 +	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 +	private int GetFromBits8(int index3d)
 +	{
@@ -362,7 +367,7 @@ index 4d0bf91..a5169d0 100644
 +		return palette[b0 | (b1 << 1) | (b2 << 2) | (b3 << 3) | (b4 << 4) | (b5 << 5) | (b6 << 6) | (b7 << 7)];
 +	}
 +
-+	/// <summary>Fast-path read for bit depth of 9. Extracts the nine least significant bits from the first nine planes.</summary>
++	/// <summary>Stratum: Fast-path read for bit depth of 9. Extracts the nine least significant bits from the first nine planes.</summary>
 +	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 +	private int GetFromBits9(int index3d)
 +	{
@@ -389,7 +394,7 @@ index 4d0bf91..a5169d0 100644
 +		return palette[b0 | (b1 << 1) | (b2 << 2) | (b3 << 3) | (b4 << 4) | (b5 << 5) | (b6 << 6) | (b7 << 7) | (b8 << 8)];
 +	}
 +
-+	/// <summary>Fast-path read for bit depth of 10. Extracts the ten least significant bits from the first ten planes.</summary>
++	/// <summary>Stratum: Fast-path read for bit depth of 10. Extracts the ten least significant bits from the first ten planes.</summary>
 +	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 +	private int GetFromBits10(int index3d)
 +	{
@@ -418,7 +423,7 @@ index 4d0bf91..a5169d0 100644
 +		return palette[b0 | (b1 << 1) | (b2 << 2) | (b3 << 3) | (b4 << 4) | (b5 << 5) | (b6 << 6) | (b7 << 7) | (b8 << 8) | (b9 << 9)];
 +	}
 +
-+	/// <summary>Fast-path read for bit depth of 11. Extracts the eleven least significant bits from the first eleven planes.</summary>
++	/// <summary>Stratum: Fast-path read for bit depth of 11. Extracts the eleven least significant bits from the first eleven planes.</summary>
 +	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 +	private int GetFromBits11(int index3d)
 +	{
@@ -449,7 +454,7 @@ index 4d0bf91..a5169d0 100644
 +		return palette[b0 | (b1 << 1) | (b2 << 2) | (b3 << 3) | (b4 << 4) | (b5 << 5) | (b6 << 6) | (b7 << 7) | (b8 << 8) | (b9 << 9) | (b10 << 10)];
 +	}
 +
-+	/// <summary>Fast-path read for bit depth of 12. Extracts the twelve least significant bits from the first twelve planes.</summary>
++	/// <summary>Stratum: Fast-path read for bit depth of 12. Extracts the twelve least significant bits from the first twelve planes.</summary>
 +	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 +	private int GetFromBits12(int index3d)
 +	{
@@ -480,9 +485,9 @@ index 4d0bf91..a5169d0 100644
 +		int b10 = (Unsafe.Add(ref base10, arrayIndex) >> shift) & 1;
 +		int b11 = (Unsafe.Add(ref base11, arrayIndex) >> shift) & 1;
 +		return palette[b0 | (b1 << 1) | (b2 << 2) | (b3 << 3) | (b4 << 4) | (b5 << 5) | (b6 << 6) | (b7 << 7) | (b8 << 8) | (b9 << 9) | (b10 << 10) | (b11 << 11)];
-+	}
-+
-+	/// <summary>Fast-path read for bit depth of 13. Extracts the thirteen least significant bits from the first thirteen planes.</summary>
+ 	}
+ 
++	/// <summary>Stratum: Fast-path read for bit depth of 13. Extracts the thirteen least significant bits from the first thirteen planes.</summary>
 +	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 +	private int GetFromBits13(int index3d)
 +	{
@@ -517,7 +522,7 @@ index 4d0bf91..a5169d0 100644
 +		return palette[b0 | (b1 << 1) | (b2 << 2) | (b3 << 3) | (b4 << 4) | (b5 << 5) | (b6 << 6) | (b7 << 7) | (b8 << 8) | (b9 << 9) | (b10 << 10) | (b11 << 11) | (b12 << 12)];
 +	}
 +
-+	/// <summary>Fast-path read for bit depth of 14. Extracts the fourteen least significant bits from all available planes.</summary>
++	/// <summary>Stratum: Fast-path read for bit depth of 14. Extracts the fourteen least significant bits from all available planes.</summary>
 +	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 +	private int GetFromBits14(int index3d)
 +	{
@@ -552,8 +557,8 @@ index 4d0bf91..a5169d0 100644
 +		int b12 = (Unsafe.Add(ref base12, arrayIndex) >> shift) & 1;
 +		int b13 = (Unsafe.Add(ref base13, arrayIndex) >> shift) & 1;
 +		return palette[b0 | (b1 << 1) | (b2 << 2) | (b3 << 3) | (b4 << 4) | (b5 << 5) | (b6 << 6) | (b7 << 7) | (b8 << 8) | (b9 << 9) | (b10 << 10) | (b11 << 11) | (b12 << 12) | (b13 << 13)];
- 	}
- 
++	}
++
 +	// Stratum end.
 +
 +	/// <summary>Selects the optimal read delegate based on the current palette bit depth.</summary>
@@ -619,8 +624,10 @@ index 4d0bf91..a5169d0 100644
 +				dataBit1 = dataBits[1];
 +				dataBit2 = dataBits[2];
 +				dataBit3 = dataBits[3];
++				// Stratum start: added dataBit4 assignment — previously the 5th plane was read through array-of-arrays. Now hoisted to a dedicated field for O(1) access on the hot path.
 +				dataBit4 = dataBits[4];
 +				return GetFromBits5;
++			// Stratum start: added case branches 6–14, each assigning one additional plane reference and returning its corresponding fast-path delegate. These mirror cases 0–5 in structure but extend the bit-depth coverage from 5 to 14 planes (the DATASLICES ceiling). Each branch keeps dataBitN = dataBits[N] so GetFromBits{N+1} can read directly without array-of-arrays indirection.
 +			case 6:
 +				dataBit0 = dataBits[0];
 +				dataBit1 = dataBits[1];
@@ -734,6 +741,7 @@ index 4d0bf91..a5169d0 100644
 +				dataBit0 = dataBits[0];
 +				return GetGeneralCase;
  		}
++		// Stratum end.
  	}
  
 +	/// <summary>Safely copies all bit-planes of the chunk into a new array of int[] pointers.</summary>
@@ -742,7 +750,7 @@ index 4d0bf91..a5169d0 100644
  		readWriteLock.AcquireReadLock();
  		int[][] array = new int[bitsize][];
  		try
-@@ -215,82 +683,125 @@ public class ChunkDataLayer
+@@ -215,82 +691,212 @@ public class ChunkDataLayer
  		{
  			readWriteLock.ReleaseReadLock();
  		}
@@ -751,31 +759,116 @@ index 4d0bf91..a5169d0 100644
 +
 +	/// <summary>
 +	/// Stratum: unsafe bulk-read variant of CopyBlocksTo — decodes every block ID in this
-+	/// layer into blocksOut without taking readWriteLock. Only safe where the caller
-+	/// already guarantees exclusive single-threaded access to this ChunkDataLayer, the
-+	/// same guarantee GetUnsafe/SetUnsafe already rely on.
++	/// layer into blocksOut without taking readWriteLock. Null-safe for uninitialized bit-planes.
++	/// Fast path: AVX2 bit-transpose (8 blocks per plane step) + VPGATHERDD palette lookup;
++	/// scalar fallback for non-AVX2 machines.
 +	/// </summary>
-+	public void CopyBlocksToUnsafe(int[] blocksOut)
++	public unsafe void CopyBlocksToUnsafe(int[] blocksOut)
 +	{
-+		if (palette == null)
++		if (blocksOut == null) return;
++
++		if (palette == null || dataBits == null || bitsize == 0)
 +		{
 +			Array.Clear(blocksOut, 0, blocksOut.Length);
 +			return;
 +		}
-+		int num = bitsize;
-+		for (int i = 0; i < blocksOut.Length; i += 32)
++
++		int num = bitsize > 15 ? 15 : bitsize;
++
++		if (Avx2.IsSupported)
 +		{
-+			int num2 = i / 32;
++			DecodePlanesAvx2(blocksOut, dataBits, palette, num);
++			return;
++		}
++
++		// Scalar fallback
++		Span<int> words = stackalloc int[num];
++		int outIdx = 0;
++
++		for (int word = 0; word < 1024; word++)
++		{
++			for (int k = 0; k < num; k++)
++			{
++				int[] plane = dataBits[k];
++				words[k] = plane != null ? plane[word] : 0;
++			}
++
 +			for (int j = 0; j < 32; j++)
 +			{
 +				int index = 0;
 +				for (int k = 0; k < num; k++)
 +				{
-+					if (((dataBits[k][num2] >> j) & 1) != 0)
-+						index |= (1 << k);
++					index |= ((words[k] >> j) & 1) << k;
 +				}
-+				blocksOut[i + j] = palette[index];
++				blocksOut[outIdx++] = (index < palette.Length) ? palette[index] : 0;
 +			}
++		}
++	}
++
++	/// <summary> Stratum: shared AVX2 bit-plane → palette-value transpose (blocks and light). </summary>
++	private static unsafe void DecodePlanesAvx2(int[] dst, int[][] planes, int[] palette, int num)
++	{
++		fixed (int* pPalette = palette)
++		fixed (int* pOut = dst)
++		{
++			Vector256<int> one = Vector256.Create(1);
++			int palLen = palette.Length;
++
++			Vector256<uint> s0 = Vector256.Create(0u, 1u, 2u, 3u, 4u, 5u, 6u, 7u);
++			Vector256<uint> s1 = Vector256.Create(8u, 9u, 10u, 11u, 12u, 13u, 14u, 15u);
++			Vector256<uint> s2 = Vector256.Create(16u, 17u, 18u, 19u, 20u, 21u, 22u, 23u);
++			Vector256<uint> s3 = Vector256.Create(24u, 25u, 26u, 27u, 28u, 29u, 30u, 31u);
++
++			int outIdx = 0;
++			for (int word = 0; word < 1024; word++)
++			{
++				Vector256<int> acc0 = Vector256<int>.Zero, acc1 = Vector256<int>.Zero;
++				Vector256<int> acc2 = Vector256<int>.Zero, acc3 = Vector256<int>.Zero;
++
++				int orAll = 0;
++				for (int k = 0; k < num; k++)
++				{
++					int[] plane = planes[k];
++					int w = plane != null ? plane[word] : 0;
++					orAll |= w;
++					if (w == 0) continue;
++
++					Vector256<int> b = Vector256.Create(w);
++					byte kk = (byte)k;
++					acc0 = Avx2.Or(acc0, Avx2.ShiftLeftLogical(Avx2.And(Avx2.ShiftRightLogicalVariable(b, s0), one), kk));
++					acc1 = Avx2.Or(acc1, Avx2.ShiftLeftLogical(Avx2.And(Avx2.ShiftRightLogicalVariable(b, s1), one), kk));
++					acc2 = Avx2.Or(acc2, Avx2.ShiftLeftLogical(Avx2.And(Avx2.ShiftRightLogicalVariable(b, s2), one), kk));
++					acc3 = Avx2.Or(acc3, Avx2.ShiftLeftLogical(Avx2.And(Avx2.ShiftRightLogicalVariable(b, s3), one), kk));
++				}
++
++				if (orAll == 0)
++				{
++					Vector256<int> z = Vector256.Create(pPalette[0]);
++					Unsafe.WriteUnaligned(pOut + outIdx, z);
++					Unsafe.WriteUnaligned(pOut + outIdx + 8, z);
++					Unsafe.WriteUnaligned(pOut + outIdx + 16, z);
++					Unsafe.WriteUnaligned(pOut + outIdx + 24, z);
++					outIdx += 32;
++					continue;
++				}
++
++				StorePaletteLane8(pOut + outIdx, pPalette, palLen, acc0);
++				StorePaletteLane8(pOut + outIdx + 8, pPalette, palLen, acc1);
++				StorePaletteLane8(pOut + outIdx + 16, pPalette, palLen, acc2);
++				StorePaletteLane8(pOut + outIdx + 24, pPalette, palLen, acc3);
++				outIdx += 32;
++			}
++		}
++	}
++
++	/// <summary> Stratum: writes 8 palette values for the 8 decoded indices in a vector lane group. </summary>
++	[MethodImpl(MethodImplOptions.AggressiveInlining)]
++	private static unsafe void StorePaletteLane8(int* dst, int* pPalette, int palLen, Vector256<int> acc)
++	{
++		for (int i = 0; i < 8; i++)
++		{
++			uint idx = (uint)acc.GetElement(i);
++			dst[i] = idx < (uint)palLen ? pPalette[idx] : 0;
 +		}
 +	}
 +
@@ -833,6 +926,7 @@ index 4d0bf91..a5169d0 100644
 +
 +				case 5: return palette[(((dataBit0[num] >> index3d) & 1)) | ((((dataBit1[num] >> index3d) & 1)) << 1) | ((((dataBit2[num] >> index3d) & 1)) << 2) | ((((dataBit3[num] >> index3d) & 1)) << 3) | ((((dataBits[4][num] >> index3d) & 1)) << 4)];
 +
++				// Stratum start: added case branches 6–14, each reading the corresponding dataBitN field instead of going through dataBits[N]. This matches the same hoisting pattern used in selectDelegate and GetFromBits{5..14}: one fewer pointer dereference per plane read on the hot path.
 +				case 6: return palette[(((dataBit0[num] >> index3d) & 1)) | ((((dataBit1[num] >> index3d) & 1)) << 1) | ((((dataBit2[num] >> index3d) & 1)) << 2) | ((((dataBit3[num] >> index3d) & 1)) << 3) | ((((dataBit4[num] >> index3d) & 1)) << 4) | ((((dataBit5[num] >> index3d) & 1)) << 5)];
 +
 +				case 7: return palette[(((dataBit0[num] >> index3d) & 1)) | ((((dataBit1[num] >> index3d) & 1)) << 1) | ((((dataBit2[num] >> index3d) & 1)) << 2) | ((((dataBit3[num] >> index3d) & 1)) << 3) | ((((dataBit4[num] >> index3d) & 1)) << 4) | ((((dataBit5[num] >> index3d) & 1)) << 5) | ((((dataBit6[num] >> index3d) & 1)) << 6)];
@@ -899,6 +993,7 @@ index 4d0bf91..a5169d0 100644
  		}
  	}
  
++	// Stratum: added lock (stratumWriteLock) wrapper — previously Set called MakeSpaceInPalette with only `lock (palette)` which could not guard against concurrent growth (see stratumWriteLock field comment). Now all writes serialize through a single monitor.
 +	/// <summary>Sets a block value at a 3D index. Looks up the palette index and updates bit-planes.</summary>
  	public void Set(int index3d, int value)
 +	{
@@ -915,7 +1010,7 @@ index 4d0bf91..a5169d0 100644
  		{
  			int num;
  			if (palette != null)
-@@ -314,19 +825,19 @@ public class ChunkDataLayer
+@@ -314,19 +920,19 @@ public class ChunkDataLayer
  									break;
  								}
  								num++;
@@ -942,12 +1037,13 @@ index 4d0bf91..a5169d0 100644
  						setBlockIndexCached = num;
  						setBlockValueCached = value;
  					}
-@@ -376,11 +887,44 @@ public class ChunkDataLayer
+@@ -376,11 +982,45 @@ public class ChunkDataLayer
  			return;
  		}
  		throw new IndexOutOfRangeException("Chunk blocks index3d must be between 0 and " + 32767 + ", was " + index3d);
  	}
  
++	// Stratum: added lock (stratumWriteLock) wrapper — SetUnsafe previously had no synchronization at all, making concurrent palette growth a data race. Now serialized through stratumWriteLock alongside all other writers.
 +	/// <summary>Sets a block value without bounds-checking the index. Used for optimized paths.</summary>
  	public void SetUnsafe(int index3d, int value)
 +	{
@@ -987,12 +1083,13 @@ index 4d0bf91..a5169d0 100644
  		index3d /= 32;
  		int num2 = ~num;
  		if (value != 0)
-@@ -449,11 +993,21 @@ public class ChunkDataLayer
+@@ -449,11 +1089,22 @@ public class ChunkDataLayer
  				dataBits[j][index3d] &= num2;
  			}
  		}
  	}
  
++	// Stratum: added lock (stratumWriteLock) wrapper — SetZero previously had no synchronization. Concurrent SetZero on a shared chunk could race with concurrent writes through Set/SetUnsafe. Now serialized through stratumWriteLock.
 +	/// <summary>Resets block bits at the index to zero, if the palette is initialized.</summary>
  	public void SetZero(int index3d)
 +	{
@@ -1009,12 +1106,13 @@ index 4d0bf91..a5169d0 100644
  		{
  			int num = 1 << index3d;
  			index3d /= 32;
-@@ -464,65 +1018,64 @@ public class ChunkDataLayer
+@@ -464,65 +1115,67 @@ public class ChunkDataLayer
  				dataBits[i][index3d] &= num2;
  			}
  		}
  	}
  
++	// Stratum: added lock (stratumWriteLock) wrapper — SetBulk previously had no synchronization. Concurrent bulk writes on the same chunk could interleave palette growth and plane updates. Now serialized through stratumWriteLock.
 +	/// <summary>Bulk-sets a value for a lenX * lenZ block region starting at the given index.</summary>
  	public void SetBulk(int index3d, int lenX, int lenZ, int value)
  	{
@@ -1025,6 +1123,7 @@ index 4d0bf91..a5169d0 100644
 +		}
 +	}
 +
++	// Stratum start: entire method body restructured — replaced per-plane for-loop that built masks incrementally with a single loop over all planes calling Array.Fill (which uses SIMD internally) to write each plane word in bulk. Also consolidated palette lookup logic into a local variable `paletteIndex` and added the same-value cache hit path at the top, reducing redundant lookups when consecutive calls set the same value.
 +	// Bulk fill left using Array.Fill to leverage CPU SIMD instructions.
 +	/// <summary>SetBulk core. Fills bit-planes with the palette-index mask derived from the target value.</summary>
 +	private void SetBulkCore(int index3d, int lenX, int lenZ, int value)
@@ -1101,6 +1200,7 @@ index 4d0bf91..a5169d0 100644
 +			Array.Fill(dataBits[i], mask, arrayIndex, lenZ);
  		}
  	}
++	// Stratum end.
  
 +	/// <summary>Initializes the bit-plane structure and palette for holding the first non-zero value.</summary>
  	protected void NewDataBitsWithFirstValue(int value)
@@ -1108,7 +1208,7 @@ index 4d0bf91..a5169d0 100644
  		if (dataBits == null)
  		{
  			dataBits = new int[15][];
-@@ -535,10 +1088,11 @@ public class ChunkDataLayer
+@@ -535,10 +1188,11 @@ public class ChunkDataLayer
  		palette[1] = value;
  		Get = GetFromBits1;
  		bitsize = 1;
@@ -1120,7 +1220,7 @@ index 4d0bf91..a5169d0 100644
  		if (bitsize > 6 && CleanUpPalette())
  		{
  			return paletteCount;
-@@ -555,10 +1109,11 @@ public class ChunkDataLayer
+@@ -555,10 +1209,11 @@ public class ChunkDataLayer
  		Get = selectDelegate(bitsize + 1);
  		bitsize++;
  		return num;
@@ -1132,7 +1232,7 @@ index 4d0bf91..a5169d0 100644
  		if (pool.server == null)
  		{
  			if (bitsize < 14)
-@@ -653,10 +1208,11 @@ public class ChunkDataLayer
+@@ -653,10 +1308,11 @@ public class ChunkDataLayer
  			}
  		}
  		return true;
@@ -1144,7 +1244,7 @@ index 4d0bf91..a5169d0 100644
  		if (paletteCount == 0)
  		{
  			return 0;
-@@ -668,10 +1224,11 @@ public class ChunkDataLayer
+@@ -668,10 +1324,11 @@ public class ChunkDataLayer
  			num2++;
  		}
  		return num2;
@@ -1156,7 +1256,7 @@ index 4d0bf91..a5169d0 100644
  		int num = paletteCount - 1;
  		for (int num2 = num / 32; num2 >= 0; num2--)
  		{
-@@ -698,23 +1255,18 @@ public class ChunkDataLayer
+@@ -698,23 +1355,18 @@ public class ChunkDataLayer
  				}
  			}
  		}
@@ -1183,7 +1283,7 @@ index 4d0bf91..a5169d0 100644
  		Get = GetFromBits0;
  		int num = bitsize;
  		bitsize = 0;
-@@ -731,10 +1283,11 @@ public class ChunkDataLayer
+@@ -731,10 +1383,11 @@ public class ChunkDataLayer
  		}
  		setBlockIndexCached = 0;
  		setBlockValueCached = 0;
@@ -1195,7 +1295,7 @@ index 4d0bf91..a5169d0 100644
  		if (dataBits == null)
  		{
  			dataBits = new int[15][];
-@@ -746,19 +1299,21 @@ public class ChunkDataLayer
+@@ -746,19 +1399,21 @@ public class ChunkDataLayer
  		paletteCount = 1;
  		Get = GetFromBits1;
  		bitsize = 1;
@@ -1217,7 +1317,7 @@ index 4d0bf91..a5169d0 100644
  		int num = 0;
  		readWriteLock.AcquireReadLock();
  		try
-@@ -774,10 +1329,11 @@ public class ChunkDataLayer
+@@ -774,10 +1429,11 @@ public class ChunkDataLayer
  			readWriteLock.ReleaseReadLock();
  		}
  		return Compression.CompressAndCombine(arrayStatic, palette, paletteCount);
@@ -1229,7 +1329,7 @@ index 4d0bf91..a5169d0 100644
  		int num = 0;
  		lock (palette ?? ((object)readWriteLock))
  		{
-@@ -806,10 +1362,11 @@ public class ChunkDataLayer
+@@ -806,10 +1462,11 @@ public class ChunkDataLayer
  			paletteCompressed = Compression.Compress(palette, paletteCount, chunkdataVersion);
  		}
  		return Compression.Compress(arrayStatic, num, chunkdataVersion);
@@ -1241,7 +1341,7 @@ index 4d0bf91..a5169d0 100644
  		paletteCount = 0;
  		palette = Compression.DecompressCombined(layerCompressed, ref dataBits, ref paletteCount, pool.NewData);
  		if (palette != null)
-@@ -827,10 +1384,11 @@ public class ChunkDataLayer
+@@ -827,10 +1484,11 @@ public class ChunkDataLayer
  		{
  			bitsize = 0;
  		}
@@ -1253,7 +1353,7 @@ index 4d0bf91..a5169d0 100644
  		palette = Compression.DecompressToInts(paletteCompressed, ref paletteCount);
  		if (palette != null)
  		{
-@@ -872,10 +1430,11 @@ public class ChunkDataLayer
+@@ -872,10 +1530,11 @@ public class ChunkDataLayer
  			Get = GetFromBits0;
  			bitsize = 0;
  		}
@@ -1265,7 +1365,7 @@ index 4d0bf91..a5169d0 100644
  		if (dataBits == null)
  		{
  			dataBits = new int[15][];
-@@ -910,39 +1469,29 @@ public class ChunkDataLayer
+@@ -910,39 +1569,106 @@ public class ChunkDataLayer
  		{
  			pool.FreeArrays(this);
  		}
@@ -1289,35 +1389,109 @@ index 4d0bf91..a5169d0 100644
 -				}
 -				if (array[j + 1] != 0)
 -				{
--					return true;
--				}
--				if (array[j + 2] != 0)
--				{
 +				if ((array[j] | array[j + 1] | array[j + 2] | array[j + 3]) != 0)
  					return true;
 -				}
--				if (array[j + 3] != 0)
--				{
+-				if (array[j + 2] != 0)
++			}
++		}
++		return false;
++	}
++
++	/// <summary>
++	/// Stratum: Decodes all light values from bit-planes into a flat int array.
++	/// Null-safe: handles uninitialized or partially initialized light layers gracefully.
++	/// </summary>
++	public unsafe void CopyLightToUnsafe(int[] lightOut)
++	{
++		if (lightOut == null) return;
++
++		if (palette == null || dataBits == null || bitsize == 0)
++		{
++			Array.Clear(lightOut, 0, lightOut.Length);
++			return;
++		}
++
++		int num = bitsize > 15 ? 15 : bitsize;
++
++		// Stratum: AVX2 path — reuses the same bit-plane → palette decode as CopyBlocksToUnsafe.
++		if (Avx2.IsSupported)
++		{
++			DecodePlanesAvx2(lightOut, dataBits, palette, num);
++			return;
++		}
++
++		// Scalar fallback — identical to original logic.
++		for (int i = 0; i < lightOut.Length; i += 32)
++		{
++			int word = i / 32;
++			for (int j = 0; j < 32; j++)
++			{
++				int index = 0;
++				for (int k = 0; k < num; k++)
+ 				{
 -					return true;
--				}
++					if (dataBits[k] != null && ((dataBits[k][word] >> j) & 1) != 0)
++						index |= (1 << k);
+ 				}
+-				if (array[j + 3] != 0)
++				lightOut[i + j] = index < palette.Length ? palette[index] : 0;
++			}
++		}
++	}
++
++	/// <summary>
++	/// Stratum: Encodes a flat int array of light values back into bit-planes, rebuilding the palette.
++	/// Takes the write lock ONCE for the entire chunk. Null-safe.
++	/// </summary>
++	public void SetLightBulkUnsafe(int[] lightIn)
++	{
++		if (lightIn == null) return;
++
++		lock (stratumWriteLock)
++		{
++			// Reset state
++			palette = null;
++			paletteCount = 0;
++			bitsize = 0;
++			Get = GetFromBits0;
++			setBlockIndexCached = 0;
++			setBlockValueCached = 0;
++
++			if (dataBits == null) dataBits = new int[15][];
++			for (int i = 0; i < dataBits.Length; i++)
++			{
++				if (dataBits[i] != null) Array.Clear(dataBits[i], 0, 1024);
++			}
++
++			// Rebuild using the existing fast-path SetUnsafeCore
++			for (int i = 0; i < 32768 && i < lightIn.Length; i++)
++			{
++				int val = lightIn[i];
++				if (val != 0)
+ 				{
+-					return true;
++					SetUnsafeCore(i, val);
+ 				}
  			}
  		}
- 		return false;
+-		return false;
  	}
  
++
 +	/// <summary>Copies all block values from bit-planes into the output array, using the palette for unpacking.</summary>
  	internal void CopyBlocksTo(int[] blocksOut)
  	{
  		readWriteLock.AcquireReadLock();
  		try
  		{
-@@ -950,54 +1499,47 @@ public class ChunkDataLayer
+@@ -950,54 +1676,48 @@ public class ChunkDataLayer
  			for (int i = 0; i < blocksOut.Length; i += 32)
  			{
  				int num2 = i / 32;
  				for (int j = 0; j < 32; j++)
  				{
-+					// Stratum: restructured the inner loop — instead of accumulating a weighted sum, uses bitwise OR which eliminates multiplication and shortens the code.
++					// Stratum start: inner loop restructured — instead of accumulating a weighted sum with multiplication, uses bitwise OR which eliminates multiplication and shortens the code. Identical result for any bitsize.
  					int num3 = 0;
 -					int num4 = 1;
 +					int index = 0;
@@ -1337,6 +1511,7 @@ index 4d0bf91..a5169d0 100644
  		{
  			readWriteLock.ReleaseReadLock();
  		}
++		// Stratum end.
  	}
  
 +	/// <summary>Finds the first occurrence of any of the given block IDs in the chunk and returns the matching position.</summary>
@@ -1364,7 +1539,7 @@ index 4d0bf91..a5169d0 100644
 -					}
 -				}
 +				if (num == 0) continue;
-+				// TrailingZeroCount — intrinsic, compiler replaces with CPU instruction BZHI/BSF
++				// Stratum: replaced manual trailing-bit scan loop with BitOperations.TrailingZeroCount — compiler replaces with CPU instruction BZHI/BSF. Identical result, single instruction on modern x86-64.
 +				int bitIndex = System.Numerics.BitOperations.TrailingZeroCount(num);
 +				return new BlockPos(bitIndex, j / 32, j % 32);
  			}
@@ -1378,7 +1553,7 @@ index 4d0bf91..a5169d0 100644
  	{
  		int num = -1;
  		for (int i = 0; i < bitsize; i++)
-@@ -1005,10 +1547,11 @@ public class ChunkDataLayer
+@@ -1005,10 +1725,11 @@ public class ChunkDataLayer
  			num &= (((needle & (1 << i)) != 0) ? dataBits[i][intIndex] : (~dataBits[i][intIndex]));
  		}
  		return num;
@@ -1390,7 +1565,7 @@ index 4d0bf91..a5169d0 100644
  		for (int i = 0; i < paletteCount; i++)
  		{
  			if (palette[i] != id)
-@@ -1025,18 +1568,20 @@ public class ChunkDataLayer
+@@ -1025,18 +1746,20 @@ public class ChunkDataLayer
  			return false;
  		}
  		return false;
@@ -1411,7 +1586,7 @@ index 4d0bf91..a5169d0 100644
  		int num = ~mask;
  		readWriteLock.AcquireWriteLock();
  		for (int i = 0; i < bitsize; i++)
-@@ -1051,10 +1596,11 @@ public class ChunkDataLayer
+@@ -1051,10 +1774,11 @@ public class ChunkDataLayer
  			}
  		}
  		readWriteLock.ReleaseWriteLock();
@@ -1423,19 +1598,196 @@ index 4d0bf91..a5169d0 100644
  		int num = paletteCount - 1;
  		readWriteLock.AcquireWriteLock();
  		int num2 = bitsize;
-@@ -1088,10 +1634,11 @@ public class ChunkDataLayer
+@@ -1088,10 +1812,188 @@ public class ChunkDataLayer
  		palette[deletePosition] = palette[num];
  		paletteCount--;
  		readWriteLock.ReleaseWriteLock();
  	}
  
++	/// <summary>
++	/// Stratum: Encodes a flat int array of block IDs back into bit-planes, rebuilding the palette.
++	/// Takes the write lock ONCE for the entire chunk. Null-safe.
++	///
++	/// Fast rebuild: instead of 32768 per-block SetUnsafeCore calls (each doing a palette scan
++	/// plus bitsize read-modify-writes into the planes), encode word-wise (32 blocks at once):
++	///   - uniform word (32 identical IDs — the dominant case for strata and air): a single
++	///     palette lookup and one mask store per plane;
++	///   - mixed word: 32 palette lookups, then a bit-transpose that writes each plane word once.
++	/// Planes are fully overwritten, so no upfront Array.Clear of all 15 planes is needed;
++	/// a plane is cleared only when it is first claimed (palette creation/growth).
++	/// Shorter critical section also cuts Monitor.Enter_SlowPath contention.
++	/// </summary>
++	public unsafe void SetBlocksBulkUnsafe(int[] blocksIn)
++	{
++		if (blocksIn == null || blocksIn.Length != length) return;
++
++		lock (stratumWriteLock)
++		{
++			// Reset state. Planes are NOT cleared here: every word below fully overwrites
++			// planes 0..bitsize-1, and a newly claimed plane is cleared at claim time.
++			palette = null;
++			paletteCount = 0;
++			bitsize = 0;
++			Get = GetFromBits0;
++			setBlockIndexCached = 0;
++			setBlockValueCached = 0;
++
++			if (dataBits == null) dataBits = new int[15][];
++
++			bool sawNonZero = false;
++			int* idxBuf = stackalloc int[32];
++
++			fixed (int* pIn = blocksIn)
++			{
++				for (int word = 0; word < 1024; word++)
++				{
++					int baseIdx = word << 5;
++					int v0 = pIn[baseIdx];
++
++					if (IsUniformWord(pIn + baseIdx, v0))
++					{
++						if (v0 == 0)
++						{
++							// Nothing to encode. If the palette does not exist yet, the planes
++							// don't exist either and are cleared at claim time, so skipping is correct.
++							if (palette != null) WritePlaneWord(word, 0);
++							continue;
++						}
++						sawNonZero = true;
++						WritePlaneWord(word, PaletteIndexForBulk(v0));
++						continue;
++					}
++
++					// Mixed word: resolve palette indices first (the palette may grow during
++					// this), then transpose bits into plane words — one store per plane.
++					for (int j = 0; j < 32; j++)
++					{
++						int v = pIn[baseIdx + j];
++						if (v == 0) { idxBuf[j] = 0; continue; }
++						sawNonZero = true;
++						idxBuf[j] = PaletteIndexForBulk(v);
++					}
++
++					int bs = bitsize;
++					for (int k = 0; k < bs; k++)
++					{
++						int wv = 0;
++						for (int j = 0; j < 32; j++) wv |= ((idxBuf[j] >> k) & 1) << j;
++						dataBits[k][word] = wv;
++					}
++				}
++			}
++
++			if (!sawNonZero)
++			{
++				// All-air chunk: restore the canonical empty state.
++				palette = null;
++				paletteCount = 0;
++				bitsize = 0;
++				Get = GetFromBits0;
++				return;
++			}
++
++			Get = selectDelegate(bitsize);
++		}
++	}
++
++	/// <summary>Stratum: true if 32 consecutive values equal v0. AVX2 byte-compare when available.</summary>
++	[MethodImpl(MethodImplOptions.AggressiveInlining)]
++	private static unsafe bool IsUniformWord(int* p, int v0)
++	{
++		if (Avx2.IsSupported)
++		{
++			// Equal ints <=> equal 4-byte sequences, so compare 32 bytes at a time.
++			// LoadDquVector256 is the unaligned-safe load (int[] is only 4-byte aligned).
++			Vector256<byte> bv = Vector256.Create(v0).AsByte();
++			return (Avx2.MoveMask(Avx2.CompareEqual(Avx2.LoadDquVector256((byte*)p), bv))
++				  & Avx2.MoveMask(Avx2.CompareEqual(Avx2.LoadDquVector256((byte*)p + 32), bv))
++				  & Avx2.MoveMask(Avx2.CompareEqual(Avx2.LoadDquVector256((byte*)p + 64), bv))
++				  & Avx2.MoveMask(Avx2.CompareEqual(Avx2.LoadDquVector256((byte*)p + 96), bv))) == -1;
++		}
++		for (int j = 1; j < 32; j++)
++		{
++			if (p[j] != v0) return false;
++		}
++		return true;
++	}
++
++	/// <summary>Stratum: writes one 32-block word as precomputed per-plane masks (-1 / 0).</summary>
++	[MethodImpl(MethodImplOptions.AggressiveInlining)]
++	private void WritePlaneWord(int word, int paletteIndex)
++	{
++		for (int k = 0; k < bitsize; k++)
++		{
++			dataBits[k][word] = ((paletteIndex >> k) & 1) != 0 ? -1 : 0;
++		}
++	}
++
++	/// <summary>
++	/// Stratum: palette lookup/grow for the bulk encode path. Caller holds stratumWriteLock.
++	/// Linear scan is fine here: distinct IDs per subchunk are few and the last-value cache
++	/// absorbs runs. Unlike MakeSpaceInPalette, no compaction is attempted — the palette built
++	/// by this path is already minimal, because every entry comes straight from the input array.
++	/// </summary>
++	private int PaletteIndexForBulk(int value)
++	{
++		if (value == setBlockValueCached) return setBlockIndexCached;
++
++		int idx;
++		if (palette == null)
++		{
++			// First non-zero value: claim plane 0 cleared, so any all-zero words skipped
++			// before this moment decode to 0.
++			dataBit0 = (dataBits[0] = pool.NewData());
++			Array.Clear(dataBit0, 0, 1024);
++			palette = new int[2];
++			palette[1] = value;
++			paletteCount = 2;
++			bitsize = 1;
++			idx = 1;
++		}
++		else
++		{
++			int count = paletteCount;
++			idx = 1;
++			while (idx < count && palette[idx] != value) idx++;
++			if (idx == count)
++			{
++				if (count == palette.Length)
++				{
++					int[] next = new int[palette.Length * 2];
++					Array.Copy(palette, next, palette.Length);
++					palette = next;
++				}
++				palette[count] = value;
++				paletteCount = count + 1;
++				idx = count;
++
++				// Claim any planes the new index needs, cleared: words encoded before this
++				// growth must read 0 in them.
++				int need = CalcBitsize(count + 1);
++				while (bitsize < need)
++				{
++					dataBits[bitsize] = pool.NewData();
++					Array.Clear(dataBits[bitsize], 0, 1024);
++					bitsize++;
++				}
++			}
++		}
++
++		setBlockIndexCached = idx;
++		setBlockValueCached = value;
++		return idx;
++	}
++
++
 +	/// <summary>Clears palette values exceeding the given maximum. Useful for purging stale or invalid data.</summary>
  	public void ClearPaletteOutsideMaxValue(int maxValue)
  	{
  		int[] array = palette;
  		if (array == null)
  		{
-@@ -1104,6 +1651,6 @@ public class ChunkDataLayer
+@@ -1104,6 +2006,6 @@ public class ChunkDataLayer
  			{
  				array[i] = 0;
  			}

--- a/patches/VintagestoryLib/Vintagestory.Common/ChunkIlluminator.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Common/ChunkIlluminator.cs.patch
@@ -1,10 +1,11 @@
 diff --git a/VintagestoryLib/Vintagestory.Common/ChunkIlluminator.cs b/VintagestoryLib/Vintagestory.Common/ChunkIlluminator.cs
-index e2ca303..82dc39c 100644
+index e2ca303..cd49466 100644
 --- a/VintagestoryLib/Vintagestory.Common/ChunkIlluminator.cs
 +++ b/VintagestoryLib/Vintagestory.Common/ChunkIlluminator.cs
-@@ -1,230 +1,361 @@
+@@ -1,1110 +1,2104 @@
  using System;
  using System.Collections.Generic;
++using System.Collections.Concurrent;
 +using System.Runtime.CompilerServices;
  using Vintagestory.API.Client.Tesselation;
  using Vintagestory.API.Common;
@@ -24,11 +25,21 @@ index e2ca303..82dc39c 100644
 +// - Batching: Clustering sources and calculating from their geometric center reduce CPU load by tens of times.
 +// - Directional Absorption: Universal face-checking system correctly handles light propagation through slabs, stairs, and volumetric transparent blocks (water, leaves) in all 6 directions.
 +// - Sunlight Invalidation: Rewrote UpdateSunLight to correctly extinguish trapped sunlight in sealed caves and rooms, recalculating only the affected chunks below the modified block.
++// - Sunlight Batching (this pass): Sunlight/SunlightFlood/SunLightFloodNeighbourChunks/SpreadSunLightInColumn now read blocks through a
++//   once-per-chunk bulk snapshot (Data.CopyBlocksToUnsafe), same idea as GenRockStrataNew's stratumBlockSnapshot, instead of paying the
++//   bit-plane decode (GetFromBits0..7) on every single Data[idx] access. Sunlight itself is now ALWAYS staged in a plain byte[] during
++//   these calls (previously only during FlushPendingSunLightUpdates) and committed to live GetSunlight/SetSunlight storage once, only for
++//   cells that actually changed. Sessions (Begin.../End...) nest via a depth counter so FullRelight and FlushPendingSunLightUpdates can wrap
++//   several calls in one shared session (no re-snapshotting per call), while each method still works correctly when called standalone.
++// - Thread Safety: All shared dictionaries are now ConcurrentDictionary, and all object pools are protected with locks to prevent
++//   race conditions when multiple WorldGen threads use the same ChunkIlluminator instance simultaneously.
++//
++//   NOTE: SunlightFlood and SpreadSunLightInColumn now take an explicit `dim` parameter instead of relying on the shared currentDimOffset
++//   field (which was only ever set inside FlushPendingSunLightUpdates). Any external caller of these two methods needs to pass dimension now.
 +
 +// Limitations:
 +// Hard limit of 128³: Light is simply "clipped" at the boundaries of the invisible cube, which will cause artifacts during large explosions. This exists in vanilla too, so it's not critical.
 +// Color distortion: The Top-4 limit slightly breaks the physics of HSV mixing if >4 multi-colored sources shine on a single point. But do we even need to mix that many colors?
-+// Not thread-safe: Shared arrays and pools require creating a separate instance of the class for each thread. Vanilla is also not thread-safe. 
 +
 +// Tested on the generation of 10200 chunk columns:
 +// - UpdateLightAt summary method execution time:  from 22.9 s to 30...42 s
@@ -109,25 +120,44 @@ index e2ca303..82dc39c 100644
 -	private BlockPos tmpDiPos = new BlockPos(0);
 +	/// <summary> Object pool for QueueOfInt instances (Zero-GC optimization). </summary>
 +	private Stack<QueueOfInt> queueOfIntPool = new Stack<QueueOfInt>();
++	private readonly object queueOfIntPoolLock = new object(); // Stratum: lock for thread-safe pool access
  
 -	private BlockPos tmpPos = new BlockPos(0);
++	// Stratum: Object pool for dense light buffers during WorldGen
++	private readonly Stack<int[]> lightBufferPool = new Stack<int[]>(256);
++	private readonly object lightBufferPoolLock = new object(); // Stratum: lock for thread-safe pool access
+ 
+-	private BlockPos tmpPosDimensionAware = new BlockPos(0);
++	internal int[] RentLightBuffer()
++	{
++		lock (lightBufferPoolLock) { if (lightBufferPool.Count > 0) return lightBufferPool.Pop(); }
++		return new int[32768];
++	}
+ 
+-	private int[] currentVisited;
++	internal void ReturnLightBuffer(int[] buffer)
++	{
++		lock (lightBufferPoolLock) { if (lightBufferPool.Count < 512) lightBufferPool.Push(buffer); }
++	}
++
 +	/// <summary> Gets a custom QueueOfInt queue from the pool and clears it. </summary>
 +	private QueueOfInt GetQueueOfInt()
 +	{
-+		if (queueOfIntPool.Count > 0)
++		lock (queueOfIntPoolLock)
 +		{
-+			var q = queueOfIntPool.Pop();
-+			while (q.Count > 0) q.Dequeue();
-+			return q;
++			if (queueOfIntPool.Count > 0)
++			{
++				var q = queueOfIntPool.Pop();
++				while (q.Count > 0) q.Dequeue();
++				return q;
++			}
 +		}
 +		return new QueueOfInt();
 +	}
 +	#endregion
- 
--	private BlockPos tmpPosDimensionAware = new BlockPos(0);
++
 +	#region Generational Grid for Multi-Source BFS
- 
--	private int[] currentVisited;
++
 +	private const int LIGHT_GRID_WIDTH = 128; // Size of the 3D grid for local light calculation
 +	private const int LIGHT_GRID_HALF = 64;
 +	private const int LIGHT_GRID_SIZE = LIGHT_GRID_WIDTH * LIGHT_GRID_WIDTH * LIGHT_GRID_WIDTH;
@@ -146,20 +176,20 @@ index e2ca303..82dc39c 100644
 +		public byte maxLevel;              // Maximum light level in the cell
 +		public byte trackedCount;          // How many sources are currently being tracked (from 0 to 4)
 +	}
-+
+ 
+-	private int iteration;
 +	/// <summary> Flat array of the 128³ light grid. </summary>
 +	private LightCell[] lightGrid;                   // Flat array of the 3D grid
 +													 /// <summary> Buckets (queues) for BFS, divided by light level (from 31 to 1). </summary>
 +	private List<(int idx, int srcIdx)>[] buckets;   // Buckets (queues) for BFS, divided by light level (from 31 to 1)
  
--	private int iteration;
+-	public bool IsValidPos(int x, int y, int z)
 +	/// <summary> Direction vectors for traversing ALLFACES neighbors in order (N, E, S, W, U, D). </summary>
 +	private static readonly int[] dx = { 0, 1, 0, -1, 0, 0 };
 +	private static readonly int[] dy = { 0, 0, 0, 0, 1, -1 };
 +	private static readonly int[] dz = { -1, 0, 1, 0, 0, 0 };
 +	#endregion
- 
--	public bool IsValidPos(int x, int y, int z)
++
 +	#region Struct-based nearby sources (Arrays for storing nearby light sources)
 +
 +	/// <summary> Lightweight position holder for nearby light sources. </summary>
@@ -245,18 +275,16 @@ index e2ca303..82dc39c 100644
 +
 +	// ─── Sunlight staging arrays (prevents render flickering) ─────
 +	/// <summary> Per-chunk staging byte arrays for sunlight updates — prevents the renderer from seeing intermediate "zeroed" state. </summary>
-+	private readonly Dictionary<long, byte[]> currentSunStaging = new Dictionary<long, byte[]>(64);
++	private readonly ConcurrentDictionary<long, byte[]> currentSunStaging = new ConcurrentDictionary<long, byte[]>();
 +	/// <summary> Object pool for reusable staging byte arrays (Zero-GC). </summary>
 +	private readonly Stack<byte[]> sunStagingPool = new Stack<byte[]>(256);
-+	/// <summary> Pending column-based sunlight recalculation requests keyed by packed column ID. </summary>
-+	private readonly Dictionary<long, int> pendingSunlightUpdates = new Dictionary<long, int>(64);
-+	/// <summary> Cached dimension offset for the current staging operation. </summary>
-+	private int currentDimOffset;
++	private readonly object sunStagingPoolLock = new object(); // Stratum: lock for thread-safe pool access
++															   /// <summary> Pending column-based sunlight recalculation requests keyed by packed column ID. </summary>
++	private readonly ConcurrentDictionary<long, int> pendingSunlightUpdates = new ConcurrentDictionary<long, int>();
 +
-+	// ─── Staging helpers for sunlight ──────────────────────────
-+	/// <summary> Retrieves a staging array from the pool or allocates a new one if empty. </summary>
++
 +	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-+	private byte[] RentStagingArray()
++	private int[] RentBlockSnapshotArray()
  	{
 -		int num = chunkSize;
 -		Dictionary<Vec3i, IWorldChunk> dictionary = new Dictionary<Vec3i, IWorldChunk>();
@@ -274,7 +302,8 @@ index e2ca303..82dc39c 100644
 -		int num13 = num7 / num;
 -		int num14 = minPos.dimension * 1024;
 -		for (int i = num8; i <= num11; i++)
--		{
++		lock (blockSnapshotPoolLock)
+ 		{
 -			for (int j = num9; j <= num12; j++)
 -			{
 -				for (int k = num10; k <= num13; k++)
@@ -287,68 +316,84 @@ index e2ca303..82dc39c 100644
 -					}
 -				}
 -			}
--		}
++			if (blockSnapshotPool.Count > 0) return blockSnapshotPool.Pop();
+ 		}
 -		foreach (IWorldChunk value2 in dictionary.Values)
--		{
--			value2?.Lighting.ClearLight();
--		}
--		IWorldChunk[] array = new IWorldChunk[mapsizey / num];
--		for (int l = num8; l <= num11; l++)
--		{
--			for (int m = num10; m <= num13; m++)
--			{
--				bool flag = false;
--				for (int n = 0; n < array.Length; n++)
--				{
--					IWorldChunk chunk2 = chunkProvider.GetChunk(l, n + num14, m);
--					if (chunk2 == null)
--					{
--						flag = true;
--					}
--					array[n] = chunk2;
--				}
--				if (!flag)
--				{
--					Sunlight(array, l, array.Length - 1, m, minPos.dimension);
--					SunlightFlood(array, l, array.Length - 1, m);
--					SunLightFloodNeighbourChunks(array, l, array.Length - 1, m, minPos.dimension);
--				}
--			}
--		}
--		Dictionary<BlockPos, Block> dictionary2 = new Dictionary<BlockPos, Block>();
--		foreach (KeyValuePair<Vec3i, IWorldChunk> item in dictionary)
--		{
--			Vec3i key = item.Key;
--			IWorldChunk value = item.Value;
--			if (value == null)
--			{
--				continue;
--			}
--			int num15 = key.X * num;
--			int num16 = key.Y * num;
--			int num17 = key.Z * num;
--			foreach (int lightPosition in value.LightPositions)
--			{
--				int num18 = key.Y * num + lightPosition / (num * num);
--				int num19 = key.Z * num + lightPosition / num % num;
--				int num20 = key.X * num + lightPosition % num;
--				dictionary2[new BlockPos(num15 + num20, num16 + num18, num17 + num19, minPos.dimension)] = blockTypes[value.Data[lightPosition]];
--			}
--		}
--		foreach (KeyValuePair<BlockPos, Block> item2 in dictionary2)
--		{
--			byte[] lightHsv = item2.Value.GetLightHsv(readBlockAccess, item2.Key);
--			PlaceBlockLight(lightHsv, item2.Key.X, item2.Key.InternalY, item2.Key.Z);
--		}
-+		if (sunStagingPool.Count > 0) return sunStagingPool.Pop();
-+		return new byte[chunkSize * chunkSize * chunkSize];
++		return new int[chunkSize * chunkSize * chunkSize];
 +	}
 +
-+	/// <summary> Gets the staging array for a chunk by coordinates, or null if absent. </summary>
-+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-+	private byte[] GetStagingForChunk(int cx, int cyWithDim, int cz)
++	private int[] GetOrCreateBlockSnapshot(long chunkKey, IWorldChunk chunk)
 +	{
-+		return currentSunStaging.TryGetValue(chunkProvider.ChunkIndex3D(cx, cyWithDim, cz), out var s) ? s : null;
++		if (blockSnapshotCache.TryGetValue(chunkKey, out var snap)) return snap;
++
++		snap = RentBlockSnapshotArray();
++
++		if (chunk != null && chunk.Data != null)
+ 		{
+-			value2?.Lighting.ClearLight();
++			try { chunk.Data.CopyBlocksToUnsafe(snap); }
++			catch { Array.Clear(snap, 0, snap.Length); }
+ 		}
+-		IWorldChunk[] array = new IWorldChunk[mapsizey / num];
+-		for (int l = num8; l <= num11; l++)
++		else
+ 		{
+-			for (int m = num10; m <= num13; m++)
++			Array.Clear(snap, 0, snap.Length);
++		}
++
++		// Stratum: thread-safe add for ConcurrentDictionary. If another thread beat us,
++		// return their snapshot and recycle ours.
++		if (!blockSnapshotCache.TryAdd(chunkKey, snap))
++		{
++			lock (blockSnapshotPoolLock) { if (blockSnapshotPool.Count < 512) blockSnapshotPool.Push(snap); }
++			blockSnapshotCache.TryGetValue(chunkKey, out snap);
++		}
++		return snap;
++	}
++
++	private void BeginBlockSnapshotSession()
++	{
++		blockSessionDepth++;
++	}
++
++	private void EndBlockSnapshotSession()
++	{
++		if (--blockSessionDepth > 0) return;
++
++		lock (blockSnapshotPoolLock)
++		{
++			foreach (var arr in blockSnapshotCache.Values)
++				if (blockSnapshotPool.Count < 512) blockSnapshotPool.Push(arr);
++		}
++		blockSnapshotCache.Clear();
++	}
++
++
++	// ─── Batched block snapshots (bulk-decoded once per chunk instead of per Data[idx] access) ─────
++	/// <summary> Per-chunk bulk block-id snapshots, valid for the lifetime of the active block-snapshot session. </summary>
++	private readonly ConcurrentDictionary<long, int[]> blockSnapshotCache = new ConcurrentDictionary<long, int[]>();
++	/// <summary> Object pool for reusable block-snapshot arrays (Zero-GC). </summary>
++	private readonly Stack<int[]> blockSnapshotPool = new Stack<int[]>(256);
++	private readonly object blockSnapshotPoolLock = new object(); // Stratum: lock for thread-safe pool access
++																  /// <summary> Nesting depth of the active block-snapshot session (see Begin/EndBlockSnapshotSession). </summary>
++	private int blockSessionDepth;
++
++	// ─── Sunlight staging session bookkeeping (needed to commit currentSunStaging back to live storage once) ─────
++	/// <summary> Lighting interface reference for each currently staged chunk, used by the generic session commit. </summary>
++	private readonly ConcurrentDictionary<long, IChunkLight> stagingLightingRefs = new ConcurrentDictionary<long, IChunkLight>();
++	/// <summary> Chunk reference for each currently staged chunk, used to call MarkModified() on commit. </summary>
++	private readonly ConcurrentDictionary<long, IWorldChunk> stagingChunkRefs = new ConcurrentDictionary<long, IWorldChunk>();
++	/// <summary> Nesting depth of the active sunlight staging session (see Begin/EndSunStagingSession). </summary>
++	private int sunSessionDepth;
++
++	// ─── Staging helpers for sunlight ──────────────────────────
++	/// <summary> Retrieves a staging array from the pool or allocates a new one if empty. </summary>
++	[MethodImpl(MethodImplOptions.AggressiveInlining)]
++	private byte[] RentStagingArray()
++	{
++		lock (sunStagingPoolLock) { if (sunStagingPool.Count > 0) return sunStagingPool.Pop(); }
++		return new byte[chunkSize * chunkSize * chunkSize];
 +	}
 +
 +	/// <summary> Static helper: reads sunlight from staging array or live lighting. </summary>
@@ -371,10 +416,127 @@ index e2ca303..82dc39c 100644
 +	private static long PackColumn(int cx, int cz, int dim)
 +	{
 +		return ((long)(cx & 0x1FFFFF)) | ((long)(cz & 0x1FFFFF) << 21) | ((long)(dim & 0x3FF) << 42);
++	}
++
++	// ─── Batched block-snapshot session ──────────────────────────
++	
++
++	// ─── Batched sunlight staging session ──────────────────────────
++	/// <summary>
++	/// Returns the staging array for a chunk, creating and populating it from live sunlight (once per chunk, per session) if absent.
++	/// After this call all reads/writes for that chunk within the session should go through ReadSun/WriteSun using this array.
++	/// Thread-safe: uses ConcurrentDictionary with TryAdd to handle race conditions.
++	/// </summary>
++	private byte[] GetOrCreateSunStaging(long chunkKey, IWorldChunk chunk, IChunkLight lighting)
++	{
++		if (currentSunStaging.TryGetValue(chunkKey, out var st)) return st;
++
++		st = RentStagingArray();
++		int total = chunkSize * chunkSize * chunkSize;
++		for (int idx = 0; idx < total; idx++) st[idx] = (byte)lighting.GetSunlight(idx);
++
++		if (!currentSunStaging.TryAdd(chunkKey, st))
++		{
++			lock (sunStagingPoolLock) { if (sunStagingPool.Count < 512) sunStagingPool.Push(st); }
++			currentSunStaging.TryGetValue(chunkKey, out st);
++			return st;
++		}
++
++		stagingLightingRefs.TryAdd(chunkKey, lighting);
++		stagingChunkRefs.TryAdd(chunkKey, chunk);
++		return st;
++	}
++
++	/// <summary> Opens (or extends) a sunlight staging session. Must be paired with EndSunStagingSession. </summary>
++	private void BeginSunStagingSession()
++	{
++		sunSessionDepth++;
++	}
++
++	/// <summary> Closes a sunlight staging session. </summary>
++	private FastSetOfLongs EndSunStagingSession()
++	{
++		var touched = new FastSetOfLongs();
++		if (--sunSessionDepth > 0) return touched;
++
++		foreach (var kvp in currentSunStaging)
++		{
++			long key = kvp.Key;
++			byte[] staging = kvp.Value;
++
++			if (!stagingLightingRefs.TryRemove(key, out var lighting))
+ 			{
+-				bool flag = false;
+-				for (int n = 0; n < array.Length; n++)
+-				{
+-					IWorldChunk chunk2 = chunkProvider.GetChunk(l, n + num14, m);
+-					if (chunk2 == null)
+-					{
+-						flag = true;
+-					}
+-					array[n] = chunk2;
+-				}
+-				if (!flag)
++				lock (sunStagingPoolLock) { if (sunStagingPool.Count < 512) sunStagingPool.Push(staging); }
++				continue;
++			}
++
++			bool chunkChanged = false;
++			for (int idx = 0; idx < staging.Length; idx++)
++			{
++				int newVal = staging[idx];
++				if (lighting.GetSunlight(idx) != newVal)
+ 				{
+-					Sunlight(array, l, array.Length - 1, m, minPos.dimension);
+-					SunlightFlood(array, l, array.Length - 1, m);
+-					SunLightFloodNeighbourChunks(array, l, array.Length - 1, m, minPos.dimension);
++					lighting.SetSunlight(idx, newVal);
++					chunkChanged = true;
+ 				}
+ 			}
+-		}
+-		Dictionary<BlockPos, Block> dictionary2 = new Dictionary<BlockPos, Block>();
+-		foreach (KeyValuePair<Vec3i, IWorldChunk> item in dictionary)
+-		{
+-			Vec3i key = item.Key;
+-			IWorldChunk value = item.Value;
+-			if (value == null)
++
++			if (chunkChanged)
+ 			{
+-				continue;
++				touched.Add(key);
++				if (stagingChunkRefs.TryRemove(key, out var chunk)) chunk.MarkModified();
+ 			}
+-			int num15 = key.X * num;
+-			int num16 = key.Y * num;
+-			int num17 = key.Z * num;
+-			foreach (int lightPosition in value.LightPositions)
++			else
+ 			{
+-				int num18 = key.Y * num + lightPosition / (num * num);
+-				int num19 = key.Z * num + lightPosition / num % num;
+-				int num20 = key.X * num + lightPosition % num;
+-				dictionary2[new BlockPos(num15 + num20, num16 + num18, num17 + num19, minPos.dimension)] = blockTypes[value.Data[lightPosition]];
++				stagingChunkRefs.TryRemove(key, out _);
+ 			}
++
++			lock (sunStagingPoolLock) { if (sunStagingPool.Count < 512) sunStagingPool.Push(staging); }
+ 		}
+-		foreach (KeyValuePair<BlockPos, Block> item2 in dictionary2)
+-		{
+-			byte[] lightHsv = item2.Value.GetLightHsv(readBlockAccess, item2.Key);
+-			PlaceBlockLight(lightHsv, item2.Key.X, item2.Key.InternalY, item2.Key.Z);
+-		}
++
++		currentSunStaging.Clear();
++		stagingLightingRefs.Clear();
++		stagingChunkRefs.Clear();
++		return touched;
  	}
  
-+	/// <summary> Calculation of direct sunlight falling from top to bottom, taking into account absorption by blocks. </summary>
- 	public void Sunlight(IWorldChunk[] chunks, int chunkX, int chunkY, int chunkZ, int dim)
+-	public void Sunlight(IWorldChunk[] chunks, int chunkX, int chunkY, int chunkZ, int dim)
++	public void Sunlight(IWorldChunk[] chunks, int chunkX, int chunkY, int chunkZ, int dim, int[][] lightBuffers = null)
  	{
  		tmpPosDimensionAware.SetDimension(dim);
  		int num = chunkSize;
@@ -383,117 +545,196 @@ index e2ca303..82dc39c 100644
 -			chunks[chunkY + 1].Unpack();
 -		}
 -		for (int num2 = chunkY; num2 >= 0; num2--)
+-		{
+-			chunks[num2].Unpack();
+-		}
+-		int num3 = chunkX * num;
+-		int num4 = chunkZ * num;
+-		for (int i = 0; i < num; i++)
 +		int dimOffset = dim * 1024;
 +
 +		if (chunkY != chunks.Length - 1) chunks[chunkY + 1].Unpack();
 +		for (int num2 = chunkY; num2 >= 0; num2--) chunks[num2].Unpack();
 +
-+		bool stagingActive = currentSunStaging.Count > 0;
-+		byte[][] staging = new byte[chunks.Length][];
-+		IChunkLight[] lighting = new IChunkLight[chunks.Length];
-+		for (int c = 0; c < chunks.Length; c++)
- 		{
--			chunks[num2].Unpack();
-+			lighting[c] = chunks[c].Lighting;
-+			if (stagingActive) staging[c] = GetStagingForChunk(chunkX, c + dimOffset, chunkZ);
- 		}
++		bool useBuffers = lightBuffers != null;
++		bool ownSession = !useBuffers && sunSessionDepth == 0;
++		bool ownBlockSession = blockSessionDepth == 0;
++		if (ownSession) BeginSunStagingSession();
++		if (ownBlockSession) BeginBlockSnapshotSession();
 +
- 		int num3 = chunkX * num;
- 		int num4 = chunkZ * num;
-+
- 		for (int i = 0; i < num; i++)
++		try
  		{
- 			for (int j = 0; j < num; j++)
+-			for (int j = 0; j < num; j++)
++			bool stagingActive = !useBuffers;
++
++			byte[][] staging = new byte[chunks.Length][];
++			IChunkLight[] lighting = new IChunkLight[chunks.Length];
++			int[][] blockSnaps = new int[chunks.Length][];
++			for (int c = 0; c < chunks.Length; c++)
  			{
- 				int num5 = defaultSunLight;
- 				if (chunkY != chunks.Length - 1)
--				{
--					num5 = chunks[chunkY + 1].Lighting.GetSunlight(j * num + i);
--				}
-+					num5 = ReadSun(staging[chunkY + 1], lighting[chunkY + 1], j * num + i);
-+
- 				for (int num6 = chunkY; num6 >= 0; num6--)
+-				int num5 = defaultSunLight;
+-				if (chunkY != chunks.Length - 1)
++				// Stratum: skip uninitialized chunks, but still create an empty snapshot to prevent NRE in hot loop
++				if (chunks[c] == null || chunks[c].Data == null)
  				{
- 					int num7 = ((num - 1) * num + j) * num + i;
- 					IWorldChunk worldChunk = chunks[num6];
+-					num5 = chunks[chunkY + 1].Lighting.GetSunlight(j * num + i);
++					blockSnaps[c] = GetOrCreateBlockSnapshot(chunkProvider.ChunkIndex3D(chunkX, c + dimOffset, chunkZ), null);
++					continue;
+ 				}
+-				for (int num6 = chunkY; num6 >= 0; num6--)
++
++				lighting[c] = chunks[c].Lighting;
++				blockSnaps[c] = GetOrCreateBlockSnapshot(chunkProvider.ChunkIndex3D(chunkX, c + dimOffset, chunkZ), chunks[c]);
++				if (!stagingActive) continue;
++
++				if (c <= chunkY)
++					staging[c] = GetOrCreateSunStaging(chunkProvider.ChunkIndex3D(chunkX, c + dimOffset, chunkZ), chunks[c], lighting[c]);
++				else
++					staging[c] = GetStagingForChunk(chunkProvider.ChunkIndex3D(chunkX, c + dimOffset, chunkZ));
++			}
++
++			int num3 = chunkX * num;
++			int num4 = chunkZ * num;
++
++			for (int i = 0; i < num; i++)
++			{
++				for (int j = 0; j < num; j++)
+ 				{
+-					int num7 = ((num - 1) * num + j) * num + i;
+-					IWorldChunk worldChunk = chunks[num6];
 -					IChunkLight lighting = chunks[num6].Lighting;
 -					tmpPosDimensionAware.Set(num3 + i, num6 * num + num - 1, num4 + j);
-+					byte[] st = staging[num6];
-+					IChunkLight lg = lighting[num6];
+-					for (int num8 = num - 1; num8 >= 0; num8--)
++					int num5 = defaultSunLight;
++					if (chunkY != chunks.Length - 1)
++					{
++						if (useBuffers) num5 = lightBuffers[chunkY + 1][j * num + i] & 0x1F;
++						else num5 = ReadSun(staging[chunkY + 1], lighting[chunkY + 1], j * num + i);
++					}
 +
- 					for (int num8 = num - 1; num8 >= 0; num8--)
++					for (int num6 = chunkY; num6 >= 0; num6--)
  					{
-+						tmpPosDimensionAware.Set(num3 + i, num6 * num + num8, num4 + j);
- 						int lightAbsorptionAt = worldChunk.GetLightAbsorptionAt(num7, tmpPosDimensionAware, blockTypes);
+-						int lightAbsorptionAt = worldChunk.GetLightAbsorptionAt(num7, tmpPosDimensionAware, blockTypes);
 -						lighting.SetSunlight(num7, num5);
 -						num7 -= YPlus;
 -						if (lightAbsorptionAt > num5)
-+						Block block = blockTypes[worldChunk.Data[num7]];
++						if (chunks[num6] == null || chunks[num6].Data == null) continue;
 +
-+						int effectiveAbs = GetEffectiveAbsorption(
-+							block, lightAbsorptionAt, BlockFacing.DOWN, num5, tmpPosDimensionAware);
++						int num7 = ((num - 1) * num + j) * num + i;
++						IWorldChunk worldChunk = chunks[num6];
++						int[] snap = blockSnaps[num6];
++						if (snap == null) continue; // Stratum: safety fallback
++						int[] buf = useBuffers ? lightBuffers[num6] : null;
++						byte[] st = stagingActive ? staging[num6] : null;
++						IChunkLight lg = lighting[num6];
 +
-+						if (effectiveAbs > num5)
++						for (int num8 = num - 1; num8 >= 0; num8--)
  						{
-+							int solidMask = 0;
-+							if (block.SideSolid[0]) solidMask |= 1;
-+							if (block.SideSolid[1]) solidMask |= 2;
-+							if (block.SideSolid[2]) solidMask |= 4;
-+							if (block.SideSolid[3]) solidMask |= 8;
-+							if (block.SideSolid[4]) solidMask |= 16;
-+							if (block.SideSolid[5]) solidMask |= 32;
+-							num6 = -1;
+-							break;
++							tmpPosDimensionAware.Set(num3 + i, num6 * num + num8, num4 + j);
++							int lightAbsorptionAt = worldChunk.GetLightAbsorptionAt(num7, tmpPosDimensionAware, blockTypes);
++							Block block = blockTypes[snap[num7]]; // Stratum: snapshot read, no bit-plane decode
 +
-+							if (solidMask == 63)
-+								WriteSun(st, lg, num7, num5);
-+							else
-+								WriteSun(st, lg, num7, 0);
++							int effectiveAbs = GetEffectiveAbsorption(
++								block, lightAbsorptionAt, BlockFacing.DOWN, num5, tmpPosDimensionAware);
 +
- 							num6 = -1;
- 							break;
++							if (effectiveAbs > num5)
++							{
++								int solidMask = 0;
++								if (block.SideSolid[0]) solidMask |= 1;
++								if (block.SideSolid[1]) solidMask |= 2;
++								if (block.SideSolid[2]) solidMask |= 4;
++								if (block.SideSolid[3]) solidMask |= 8;
++								if (block.SideSolid[4]) solidMask |= 16;
++								if (block.SideSolid[5]) solidMask |= 32;
++
++								if (solidMask == 63)
++								{
++									if (useBuffers) buf[num7] = (buf[num7] & -32) | (num5 & 0x1F);
++									else WriteSun(st, lg, num7, num5);
++								}
++								else
++								{
++									if (useBuffers) buf[num7] = buf[num7] & -32;
++									else WriteSun(st, lg, num7, 0);
++								}
++
++								num6 = -1;
++								break;
++							}
++
++							if (useBuffers) buf[num7] = (buf[num7] & -32) | (num5 & 0x1F);
++							else WriteSun(st, lg, num7, num5);
++
++							num7 -= YPlus;
++							num5 -= (ushort)effectiveAbs;
++							tmpPosDimensionAware.Y--;
  						}
 -						num5 -= (ushort)lightAbsorptionAt;
-+
-+						WriteSun(st, lg, num7, num5);
-+						num7 -= YPlus;
-+						num5 -= (ushort)effectiveAbs;
- 						tmpPosDimensionAware.Y--;
+-						tmpPosDimensionAware.Y--;
  					}
  				}
  			}
  		}
++		finally
++		{
++			if (ownBlockSession) EndBlockSnapshotSession();
++			if (ownSession) EndSunStagingSession();
++		}
  	}
  
+-	public void SunlightFlood(IWorldChunk[] chunks, int chunkX, int chunkY, int chunkZ)
 +	/// <summary> Horizontal propagation of sunlight inside chunks. </summary>
- 	public void SunlightFlood(IWorldChunk[] chunks, int chunkX, int chunkY, int chunkZ)
++	public void SunlightFlood(IWorldChunk[] chunks, int chunkX, int chunkY, int chunkZ, int dim, int[][] lightBuffers = null)
  	{
++		tmpPosDimensionAware.SetDimension(dim);
  		int num = chunkSize;
 -		Stack<BlockPos> stack = new Stack<BlockPos>();
++		int dimOffset = dim * 1024;
 +		Stack<FastBlockPos> stack = new Stack<FastBlockPos>();
  		int num2 = chunkX * num;
  		int num3 = chunkZ * num;
+-		for (int num4 = chunkY; num4 >= 0; num4--)
 +
-+		bool stagingActive = currentSunStaging.Count > 0;
++		bool useBuffers = lightBuffers != null;
++		bool ownSession = !useBuffers && sunSessionDepth == 0;
++		bool ownBlockSession = blockSessionDepth == 0;          // Stratum: added — keep snapshot cache alive across all internal SpreadSunLightInColumn flushes
++		if (ownSession) BeginSunStagingSession();
++		if (ownBlockSession) BeginBlockSnapshotSession();      // Stratum: added
 +
- 		for (int num4 = chunkY; num4 >= 0; num4--)
++		try
  		{
- 			IWorldChunk worldChunk = chunks[num4];
- 			worldChunk.Unpack();
+-			IWorldChunk worldChunk = chunks[num4];
+-			worldChunk.Unpack();
 -			_ = worldChunk.Data;
 -			IChunkLight lighting = worldChunk.Lighting;
-+			byte[] st = stagingActive ? GetStagingForChunk(chunkX, num4 + currentDimOffset, chunkZ) : null;
-+			IChunkLight lg = worldChunk.Lighting;
+-			for (int i = 0; i < num; i++)
++			bool stagingActive = !useBuffers;
 +
- 			for (int i = 0; i < num; i++)
++			for (int num4 = chunkY; num4 >= 0; num4--)
  			{
- 				tmpPosDimensionAware.Set(num2 + i, num4 * num + num, num3);
- 				for (int j = 0; j < num; j++)
+-				tmpPosDimensionAware.Set(num2 + i, num4 * num + num, num3);
+-				for (int j = 0; j < num; j++)
++				if (chunks[num4] == null) continue; // Null-safe
++
++				IWorldChunk worldChunk = chunks[num4];
++				worldChunk.Unpack();
++
++				int[] buf = useBuffers ? lightBuffers[num4] : null;
++				byte[] st = stagingActive ? GetOrCreateSunStaging(chunkProvider.ChunkIndex3D(chunkX, num4 + dimOffset, chunkZ), worldChunk, worldChunk.Lighting) : null;
++				IChunkLight lg = worldChunk.Lighting;
++
++				for (int i = 0; i < num; i++)
  				{
-@@ -232,879 +363,1396 @@ public class ChunkIlluminator
- 					tmpPosDimensionAware.Z = num3 + j;
- 					for (int num6 = num - 1; num6 >= 0; num6--)
+-					int num5 = (num * num + j) * num + i;
+-					tmpPosDimensionAware.Z = num3 + j;
+-					for (int num6 = num - 1; num6 >= 0; num6--)
++					tmpPosDimensionAware.Set(num2 + i, num4 * num + num, num3);
++					for (int j = 0; j < num; j++)
  					{
- 						num5 -= YPlus;
- 						tmpPosDimensionAware.Y--;
+-						num5 -= YPlus;
+-						tmpPosDimensionAware.Y--;
 -						int num7 = lighting.GetSunlight(num5) - 1;
 -						if (num7 <= 0)
 -						{
@@ -502,31 +743,57 @@ index e2ca303..82dc39c 100644
 -						int lightAbsorptionAt = worldChunk.GetLightAbsorptionAt(num5, tmpPosDimensionAware, blockTypes);
 -						num7 -= lightAbsorptionAt;
 -						if (num7 > 0 && ((i < num - 1 && lighting.GetSunlight(num5 + XPlus) < num7) || (j < num - 1 && lighting.GetSunlight(num5 + ZPlus) < num7) || (i > 0 && lighting.GetSunlight(num5 - XPlus) < num7) || (j > 0 && lighting.GetSunlight(num5 - ZPlus) < num7)))
-+						int num7 = ReadSun(st, lg, num5) - 1;
-+						if (num7 <= 0) break;
-+
-+						if ((i < num - 1 && ReadSun(st, lg, num5 + XPlus) < num7) ||
-+							(j < num - 1 && ReadSun(st, lg, num5 + ZPlus) < num7) ||
-+							(i > 0 && ReadSun(st, lg, num5 - XPlus) < num7) ||
-+							(j > 0 && ReadSun(st, lg, num5 - ZPlus) < num7))
++						int num5 = (num * num + j) * num + i;
++						tmpPosDimensionAware.Z = num3 + j;
++						for (int num6 = num - 1; num6 >= 0; num6--)
  						{
 -							stack.Push(new BlockPos(num2 + i, num4 * num + num6, num3 + j, tmpPosDimensionAware.dimension));
 -							if (stack.Count > 50)
--							{
++							num5 -= YPlus;
++							tmpPosDimensionAware.Y--;
++
++							int currentSun = useBuffers ? (buf != null ? buf[num5] & 0x1F : 0) : ReadSun(st, lg, num5);
++							int num7 = currentSun - 1;
++							if (num7 <= 0) break;
++
++							int nE, nW, nS, nN;
++							if (useBuffers)
++							{
++								nE = (i < num - 1 && buf != null) ? (buf[num5 + XPlus] & 0x1F) : 0;
++								nS = (j < num - 1 && buf != null) ? (buf[num5 + ZPlus] & 0x1F) : 0;
++								nW = (i > 0 && buf != null) ? (buf[num5 - XPlus] & 0x1F) : 0;
++								nN = (j > 0 && buf != null) ? (buf[num5 - ZPlus] & 0x1F) : 0;
++							}
++							else
++							{
++								nE = (i < num - 1) ? ReadSun(st, lg, num5 + XPlus) : 0;
++								nS = (j < num - 1) ? ReadSun(st, lg, num5 + ZPlus) : 0;
++								nW = (i > 0) ? ReadSun(st, lg, num5 - XPlus) : 0;
++								nN = (j > 0) ? ReadSun(st, lg, num5 - ZPlus) : 0;
++							}
++
++							if (nE < num7 || nS < num7 || nW < num7 || nN < num7)
+ 							{
 -								SpreadSunLightInColumn(stack, chunks);
--							}
-+							stack.Push(new FastBlockPos(num2 + i, num4 * num + num6, num3 + j, tmpPosDimensionAware.dimension));
-+							if (stack.Count > 50) SpreadSunLightInColumn(stack, chunks);
++								stack.Push(new FastBlockPos(num2 + i, num4 * num + num6, num3 + j, tmpPosDimensionAware.dimension));
++								if (stack.Count > 50) SpreadSunLightInColumn(stack, chunks, dim, lightBuffers);
+ 							}
  						}
  					}
  				}
  			}
++			SpreadSunLightInColumn(stack, chunks, dim, lightBuffers);
++		}
++		finally
++		{
++			if (ownBlockSession) EndBlockSnapshotSession();    // Stratum: added
++			if (ownSession) EndSunStagingSession();
  		}
- 		SpreadSunLightInColumn(stack, chunks);
+-		SpreadSunLightInColumn(stack, chunks);
  	}
  
-+	/// <summary> Exchange of sunlight across the boundaries of neighboring chunks. </summary>
- 	public byte SunLightFloodNeighbourChunks(IWorldChunk[] curChunks, int chunkX, int chunkY, int chunkZ, int dimension)
+-	public byte SunLightFloodNeighbourChunks(IWorldChunk[] curChunks, int chunkX, int chunkY, int chunkZ, int dimension)
++	public byte SunLightFloodNeighbourChunks(IWorldChunk[] curChunks, int chunkX, int chunkY, int chunkZ, int dimension, int[][] lightBuffers = null)
  	{
  		tmpPosDimensionAware.SetDimension(dimension);
  		int num = chunkSize;
@@ -543,7 +810,12 @@ index e2ca303..82dc39c 100644
 -		BlockFacing[] hORIZONTALS = BlockFacing.HORIZONTALS;
 -		foreach (BlockFacing blockFacing in hORIZONTALS)
 +		int dimOffset = dimension * 1024;
-+		bool stagingActive = currentSunStaging.Count > 0;
++
++		bool useBuffers = lightBuffers != null;
++		// Stratum: NO ownSession and NO block snapshots here. Boundary exchange is sparse:
++		// decoding whole 32768-block chunks to read a few thousand boundary blocks costs
++		// far more than the direct Data[idx] reads it replaces.
++		bool stagingActive = !useBuffers && sunSessionDepth > 0;
 +
 +		foreach (BlockFacing blockFacing in BlockFacing.HORIZONTALS)
  		{
@@ -606,9 +878,14 @@ index e2ca303..82dc39c 100644
 -				IChunkLight lighting = worldChunk.Lighting;
 -				IChunkLight lighting2 = worldChunk2.Lighting;
 +
-+				byte[] stCur = stagingActive ? GetStagingForChunk(chunkX, num6 + dimOffset, chunkZ) : null;
-+				byte[] stN = stagingActive ? GetStagingForChunk(chunkX + x, num6 + dimOffset, chunkZ + z) : null;
++				// Stratum: skip if neighbor or current chunk is uninitialized
++				if (worldChunk == null || worldChunk.Data == null || worldChunk2 == null || worldChunk2.Data == null) continue;
++
++				int[] bufCur = useBuffers ? lightBuffers[num6] : null;
++				byte[] stCur = stagingActive ? GetOrCreateSunStaging(chunkProvider.ChunkIndex3D(chunkX, num6 + dimOffset, chunkZ), worldChunk2, worldChunk2.Lighting) : null;
 +				IChunkLight lgCur = worldChunk2.Lighting;
++
++				byte[] stN = stagingActive ? GetStagingForChunk(chunkProvider.ChunkIndex3D(chunkX + x, num6 + dimOffset, chunkZ + z)) : null;
 +				IChunkLight lgN = worldChunk.Lighting;
 +
  				for (int num7 = num - 1; num7 >= 0; num7--)
@@ -633,12 +910,13 @@ index e2ca303..82dc39c 100644
 -						int num14 = num12 - lightAbsorptionAt;
 -						if (num14 > num11)
 +
-+						int curLight = ReadSun(stCur, lgCur, index3d);
++						int curLight = useBuffers ? (bufCur[index3d] & 0x1F) : ReadSun(stCur, lgCur, index3d);
 +						int nLight = ReadSun(stN, lgN, index3d2);
 +
 +						BlockFacing dir = blockFacing;
 +						BlockFacing oppDir = dir.Opposite;
 +
++						// Stratum: sparse direct reads — only boundary blocks, no full-chunk snapshot
 +						Block curBlock = blockTypes[worldChunk2.Data[index3d]];
 +						int curBaseAbs = worldChunk2.GetLightAbsorptionAt(index3d, tmpPosDimensionAware, blockTypes);
 +						tmpPos2.Set(num2 + array2[0], num6 * num + array2[1], num3 + array2[2]);
@@ -672,12 +950,14 @@ index e2ca303..82dc39c 100644
  						{
 -							lighting2.SetSunlight(index3d, num13);
 -							stack.Push(new BlockPos(num2 + array2[0], num6 * num + array2[1], num3 + array2[2], dimension));
-+							WriteSun(stCur, lgCur, index3d, finalLightToCur);
++							if (useBuffers) bufCur[index3d] = (bufCur[index3d] & -32) | (finalLightToCur & 0x1F);
++							else WriteSun(stCur, lgCur, index3d, finalLightToCur);
++
 +							stack.Push(new FastBlockPos(num2 + array2[0], num6 * num + array2[1], num3 + array2[2], dimension));
  						}
  					}
  				}
- 			}
+-			}
 -			if (stack2.Count > 0)
 -			{
 -				SpreadSunLightInColumn(stack2, array3);
@@ -689,24 +969,25 @@ index e2ca303..82dc39c 100644
 -			if (stack.Count > 0)
 -			{
 -				SpreadSunLightInColumn(stack, curChunks);
--			}
-+			if (stack2.Count > 0) SpreadSunLightInColumn(stack2, array3);
-+			if (stack.Count > 0) SpreadSunLightInColumn(stack, curChunks);
++				if (stack2.Count > 0) SpreadSunLightInColumn(stack2, array3, dimension);
++				if (stack.Count > 0) SpreadSunLightInColumn(stack, curChunks, dimension, lightBuffers);
+ 			}
  		}
  		return b;
  	}
  
 -	public void SpreadSunLightInColumn(Stack<BlockPos> stack, IWorldChunk[] chunks)
-+	/// <summary> BFS propagation of sunlight over a stack of coordinates. </summary>
-+	private void SpreadSunLightInColumn(Stack<FastBlockPos> stack, IWorldChunk[] chunks)
++	private void SpreadSunLightInColumn(Stack<FastBlockPos> stack, IWorldChunk[] chunks, int dim, int[][] lightBuffers = null)
  	{
  		int num = chunkSize;
-+		bool stagingActive = currentSunStaging.Count > 0;
-+		int cachedChunkY = int.MinValue;
-+		byte[] st = null;
-+		IChunkLight lg = null;
+-		while (stack.Count > 0)
++		int dimOffset = dim * 1024;
++		bool useBuffers = lightBuffers != null;
++		bool stagingActive = !useBuffers && sunSessionDepth > 0;
++		bool ownBlockSession = blockSessionDepth == 0;
++		if (ownBlockSession) BeginBlockSnapshotSession();
 +
- 		while (stack.Count > 0)
++		try
  		{
 -			BlockPos blockPos = stack.Pop();
 -			int num2 = blockPos.X / num;
@@ -720,110 +1001,143 @@ index e2ca303..82dc39c 100644
 -			int lightAbsorptionAt = worldChunk.GetLightAbsorptionAt(index3d, blockPos, blockTypes);
 -			int num8 = worldChunk.Lighting.GetSunlight(index3d) - lightAbsorptionAt - 1;
 -			if (num8 <= 0)
-+			FastBlockPos pos = stack.Pop();
-+			int chunkX = pos.X >> chunkSizeLog2;
-+			int chunkY = pos.Y >> chunkSizeLog2;
-+			int chunkZ = pos.Z >> chunkSizeLog2;
-+			int localX = pos.X & chunkSizeMask;
-+			int localY = pos.Y & chunkSizeMask;
-+			int localZ = pos.Z & chunkSizeMask;
-+			int index3d = (localY * num + localZ) * num + localX;
-+
-+			IWorldChunk worldChunk = chunks[chunkY];
-+			tmpPos.Set(pos.X, pos.Y, pos.Z);
-+			tmpPos.dimension = pos.Dim;
-+
-+			if (chunkY != cachedChunkY)
- 			{
+-			{
 -				continue;
-+				cachedChunkY = chunkY;
-+				st = stagingActive ? GetStagingForChunk(chunkX, chunkY + currentDimOffset, chunkZ) : null;
-+				lg = worldChunk.Lighting;
- 			}
+-			}
 -			int num9 = num3;
+-			for (int i = 0; i < 6; i++)
++			int cachedChunkY = int.MinValue;
++			int[] buf = null;
++			byte[] st = null;
++			IChunkLight lg = null;
++			int[] snap = null;
 +
-+			int baseAbsorption = worldChunk.GetLightAbsorptionAt(index3d, tmpPos, blockTypes);
-+			Block posBlock = blockTypes[worldChunk.Data[index3d]];
-+			int currentLight = ReadSun(st, lg, index3d);
-+
-+			if (currentLight <= 0) continue;
-+
-+			int lastChunkY = chunkY;
- 			for (int i = 0; i < 6; i++)
++			while (stack.Count > 0)
  			{
- 				Vec3i vec3i = BlockFacing.ALLNORMALI[i];
+-				Vec3i vec3i = BlockFacing.ALLNORMALI[i];
 -				int num10 = blockPos.Y + vec3i.Y;
 -				int num11 = num5 + vec3i.X;
 -				int num12 = num7 + vec3i.Z;
 -				if (num11 >= 0 && num10 >= 0 && num12 >= 0 && num11 < num && num10 < mapsizey && num12 < num)
-+				int ny = pos.Y + vec3i.Y;
-+				int nlx = localX + vec3i.X;
-+				int nlz = localZ + vec3i.Z;
++				FastBlockPos pos = stack.Pop();
++				int chunkX = pos.X >> chunkSizeLog2;
++				int chunkY = pos.Y >> chunkSizeLog2;
++				int chunkZ = pos.Z >> chunkSizeLog2;
++				int localX = pos.X & chunkSizeMask;
++				int localY = pos.Y & chunkSizeMask;
++				int localZ = pos.Z & chunkSizeMask;
++				int index3d = (localY * num + localZ) * num + localX;
 +
-+				if (nlx >= 0 && ny >= 0 && nlz >= 0 && nlx < num && ny < mapsizey && nlz < num)
++				if (chunkY < 0 || chunkY >= chunks.Length || chunks[chunkY] == null) continue;
++				IWorldChunk worldChunk = chunks[chunkY];
++				if (worldChunk.Data == null) continue;
++
++				tmpPos.Set(pos.X, pos.Y, pos.Z);
++				tmpPos.dimension = pos.Dim;
++
++				if (chunkY != cachedChunkY)
  				{
 -					num3 = num10 / num;
 -					if (num3 != num9)
-+					int nChunkY = ny >> chunkSizeLog2;
-+					if (nChunkY != lastChunkY)
-+					{
-+						worldChunk = chunks[nChunkY];
-+						lastChunkY = nChunkY;
-+					}
-+
-+					int nIndex3d = ((ny & chunkSizeMask) * num + nlz) * num + nlx;
-+					BlockFacing dir = BlockFacing.ALLFACES[i];
-+					int effectiveAbs = GetEffectiveAbsorption(posBlock, baseAbsorption, dir, currentLight, tmpPos);
-+					int newLight = currentLight - effectiveAbs - 1;
-+
-+					if (newLight <= 0) continue;
-+
-+					Block nBlock = blockTypes[worldChunk.Data[nIndex3d]];
-+					tmpPos.Set(chunkX * num + nlx, ny, chunkZ * num + nlz);
-+					int nBaseAbs = worldChunk.GetLightAbsorptionAt(nIndex3d, tmpPos, blockTypes);
-+					tmpPos2.Set(chunkX * num + nlx, ny, chunkZ * num + nlz);
-+					tmpPos2.dimension = pos.Dim;
-+					int nEffectiveAbs = GetEffectiveAbsorption(nBlock, nBaseAbs, dir, newLight, tmpPos2);
-+
-+					int finalLight = newLight;
-+					if (nEffectiveAbs > newLight)
-+					{
-+						int solidMask = 0;
-+						if (nBlock.SideSolid[0]) solidMask |= 1;
-+						if (nBlock.SideSolid[1]) solidMask |= 2;
-+						if (nBlock.SideSolid[2]) solidMask |= 4;
-+						if (nBlock.SideSolid[3]) solidMask |= 8;
-+						if (nBlock.SideSolid[4]) solidMask |= 16;
-+						if (nBlock.SideSolid[5]) solidMask |= 32;
-+
-+						if (solidMask != 63) finalLight = 0;
-+					}
-+
-+					byte[] nSt = st;
-+					IChunkLight nLg = lg;
-+					if (nChunkY != cachedChunkY)
- 					{
+-					{
 -						worldChunk = chunks[num3];
 -						worldChunk.Unpack();
 -						num9 = num3;
-+						nSt = stagingActive ? GetStagingForChunk(chunkX, nChunkY + currentDimOffset, chunkZ) : null;
-+						nLg = worldChunk.Lighting;
- 					}
+-					}
 -					index3d = (num10 % num * num + num12) * num + num11;
 -					if (worldChunk.Lighting.GetSunlight(index3d) < num8)
++					cachedChunkY = chunkY;
++					buf = useBuffers ? lightBuffers[chunkY] : null;
++					st = stagingActive ? GetStagingForChunk(chunkProvider.ChunkIndex3D(chunkX, chunkY + dimOffset, chunkZ)) : null;
++					lg = worldChunk.Lighting;
++					snap = GetOrCreateBlockSnapshot(chunkProvider.ChunkIndex3D(chunkX, chunkY + dimOffset, chunkZ), worldChunk);
++					if (snap == null) continue; // Stratum: safety fallback
++				}
 +
-+					if (ReadSun(nSt, nLg, nIndex3d) < finalLight)
++				int baseAbsorption = worldChunk.GetLightAbsorptionAt(index3d, tmpPos, blockTypes);
++				Block posBlock = blockTypes[snap[index3d]];
++				int currentLight = useBuffers ? (buf[index3d] & 0x1F) : ReadSun(st, lg, index3d);
++
++				if (currentLight <= 0) continue;
++
++				int lastChunkY = chunkY;
++				int[] nSnap = snap;
++				for (int i = 0; i < 6; i++)
++				{
++					Vec3i vec3i = BlockFacing.ALLNORMALI[i];
++					int ny = pos.Y + vec3i.Y;
++					int nlx = localX + vec3i.X;
++					int nlz = localZ + vec3i.Z;
++
++					if (nlx >= 0 && ny >= 0 && nlz >= 0 && nlx < num && ny < mapsizey && nlz < num)
  					{
 -						worldChunk.Lighting.SetSunlight(index3d, num8);
 -						stack.Push(new BlockPos(num2 * num + num11, num10, num4 * num + num12, blockPos.dimension));
-+						WriteSun(nSt, nLg, nIndex3d, finalLight);
-+						int absX = chunkX * num + nlx;
-+						int absZ = chunkZ * num + nlz;
-+						stack.Push(new FastBlockPos(absX, ny, absZ, pos.Dim));
++						int nChunkY = ny >> chunkSizeLog2;
++						if (nChunkY != lastChunkY)
++						{
++							if (nChunkY < 0 || nChunkY >= chunks.Length || chunks[nChunkY] == null || chunks[nChunkY].Data == null) continue;
++							worldChunk = chunks[nChunkY];
++							lastChunkY = nChunkY;
++							nSnap = GetOrCreateBlockSnapshot(chunkProvider.ChunkIndex3D(chunkX, nChunkY + dimOffset, chunkZ), worldChunk);
++						}
++
++						int nIndex3d = ((ny & chunkSizeMask) * num + nlz) * num + nlx;
++						BlockFacing dir = BlockFacing.ALLFACES[i];
++						int effectiveAbs = GetEffectiveAbsorption(posBlock, baseAbsorption, dir, currentLight, tmpPos);
++						int newLight = currentLight - effectiveAbs - 1;
++
++						if (newLight <= 0) continue;
++
++						Block nBlock = blockTypes[nSnap[nIndex3d]];
++						tmpPos.Set(chunkX * num + nlx, ny, chunkZ * num + nlz);
++						int nBaseAbs = worldChunk.GetLightAbsorptionAt(nIndex3d, tmpPos, blockTypes);
++						tmpPos2.Set(chunkX * num + nlx, ny, chunkZ * num + nlz);
++						tmpPos2.dimension = pos.Dim;
++						int nEffectiveAbs = GetEffectiveAbsorption(nBlock, nBaseAbs, dir, newLight, tmpPos2);
++
++						int finalLight = newLight;
++						if (nEffectiveAbs > newLight)
++						{
++							int solidMask = 0;
++							if (nBlock.SideSolid[0]) solidMask |= 1;
++							if (nBlock.SideSolid[1]) solidMask |= 2;
++							if (nBlock.SideSolid[2]) solidMask |= 4;
++							if (nBlock.SideSolid[3]) solidMask |= 8;
++							if (nBlock.SideSolid[4]) solidMask |= 16;
++							if (nBlock.SideSolid[5]) solidMask |= 32;
++
++							if (solidMask != 63) finalLight = 0;
++						}
++
++						int[] nBuf = buf;
++						byte[] nSt = st;
++						IChunkLight nLg = lg;
++						if (nChunkY != cachedChunkY)
++						{
++							nBuf = useBuffers ? lightBuffers[nChunkY] : null;
++							nSt = stagingActive ? GetStagingForChunk(chunkProvider.ChunkIndex3D(chunkX, nChunkY + dimOffset, chunkZ)) : null;
++							nLg = worldChunk.Lighting;
++						}
++
++						int nLightCurrent = useBuffers ? (nBuf[nIndex3d] & 0x1F) : ReadSun(nSt, nLg, nIndex3d);
++						if (nLightCurrent < finalLight)
++						{
++							if (useBuffers) nBuf[nIndex3d] = (nBuf[nIndex3d] & -32) | (finalLight & 0x1F);
++							else WriteSun(nSt, nLg, nIndex3d, finalLight);
++
++							int absX = chunkX * num + nlx;
++							int absZ = chunkZ * num + nlz;
++							stack.Push(new FastBlockPos(absX, ny, absZ, pos.Dim));
++						}
  					}
  				}
  			}
  		}
++		finally
++		{
++			if (ownBlockSession) EndBlockSnapshotSession();
++		}
  	}
  
 -	private int SunLightLevelAt(int posX, int posY, int posZ, bool substractAbsorb = false)
@@ -833,55 +1147,24 @@ index e2ca303..82dc39c 100644
 -		int num = chunkSize;
 -		IWorldChunk unpackedChunkFast = chunkProvider.GetUnpackedChunkFast(posX / num, posY / num, posZ / num, notRecentlyAccessed: true);
 -		if (unpackedChunkFast == null)
--		{
--			return defaultSunLight;
--		}
--		int index3d = (posY % num * num + posZ % num) * num + posX % num;
--		return unpackedChunkFast.Lighting.GetSunlight(index3d) - (substractAbsorb ? unpackedChunkFast.GetLightAbsorptionAt(index3d, tmpPos.Set(posX, posY, posZ), blockTypes) : 0);
--	}
 +		FastSetOfLongs touchedChunks = new FastSetOfLongs();
 +		if (newAbsorb == oldAbsorb) return touchedChunks;
- 
--	private void SetSunLightLevelAt(int posX, int posY, int posZ, int level)
--	{
--		int num = chunkSize;
--		IWorldChunk unpackedChunkFast = chunkProvider.GetUnpackedChunkFast(posX / num, posY / num, posZ / num, notRecentlyAccessed: true);
--		if (unpackedChunkFast != null)
--		{
--			int index3d = (posY % num * num + posZ % num) * num + posX % num;
--			unpackedChunkFast.Lighting.SetSunlight(index3d, level);
--		}
--	}
++
 +		if (posX < 0 || posY < 0 || posZ < 0 ||
 +			posX >= mapsizex || posY >= mapsizey || posZ >= mapsizez)
 +			return touchedChunks;
- 
--	private void ClearSunLightLevelAt(int posX, int posY, int posZ)
--	{
--		SetSunLightLevelAt(posX, posY, posZ, 0);
--	}
++
 +		int chunkX = posX >> chunkSizeLog2;
 +		int chunkZ = posZ >> chunkSizeLog2;
 +		int dim = posY / 32768;
 +		int localY = posY - dim * 32768;
 +		int chunkY = localY >> chunkSizeLog2;
- 
--	private int GetSunLightFromNeighbour(int posX, int posY, int posZ, bool directlyIlluminated)
--	{
--		int num = posY / 32768 * 32768;
--		int num2 = 0;
--		for (int i = 0; i < 6; i++)
++
 +		for (int dx = -1; dx <= 1; dx++)
  		{
--			Vec3i vec3i = BlockFacing.ALLNORMALI[i];
--			int num3 = posX + vec3i.X;
--			int num4 = posY + vec3i.Y;
--			int num5 = posZ + vec3i.Z;
--			if ((num3 | num5) >= 0 && num4 >= num && num3 < mapsizex && num4 < mapsizey + num && num5 < mapsizez)
+-			return defaultSunLight;
 +			for (int dz = -1; dz <= 1; dz++)
- 			{
--				IWorldChunk unpackedChunkFast = chunkProvider.GetUnpackedChunkFast(num3 / chunkSize, num4 / chunkSize, num5 / chunkSize);
--				if (unpackedChunkFast != null)
++			{
 +				if (dx != 0 && dz != 0) continue;
 +				int cx = chunkX + dx;
 +				int cz = chunkZ + dz;
@@ -889,39 +1172,22 @@ index e2ca303..82dc39c 100644
 +					continue;
 +
 +				long key = PackColumn(cx, cz, dim);
-+				if (!pendingSunlightUpdates.TryGetValue(key, out int maxY) || chunkY > maxY)
- 				{
--					int index3d = (num4 % chunkSize * chunkSize + num5 % chunkSize) * chunkSize + num3 % chunkSize;
--					int lightAbsorptionAt = unpackedChunkFast.GetLightAbsorptionAt(index3d, tmpPos.Set(num3, num4, num5), blockTypes);
--					int val = unpackedChunkFast.Lighting.GetSunlight(index3d) - lightAbsorptionAt - ((!(i == 4 && directlyIlluminated)) ? 1 : 0);
--					num2 = Math.Max(num2, val);
-+					pendingSunlightUpdates[key] = chunkY;
- 				}
- 			}
++				// Stratum: Thread-safe update for ConcurrentDictionary
++				pendingSunlightUpdates.AddOrUpdate(key, chunkY, (k, oldY) => Math.Max(oldY, chunkY));
++			}
  		}
--		return num2;
+-		int index3d = (posY % num * num + posZ % num) * num + posX % num;
+-		return unpackedChunkFast.Lighting.GetSunlight(index3d) - (substractAbsorb ? unpackedChunkFast.GetLightAbsorptionAt(index3d, tmpPos.Set(posX, posY, posZ), blockTypes) : 0);
 +		return touchedChunks; // Returns an empty set; actual chunks will be in Flush
  	}
  
--	public FastSetOfLongs UpdateSunLight(int posX, int posY, int posZ, int oldAbsorb, int newAbsorb)
+-	private void SetSunLightLevelAt(int posX, int posY, int posZ, int level)
 +	/// <summary> Full recalculation of light in a given cubic region </summary>
 +	public void FullRelight(BlockPos minPos, BlockPos maxPos)
  	{
--		FastSetOfLongs fastSetOfLongs = new FastSetOfLongs();
--		if (newAbsorb == oldAbsorb)
--		{
--			return fastSetOfLongs;
--		}
--		int num = posY / 32768 * 32768;
--		if (posX < 0 || posY < 0 || posZ < 0 || posX >= mapsizex || posY >= num + mapsizey || posZ >= mapsizez)
--		{
--			return fastSetOfLongs;
--		}
--		QueueOfInt queueOfInt = new QueueOfInt();
--		bool flag = IsDirectlyIlluminated(posX, posY, posZ);
--		BlockPos centerPos = new BlockPos(posX, posY, posZ);
--		if (newAbsorb > oldAbsorb)
-+		int num = chunkSize;
+ 		int num = chunkSize;
+-		IWorldChunk unpackedChunkFast = chunkProvider.GetUnpackedChunkFast(posX / num, posY / num, posZ / num, notRecentlyAccessed: true);
+-		if (unpackedChunkFast != null)
 +		Dictionary<Vec3i, IWorldChunk> dictionary = new Dictionary<Vec3i, IWorldChunk>();
 +
 +		// 1. Expand the region boundaries by 1 chunk in all directions so that light can correctly flow across boundaries
@@ -946,80 +1212,78 @@ index e2ca303..82dc39c 100644
 +		// 2. Load and unpack all necessary chunks
 +		for (int i = num8; i <= num11; i++)
  		{
--			IWorldChunk unpackedChunkFast = chunkProvider.GetUnpackedChunkFast(posX / chunkSize, posY / chunkSize, posZ / chunkSize, notRecentlyAccessed: true);
--			if (unpackedChunkFast == null)
--			{
--				return fastSetOfLongs;
--			}
--			int index3d = (posY % chunkSize * chunkSize + posZ % chunkSize) * chunkSize + posX % chunkSize;
--			int sunlight = unpackedChunkFast.Lighting.GetSunlight(index3d);
--			unpackedChunkFast.Lighting.SetSunlight_Buffered(index3d, 0);
--			QueueOfInt queueOfInt2 = new QueueOfInt();
--			for (int i = 0; i < 6; i++)
+-			int index3d = (posY % num * num + posZ % num) * num + posX % num;
+-			unpackedChunkFast.Lighting.SetSunlight(index3d, level);
 +			for (int j = num9; j <= num12; j++)
- 			{
--				Vec3i vec3i = BlockFacing.ALLNORMALI[i];
--				int num2 = posX + vec3i.X;
--				int num3 = posY + vec3i.Y;
--				int num4 = posZ + vec3i.Z;
--				if (num2 >= 0 && num3 >= num && num4 >= 0 && num2 < mapsizex && num3 < num + mapsizey && num4 < mapsizez)
++			{
 +				for (int k = num10; k <= num13; k++)
- 				{
--					int num5 = sunlight - oldAbsorb - 1 + ((flag && i == 5) ? 1 : 0);
--					int num6 = SunLightLevelAt(num2, num3, num4);
--					if (num5 >= num6)
++				{
 +					chunk = chunkProvider.GetChunk(i, j + num14, k);
 +					if (chunk is not null)
- 					{
--						queueOfInt2.Enqueue(vec3i.X, vec3i.Y, vec3i.Z, num5 + (TileSideEnum.GetOpposite(i) + 1 << 5));
++					{
 +						chunk.Unpack();
 +						dictionary[new Vec3i(i, j, k)] = chunk;
- 					}
- 				}
- 			}
--			ClearSunlightAt(queueOfInt2, centerPos, flag, queueOfInt, fastSetOfLongs);
++					}
++				}
++			}
  		}
--		queueOfInt.Enqueue(0, 0, 0, GetSunLightFromNeighbour(posX, posY, posZ, flag));
--		SpreadSunlightAt(queueOfInt, centerPos, flag, fastSetOfLongs);
--		if (posY > 0)
-+
+-	}
+ 
+-	private void ClearSunLightLevelAt(int posX, int posY, int posZ)
+-	{
+-		SetSunLightLevelAt(posX, posY, posZ, 0);
+-	}
 +		// 3. Completely clear the old light in all affected chunks
 +		foreach (IWorldChunk value2 in dictionary.Values)
- 		{
--			SetSunLightLevelAt(posX, posY - 1, posZ, GetSunLightFromNeighbour(posX, posY - 1, posZ, flag));
++		{
 +			value2?.Lighting.ClearLight();
- 		}
--		if (newAbsorb > oldAbsorb)
-+
++		}
+ 
+-	private int GetSunLightFromNeighbour(int posX, int posY, int posZ, bool directlyIlluminated)
+-	{
+-		int num = posY / 32768 * 32768;
+-		int num2 = 0;
+-		for (int i = 0; i < 6; i++)
 +		IWorldChunk[] array = new IWorldChunk[mapsizey / num];
 +		IWorldChunk chunk2;
 +
 +		// 4. Calculate sunlight top-down for each column of chunks
 +		for (int l = num8; l <= num11; l++)
  		{
--			for (int j = 0; j < 6; j++)
+-			Vec3i vec3i = BlockFacing.ALLNORMALI[i];
+-			int num3 = posX + vec3i.X;
+-			int num4 = posY + vec3i.Y;
+-			int num5 = posZ + vec3i.Z;
+-			if ((num3 | num5) >= 0 && num4 >= num && num3 < mapsizex && num4 < mapsizey + num && num5 < mapsizez)
 +			for (int m = num10; m <= num13; m++)
  			{
--				Vec3i vec3i2 = BlockFacing.ALLNORMALI[j];
--				int num7 = posX + vec3i2.X;
--				int num8 = posY + vec3i2.Y;
--				int num9 = posZ + vec3i2.Z;
--				if (IsValidPos(num7, num8, num9))
+-				IWorldChunk unpackedChunkFast = chunkProvider.GetUnpackedChunkFast(num3 / chunkSize, num4 / chunkSize, num5 / chunkSize);
+-				if (unpackedChunkFast != null)
 +				bool flag = false;
 +				for (int n = 0; n < array.Length; n++)
  				{
--					int sunLightFromNeighbour = GetSunLightFromNeighbour(num7, num8, num9, IsDirectlyIlluminated(num7, num8, num9));
--					if (sunLightFromNeighbour > SunLightLevelAt(num7, num8, num9))
+-					int index3d = (num4 % chunkSize * chunkSize + num5 % chunkSize) * chunkSize + num3 % chunkSize;
+-					int lightAbsorptionAt = unpackedChunkFast.GetLightAbsorptionAt(index3d, tmpPos.Set(num3, num4, num5), blockTypes);
+-					int val = unpackedChunkFast.Lighting.GetSunlight(index3d) - lightAbsorptionAt - ((!(i == 4 && directlyIlluminated)) ? 1 : 0);
+-					num2 = Math.Max(num2, val);
 +					chunk2 = chunkProvider.GetChunk(l, n + num14, m);
 +					if (chunk2 is null) flag = true;
 +					array[n] = chunk2;
-+				}
+ 				}
 +
 +				if (!flag) // If the chunk column is fully loaded
 +				{
++					// Stratum: one shared block-snapshot / sunlight-staging session across all three calls for this
++					// column, so blocks and staged light are snapshotted once instead of once per call.
++					BeginBlockSnapshotSession();
++					BeginSunStagingSession();
++
 +					Sunlight(array, l, array.Length - 1, m, minPos.dimension);           // Direct light from above
-+					SunlightFlood(array, l, array.Length - 1, m);                         // Scattering inside the chunk
++					SunlightFlood(array, l, array.Length - 1, m, minPos.dimension);       // Scattering inside the chunk
 +					SunLightFloodNeighbourChunks(array, l, array.Length - 1, m, minPos.dimension); // Flowing into neighboring chunks
++
++					EndBlockSnapshotSession();
++					EndSunStagingSession();
 +				}
 +			}
 +		}
@@ -1067,7 +1331,7 @@ index e2ca303..82dc39c 100644
 +
 +				byte[] hsv = kvp.Value.GetLightHsv(readBlockAccess, kvp.Key);
 +				if (hsv[2] > maxRange) maxRange = hsv[2];
-+			}
+ 			}
 +
 +			int centerX = (int)(sumX / dictionary2.Count);
 +			int centerY = (int)(sumY / dictionary2.Count);
@@ -1076,11 +1340,13 @@ index e2ca303..82dc39c 100644
 +			// A SINGLE call to UpdateLightAt from the center
 +			FastSetOfLongs touchedChunks = new FastSetOfLongs();
 +			UpdateLightAt(maxRange, centerX, centerY, centerZ, touchedChunks);
-+		}
-+	}
-+
+ 		}
+-		return num2;
+ 	}
+ 
+-	public FastSetOfLongs UpdateSunLight(int posX, int posY, int posZ, int oldAbsorb, int newAbsorb)
 +	/// <summary>
-+	/// Universal calculation of effective light absorption by a block for a given ray direction.
++	/// Universal calculated effective light absorption by a block for a given ray direction.
 +	/// </summary>
 +	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 +	private int GetEffectiveAbsorption(
@@ -1089,7 +1355,9 @@ index e2ca303..82dc39c 100644
 +		BlockFacing dir,
 +		float incomingEnergy,
 +		BlockPos pos = null)
-+	{
+ 	{
+-		FastSetOfLongs fastSetOfLongs = new FastSetOfLongs();
+-		if (newAbsorb == oldAbsorb)
 +		// Stage 0: fully transparent — no absorption at all
 +		if (baseAbsorption <= 0)
 +			return 0;
@@ -1153,7 +1421,8 @@ index e2ca303..82dc39c 100644
 +		var validColumns = new List<(int cx, int cz, int dim, int startChunkY, IWorldChunk[] chunks)>();
 +
 +		foreach (var kvp in updates)
-+		{
+ 		{
+-			return fastSetOfLongs;
 +			long key = kvp.Key;
 +			int startChunkY = kvp.Value;
 +			int cx = (int)(key & 0x1FFFFF);
@@ -1174,15 +1443,24 @@ index e2ca303..82dc39c 100644
 +				chunks[cy].Unpack();
 +			}
 +			if (allLoaded) validColumns.Add((cx, cz, dim, startChunkY, chunks));
-+		}
+ 		}
+-		int num = posY / 32768 * 32768;
+-		if (posX < 0 || posY < 0 || posZ < 0 || posX >= mapsizex || posY >= num + mapsizey || posZ >= mapsizez)
 +
 +		if (validColumns.Count == 0) return touchedChunks;
 +
 +		currentSunStaging.Clear();
 +
++		// Stratum: keep the whole flush batch in one shared session, so the Sunlight/SunlightFlood/SunLightFloodNeighbourChunks
++		// calls below reuse (rather than prematurely commit/release) both the block snapshots and the staged sunlight arrays
++		// this method itself manages manually via currentSunStaging.
++		BeginSunStagingSession();
++		BeginBlockSnapshotSession();
++
 +		// 1. Allocate staging arrays and copy old light
 +		foreach (var (cx, cz, dim, startChunkY, chunks) in validColumns)
-+		{
+ 		{
+-			return fastSetOfLongs;
 +			int dimOffset = dim * 1024;
 +			for (int cy = 0; cy <= startChunkY; cy++)
 +			{
@@ -1195,46 +1473,66 @@ index e2ca303..82dc39c 100644
 +				for (int idx = 0; idx < totalBlocks; idx++)
 +					staging[idx] = (byte)lighting.GetSunlight(idx);
 +			}
-+		}
+ 		}
+-		QueueOfInt queueOfInt = new QueueOfInt();
+-		bool flag = IsDirectlyIlluminated(posX, posY, posZ);
+-		BlockPos centerPos = new BlockPos(posX, posY, posZ);
+-		if (newAbsorb > oldAbsorb)
 +
 +		// 2. Zero the range and recalculate inside the staging buffer
 +		foreach (var (cx, cz, dim, startChunkY, chunks) in validColumns)
-+		{
-+			currentDimOffset = dim * 1024;
-+			int dimOffset = currentDimOffset;
+ 		{
+-			IWorldChunk unpackedChunkFast = chunkProvider.GetUnpackedChunkFast(posX / chunkSize, posY / chunkSize, posZ / chunkSize, notRecentlyAccessed: true);
+-			if (unpackedChunkFast == null)
++			int dimOffset = dim * 1024;
 +			for (int cy = startChunkY; cy >= 0; cy--)
-+			{
+ 			{
+-				return fastSetOfLongs;
 +				long chunkKey = chunkProvider.ChunkIndex3D(cx, cy + dimOffset, cz);
 +				Array.Clear(currentSunStaging[chunkKey], 0, totalBlocks);
-+			}
+ 			}
+-			int index3d = (posY % chunkSize * chunkSize + posZ % chunkSize) * chunkSize + posX % chunkSize;
+-			int sunlight = unpackedChunkFast.Lighting.GetSunlight(index3d);
+-			unpackedChunkFast.Lighting.SetSunlight_Buffered(index3d, 0);
+-			QueueOfInt queueOfInt2 = new QueueOfInt();
+-			for (int i = 0; i < 6; i++)
 +			Sunlight(chunks, cx, startChunkY, cz, dim);
-+			SunlightFlood(chunks, cx, startChunkY, cz);
++			SunlightFlood(chunks, cx, startChunkY, cz, dim);
 +		}
 +
 +		// 3. Cross-chunk boundary exchange
 +		foreach (var (cx, cz, dim, startChunkY, chunks) in validColumns)
 +		{
-+			currentDimOffset = dim * 1024;
 +			SunLightFloodNeighbourChunks(chunks, cx, startChunkY, cz, dim);
 +		}
++
++		EndBlockSnapshotSession(); // blocks no longer needed past this point
 +
 +		// 4. Atomic commit to live lighting arrays
 +		foreach (var (cx, cz, dim, startChunkY, chunks) in validColumns)
 +		{
 +			int dimOffset = dim * 1024;
 +			for (int cy = startChunkY; cy >= 0; cy--)
-+			{
+ 			{
+-				Vec3i vec3i = BlockFacing.ALLNORMALI[i];
+-				int num2 = posX + vec3i.X;
+-				int num3 = posY + vec3i.Y;
+-				int num4 = posZ + vec3i.Z;
+-				if (num2 >= 0 && num3 >= num && num4 >= 0 && num2 < mapsizex && num3 < num + mapsizey && num4 < mapsizez)
 +				long chunkKey = chunkProvider.ChunkIndex3D(cx, cy + dimOffset, cz);
 +				var staging = currentSunStaging[chunkKey];
 +				var lighting = chunks[cy].Lighting;
 +				bool chunkChanged = false;
 +				for (int idx = 0; idx < totalBlocks; idx++)
-+				{
+ 				{
+-					int num5 = sunlight - oldAbsorb - 1 + ((flag && i == 5) ? 1 : 0);
+-					int num6 = SunLightLevelAt(num2, num3, num4);
+-					if (num5 >= num6)
 +					int oldSun = lighting.GetSunlight(idx);
 +					int newSun = staging[idx];
 +					if (oldSun != newSun)
  					{
--						SetSunLightLevelAt(num7, num8, num9, sunLightFromNeighbour);
+-						queueOfInt2.Enqueue(vec3i.X, vec3i.Y, vec3i.Z, num5 + (TileSideEnum.GetOpposite(i) + 1 << 5));
 +						lighting.SetSunlight(idx, newSun);
 +						chunkChanged = true;
  					}
@@ -1245,15 +1543,23 @@ index e2ca303..82dc39c 100644
 +					chunks[cy].MarkModified();
 +				}
  			}
+-			ClearSunlightAt(queueOfInt2, centerPos, flag, queueOfInt, fastSetOfLongs);
  		}
--		return fastSetOfLongs;
+-		queueOfInt.Enqueue(0, 0, 0, GetSunLightFromNeighbour(posX, posY, posZ, flag));
+-		SpreadSunlightAt(queueOfInt, centerPos, flag, fastSetOfLongs);
+-		if (posY > 0)
 +
 +		// 5. Return staging arrays to the pool (Zero-GC)
 +		foreach (var arr in currentSunStaging.Values)
-+		{
-+			if (sunStagingPool.Count < 512) sunStagingPool.Push(arr);
-+		}
+ 		{
+-			SetSunLightLevelAt(posX, posY - 1, posZ, GetSunLightFromNeighbour(posX, posY - 1, posZ, flag));
++			lock (sunStagingPoolLock) { if (sunStagingPool.Count < 512) sunStagingPool.Push(arr); }
+ 		}
+-		if (newAbsorb > oldAbsorb)
 +		currentSunStaging.Clear();
++
++		// currentSunStaging is now empty, so this just resets the session depth to 0 without redundant work.
++		EndSunStagingSession();
 +
 +		return touchedChunks;
 +	}
@@ -1269,16 +1575,27 @@ index e2ca303..82dc39c 100644
 +		BlockPos blockPos = new BlockPos(0);
 +
 +		foreach (Vec4i item in scheduledUpdates)
-+		{
+ 		{
+-			for (int j = 0; j < 6; j++)
 +			Block block = blockTypes[item.W];
 +			blockPos.SetAndCorrectDimension(item.X, item.Y, item.Z);
 +			byte[] lightHsv = block.GetLightHsv(readBlockAccess, blockPos);
 +
 +			if (lightHsv[2] > 0) // Only light sources (brightness > 0)
-+			{
+ 			{
+-				Vec3i vec3i2 = BlockFacing.ALLNORMALI[j];
+-				int num7 = posX + vec3i2.X;
+-				int num8 = posY + vec3i2.Y;
+-				int num9 = posZ + vec3i2.Z;
+-				if (IsValidPos(num7, num8, num9))
 +				IWorldChunk chunkAtPos = GetChunkAtPos(blockPos.X, blockPos.InternalY, blockPos.Z);
 +				if (chunkAtPos is not null)
-+				{
+ 				{
+-					int sunLightFromNeighbour = GetSunLightFromNeighbour(num7, num8, num9, IsDirectlyIlluminated(num7, num8, num9));
+-					if (sunLightFromNeighbour > SunLightLevelAt(num7, num8, num9))
+-					{
+-						SetSunLightLevelAt(num7, num8, num9, sunLightFromNeighbour);
+-					}
 +					int inChunkIndex = InChunkIndex(blockPos.X, blockPos.InternalY, blockPos.Z);
 +
 +					// Protection against duplicates: one block can be in the list multiple times
@@ -1287,9 +1604,10 @@ index e2ca303..82dc39c 100644
 +
 +					sources.Add((blockPos.X, blockPos.InternalY, blockPos.Z,
 +								 lightHsv[0], lightHsv[1], lightHsv[2]));
-+				}
-+			}
-+		}
+ 				}
+ 			}
+ 		}
+-		return fastSetOfLongs;
 +
 +		if (sources.Count == 0)
 +			return;
@@ -1613,9 +1931,8 @@ index e2ca303..82dc39c 100644
 +
  				index3d = (num9 % num * num + num10 % num) * num + num8 % num;
  				int sunlight2 = unpackedChunkFast.Lighting.GetSunlight(index3d);
-+
- 				if (sunlight2 != 0)
- 				{
+-				if (sunlight2 != 0)
+-				{
 -					if (sunlight2 <= num11)
 -					{
 -						positionsToClear.EnqueueIfLarger(num8 - centerPos.X, num9 - centerPos.Y, num10 - centerPos.Z, num11 + (TileSideEnum.GetOpposite(i) + 1 << 5));
@@ -1624,6 +1941,9 @@ index e2ca303..82dc39c 100644
 -					{
 -						fastSetOfInts.Add(num8 - centerPos.X, num9 - centerPos.Y, num10 - centerPos.Z, sunlight2);
 -					}
++
++				if (sunlight2 != 0)
++				{
 +					if (sunlight2 <= num11) positionsToClear.EnqueueIfLarger(num8 - centerPos.X, num9 - centerPos.Y, num10 - centerPos.Z, num11 + (TileSideEnum.GetOpposite(i) + 1 << 5));
 +					else fastSetOfInts.Add(num8 - centerPos.X, num9 - centerPos.Y, num10 - centerPos.Z, sunlight2);
  				}
@@ -1663,7 +1983,7 @@ index e2ca303..82dc39c 100644
 -			NonBlendingLightAxis(lightHsv[0], lightHsv[1], lightHsv[2], posX, posY, posZ, face);
 -		}
 -	}
- 
+-
 -	private void SetBlockLightLevel(byte hue, byte saturation, int value, int posX, int posY, int posZ)
 -	{
 -		IWorldChunk chunkAtPos = GetChunkAtPos(posX, posY, posZ);
@@ -1686,7 +2006,7 @@ index e2ca303..82dc39c 100644
 -		}
 -		return 0;
 -	}
--
+ 
 -	private void NonBlendingLightAxis(byte hue, byte saturation, int lightLevel, int x, int y, int z, BlockFacing face)
 -	{
 -		int num = lightLevel - 1;
@@ -1809,8 +2129,7 @@ index e2ca303..82dc39c 100644
 +		int baseZ = posZ - LIGHT_GRID_HALF;
 +
 +		for (int i = 0; i < touchedCells.Count; i++)
- 		{
--			CollectLightValuesForLightSource(nearbyLightSource.posX, nearbyLightSource.posY, nearbyLightSource.posZ, posX, posY, posZ, range);
++		{
 +			int idx = touchedCells[i];
 +			ref var cell = ref lightGrid[idx];
 +
@@ -1820,8 +2139,7 @@ index e2ca303..82dc39c 100644
 +			// Pass cell by reference
 +			RecalcBlockLightAtPos(wx, wy, wz, ref cell);
 +			touchedChunks.Add(chunkProvider.ChunkIndex3D(wx / num, wy / num, wz / num));
- 		}
--		foreach (KeyValuePair<Vec3i, LightSourcesAtBlock> visitedNode in VisitedNodes)
++		}
 +
 +	}
 +
@@ -1876,8 +2194,7 @@ index e2ca303..82dc39c 100644
 +		// 1. Initialization: place all light sources in their starting positions
 +		for (int srcIdx = 0; srcIdx < nearbyCount; srcIdx++)
  		{
--			RecalcBlockLightAtPos(visitedNode.Key, visitedNode.Value);
--			touchedChunks.Add(chunkProvider.ChunkIndex3D(visitedNode.Key.X / num, visitedNode.Key.Y / num, visitedNode.Key.Z / num));
+-			CollectLightValuesForLightSource(nearbyLightSource.posX, nearbyLightSource.posY, nearbyLightSource.posZ, posX, posY, posZ, range);
 +			byte h = nearbyH[srcIdx], s = nearbyS[srcIdx], b = nearbyB[srcIdx];
 +			if (b <= 0) continue;
 +
@@ -1910,13 +2227,16 @@ index e2ca303..82dc39c 100644
 +			}
 +
 +			buckets[b].Add((idx, srcIdx));
-+		}
+ 		}
+-		foreach (KeyValuePair<Vec3i, LightSourcesAtBlock> visitedNode in VisitedNodes)
 +
 +		IWorldChunk chunk;
 +
 +		// 2. BFS traversal from the brightest (31) to the dimmest (1)
 +		for (int level = 31; level >= 1; level--)
-+		{
+ 		{
+-			RecalcBlockLightAtPos(visitedNode.Key, visitedNode.Value);
+-			touchedChunks.Add(chunkProvider.ChunkIndex3D(visitedNode.Key.X / num, visitedNode.Key.Y / num, visitedNode.Key.Z / num));
 +			var bucket = buckets[level];
 +
 +			for (int bi = 0; bi < bucket.Count; bi++)
@@ -2150,10 +2470,14 @@ index e2ca303..82dc39c 100644
  				}
  			}
  		}
--	}
++
++		queueOfIntPool.Push(queueOfInt);
+ 	}
  
 -	private void CollectLightValuesForLightSource(int posX, int posY, int posZ, int forPosX, int forPosY, int forPosZ, int forRange)
--	{
++	/// <summary> Horizontal propagation of sunlight inside chunks. Backward-compatible overload (default dim = 0). </summary>
++	public void SunlightFlood(IWorldChunk[] chunks, int chunkX, int chunkY, int chunkZ)
+ 	{
 -		int num = chunkSize;
 -		QueueOfInt queueOfInt = new QueueOfInt();
 -		Block block = GetBlock(posX, posY, posZ);
@@ -2222,10 +2546,18 @@ index e2ca303..82dc39c 100644
 -				}
 -			}
 -		}
-+		queueOfIntPool.Push(queueOfInt);
++		SunlightFlood(chunks, chunkX, chunkY, chunkZ, /*dim*/ 0);
++	}
++
++
++	/// <summary> BFS propagation of sunlight over a stack of coordinates. Backward-compatible overload (default dim = 0). </summary>
++	private void SpreadSunLightInColumn(Stack<FastBlockPos> stack, IWorldChunk[] chunks)
++	{
++		SpreadSunLightInColumn(stack, chunks, /*dim*/ 0);
  	}
  
 -	private void RecalcBlockLightAtPos(Vec3i pos, LightSourcesAtBlock lsab)
++
 +
 +	/// <summary> Final color mixing (HSV -> RGB -> HSV) from all sources at a specific point. </summary>
 +	private void RecalcBlockLightAtPos(int posX, int posY, int posZ, ref LightCell cell)
@@ -2305,7 +2637,11 @@ index e2ca303..82dc39c 100644
  	}
  
 -	private Block GetBlock(int posX, int posY, int posZ)
--	{
++
++	/// <summary> Non-creating staging lookup: returns the staged array if the chunk is already part of the active session, otherwise null (live lighting). </summary>
++	[MethodImpl(MethodImplOptions.AggressiveInlining)]
++	private byte[] GetStagingForChunk(long chunkKey)
+ 	{
 -		if ((posX | posY | posZ) < 0)
 -		{
 -			return null;
@@ -2318,7 +2654,8 @@ index e2ca303..82dc39c 100644
 -		}
 -		int index3d = (posY % num * num + posZ % num) * num + posX % num;
 -		return blockTypes[unpackedChunkFast.Data[index3d]];
--	}
++		return currentSunStaging.TryGetValue(chunkKey, out var s) ? s : null;
+ 	}
  
 +	/// <summary> Fast retrieval of a chunk by block coordinates. </summary>
 +	[MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -2334,6 +2671,22 @@ index e2ca303..82dc39c 100644
  		return (posY % chunkSize * chunkSize + posZ % chunkSize) * chunkSize + posX % chunkSize;
  	}
  
++	/// <summary>
++	/// Stratum: exposes block-snapshot session control so WorldAPI can wrap a whole column pass
++	/// (Sunlight + SunlightFlood + neighbour exchange) in ONE shared session, decoding each chunk
++	/// exactly once instead of once per BFS flush.
++	/// </summary>
++	internal void BeginWorldGenLightingSession()
++	{
++		BeginBlockSnapshotSession();
++	}
++
++	internal void EndWorldGenLightingSession()
++	{
++		EndBlockSnapshotSession();
++	}
++
++
 +	/// <summary> Calculation of the global 64-bit chunk index in the world. </summary>
 +	[MethodImpl(MethodImplOptions.AggressiveInlining)]
  	internal long GetChunkIndexForPos(int posX, int posY, int posZ)

--- a/patches/VintagestoryLib/Vintagestory.Common/NoChunkData.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Common/NoChunkData.cs.patch
@@ -1,23 +1,56 @@
 diff --git a/VintagestoryLib/Vintagestory.Common/NoChunkData.cs b/VintagestoryLib/Vintagestory.Common/NoChunkData.cs
-index db9ffef..a72ce6a 100644
+index db9ffef..4060d59 100644
 --- a/VintagestoryLib/Vintagestory.Common/NoChunkData.cs
 +++ b/VintagestoryLib/Vintagestory.Common/NoChunkData.cs
-@@ -41,10 +41,22 @@ public class NoChunkData : IChunkBlocks
+@@ -6,17 +6,12 @@ namespace Vintagestory.Common;
+ 
+ public class NoChunkData : IChunkBlocks
+ {
+ 	public int this[int index3d]
+ 	{
+-		get
+-		{
+-			return 0;
+-		}
+-		set
+-		{
+-		}
++		get { return 0; }
++		set { }
+ 	}
+ 
+ 	public int Length { get; set; }
+ 
+ 	public static NoChunkData CreateNew(int chunksize)
+@@ -41,10 +36,35 @@ public class NoChunkData : IChunkBlocks
  
  	public void SetBlockUnsafe(int index3d, int blockId)
  	{
  	}
  
-+
-+	// Stratum: necessary interface overload
++	// Stratum: added to satisfy IChunkBlocks interface (bulk unsafe set with parallel lists of indices and values)
 +	public void SetBlocksUnsafe(List<int> indices, List<int> values)
 +	{
 +	}
 +
-+	// Stratum: necessary interface overload
++	// Stratum: added to satisfy IChunkBlocks interface (copy all block IDs into a flat array)
 +	public void CopyBlocksToUnsafe(int[] blocksOut)
 +	{
++	}
 +
++	// Stratum: added to satisfy IChunkBlocks interface (bulk unsafe set from flat int array of block values)
++	public void SetBlocksBulkUnsafe(int[] blocksIn)
++	{
++	}
++
++	// Stratum: added to satisfy IChunkBlocks interface (copy all light values into a flat array)
++	public void CopyLightToUnsafe(int[] lightOut)
++	{
++	}
++
++	// Stratum: added to satisfy IChunkBlocks interface (bulk unsafe set from flat int array of light values)
++	public void SetLightBulkUnsafe(int[] lightIn)
++	{
 +	}
 +
  	public void SetBlockAir(int index3d)
@@ -25,3 +58,12 @@ index db9ffef..a72ce6a 100644
  	}
  
  	public int GetBlockId(int index, int layer)
+@@ -82,6 +102,6 @@ public class NoChunkData : IChunkBlocks
+ 
+ 	public void FuzzyListBlockIds(List<int> reusableList)
+ 	{
+ 		reusableList.Add(0);
+ 	}
+-}
++}
+\ No newline at end of file

--- a/patches/VintagestoryLib/Vintagestory.Server/WorldAPI.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/WorldAPI.cs.patch
@@ -1,31 +1,37 @@
 diff --git a/VintagestoryLib/Vintagestory.Server/WorldAPI.cs b/VintagestoryLib/Vintagestory.Server/WorldAPI.cs
-index 2b525d3..e3e2830 100644
+index 2b525d3..e6a2f25 100644
 --- a/VintagestoryLib/Vintagestory.Server/WorldAPI.cs
 +++ b/VintagestoryLib/Vintagestory.Server/WorldAPI.cs
-@@ -9,10 +9,15 @@ using Vintagestory.Common;
+@@ -9,10 +9,18 @@ using Vintagestory.Common;
  
  namespace Vintagestory.Server;
  
  internal class WorldAPI : ServerAPIComponentBase, IWorldManagerAPI
  {
-+	// Stratum: cache AllLoadedMapRegions per server frame. The property copies the
-+	// entire dictionary on every access. Weather ticks call it multiple times per frame.
++	// Stratum start: added two private fields to cache AllLoadedMapRegions per server tick.
++	// stratumCachedMapRegions — the snapshot dictionary returned by the getter.
++	// stratumMapRegionsCacheTick — the last tick for which the cache is valid; compared
++	// against server.StratumTickSequence to decide whether to rebuild the copy.
 +	private Dictionary<long, IMapRegion> stratumCachedMapRegions;
 +	private long stratumMapRegionsCacheTick = -1;
++	// Stratum end
 +
  	public PlayStyle CurrentPlayStyle
  	{
  		get
  		{
  			foreach (Mod mod in server.api.ModLoader.Mods)
-@@ -129,15 +134,24 @@ internal class WorldAPI : ServerAPIComponentBase, IWorldManagerAPI
+@@ -129,18 +137,31 @@ internal class WorldAPI : ServerAPIComponentBase, IWorldManagerAPI
  
  	public Dictionary<long, IMapRegion> AllLoadedMapRegions
  	{
  		get
  		{
 -			Dictionary<long, IMapRegion> dictionary = new Dictionary<long, IMapRegion>();
-+			// Stratum: rebuild once per server frame regardless of count changes.
++			// Stratum start: replaced unconditional full copy with tick-gated cache invalidation.
++			// On each server tick the dictionary is rebuilt once; subsequent calls within the
++			// same tick return the cached snapshot, eliminating repeated allocations and O(n)
++			// copies when multiple subsystems (e.g., weather) read this property per frame.
 +			long tick = server.StratumTickSequence;
 +			if (stratumMapRegionsCacheTick == tick && stratumCachedMapRegions != null)
 +			{
@@ -42,5 +48,80 @@ index 2b525d3..e3e2830 100644
  			return dictionary;
  		}
  	}
++	// Stratum end
  
  	public List<LandClaim> LandClaims => server.WorldMap.All;
+ 
+ 	internal int RegionMapSizeX => server.WorldMap.RegionMapSizeX;
+ 
+@@ -293,22 +314,59 @@ internal class WorldAPI : ServerAPIComponentBase, IWorldManagerAPI
+ 		{
+ 			IWorldChunk obj = chunks[i];
+ 			obj.Unpack();
+ 			obj.Lighting.FillWithSunlight(sunLight);
+ 		}
+-		server.WorldMap.chunkIlluminatorWorldGen.Sunlight(chunks, chunkX, num, chunkZ, 0);
+-		server.WorldMap.chunkIlluminatorWorldGen.SunlightFlood(chunks, chunkX, num, chunkZ);
++
++		// Stratum start: entire body rewritten to use rented flat int[] buffers and a shared
++		// lighting session so each chunk is decoded only once instead of per BFS flush.
++		// Steps: (1) snapshot only the recomputed range + one read-only source row,
++		//        (2) run Sunlight/SunlightFlood on flat arrays to avoid interface/GC overhead,
++		//        (3) commit back ONLY chunks that were actually written (0..num),
++		//        (4) return buffers and end the session in finally.
++		int chunksPerColumn = server.WorldMap.ChunkMapSizeY;
++		int bufferedCount = Math.Min(num + 2, chunksPerColumn);
++		int[][] lightBuffers = new int[chunksPerColumn][];
++		for (int i = 0; i < bufferedCount; i++)
++			lightBuffers[i] = server.WorldMap.chunkIlluminatorWorldGen.RentLightBuffer();
++
++		// Stratum: ONE shared block-snapshot session for the entire column pass —
++		// each chunk is decoded exactly once instead of once per BFS flush.
++		server.WorldMap.chunkIlluminatorWorldGen.BeginWorldGenLightingSession();
++		try
++		{
++			// 1. Snapshot only the range we recompute (+ source row)
++			for (int i = 0; i < bufferedCount; i++)
++				chunks[i].Data.CopyLightToUnsafe(lightBuffers[i]);
++
++			// 2. Calculate sunlight entirely in flat arrays (Zero-Interface, Zero-GC)
++			server.WorldMap.chunkIlluminatorWorldGen.Sunlight(chunks, chunkX, num, chunkZ, 0, lightBuffers);
++			server.WorldMap.chunkIlluminatorWorldGen.SunlightFlood(chunks, chunkX, num, chunkZ, 0, lightBuffers);
++
++			// 3. Commit ONLY the chunks Sunlight actually wrote (0..num)
++			for (int i = 0; i <= num; i++)
++				chunks[i].Data.SetLightBulkUnsafe(lightBuffers[i]);
++		}
++		finally
++		{
++			server.WorldMap.chunkIlluminatorWorldGen.EndWorldGenLightingSession();
++			for (int i = 0; i < bufferedCount; i++)
++				server.WorldMap.chunkIlluminatorWorldGen.ReturnLightBuffer(lightBuffers[i]);
++		}
+ 	}
++	// Stratum end
+ 
+ 	public void SunFloodChunkColumnNeighboursForWorldGen(IWorldChunk[] chunks, int chunkX, int chunkZ)
+ 	{
+ 		IMapChunk mapChunk = GetMapChunk(chunkX + 1, chunkZ);
+ 		IMapChunk mapChunk2 = GetMapChunk(chunkX - 1, chunkZ);
+ 		IMapChunk mapChunk3 = GetMapChunk(chunkX, chunkZ + 1);
+ 		IMapChunk mapChunk4 = GetMapChunk(chunkX, chunkZ - 1);
+ 		int mapSizeY = server.WorldMap.MapSizeY;
+ 		int chunkY = GameMath.Max(chunks[0].MapChunk.YMax, ((int?)mapChunk?.YMax) ?? (mapSizeY - 1), ((int?)mapChunk2?.YMax) ?? (mapSizeY - 1), ((int?)mapChunk3?.YMax) ?? (mapSizeY - 1), ((int?)mapChunk4?.YMax) ?? (mapSizeY - 1)) / ChunkSize;
++
++		// Stratum: sparse boundary exchange — no dense buffers, no snapshot session needed.
+ 		server.WorldMap.chunkIlluminatorWorldGen.SunLightFloodNeighbourChunks(chunks, chunkX, chunkY, chunkZ, 0);
+ 	}
+ 
+ 	public void LoadChunkColumn(int chunkX, int chunkZ, bool keepLoaded = false)
+ 	{
+@@ -567,6 +625,6 @@ internal class WorldAPI : ServerAPIComponentBase, IWorldManagerAPI
+ 		{
+ 			throw new InvalidOperationException("Can not be executed after EnumServerRunPhase.WorldReady");
+ 		}
+ 		return server.BlockingLoadChunkColumn(chunkX, chunkZ);
+ 	}
+-}
++}
+\ No newline at end of file


### PR DESCRIPTION
## Summary

Continued work on chunk data batching.
- The light system has been switched to reading and writing light in batches.
- Branches using AVX2 processor instructions have been added to the chunkdatalayer for bulk data reading and writing. These greatly speed up data handling. If the processor doesn't support them, the code will execute as usual without them.
- The chunk data writing system has been improved in GenRockStrataNew. Now, all changes are written directly to the snapshot and then bulk written to the chunk.
- Fixed a bug where ProPickWorkSpace was causing memory leaks because it didn't take into account the batching system in GenRockStrataNew.

Write batching for GenRockStrata has been improved.

## Type

- [ ] Bug fix
- [x] Performance
- [ ] New feature
- [ ] Refactor or cleanup
- [ ] Docs or build

## Checklist

- [x] `.\scripts\extract-patches.ps1` ran clean.
- [x] `dotnet build VintageStory.slnx -c Release` is green.
- [x] Every vanilla edit has a `// Stratum` marker.
- [x] No vanilla source committed.
- [x] Tested on a real server start, not just compilation.

## Performance numbers

Tested on the generation of 31417 chunk columns (6 threads):
- GenRockStrataNew.StratumGenChunkColumn method execution time: reduced from 88880 ms to 65377 ms;
- SunFloodChunkColumnForWorldGen method execution time: reduced from 117987 ms to 87647 ms;

**Before**
<img width="848" height="644" alt="image" src="https://github.com/user-attachments/assets/77df9d3a-3939-475c-aa8c-5a1ab5e38ba3" />
<img width="829" height="501" alt="image" src="https://github.com/user-attachments/assets/01c9d09d-a59d-4d51-95ab-1ee51c24a7c9" />




**After**
<img width="834" height="606" alt="image" src="https://github.com/user-attachments/assets/d861e26f-f921-4033-a471-c8fc17b0111b" />
<img width="848" height="532" alt="image" src="https://github.com/user-attachments/assets/ac9b74c4-3eda-41be-83c6-fff810616198" />


