### PR TITLE
Add automatic punishment ladder for repeat anticheat violations

### DIFF
--- a/sources/VintagestoryLib/Vintagestory.Server/CmdStratum.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/CmdStratum.cs
@@ -243,7 +243,7 @@ internal class CmdStratum
 
 	private TextCommandResult HandleAnticheat(string playerName)
 	{
-		return TextCommandResult.Success(StratumAnticheatReporter.BuildReport(playerName));
+		return TextCommandResult.Success(StratumAnticheatReporter.BuildReport(server, playerName));
 	}
 
 	private TextCommandResult HandleHealth()

--- a/sources/VintagestoryLib/Vintagestory.Server/CmdStratumStaffCommands.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/CmdStratumStaffCommands.cs
@@ -17,6 +17,13 @@ internal class CmdStratumStaffCommands
 {
 	private const string VanishIndicatorCode = "stratum-vanish-active";
 
+	// Constructed exactly once per server (ServerSystemCommands.cs.patch), never held onto by its
+	// caller. StratumAnticheatPunishments needs the jail mechanism this class owns (the active-jail
+	// tracking set and the tick loop that enforces it are both instance state, not reusable statics
+	// the way Freeze and BanPlayer already are), so this is the smallest way to reach it from
+	// outside without duplicating that tracking elsewhere.
+	internal static CmdStratumStaffCommands Instance { get; private set; }
+
 	private readonly ServerMain server;
 	private readonly Dictionary<string, string> lastMessagePartnerByUid = new Dictionary<string, string>(StringComparer.Ordinal);
 	private readonly Dictionary<string, long> lastVanishIndicatorMsByUid = new Dictionary<string, long>(StringComparer.Ordinal);
@@ -25,6 +32,7 @@ internal class CmdStratumStaffCommands
 
 	public CmdStratumStaffCommands(ServerMain server)
 	{
+		Instance = this;
 		this.server = server;
 		server.EventManager.OnPlayerJoin += OnPlayerJoin;
 		server.EventManager.OnPlayerDisconnect += OnPlayerDisconnect;
@@ -1432,6 +1440,21 @@ internal class CmdStratumStaffCommands
 		string reason = args[1] as string;
 		Caller caller = args.Caller;
 		return RunForKnownTargets(token, (targetData, onlineTarget) => JailSingleTarget(targetData, onlineTarget, caller, reason, jailPosition));
+	}
+
+	// Entry point for StratumAnticheatPunishments. Same jailing as /jail, minus the command-access
+	// check a staff member already passed by definition and an automated punishment has no caller
+	// to check against; resolves the configured jail location itself since there is no
+	// TextCommandCallingArgs to read it from.
+	internal TextCommandResult JailAutomatically(ServerPlayerData targetData, ConnectedClient onlineTarget, Caller caller, string reason)
+	{
+		if (!TryGetJailLocation(out EntityPos jailPosition, out string error))
+		{
+			StratumRuntime.LogWarning("anticheat punishment could not jail " + targetData?.LastKnownPlayername + ": " + error);
+			return TextCommandResult.Error(error);
+		}
+
+		return JailSingleTarget(targetData, onlineTarget, caller, reason, jailPosition);
 	}
 
 	private TextCommandResult JailSingleTarget(ServerPlayerData targetData, ConnectedClient onlineTarget, Caller caller, string reason, EntityPos jailPosition)

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumAnticheatConfig.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumAnticheatConfig.cs
@@ -30,6 +30,8 @@ internal class StratumAnticheatConfig
 
 	public StratumMovementAuthorityAnticheatConfig MovementAuthority { get; set; } = new StratumMovementAuthorityAnticheatConfig();
 
+	public StratumAnticheatPunishmentConfig Punishments { get; set; } = new StratumAnticheatPunishmentConfig();
+
 	public void EnsureSane()
 	{
 		MaxStoredViolationsPerPlayer = Math.Clamp(MaxStoredViolationsPerPlayer, 16, 2048);
@@ -43,6 +45,7 @@ internal class StratumAnticheatConfig
 		NoFall ??= new StratumNoFallAnticheatConfig();
 		MultiBreak ??= new StratumMultiBreakAnticheatConfig();
 		MovementAuthority ??= new StratumMovementAuthorityAnticheatConfig();
+		Punishments ??= new StratumAnticheatPunishmentConfig();
 		BlockEntityOutOfRange.EnsureSane();
 		BlockInteractionOutOfRange.EnsureSane();
 		EntityInteractionOutOfRange.EnsureSane();
@@ -52,6 +55,49 @@ internal class StratumAnticheatConfig
 		NoFall.EnsureSane();
 		MultiBreak.EnsureSane();
 		MovementAuthority.EnsureSane();
+		Punishments.EnsureSane();
+	}
+}
+
+// Cross-rule escalation ladder, evaluated in StratumAnticheatPunishments against the persistent
+// total in StratumAnticheatHistory, not any single rule's own rolling count above. Off by default:
+// every action here already exists and is already tested (Freeze, jail, DropAll/Clear, BanPlayer),
+// but chaining them into automatic consequences on a false positive is a different risk profile
+// than an alert or even a kick, so an operator has to opt in with eyes open, the same way
+// KickConfirmedCheats does per rule.
+internal class StratumAnticheatPunishmentConfig
+{
+	public bool Enabled { get; set; } = false;
+
+	public int DropInventoryAfterFlags { get; set; } = 15;
+
+	// Off by default: dropped items land on the ground and can be walked back to if the flag turns
+	// out to be wrong. A wipe destroys them outright, with nothing to reverse.
+	public bool WipeInsteadOfDrop { get; set; } = false;
+
+	public int FreezeAfterFlags { get; set; } = 25;
+
+	public int JailAfterFlags { get; set; } = 40;
+
+	public int BanAfterFlags { get; set; } = 60;
+
+	// Hours until the ban lifts on its own. 0 means permanent. Defaults to a long timeout rather
+	// than permanent, so an unnoticed false positive at the top of the ladder is not unrecoverable.
+	public int BanDurationHours { get; set; } = 720;
+
+	public string JailReason { get; set; } = "Stratum anticheat: repeated confirmed violations";
+
+	public string BanReason { get; set; } = "Stratum anticheat: repeated confirmed violations";
+
+	public void EnsureSane()
+	{
+		DropInventoryAfterFlags = Math.Clamp(DropInventoryAfterFlags, 3, 100000);
+		FreezeAfterFlags = Math.Clamp(FreezeAfterFlags, DropInventoryAfterFlags, 100000);
+		JailAfterFlags = Math.Clamp(JailAfterFlags, FreezeAfterFlags, 100000);
+		BanAfterFlags = Math.Clamp(BanAfterFlags, JailAfterFlags, 100000);
+		BanDurationHours = Math.Clamp(BanDurationHours, 0, 87600);
+		JailReason ??= "Stratum anticheat: repeated confirmed violations";
+		BanReason ??= "Stratum anticheat: repeated confirmed violations";
 	}
 }
 

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumAnticheatHistory.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumAnticheatHistory.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Vintagestory.Server;
+
+/// <summary>
+/// Cross-session confirmed-violation count per player. StratumAnticheatReporter's own
+/// PlayerViolations dictionary is in-memory only and prunes a player out after
+/// KeepPlayerViolationsMinutes of inactivity, so a repeat offender who logs off and back on starts
+/// over there. This store is what StratumAnticheatPunishments reads to decide whether a player has
+/// accumulated enough flags for the next rung of the punishment ladder, persisted the same way
+/// StratumModerationStore and StratumCustodyStore already persist their own player-scoped state.
+/// </summary>
+internal static class StratumAnticheatHistory
+{
+	private const string HistoryKey = "stratum.anticheat.history.v1";
+
+	public static StratumAnticheatHistoryRecord RecordFlag(ServerMain server, ServerPlayerData target)
+	{
+		StratumAnticheatHistoryRecord record = Load(target);
+		record.TotalFlags++;
+		record.LastFlagUtc = DateTime.UtcNow;
+		Save(server, target, record);
+		return record;
+	}
+
+	public static void MarkPunishmentApplied(ServerMain server, ServerPlayerData target, StratumAnticheatHistoryRecord record, int tier)
+	{
+		record.HighestPunishmentApplied = tier;
+		record.LastPunishmentUtc = DateTime.UtcNow;
+		Save(server, target, record);
+	}
+
+	public static StratumAnticheatHistoryRecord Load(ServerPlayerData target)
+	{
+		if (target?.CustomPlayerData == null || !target.CustomPlayerData.TryGetValue(HistoryKey, out string json) || string.IsNullOrWhiteSpace(json))
+		{
+			return new StratumAnticheatHistoryRecord();
+		}
+
+		try
+		{
+			return JsonConvert.DeserializeObject<StratumAnticheatHistoryRecord>(json) ?? new StratumAnticheatHistoryRecord();
+		}
+		catch (Exception exception)
+		{
+			StratumRuntime.LogWarning("failed to read anticheat history for " + target.LastKnownPlayername + ": " + exception.Message);
+			return new StratumAnticheatHistoryRecord();
+		}
+	}
+
+	private static void Save(ServerMain server, ServerPlayerData target, StratumAnticheatHistoryRecord record)
+	{
+		target.CustomPlayerData ??= new Dictionary<string, string>();
+		target.CustomPlayerData[HistoryKey] = JsonConvert.SerializeObject(record);
+		server.PlayerDataManager.playerDataDirty = true;
+	}
+}
+
+internal sealed class StratumAnticheatHistoryRecord
+{
+	public int TotalFlags { get; set; }
+
+	// Ordinal of StratumAnticheatPunishments.Tier. Kept as a plain int here rather than the enum
+	// itself so this record never needs to change shape if the ladder gains or reorders tiers.
+	public int HighestPunishmentApplied { get; set; }
+
+	public DateTime? LastFlagUtc { get; set; }
+
+	public DateTime? LastPunishmentUtc { get; set; }
+}

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumAnticheatPunishments.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumAnticheatPunishments.cs
@@ -1,0 +1,175 @@
+using System;
+using System.Globalization;
+using Vintagestory.API.Common;
+using Vintagestory.API.Config;
+using Vintagestory.API.MathTools;
+using Vintagestory.API.Server;
+
+namespace Vintagestory.Server;
+
+/// <summary>
+/// The punishment half of #221. RecordViolation in StratumAnticheatReporter already funnels every
+/// confirmed violation type through one place; this is the single call slotted in right after it,
+/// per player, once the recording lock has been released. Every action here delegates to a
+/// primitive that already exists and is already tested elsewhere: Freeze, jail via
+/// StratumCustodyStore, InventoryBase.DropAll/Clear, PlayerDataManager.BanPlayer. Nothing new is
+/// invented here, only chained together against a threshold ladder.
+///
+/// Runs synchronously in whatever thread called RecordViolation, on purpose. The reporter already
+/// does exactly that for staff alerts and for KickConfirmedCheats: every Record*Violation call site
+/// calls server.DisconnectPlayer directly, immediately, with no queue, right after the lock
+/// releases. That calling context is already proven safe for real game-state actions, not only
+/// logging, so a deferred tick-queue here would add real complexity for a correctness problem this
+/// codebase does not already have.
+/// </summary>
+internal static class StratumAnticheatPunishments
+{
+	// Highest tier first: a single burst that crosses several thresholds at once (a confirmed
+	// nuker burst, for instance) applies only the tier it actually deserves, not every rung on the
+	// way up. HighestPunishmentApplied on the history record is this ordinal, so a later, smaller
+	// violation cannot re-trigger a lower tier the player already passed.
+	private enum Tier
+	{
+		None = 0,
+		DropInventory = 1,
+		Freeze = 2,
+		Jail = 3,
+		Ban = 4
+	}
+
+	public static void Evaluate(ServerMain server, ServerPlayer player)
+	{
+		StratumAnticheatPunishmentConfig config = StratumRuntime.Config.Anticheat.Punishments;
+		if (!config.Enabled || server == null || player == null)
+		{
+			return;
+		}
+
+		ServerPlayerData target = player.client?.ServerData;
+		if (target == null)
+		{
+			return;
+		}
+
+		StratumAnticheatHistoryRecord history = StratumAnticheatHistory.RecordFlag(server, target);
+		Tier applied = (Tier)history.HighestPunishmentApplied;
+		Tier due = HighestDueTier(config, history.TotalFlags, applied);
+		if (due == Tier.None)
+		{
+			return;
+		}
+
+		Apply(server, player, target, config, due, history.TotalFlags);
+		StratumAnticheatHistory.MarkPunishmentApplied(server, target, history, (int)due);
+	}
+
+	private static Tier HighestDueTier(StratumAnticheatPunishmentConfig config, int totalFlags, Tier applied)
+	{
+		if (totalFlags >= config.BanAfterFlags && applied < Tier.Ban)
+		{
+			return Tier.Ban;
+		}
+
+		if (totalFlags >= config.JailAfterFlags && applied < Tier.Jail)
+		{
+			return Tier.Jail;
+		}
+
+		if (totalFlags >= config.FreezeAfterFlags && applied < Tier.Freeze)
+		{
+			return Tier.Freeze;
+		}
+
+		if (totalFlags >= config.DropInventoryAfterFlags && applied < Tier.DropInventory)
+		{
+			return Tier.DropInventory;
+		}
+
+		return Tier.None;
+	}
+
+	private static void Apply(ServerMain server, ServerPlayer player, ServerPlayerData target, StratumAnticheatPunishmentConfig config, Tier tier, int totalFlags)
+	{
+		string label;
+		switch (tier)
+		{
+			case Tier.DropInventory:
+				ApplyInventoryPunishment(player, config);
+				label = config.WipeInsteadOfDrop ? "wiped their inventory" : "dropped their inventory";
+				break;
+			case Tier.Freeze:
+				StratumStaffCommandState.Freeze(player);
+				label = "frozen them";
+				break;
+			case Tier.Jail:
+				ApplyJail(player, target, config);
+				label = "jailed them";
+				break;
+			case Tier.Ban:
+				ApplyBan(server, player, config);
+				label = "banned them";
+				break;
+			default:
+				return;
+		}
+
+		StratumRuntime.LogAudit("anticheat-punishment target=" + player.PlayerName + " tier=" + tier + " totalFlags=" + totalFlags.ToString(CultureInfo.InvariantCulture), true);
+		AnnouncePunishment(server, player, label, totalFlags);
+	}
+
+	private static void ApplyInventoryPunishment(ServerPlayer player, StratumAnticheatPunishmentConfig config)
+	{
+		Vec3d pos = player.Entity?.Pos?.XYZ;
+		foreach (InventoryBase inventory in player.InventoryManager.InventoriesOrdered)
+		{
+			// Matches the skip EntityPlayer.WalkInventory already uses: a creative inventory is
+			// infinite, dropping or clearing it punishes nothing and can misbehave.
+			if (inventory.ClassName == "creative")
+			{
+				continue;
+			}
+
+			if (config.WipeInsteadOfDrop || pos == null)
+			{
+				inventory.Clear();
+			}
+			else
+			{
+				inventory.DropAll(pos);
+			}
+		}
+	}
+
+	private static void ApplyJail(ServerPlayer player, ServerPlayerData target, StratumAnticheatPunishmentConfig config)
+	{
+		Caller system = new Caller { Type = EnumCallerType.Console };
+		CmdStratumStaffCommands.Instance?.JailAutomatically(target, player.client, system, config.JailReason);
+	}
+
+	private static void ApplyBan(ServerMain server, ServerPlayer player, StratumAnticheatPunishmentConfig config)
+	{
+		DateTime? untilDate = config.BanDurationHours <= 0 ? (DateTime?)null : DateTime.UtcNow.AddHours(config.BanDurationHours);
+		server.PlayerDataManager.BanPlayer(player.PlayerName, player.PlayerUID, "Stratum Anticheat", config.BanReason, untilDate);
+		server.DisconnectPlayer(player.client, config.BanReason, config.BanReason);
+	}
+
+	private static void AnnouncePunishment(ServerMain server, ServerPlayer player, string label, int totalFlags)
+	{
+		string message = StratumCommandText.Pill("Stratum AC", StratumCommandText.Bad)
+			+ " automatically "
+			+ label
+			+ " "
+			+ StratumCommandText.Warning(player.PlayerName)
+			+ " after "
+			+ totalFlags.ToString(CultureInfo.InvariantCulture)
+			+ " accumulated flags.";
+
+		foreach (ConnectedClient client in server.Clients.Values)
+		{
+			if (StratumAnticheatReporter.ShouldReceiveStaffAlert(client))
+			{
+				client.Player.SendMessage(GlobalConstants.GeneralChatGroup, message, EnumChatType.Notification);
+			}
+		}
+	}
+}

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumAnticheatReporter.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumAnticheatReporter.cs
@@ -41,7 +41,7 @@ internal static class StratumAnticheatReporter
 		}
 
 		DateTime now = DateTime.UtcNow;
