### PR TITLE
Silence CS8632 nullable annotation spam project-wide

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
     <FrameworkVersion>net10.0</FrameworkVersion>
     <LangVersion>latest</LangVersion>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
-    <NoWarn>$(NoWarn);CS1591;CS1572;CS1573;CS1570;CS0649;CS0414;CS0169;CS0162;CS0168</NoWarn>
+    <NoWarn>$(NoWarn);CS1591;CS1572;CS1573;CS1570;CS0649;CS0414;CS0169;CS0162;CS0168;CS8632</NoWarn>
   </PropertyGroup>
 
   <Import Project="Directory.Build.local.props" Condition="Exists('Directory.Build.local.props')" />


### PR DESCRIPTION
## Summary

A clean build of `VintageStory.slnx` produces 1565 warnings, and 2796 of the raw warning lines are CS8632 ("nullable annotation used outside a #nullable context"). All of it comes from vanilla files the decompiler emits with the original assembly's own nullable annotations intact, not from Stratum's own patches. A real compile error sitting among that many warnings is easy to miss, which is exactly what #263 reports and screenshots: a genuine `CS1503` buried in a wall of `CS8632`.

Fix: add `CS8632` to `Directory.Build.props`'s existing `NoWarn` list, the same mechanism already silencing eight other decompiler-inherent codes (`CS1591`, `CS1572`, `CS1573`, `CS1570`, `CS0649`, `CS0414`, `CS0169`, `CS0162`, `CS0168`). `NoWarn` only affects warnings; a real compile error still stops the build and prints regardless of this list, so nothing about error visibility changes, only the noise around it.

## Type

- [x] Bug fix
- [ ] Performance
- [ ] New feature
- [ ] Refactor or cleanup
- [ ] Docs or build

## Checklist

- [ ] `.\scripts\extract-patches.ps1` ran clean. Not applicable: no vanilla file touched, only the shared `Directory.Build.props` MSBuild config, so there's nothing for extract-patches to regenerate.
- [x] `dotnet build VintageStory.slnx -c Release` is green.
- [ ] Every vanilla edit has a `// Stratum` marker. Not applicable, same reason: no vanilla file edited.
- [x] No vanilla source committed.
- [x] Tested on a real server start, not just compilation.

## Performance numbers

Not a performance change, but the fix is a number, so here it is anyway. Clean rebuild (`--no-incremental`) before and after, same tree:

| | Before | After |
| --- | --- | --- |
| Total warnings | 1565 | 167 |
| CS8632 | 2796 raw lines | 0 |
| Errors | 0 | 0 |

Smoke test passes both before and after: server reaches `RunGame`, no fatal errors.

## Related issues

Fixes #263