-		ViolationRecordResult result = RecordViolation(player, now, BlockEntityOutOfRangeType, FormatBlockPos(pos), config, config.BlockEntityOutOfRange);
+		ViolationRecordResult result = RecordViolation(player, now, BlockEntityOutOfRangeType, FormatBlockPos(pos), config, config.BlockEntityOutOfRange, server);
 
 		if (result.ShouldAlert)
 		{
@@ -66,7 +66,7 @@ internal static class StratumAnticheatReporter
 
 		string detail = action + " at " + FormatBlockPos(pos) + " distance=" + distance.ToString("0.##", CultureInfo.InvariantCulture) + "/" + maxRange.ToString("0.##", CultureInfo.InvariantCulture);
 		DateTime now = DateTime.UtcNow;
-		ViolationRecordResult result = RecordViolation(player, now, BlockInteractionOutOfRangeType, detail, config, config.BlockInteractionOutOfRange);
+		ViolationRecordResult result = RecordViolation(player, now, BlockInteractionOutOfRangeType, detail, config, config.BlockInteractionOutOfRange, server);
 		if (result.ShouldAlert)
 		{
 			SendStaffAlert(server, player, "survival block reach", pos, result.RollingCount, result.TotalCount, config.BlockInteractionOutOfRange.AlertWindowSeconds);
@@ -102,7 +102,7 @@ internal static class StratumAnticheatReporter
 		string who = target.Code?.ToString() ?? target.EntityId.ToString(CultureInfo.InvariantCulture);
 		string detail = "entity " + who + " at " + FormatBlockPos(pos) + " distance=" + distance.ToString("0.##", CultureInfo.InvariantCulture) + "/" + maxRange.ToString("0.##", CultureInfo.InvariantCulture);
 		DateTime now = DateTime.UtcNow;
-		ViolationRecordResult result = RecordViolation(player, now, EntityInteractionOutOfRangeType, detail, config, config.EntityInteractionOutOfRange);
+		ViolationRecordResult result = RecordViolation(player, now, EntityInteractionOutOfRangeType, detail, config, config.EntityInteractionOutOfRange, server);
 		if (result.ShouldAlert)
 		{
 			SendStaffAlert(server, player, "survival entity reach", pos, result.RollingCount, result.TotalCount, config.EntityInteractionOutOfRange.AlertWindowSeconds);
@@ -141,7 +141,7 @@ internal static class StratumAnticheatReporter
 		}
 
 		DateTime now = DateTime.UtcNow;
-		ViolationRecordResult result = RecordViolation(player, now, MovementAuthorityType, detail, config, config.MovementAuthority);
+		ViolationRecordResult result = RecordViolation(player, now, MovementAuthorityType, detail, config, config.MovementAuthority, server);
 		if (result.ShouldAlert)
 		{
 			SendStaffAlert(server, player, "movement authority", pos, result.RollingCount, result.TotalCount, config.MovementAuthority.AlertWindowSeconds);
@@ -175,7 +175,7 @@ internal static class StratumAnticheatReporter
 
 		string detail = "broke " + breaksInWindow.ToString(CultureInfo.InvariantCulture) + " blocks in " + config.MultiBreak.WindowMs.ToString(CultureInfo.InvariantCulture) + "ms" + (fingerprinted ? " (all dead-centre hits)" : "") + (pos != null ? " near " + FormatBlockPos(pos) : "");
 		DateTime now = DateTime.UtcNow;
-		ViolationRecordResult result = RecordViolation(player, now, MultiBreakType, detail, config, config.MultiBreak);
+		ViolationRecordResult result = RecordViolation(player, now, MultiBreakType, detail, config, config.MultiBreak, server);
 		if (result.ShouldAlert)
 		{
 			SendStaffAlert(server, player, "multi-break", pos, result.RollingCount, result.TotalCount, config.MultiBreak.AlertWindowSeconds);
@@ -213,7 +213,7 @@ internal static class StratumAnticheatReporter
 
 		string detail = "fell " + fallBlocks.ToString("0.#", CultureInfo.InvariantCulture) + " blocks with no fall damage" + (pos != null ? " at " + FormatBlockPos(pos) : "");
 		DateTime now = DateTime.UtcNow;
-		ViolationRecordResult result = RecordViolation(player, now, NoFallType, detail, config, config.NoFall);
+		ViolationRecordResult result = RecordViolation(player, now, NoFallType, detail, config, config.NoFall, server);
 		if (result.ShouldAlert)
 		{
 			SendStaffAlert(server, player, "no-fall", pos, result.RollingCount, result.TotalCount, config.NoFall.AlertWindowSeconds);
@@ -247,7 +247,7 @@ internal static class StratumAnticheatReporter
 
 		string detail = string.IsNullOrWhiteSpace(reason) ? FormatBlockPos(pos) : reason;
 		DateTime now = DateTime.UtcNow;
-		ViolationRecordResult result = RecordViolation(player, now, BlockBreakProgressType, detail, config, config.BlockBreakProgress);
+		ViolationRecordResult result = RecordViolation(player, now, BlockBreakProgressType, detail, config, config.BlockBreakProgress, server);
 		if (result.ShouldAlert)
 		{
 			SendStaffAlert(server, player, "block break progress", pos, result.RollingCount, result.TotalCount, config.BlockBreakProgress.AlertWindowSeconds);
@@ -281,7 +281,7 @@ internal static class StratumAnticheatReporter
 
 		string detail = string.IsNullOrWhiteSpace(reason) ? (pos != null ? FormatBlockPos(pos) : "movement") : reason;
 		DateTime now = DateTime.UtcNow;
-		ViolationRecordResult result = RecordViolation(player, now, MovementType, detail, config, config.Movement);
+		ViolationRecordResult result = RecordViolation(player, now, MovementType, detail, config, config.Movement, server);
 		if (result.ShouldAlert)
 		{
 			SendStaffAlert(server, player, "suspicious movement", pos, result.RollingCount, result.TotalCount, config.Movement.AlertWindowSeconds);
@@ -315,7 +315,7 @@ internal static class StratumAnticheatReporter
 
 		string detail = string.IsNullOrWhiteSpace(reason) ? "combat" : reason;
 		DateTime now = DateTime.UtcNow;
-		ViolationRecordResult result = RecordViolation(player, now, CombatType, detail, config, config.Combat);
+		ViolationRecordResult result = RecordViolation(player, now, CombatType, detail, config, config.Combat, server);
 		if (result.ShouldAlert)
 		{
 			SendStaffAlert(server, player, "combat", pos, result.RollingCount, result.TotalCount, config.Combat.AlertWindowSeconds);
@@ -332,7 +332,7 @@ internal static class StratumAnticheatReporter
 		return false;
 	}
 
-	public static string BuildReport(string playerFilter, int maxEvents = 12)
+	public static string BuildReport(ServerMain server, string playerFilter, int maxEvents = 12)
 	{
 		StratumRuntime.Config.EnsurePopulated();
 		DateTime now = DateTime.UtcNow;
@@ -375,7 +375,7 @@ internal static class StratumAnticheatReporter
 			return output.ToString();
 		}
 
-		AppendPlayerReport(output, players[0], now);
+		AppendPlayerReport(output, server, players[0], now);
 		output.Append(StratumCommandText.Row("Overview", "/stratum ac"));
 		return output.ToString();
 	}
@@ -404,11 +404,12 @@ internal static class StratumAnticheatReporter
 		}
 	}
 
-	private static void AppendPlayerReport(StringBuilder output, PlayerViolationSnapshot player, DateTime now)
+	private static void AppendPlayerReport(StringBuilder output, ServerMain server, PlayerViolationSnapshot player, DateTime now)
 	{
 		output.Append("\n").Append(StratumCommandText.Title("Player: " + player.PlayerName));
 		output.Append(StratumCommandText.Row("Total", player.TotalCount.ToString(CultureInfo.InvariantCulture) + " recorded violations"));
 		output.Append(StratumCommandText.Row("Last seen", FormatAge(now - player.LastSeenUtc) + " ago"));
+		AppendPunishmentStanding(output, server, player.PlayerKey);
 
 		output.Append("\n").Append(StratumCommandText.Title("Breakdown"));
 		foreach (ViolationTypeCount entry in player.TypeCounts.OrderByDescending(entry => entry.Count))
@@ -423,6 +424,52 @@ internal static class StratumAnticheatReporter
 				FriendlyTypeName(entry.Type),
 				StratumCommandText.Escape(FormatAge(now - entry.Utc) + " ago, " + FriendlyDetail(entry))));
 		}
+	}
+
+	// Cross-session standing, separate from the in-memory TotalCount above: that count resets when
+	// a player is pruned for inactivity, this one is what StratumAnticheatPunishments actually
+	// judges against and survives relogs and restarts.
+	private static void AppendPunishmentStanding(StringBuilder output, ServerMain server, string playerKey)
+	{
+		StratumAnticheatPunishmentConfig config = StratumRuntime.Config.Anticheat.Punishments;
+		if (!config.Enabled || server == null || string.IsNullOrWhiteSpace(playerKey))
+		{
+			return;
+		}
+
+		ServerPlayerData target = server.PlayerDataManager.GetServerPlayerData(playerKey) ?? server.PlayerDataManager.GetServerPlayerDataByLastKnownPlayername(playerKey);
+		if (target == null)
+		{
+			return;
+		}
+
+		StratumAnticheatHistoryRecord history = StratumAnticheatHistory.Load(target);
+		output.Append(StratumCommandText.Row("Punishment standing", history.TotalFlags.ToString(CultureInfo.InvariantCulture) + " accumulated flags, " + DescribeNextTier(config, history)));
+	}
+
+	private static string DescribeNextTier(StratumAnticheatPunishmentConfig config, StratumAnticheatHistoryRecord history)
+	{
+		if (history.TotalFlags < config.DropInventoryAfterFlags && history.HighestPunishmentApplied < 1)
+		{
+			return "next: " + (config.WipeInsteadOfDrop ? "wipe inventory" : "drop inventory") + " at " + config.DropInventoryAfterFlags.ToString(CultureInfo.InvariantCulture);
+		}
+
+		if (history.TotalFlags < config.FreezeAfterFlags && history.HighestPunishmentApplied < 2)
+		{
+			return "next: freeze at " + config.FreezeAfterFlags.ToString(CultureInfo.InvariantCulture);
+		}
+
+		if (history.TotalFlags < config.JailAfterFlags && history.HighestPunishmentApplied < 3)
+		{
+			return "next: jail at " + config.JailAfterFlags.ToString(CultureInfo.InvariantCulture);
+		}
+
+		if (history.TotalFlags < config.BanAfterFlags && history.HighestPunishmentApplied < 4)
+		{
+			return "next: ban at " + config.BanAfterFlags.ToString(CultureInfo.InvariantCulture);
+		}
+
+		return history.HighestPunishmentApplied >= 4 ? "already banned" : "no further tier configured";
 	}
 
 	private static string FriendlyTypeName(string type)
@@ -497,7 +544,7 @@ internal static class StratumAnticheatReporter
 		return detail;
 	}
 
-	private static ViolationRecordResult RecordViolation(ServerPlayer player, DateTime now, string type, string detail, StratumAnticheatConfig config, StratumAnticheatRuleConfig rule)
+	private static ViolationRecordResult RecordViolation(ServerPlayer player, DateTime now, string type, string detail, StratumAnticheatConfig config, StratumAnticheatRuleConfig rule, ServerMain server)
 	{
 		int rollingCount;
 		int totalCount;
@@ -541,6 +588,11 @@ internal static class StratumAnticheatReporter
 			}
 		}
 
+		// Outside the lock on purpose: this is where StaffAlerts and KickConfirmedCheats already run
+		// for every caller above (see the DisconnectPlayer calls at each Record*Violation call site),
+		// so punishment escalation belongs at the exact same place, not behind a separate queue.
+		StratumAnticheatPunishments.Evaluate(server, player);
+
 		return new ViolationRecordResult(rollingCount, totalCount, shouldAlert);
 	}
 
@@ -577,7 +629,7 @@ internal static class StratumAnticheatReporter
 		}
 	}
 
-	private static bool ShouldReceiveStaffAlert(ConnectedClient client)
+	internal static bool ShouldReceiveStaffAlert(ConnectedClient client)
 	{
 		if (client == null || !client.State.IsAdmitted() || client.Player == null)
 		{

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumRuntime.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumRuntime.cs
@@ -345,6 +345,27 @@ internal static class StratumRuntime
 			report.Warnings.Add("Anticheat.BlockBreakProgress KickAfterViolations is very low; raise it while validating modded mining behavior");
 		}
 
+		StratumAnticheatPunishmentConfig punishments = Config.Anticheat.Punishments;
+		if (punishments.Enabled && !Config.Anticheat.Enabled)
+		{
+			report.Warnings.Add("Anticheat.Punishments is enabled but Anticheat itself is disabled; punishments will never trigger");
+		}
+
+		if (punishments.Enabled && punishments.WipeInsteadOfDrop)
+		{
+			report.Warnings.Add("Anticheat.Punishments.WipeInsteadOfDrop discards items instead of dropping them; a false positive at that tier is unrecoverable");
+		}
+
+		if (punishments.Enabled && punishments.DropInventoryAfterFlags < 10)
+		{
+			report.Warnings.Add("Anticheat.Punishments.DropInventoryAfterFlags is very low; watch /stratum ac's false-positive rate in monitor-only mode before automating consequences");
+		}
+
+		if (punishments.Enabled && punishments.BanDurationHours == 0)
+		{
+			report.Warnings.Add("Anticheat.Punishments.BanDurationHours is 0 (permanent); a false positive at the top of the ladder has no automatic recovery");
+		}
+
 		if (blockBreak.RequiredProgressRatio > 0.95f && blockBreak.GraceSeconds <= 0.1f)
 		{
 			report.Warnings.Add("BlockBreakGuards has a strict progress ratio with little grace; this can false-positive under latency");


### PR DESCRIPTION
## Summary

Adds an opt-in escalation ladder for players who keep accumulating confirmed anticheat flags: inventory drop/wipe, then freeze, then jail, then a timed ban, in that order, based on a persistent per-player flag count that survives relogs and restarts.

Every action the ladder takes reuses an existing, already-tested primitive:
- Inventory drop/wipe: `InventoryBase.DropAll`/`Clear`, same as normal death handling, skipping the creative inventory the same way `EntityPlayer.WalkInventory` already does.
- Freeze: `StratumStaffCommandState.Freeze`, the same as `/freeze`.
- Jail: a new `CmdStratumStaffCommands.JailAutomatically` entry point that reuses the existing `TryGetJailLocation` + `JailSingleTarget` methods unchanged, reached through a minimal `internal static Instance` reference since the active-jail tracking and enforcement tick loop are instance state with no prior external access point.
- Ban: `PlayerDataManager.BanPlayer` + `DisconnectPlayer`, same as `/ban`.

Nothing new is invented for enforcement; only the threshold ladder and the persistent standing behind it are new.

Standing is tracked separately from `StratumAnticheatReporter`'s existing in-memory `PlayerViolations` dictionary, which is intentionally rolling and prunes a player out after `KeepPlayerViolationsMinutes` of inactivity. A new `StratumAnticheatHistory` store persists `TotalFlags` and the highest tier already applied in `CustomPlayerData`, the same pattern `StratumModerationStore`/`StratumCustodyStore` already use, so a repeat offender who logs off can't reset their standing by relogging.

The escalation check runs synchronously right after `RecordViolation`'s lock releases, in the same place every `Record*Violation` call site already calls `DisconnectPlayer` directly for `KickConfirmedCheats` today. That existing pattern already proves the calling context is safe for real game-state actions, not only logging, so this needed no new queue or deferred-execution scheduling.

`/stratum ac <player>` now also shows accumulated flags and the next tier due. `StratumRuntime`'s config safety check gained four warnings for risky combinations: punishments enabled while anticheat itself is disabled, wipe-instead-of-drop, a very low first threshold, and a permanent (non-recovering) ban duration.

Off by default (`Anticheat.Punishments.Enabled = false`), same posture as `KickConfirmedCheats` per rule: an operator has to opt in with eyes open, since chaining these into automatic consequences on a false positive is a materially different risk than an alert or a single kick.

## Type

- [x] New feature

## Checklist

- [x] `scripts/extract-patches.sh` ran clean (no vanilla-file changes; every edit here is under `sources/`, no `patches/` diffs touched).
- [x] `dotnet build VintageStory.slnx -c Release` is green (0 errors, 0 new warnings; verified no warnings in any touched file).
- [x] Every vanilla edit has a `// Stratum` marker. (N/A: no vanilla files touched, only Stratum-original files under `sources/`.)
- [x] No vanilla source committed.
- [x] Tested on a real server start, not just compilation (`make smoke`: PASS, reached `WorldReady`, no fatal errors).

## Related issues

Fixes #221
