### PR TITLE
Add live kit creator: /kit and /kitedit

### DIFF
--- a/patches/VintagestoryLib/Vintagestory.Server/ServerSystemCommands.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/ServerSystemCommands.cs.patch
@@ -1,8 +1,8 @@
 diff --git a/VintagestoryLib/Vintagestory.Server/ServerSystemCommands.cs b/VintagestoryLib/Vintagestory.Server/ServerSystemCommands.cs
-index 1d4be19..7938c76 100644
+index 1d4be19..8acd529 100644
 --- a/VintagestoryLib/Vintagestory.Server/ServerSystemCommands.cs
 +++ b/VintagestoryLib/Vintagestory.Server/ServerSystemCommands.cs
-@@ -21,10 +21,21 @@ internal class ServerSystemCommands : ServerSystem
+@@ -21,10 +21,22 @@ internal class ServerSystemCommands : ServerSystem
  		new CmdEntity(server);
  		new CmdGive(server);
  		new CmdDebug(server);
@@ -13,6 +13,7 @@ index 1d4be19..7938c76 100644
 +		new CmdStratumEssentials(server);
 +		new CmdStratumStaffCommands(server);
 +		new CmdStratumRoles(server); // Stratum: runtime role editing
++		new CmdStratumKits(server); // Stratum: issue #210 kit creator
 +		new StratumMobSpawningSystem(server); // Stratum: issue #216 natural mob spawning controls
 +		new StratumLoginProtection(server);
 +		new StratumCombatLogSystem(server);
@@ -24,7 +25,7 @@ index 1d4be19..7938c76 100644
  		new CmdModDBUtil(server);
  		if (!server.IsDedicatedServer)
  		{
-@@ -33,6 +44,10 @@ internal class ServerSystemCommands : ServerSystem
+@@ -33,6 +45,10 @@ internal class ServerSystemCommands : ServerSystem
  		new CmdSetBlock(server);
  		new CmdExecuteAs(server);
  		new CmdActivate(server);

--- a/sources/VintagestoryLib/Vintagestory.Server/CmdStratumKits.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/CmdStratumKits.cs
@@ -2,8 +2,11 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Vintagestory.API.Common;
 using Vintagestory.API.Config;
+using Vintagestory.API.Datastructures;
 using Vintagestory.API.Server;
 
 namespace Vintagestory.Server;
@@ -29,10 +32,7 @@ internal class CmdStratumKits
 		StratumKitStore.Load();
 		server.EventManager.OnPlayerRespawn += OnPlayerRespawn;
 
-		if (!StratumRuntime.Config.Commands.Enabled)
-		{
-			return;
-		}
+		if (!StratumRuntime.Config.Commands.Enabled) return;
 
 		CommandArgumentParsers parsers = server.api.commandapi.Parsers;
 
@@ -54,9 +54,7 @@ internal class CmdStratumKits
 				.WithArgs(
 					parsers.WordRange("action", "create", "additem", "removeitem", "delete", "rename", "setrole", "setcooldown", "onrespawn", "oneperlife", "preview", "give", "list"),
 					parsers.OptionalWord("name"),
-					parsers.OptionalWord("value"),
-					parsers.OptionalWord("value2"))
-				.RequiresPrivilege(Privilege.gamemode)
+					parsers.OptionalWord("value"))
 				.HandleWith(HandleKitEdit);
 		}
 	}
@@ -66,17 +64,14 @@ internal class CmdStratumKits
 	// itself is keyed to.
 	private void OnPlayerRespawn(IServerPlayer player)
 	{
-		if (player?.ServerData == null)
+		if (player?.ServerData == null) return;
+
+		if (player.ServerData.CustomPlayerData.Remove(RedeemedThisLifeKey))
 		{
-			return;
+			server.PlayerDataManager.playerDataDirty = true;
 		}
 
-		player.ServerData.CustomPlayerData.Remove(RedeemedThisLifeKey);
-
-		if (!StratumRuntime.Config.Commands.Kits.Enabled)
-		{
-			return;
-		}
+		if (!StratumRuntime.Config.Commands.Kits.Enabled) return;
 
 		// This event fires before the player is actually revived: vanilla's own handler for it
 		// (ServerSystemEntitySimulation.OnPlayerRespawn) only starts an async teleport, calling
@@ -91,16 +86,10 @@ internal class CmdStratumKits
 		{
 			ConnectedClient client = server.GetClientByUID(playerUid);
 			bool alive = client?.Player?.Entity?.Alive == true;
-			if (!alive && client != null && --attemptsRemaining > 0)
-			{
-				return;
-			}
+			if (!alive && client != null && --attemptsRemaining > 0) return;
 
 			server.UnregisterGameTickListener(listenerId);
-			if (client?.Player == null || !alive)
-			{
-				return;
-			}
+			if (client?.Player == null || !alive) return;
 
 			GiveAssignedRespawnKits(client.Player, client.ServerData);
 		}, 250);
@@ -110,7 +99,9 @@ internal class CmdStratumKits
 	{
 		foreach (StratumKitDefinition kit in StratumKitStore.All())
 		{
-			if (kit.GiveOnRespawn && IsAssignedTo(kit, data))
+			if (kit.GiveOnRespawn
+				&& IsAssignedTo(kit, data)
+				&& StratumCommandAccessCatalog.PlayerHasAccess(target, StratumRuntime.Config.Commands.Kits))
 			{
 				StratumKitGiver.Give(target, kit);
 				MarkRedeemedThisLife(data, kit.Name);
@@ -203,7 +194,6 @@ internal class CmdStratumKits
 		string action = (args[0] as string)?.ToLowerInvariant();
 		string name = args.Parsers[1].IsMissing ? null : args[1] as string;
 		string value = args.Parsers[2].IsMissing ? null : args[2] as string;
-		string value2 = args.Parsers[3].IsMissing ? null : args[3] as string;
 
 		return action switch
 		{
@@ -481,8 +471,9 @@ internal class CmdStratumKits
 		List<StratumKitItem> items = new List<StratumKitItem>();
 		foreach (InventoryBase inventory in player.InventoryManager.InventoriesOrdered)
 		{
+			// A worn backpack's contents are stored in the backpack stack in the character inventory.
+			// Walking the backpack inventory too would add every content item a second time.
 			if (inventory.ClassName != GlobalConstants.hotBarInvClassName
-				&& inventory.ClassName != GlobalConstants.backpackInvClassName
 				&& inventory.ClassName != GlobalConstants.characterInvClassName)
 			{
 				continue;
@@ -502,9 +493,27 @@ internal class CmdStratumKits
 
 	private static StratumKitItem EncodeStack(ItemStack stack)
 	{
+		JsonItemStack jsonStack = new JsonItemStack
+		{
+			Type = stack.Class,
+			Code = stack.Collectible?.Code,
+			StackSize = stack.StackSize,
+			Attributes = stack.Attributes == null ? null : JsonObject.FromJson(stack.Attributes.ToJsonToken())
+		};
+		JObject json = new JObject
+		{
+			["type"] = jsonStack.Type == EnumItemClass.Block ? "block" : "item",
+			["code"] = jsonStack.Code?.ToShortString(),
+			["stacksize"] = jsonStack.StackSize
+		};
+		if (jsonStack.Attributes?.Token != null)
+		{
+			json["attributes"] = jsonStack.Attributes.Token.DeepClone();
+		}
+
 		return new StratumKitItem
 		{
-			Base64 = Convert.ToBase64String(stack.Clone().ToBytes()),
+			StackJson = json.ToString(Formatting.None),
 			Code = stack.Collectible?.Code?.ToString() ?? "unknown",
 			Quantity = stack.StackSize
 		};
@@ -544,6 +553,12 @@ internal class CmdStratumKits
 	private bool CheckAccess(TextCommandCallingArgs args, string commandLabel, StratumCommandAccessConfig access, out TextCommandResult failure)
 	{
 		failure = null;
+		if (!StratumRuntime.Config.Commands.Enabled)
+		{
+			failure = TextCommandResult.Error("Stratum commands are disabled.");
+			return false;
+		}
+
 		if (access == null || !access.Enabled)
 		{
 			failure = TextCommandResult.Error("/" + commandLabel + " is disabled.");

--- a/sources/VintagestoryLib/Vintagestory.Server/CmdStratumKits.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/CmdStratumKits.cs
@@ -1,0 +1,567 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Vintagestory.API.Common;
+using Vintagestory.API.Config;
+using Vintagestory.API.Server;
+
+namespace Vintagestory.Server;
+
+/// <summary>
+/// #210: kits editable live, in-game, via commands, with role assignment and configurable
+/// activation. /kit redeems a kit the caller is entitled to; /kitedit is the staff-facing CRUD
+/// surface. No UI is possible (the issue's own scope checkbox: server-side only, no custom
+/// client), so every /kitedit sub-verb that would otherwise need an item code instead snapshots a
+/// live ItemStack off the caller: create snapshots the caller's whole inventory, additem
+/// snapshots their active hotbar slot.
+/// </summary>
+internal class CmdStratumKits
+{
+	private const string RedeemedThisLifeKey = "stratum.kit.redeemed-this-life.v1";
+
+	private readonly ServerMain server;
+
+	public CmdStratumKits(ServerMain server)
+	{
+		this.server = server;
+		StratumRuntime.Config.EnsurePopulated();
+		StratumKitStore.Load();
+		server.EventManager.OnPlayerRespawn += OnPlayerRespawn;
+
+		if (!StratumRuntime.Config.Commands.Enabled)
+		{
+			return;
+		}
+
+		CommandArgumentParsers parsers = server.api.commandapi.Parsers;
+
+		StratumCommandAccessConfig kitAccess = StratumRuntime.Config.Commands.Kits;
+		if (StratumCommandRegistration.ShouldRegister(kitAccess, "/kit", "Commands.Kits"))
+		{
+			server.api.commandapi.Create("kit")
+				.WithDescription("Redeem a kit you have been assigned, or list the ones you can use: /kit [name]")
+				.WithArgs(parsers.OptionalWord("name"))
+				.RequiresPrivilege(Privilege.chat)
+				.HandleWith(HandleKit);
+		}
+
+		StratumCommandAccessConfig kitEditAccess = StratumRuntime.Config.Commands.KitEdit;
+		if (StratumCommandRegistration.ShouldRegister(kitEditAccess, "/kitedit", "Commands.KitEdit"))
+		{
+			server.api.commandapi.Create("kitedit")
+				.WithDescription("Create and manage kits: /kitedit create|additem|removeitem|delete|rename|setrole|setcooldown|onrespawn|oneperlife|preview|give|list <...>")
+				.WithArgs(
+					parsers.WordRange("action", "create", "additem", "removeitem", "delete", "rename", "setrole", "setcooldown", "onrespawn", "oneperlife", "preview", "give", "list"),
+					parsers.OptionalWord("name"),
+					parsers.OptionalWord("value"),
+					parsers.OptionalWord("value2"))
+				.RequiresPrivilege(Privilege.gamemode)
+				.HandleWith(HandleKitEdit);
+		}
+	}
+
+	// #210: "activate the kit ... through respawn, which is configurable". Also clears the
+	// one-per-life redeemed set for every kit, the same life boundary the give-on-respawn pass
+	// itself is keyed to.
+	private void OnPlayerRespawn(IServerPlayer player)
+	{
+		if (player?.ServerData == null)
+		{
+			return;
+		}
+
+		player.ServerData.CustomPlayerData.Remove(RedeemedThisLifeKey);
+
+		if (!StratumRuntime.Config.Commands.Kits.Enabled)
+		{
+			return;
+		}
+
+		// This event fires before the player is actually revived: vanilla's own handler for it
+		// (ServerSystemEntitySimulation.OnPlayerRespawn) only starts an async teleport, calling
+		// Entity.Revive() later once the target chunk has finished loading. Giving kit items
+		// synchronously here would race that revive and could be silently lost, so this polls
+		// for Alive first instead, giving up after ~10s if it never arrives (e.g. the player
+		// disconnected mid-respawn).
+		string playerUid = player.PlayerUID;
+		int attemptsRemaining = 40;
+		long listenerId = 0;
+		listenerId = server.RegisterGameTickListener(_ =>
+		{
+			ConnectedClient client = server.GetClientByUID(playerUid);
+			bool alive = client?.Player?.Entity?.Alive == true;
+			if (!alive && client != null && --attemptsRemaining > 0)
+			{
+				return;
+			}
+
+			server.UnregisterGameTickListener(listenerId);
+			if (client?.Player == null || !alive)
+			{
+				return;
+			}
+
+			GiveAssignedRespawnKits(client.Player, client.ServerData);
+		}, 250);
+	}
+
+	private void GiveAssignedRespawnKits(ServerPlayer target, ServerPlayerData data)
+	{
+		foreach (StratumKitDefinition kit in StratumKitStore.All())
+		{
+			if (kit.GiveOnRespawn && IsAssignedTo(kit, data))
+			{
+				StratumKitGiver.Give(target, kit);
+				MarkRedeemedThisLife(data, kit.Name);
+			}
+		}
+	}
+
+	private TextCommandResult HandleKit(TextCommandCallingArgs args)
+	{
+		if (!CheckAccess(args, "kit", StratumRuntime.Config.Commands.Kits, out TextCommandResult failure))
+		{
+			return failure;
+		}
+
+		IServerPlayer caller = args.Caller.Player as IServerPlayer;
+		if (caller?.ServerData == null)
+		{
+			return TextCommandResult.Error("Only a connected player can use /kit.");
+		}
+
+		if (args.Parsers[0].IsMissing)
+		{
+			return ListAvailableKits(caller);
+		}
+
+		string name = args[0] as string;
+		StratumKitDefinition kit = StratumKitStore.Find(name);
+		if (kit == null)
+		{
+			return TextCommandResult.Error("No kit named '" + name + "'.");
+		}
+
+		if (!IsAssignedTo(kit, caller.ServerData))
+		{
+			return TextCommandResult.Error("You are not assigned the kit '" + kit.Name + "'.");
+		}
+
+		if (kit.OnePerLife && HasRedeemedThisLife(caller.ServerData, kit.Name))
+		{
+			return TextCommandResult.Error("You have already redeemed '" + kit.Name + "' this life.");
+		}
+
+		StratumCommandAccessConfig perKitCooldown = new StratumCommandAccessConfig
+		{
+			CooldownSeconds = kit.CooldownSeconds,
+			CooldownBypassForStaff = true
+		};
+		if (!StratumCommandCooldowns.TryUse(args.Caller, server, "kit:" + kit.Name, perKitCooldown, out TimeSpan remaining))
+		{
+			return TextCommandResult.Error("Wait " + Math.Ceiling(remaining.TotalSeconds) + "s before redeeming '" + kit.Name + "' again.");
+		}
+
+		ServerPlayer target = server.GetClientByUID(caller.PlayerUID)?.Player;
+		if (target == null)
+		{
+			return TextCommandResult.Error("Could not resolve your player entity.");
+		}
+
+		StratumKitGiver.KitGiveResult result = StratumKitGiver.Give(target, kit);
+		MarkRedeemedThisLife(caller.ServerData, kit.Name);
+		StratumRuntime.LogAudit("kit redeemed name=" + kit.Name + " actor=" + args.Caller.GetName() + " given=" + result.GivenCount + " dropped=" + result.DroppedCount + " failed=" + result.FailedCount, true);
+		return DescribeGiveResult(kit, result);
+	}
+
+	private TextCommandResult ListAvailableKits(IServerPlayer caller)
+	{
+		List<StratumKitDefinition> available = StratumKitStore.All().Where(kit => IsAssignedTo(kit, caller.ServerData)).ToList();
+		if (available.Count == 0)
+		{
+			return TextCommandResult.Success(StratumCommandText.Info("You are not assigned any kits."));
+		}
+
+		StringBuilder output = new StringBuilder(StratumCommandText.Title("Your kits"));
+		foreach (StratumKitDefinition kit in available.OrderBy(kit => kit.Name, StringComparer.OrdinalIgnoreCase))
+		{
+			output.Append(StratumCommandText.Bullet(kit.Name, kit.Items.Count + " item(s)" + (kit.CooldownSeconds > 0 ? ", cooldown " + kit.CooldownSeconds + "s" : "") + (kit.OnePerLife ? ", once per life" : "")));
+		}
+
+		output.Append(StratumCommandText.Row("Redeem", "/kit <name>"));
+		return TextCommandResult.Success(output.ToString());
+	}
+
+	private TextCommandResult HandleKitEdit(TextCommandCallingArgs args)
+	{
+		if (!CheckAccess(args, "kitedit", StratumRuntime.Config.Commands.KitEdit, out TextCommandResult failure))
+		{
+			return failure;
+		}
+
+		string action = (args[0] as string)?.ToLowerInvariant();
+		string name = args.Parsers[1].IsMissing ? null : args[1] as string;
+		string value = args.Parsers[2].IsMissing ? null : args[2] as string;
+		string value2 = args.Parsers[3].IsMissing ? null : args[3] as string;
+
+		return action switch
+		{
+			"create" => CreateKit(name, args.Caller),
+			"additem" => AddItem(name, args.Caller),
+			"removeitem" => RemoveItem(name, value),
+			"delete" => DeleteKit(name),
+			"rename" => RenameKit(name, value),
+			"setrole" => SetRole(name, value),
+			"setcooldown" => SetCooldown(name, value),
+			"onrespawn" => SetFlag(name, value, "onrespawn"),
+			"oneperlife" => SetFlag(name, value, "oneperlife"),
+			"preview" => PreviewKit(name),
+			"give" => GiveKit(name, value),
+			"list" => ListAllKits(),
+			_ => TextCommandResult.Error("Unknown /kitedit action '" + action + "'.")
+		};
+	}
+
+	private TextCommandResult CreateKit(string name, Caller caller)
+	{
+		if (string.IsNullOrWhiteSpace(name))
+		{
+			return TextCommandResult.Error("Usage: /kitedit create <name>");
+		}
+
+		IPlayer player = caller.Player;
+		if (player?.InventoryManager == null)
+		{
+			return TextCommandResult.Error("Only a connected player can snapshot a kit from their own inventory.");
+		}
+
+		List<StratumKitItem> items = SnapshotInventory(player);
+		if (items.Count == 0)
+		{
+			return TextCommandResult.Error("Your inventory is empty; nothing to snapshot.");
+		}
+
+		StratumKitDefinition existing = StratumKitStore.Find(name);
+		StratumKitDefinition kit = existing ?? new StratumKitDefinition
+		{
+			Name = name,
+			CreatedByUid = player.PlayerUID,
+			CreatedByName = player.PlayerName,
+			CreatedUtc = DateTime.UtcNow
+		};
+		kit.Items = items;
+		StratumKitStore.Upsert(kit);
+		StratumRuntime.LogAudit("kitedit create name=" + kit.Name + " items=" + items.Count + " actor=" + caller.GetName(), true);
+		return TextCommandResult.Success(StratumCommandText.Confirm((existing != null ? "Kit updated" : "Kit created"), kit.Name + ": " + items.Count + " item(s) snapshotted from your inventory."));
+	}
+
+	private TextCommandResult AddItem(string name, Caller caller)
+	{
+		StratumKitDefinition kit = StratumKitStore.Find(name);
+		if (kit == null)
+		{
+			return TextCommandResult.Error("No kit named '" + name + "'.");
+		}
+
+		ItemSlot activeSlot = caller.Player?.InventoryManager?.ActiveHotbarSlot;
+		if (activeSlot?.Itemstack == null)
+		{
+			return TextCommandResult.Error("Hold the item you want to add in your active hotbar slot.");
+		}
+
+		StratumKitItem item = EncodeStack(activeSlot.Itemstack);
+		kit.Items.Add(item);
+		StratumKitStore.Save();
+		StratumRuntime.LogAudit("kitedit additem name=" + kit.Name + " item=" + item.Code + " actor=" + caller.GetName(), true);
+		return TextCommandResult.Success(StratumCommandText.Confirm("Item added", item.Code + " x" + item.Quantity + " added to '" + kit.Name + "' (now " + kit.Items.Count + " item(s))."));
+	}
+
+	private TextCommandResult RemoveItem(string name, string indexText)
+	{
+		StratumKitDefinition kit = StratumKitStore.Find(name);
+		if (kit == null)
+		{
+			return TextCommandResult.Error("No kit named '" + name + "'.");
+		}
+
+		if (!int.TryParse(indexText, out int index) || index < 1 || index > kit.Items.Count)
+		{
+			return TextCommandResult.Error("Usage: /kitedit removeitem <name> <index 1-" + kit.Items.Count + ">. See /kitedit preview " + kit.Name + ".");
+		}
+
+		StratumKitItem removed = kit.Items[index - 1];
+		kit.Items.RemoveAt(index - 1);
+		StratumKitStore.Save();
+		return TextCommandResult.Success(StratumCommandText.Confirm("Item removed", removed.Code + " removed from '" + kit.Name + "' (now " + kit.Items.Count + " item(s))."));
+	}
+
+	private TextCommandResult DeleteKit(string name)
+	{
+		if (!StratumKitStore.Delete(name))
+		{
+			return TextCommandResult.Error("No kit named '" + name + "'.");
+		}
+
+		return TextCommandResult.Success(StratumCommandText.Confirm("Kit deleted", name));
+	}
+
+	private TextCommandResult RenameKit(string name, string newName)
+	{
+		if (string.IsNullOrWhiteSpace(newName))
+		{
+			return TextCommandResult.Error("Usage: /kitedit rename <name> <newName>");
+		}
+
+		if (!StratumKitStore.Rename(name, newName))
+		{
+			return TextCommandResult.Error("Rename failed: either '" + name + "' does not exist, or '" + newName + "' is already taken.");
+		}
+
+		return TextCommandResult.Success(StratumCommandText.Confirm("Kit renamed", name + " -> " + newName));
+	}
+
+	// Toggle: setrole adds the role scope if the kit does not already carry it, removes it if it
+	// does. Repeated calls build up or tear down a multi-role AssignedTo list without a separate
+	// "clear" verb.
+	private TextCommandResult SetRole(string name, string roleCode)
+	{
+		StratumKitDefinition kit = StratumKitStore.Find(name);
+		if (kit == null)
+		{
+			return TextCommandResult.Error("No kit named '" + name + "'.");
+		}
+
+		if (string.IsNullOrWhiteSpace(roleCode))
+		{
+			return TextCommandResult.Error("Usage: /kitedit setrole <name> <role>");
+		}
+
+		if (!server.Config.RolesByCode.ContainsKey(roleCode))
+		{
+			return TextCommandResult.Error("No role found for '" + roleCode + "'.");
+		}
+
+		string scope = "role:" + roleCode;
+		bool removed = kit.AssignedTo.RemoveAll(entry => string.Equals(entry, scope, StringComparison.OrdinalIgnoreCase)) > 0;
+		if (!removed)
+		{
+			kit.AssignedTo.Add(scope);
+		}
+
+		StratumKitStore.Save();
+		return TextCommandResult.Success(StratumCommandText.Confirm(removed ? "Role unassigned" : "Role assigned", roleCode + (removed ? " no longer gets " : " now gets ") + kit.Name));
+	}
+
+	private TextCommandResult SetCooldown(string name, string secondsText)
+	{
+		StratumKitDefinition kit = StratumKitStore.Find(name);
+		if (kit == null)
+		{
+			return TextCommandResult.Error("No kit named '" + name + "'.");
+		}
+
+		if (!int.TryParse(secondsText, out int seconds) || seconds < 0)
+		{
+			return TextCommandResult.Error("Usage: /kitedit setcooldown <name> <seconds>=0");
+		}
+
+		kit.CooldownSeconds = seconds;
+		StratumKitStore.Save();
+		return TextCommandResult.Success(StratumCommandText.Confirm("Cooldown set", kit.Name + " = " + seconds + "s"));
+	}
+
+	private TextCommandResult SetFlag(string name, string onOff, string flag)
+	{
+		StratumKitDefinition kit = StratumKitStore.Find(name);
+		if (kit == null)
+		{
+			return TextCommandResult.Error("No kit named '" + name + "'.");
+		}
+
+		bool? on = string.Equals(onOff, "on", StringComparison.OrdinalIgnoreCase) ? true
+			: string.Equals(onOff, "off", StringComparison.OrdinalIgnoreCase) ? false
+			: (bool?)null;
+		if (on == null)
+		{
+			return TextCommandResult.Error("Usage: /kitedit " + flag + " <name> on|off");
+		}
+
+		if (flag == "onrespawn")
+		{
+			kit.GiveOnRespawn = on.Value;
+		}
+		else
+		{
+			kit.OnePerLife = on.Value;
+		}
+
+		StratumKitStore.Save();
+		return TextCommandResult.Success(StratumCommandText.Confirm(flag + " set", kit.Name + " = " + (on.Value ? "on" : "off")));
+	}
+
+	private TextCommandResult PreviewKit(string name)
+	{
+		StratumKitDefinition kit = StratumKitStore.Find(name);
+		if (kit == null)
+		{
+			return TextCommandResult.Error("No kit named '" + name + "'.");
+		}
+
+		StringBuilder output = new StringBuilder(StratumCommandText.Title("Kit: " + kit.Name));
+		output.Append(StratumCommandText.Row("Assigned to", kit.AssignedTo.Count == 0 ? "everyone with stratum.kits" : string.Join(", ", kit.AssignedTo)));
+		output.Append(StratumCommandText.Row("Cooldown", kit.CooldownSeconds + "s"));
+		output.Append(StratumCommandText.Row("One per life", kit.OnePerLife ? "yes" : "no"));
+		output.Append(StratumCommandText.Row("Give on respawn", kit.GiveOnRespawn ? "yes" : "no"));
+		output.Append("\n").Append(StratumCommandText.Title("Items"));
+		for (int i = 0; i < kit.Items.Count; i++)
+		{
+			StratumKitItem item = kit.Items[i];
+			output.Append(StratumCommandText.Bullet((i + 1).ToString(), item.Code + " x" + item.Quantity));
+		}
+
+		return TextCommandResult.Success(output.ToString());
+	}
+
+	private TextCommandResult GiveKit(string name, string playerName)
+	{
+		StratumKitDefinition kit = StratumKitStore.Find(name);
+		if (kit == null)
+		{
+			return TextCommandResult.Error("No kit named '" + name + "'.");
+		}
+
+		ConnectedClient client = server.Clients.Values.FirstOrDefault(candidate => string.Equals(candidate.Player?.PlayerName, playerName, StringComparison.OrdinalIgnoreCase));
+		if (client?.Player == null)
+		{
+			return TextCommandResult.Error("No online player named '" + playerName + "'.");
+		}
+
+		StratumKitGiver.KitGiveResult result = StratumKitGiver.Give(client.Player, kit);
+		return DescribeGiveResult(kit, result);
+	}
+
+	private TextCommandResult ListAllKits()
+	{
+		IReadOnlyList<StratumKitDefinition> kits = StratumKitStore.All();
+		if (kits.Count == 0)
+		{
+			return TextCommandResult.Success(StratumCommandText.Info("No kits exist yet. Create one with /kitedit create <name>."));
+		}
+
+		StringBuilder output = new StringBuilder(StratumCommandText.Title("All kits"));
+		foreach (StratumKitDefinition kit in kits.OrderBy(kit => kit.Name, StringComparer.OrdinalIgnoreCase))
+		{
+			output.Append(StratumCommandText.Bullet(kit.Name, kit.Items.Count + " item(s), assigned to " + (kit.AssignedTo.Count == 0 ? "everyone" : string.Join(", ", kit.AssignedTo))));
+		}
+
+		return TextCommandResult.Success(output.ToString());
+	}
+
+	private static TextCommandResult DescribeGiveResult(StratumKitDefinition kit, StratumKitGiver.KitGiveResult result)
+	{
+		string summary = result.GivenCount + " given";
+		if (result.DroppedCount > 0)
+		{
+			summary += ", " + result.DroppedCount + " dropped at feet (inventory full)";
+		}
+
+		if (result.FailedCount > 0)
+		{
+			summary += ", " + result.FailedCount + " failed to decode";
+		}
+
+		return result.AllGiven
+			? TextCommandResult.Success(StratumCommandText.Confirm("Kit '" + kit.Name + "' given", summary))
+			: TextCommandResult.Success(StratumCommandText.Warning("Kit '" + kit.Name + "' partially given: " + summary));
+	}
+
+	private static List<StratumKitItem> SnapshotInventory(IPlayer player)
+	{
+		List<StratumKitItem> items = new List<StratumKitItem>();
+		foreach (InventoryBase inventory in player.InventoryManager.InventoriesOrdered)
+		{
+			if (inventory.ClassName != GlobalConstants.hotBarInvClassName
+				&& inventory.ClassName != GlobalConstants.backpackInvClassName
+				&& inventory.ClassName != GlobalConstants.characterInvClassName)
+			{
+				continue;
+			}
+
+			foreach (ItemSlot slot in inventory)
+			{
+				if (slot.Itemstack != null)
+				{
+					items.Add(EncodeStack(slot.Itemstack));
+				}
+			}
+		}
+
+		return items;
+	}
+
+	private static StratumKitItem EncodeStack(ItemStack stack)
+	{
+		return new StratumKitItem
+		{
+			Base64 = Convert.ToBase64String(stack.Clone().ToBytes()),
+			Code = stack.Collectible?.Code?.ToString() ?? "unknown",
+			Quantity = stack.StackSize
+		};
+	}
+
+	private static bool IsAssignedTo(StratumKitDefinition kit, IServerPlayerData playerData)
+	{
+		if (kit.AssignedTo == null || kit.AssignedTo.Count == 0)
+		{
+			return true;
+		}
+
+		return kit.AssignedTo.Any(scope => string.Equals(scope, "role:" + playerData.RoleCode, StringComparison.OrdinalIgnoreCase));
+	}
+
+	private static bool HasRedeemedThisLife(IServerPlayerData playerData, string kitName)
+	{
+		if (!playerData.CustomPlayerData.TryGetValue(RedeemedThisLifeKey, out string raw) || string.IsNullOrWhiteSpace(raw))
+		{
+			return false;
+		}
+
+		return raw.Split(';').Contains(kitName, StringComparer.OrdinalIgnoreCase);
+	}
+
+	private void MarkRedeemedThisLife(IServerPlayerData playerData, string kitName)
+	{
+		playerData.CustomPlayerData.TryGetValue(RedeemedThisLifeKey, out string raw);
+		HashSet<string> redeemed = string.IsNullOrWhiteSpace(raw)
+			? new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+			: new HashSet<string>(raw.Split(';'), StringComparer.OrdinalIgnoreCase);
+		redeemed.Add(kitName);
+		playerData.CustomPlayerData[RedeemedThisLifeKey] = string.Join(";", redeemed);
+		server.PlayerDataManager.playerDataDirty = true;
+	}
+
+	private bool CheckAccess(TextCommandCallingArgs args, string commandLabel, StratumCommandAccessConfig access, out TextCommandResult failure)
+	{
+		failure = null;
+		if (access == null || !access.Enabled)
+		{
+			failure = TextCommandResult.Error("/" + commandLabel + " is disabled.");
+			return false;
+		}
+
+		if (!StratumCommandAccessCatalog.CallerHasAccess(args.Caller, server, access))
+		{
+			failure = TextCommandResult.Error("You do not have permission to use /" + commandLabel + ".");
+			return false;
+		}
+
+		if (!StratumCommandCooldowns.TryUse(args.Caller, server, commandLabel, access, out TimeSpan remaining))
+		{
+			failure = TextCommandResult.Error("Wait " + Math.Ceiling(remaining.TotalSeconds) + "s before using /" + commandLabel + " again.");
+			return false;
+		}
+
+		return true;
+	}
+}

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumCommandAccessCatalog.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumCommandAccessCatalog.cs
@@ -61,6 +61,8 @@ internal static class StratumCommandAccessCatalog
 		yield return new StratumCommandAccessEntry("notes", "/note", commands.Notes, "Use /note and /notes");
 		yield return new StratumCommandAccessEntry("report", "/report", commands.Report, "Use /report");
 		yield return new StratumCommandAccessEntry("reports", "/reports", commands.ReportManage, "Use /reports staff queue commands");
+		yield return new StratumCommandAccessEntry("kit", "/kit", commands.Kits, "Use /kit");
+		yield return new StratumCommandAccessEntry("kitedit", "/kitedit", commands.KitEdit, "Manage kits");
 	}
 
 	public static StratumCommandAccessEntry Find(StratumCommandsConfig commands, string command)

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumConfig.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumConfig.cs
@@ -1635,6 +1635,10 @@ internal class StratumCommandsConfig
 
 	public StratumCommandAccessConfig ClearItems { get; set; } = StratumCommandAccessConfig.ForPrivilege("stratum.clearitems");
 
+	public StratumCommandAccessConfig Kits { get; set; } = StratumCommandAccessConfig.ForPrivilege("stratum.kits");
+
+	public StratumCommandAccessConfig KitEdit { get; set; } = StratumCommandAccessConfig.ForPrivilege("stratum.kitedit");
+
 	public int NearDefaultRadiusBlocks { get; set; } = 128;
 
 	public int NearMaxRadiusBlocks { get; set; } = 512;
@@ -1678,6 +1682,8 @@ internal class StratumCommandsConfig
 		ReportManage ??= StratumCommandAccessConfig.ForPrivilege("stratum.reports");
 		Restart ??= StratumCommandAccessConfig.ForPrivilege("stratum.restart");
 		ClearItems ??= StratumCommandAccessConfig.ForPrivilege("stratum.clearitems");
+		Kits ??= StratumCommandAccessConfig.ForPrivilege("stratum.kits");
+		KitEdit ??= StratumCommandAccessConfig.ForPrivilege("stratum.kitedit");
 		JailSettings ??= new StratumJailConfig();
 		Spawn.EnsurePopulated("stratum.spawn");
 		SetSpawn.EnsurePopulated("setspawn");
@@ -1710,6 +1716,8 @@ internal class StratumCommandsConfig
 		ReportManage.EnsurePopulated("stratum.reports");
 		Restart.EnsurePopulated("stratum.restart");
 		ClearItems.EnsurePopulated("stratum.clearitems");
+		Kits.EnsurePopulated("stratum.kits");
+		KitEdit.EnsurePopulated("stratum.kitedit");
 		NearDefaultRadiusBlocks = Math.Max(1, NearDefaultRadiusBlocks);
 		NearMaxRadiusBlocks = Math.Max(NearDefaultRadiusBlocks, NearMaxRadiusBlocks);
 		SlowmodeMaxSeconds = Math.Max(0, SlowmodeMaxSeconds);

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumKitGiver.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumKitGiver.cs
@@ -1,0 +1,148 @@
+using System;
+using Vintagestory.API.Common;
+using Vintagestory.API.Config;
+using Vintagestory.API.MathTools;
+using Vintagestory.API.Server;
+
+namespace Vintagestory.Server;
+
+/// <summary>
+/// Turns a StratumKitDefinition's stored bytes back into real ItemStacks and places them. Armor
+/// goes to the character inventory explicitly, matched by slot compatibility (ItemSlotCharacter's
+/// own CanHold already enforces EnumCharacterDressType, so this does not duplicate that check
+/// itself); everything else goes through Entity.TryGiveItemStack, the same entry point Stratum's
+/// own /giveitem command already uses in production (StratumTargetSelectors.cs). A worn backpack's
+/// own contents travel inside its ItemStack's own attribute tree already (CollectibleBehaviorHeldBag
+/// stores them under a "backpack" tree on the bag's stack), so ToBytes/FromBytes round-trips a
+/// filled backpack in one piece; giving it back does not need a separate "fill it after" step.
+/// </summary>
+internal static class StratumKitGiver
+{
+	public sealed class KitGiveResult
+	{
+		public int GivenCount;
+		public int DroppedCount;
+		public int FailedCount;
+
+		public bool AllGiven => DroppedCount == 0 && FailedCount == 0;
+	}
+
+	public static KitGiveResult Give(ServerPlayer player, StratumKitDefinition kit)
+	{
+		KitGiveResult result = new KitGiveResult();
+		if (player?.Entity == null || kit?.Items == null)
+		{
+			return result;
+		}
+
+		foreach (StratumKitItem entry in kit.Items)
+		{
+			ItemStack stack = DecodeStack(player.Entity.World, entry);
+			if (stack == null)
+			{
+				result.FailedCount++;
+				continue;
+			}
+
+			if (TryGiveOne(player, stack))
+			{
+				result.GivenCount++;
+			}
+			else
+			{
+				result.DroppedCount++;
+			}
+		}
+
+		return result;
+	}
+
+	public static ItemStack DecodeStack(IWorldAccessor world, StratumKitItem entry)
+	{
+		if (string.IsNullOrWhiteSpace(entry?.Base64))
+		{
+			return null;
+		}
+
+		try
+		{
+			byte[] data = Convert.FromBase64String(entry.Base64);
+			ItemStack stack = new ItemStack(data);
+			if (!stack.ResolveBlockOrItem(world))
+			{
+				return null;
+			}
+
+			if (entry.Quantity > 0)
+			{
+				stack.StackSize = entry.Quantity;
+			}
+
+			return stack;
+		}
+		catch (Exception exception)
+		{
+			StratumRuntime.LogWarning("failed to decode kit item '" + entry.Code + "': " + exception.Message);
+			return null;
+		}
+	}
+
+	private static bool TryGiveOne(ServerPlayer player, ItemStack stack)
+	{
+		if (TryPlaceArmor(player, stack))
+		{
+			return true;
+		}
+
+		// A clone, not the original: PlayerInventoryManager.TryGiveItemstack zeroes out whatever
+		// stack it was handed once its internal transfer slot ends up empty, even when the
+		// overall give reports failure (a partial absorption into an inventory that does not
+		// count as a completed transfer). Passing the original here would risk dropping an
+		// already-emptied stack below, silently discarding the item exactly like the loss this
+		// fallback exists to prevent.
+		ItemStack remainder = stack.Clone();
+		if (player.Entity.TryGiveItemStack(remainder))
+		{
+			return true;
+		}
+
+		if (remainder.StackSize <= 0)
+		{
+			return true; // Absorbed somewhere despite the false return; nothing left to drop.
+		}
+
+		// Every slot the auto-placement logic tried was full or incompatible: drop what's left
+		// at the player's feet rather than silently discarding it.
+		Vec3d pos = player.Entity.Pos?.XYZ;
+		if (pos != null)
+		{
+			player.Entity.World.SpawnItemEntity(remainder, pos);
+		}
+
+		return false;
+	}
+
+	private static bool TryPlaceArmor(ServerPlayer player, ItemStack stack)
+	{
+		IInventory character = player.InventoryManager?.GetOwnInventory(GlobalConstants.characterInvClassName);
+		if (character == null)
+		{
+			return false;
+		}
+
+		ItemSlot source = new DummySlot(stack);
+		foreach (ItemSlot slot in character)
+		{
+			if (slot.Itemstack != null || !slot.CanHold(source))
+			{
+				continue;
+			}
+
+			slot.Itemstack = stack;
+			slot.MarkDirty();
+			return true;
+		}
+
+		return false;
+	}
+}

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumKitGiver.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumKitGiver.cs
@@ -59,13 +59,35 @@ internal static class StratumKitGiver
 
 	public static ItemStack DecodeStack(IWorldAccessor world, StratumKitItem entry)
 	{
-		if (string.IsNullOrWhiteSpace(entry?.Base64))
+		if (string.IsNullOrWhiteSpace(entry?.StackJson) && string.IsNullOrWhiteSpace(entry?.Base64))
 		{
 			return null;
 		}
 
 		try
 		{
+			if (!string.IsNullOrWhiteSpace(entry.StackJson))
+			{
+				JsonItemStack jsonStack = JsonItemStack.FromString(entry.StackJson);
+				if (jsonStack == null || !jsonStack.Resolve(world, "Stratum kit", false))
+				{
+					return null;
+				}
+
+				ItemStack resolvedStack = jsonStack.ResolvedItemstack;
+				if (resolvedStack == null)
+				{
+					return null;
+				}
+
+				if (entry.Quantity > 0)
+				{
+					resolvedStack.StackSize = entry.Quantity;
+				}
+
+				return resolvedStack;
+			}
+
 			byte[] data = Convert.FromBase64String(entry.Base64);
 			ItemStack stack = new ItemStack(data);
 			if (!stack.ResolveBlockOrItem(world))

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumKitStore.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumKitStore.cs
@@ -8,14 +8,18 @@ using Vintagestory.API.Config;
 namespace Vintagestory.Server;
 
 /// <summary>
-/// One item inside a kit. Base64 is the source of truth (a full ItemStack.ToBytes(), attributes
-/// and stack size included, the same format every chest and player inventory already persists
-/// through); Code and Quantity are a human-readable mirror so a server owner can tell what a kit
-/// contains, and hand-edit Quantity, without needing to know item codes, per #210's own complaint.
-/// Regenerating an item via /kitedit additem replaces both together.
+/// One item inside a kit. StackJson stores a JsonItemStack with a stable asset code and the stack
+/// attributes. Code and Quantity are human-readable mirrors so a server owner can tell what a kit
+/// contains and hand-edit Quantity without needing to know item codes. Base64 remains as a legacy
+/// fallback for kits saved by an earlier build.
 /// </summary>
 internal sealed class StratumKitItem
 {
+	public string StackJson { get; set; }
+
+	/// <summary>
+	/// Legacy ItemStack serialization. New kits use StackJson instead.
+	/// </summary>
 	public string Base64 { get; set; }
 
 	public string Code { get; set; }

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumKitStore.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumKitStore.cs
@@ -1,0 +1,148 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Newtonsoft.Json;
+using Vintagestory.API.Config;
+
+namespace Vintagestory.Server;
+
+/// <summary>
+/// One item inside a kit. Base64 is the source of truth (a full ItemStack.ToBytes(), attributes
+/// and stack size included, the same format every chest and player inventory already persists
+/// through); Code and Quantity are a human-readable mirror so a server owner can tell what a kit
+/// contains, and hand-edit Quantity, without needing to know item codes, per #210's own complaint.
+/// Regenerating an item via /kitedit additem replaces both together.
+/// </summary>
+internal sealed class StratumKitItem
+{
+	public string Base64 { get; set; }
+
+	public string Code { get; set; }
+
+	public int Quantity { get; set; }
+}
+
+internal sealed class StratumKitDefinition
+{
+	public string Name { get; set; }
+
+	public List<StratumKitItem> Items { get; set; } = new List<StratumKitItem>();
+
+	// Scope strings, e.g. "role:admin". Empty means every player holding the stratum.kits
+	// privilege. Kept as a general scope rather than a role-only field on purpose: #203 wants team
+	// kits later, and AssignedTo can grow a "team:" prefix without a rewrite.
+	public List<string> AssignedTo { get; set; } = new List<string>();
+
+	public int CooldownSeconds { get; set; }
+
+	public bool OnePerLife { get; set; }
+
+	public bool GiveOnRespawn { get; set; }
+
+	public string CreatedByUid { get; set; }
+
+	public string CreatedByName { get; set; }
+
+	public DateTime CreatedUtc { get; set; }
+}
+
+/// <summary>
+/// Global, not per-player, so it does not fit CustomPlayerData the way StratumModerationStore and
+/// StratumAnticheatHistory do. Its own sidecar file instead, lazily loaded on first use rather than
+/// wired into StratumRuntime's config load/save cycle: kits are staff-authored operational data
+/// created and edited live via /kitedit, not tunable settings meant to be replaced wholesale on
+/// every config save the way Commands/Performance are.
+/// </summary>
+internal static class StratumKitStore
+{
+	private static List<StratumKitDefinition> kits;
+	private static string path;
+
+	// Called once from CmdStratumKits's constructor, unconditionally, the same way
+	// StratumRuntime.LoadOrCreateConfig runs fresh on every server boot rather than caching
+	// across a process's lifetime: GamePaths.Config is only correct for the CURRENT boot's data
+	// directory, so a lazy load-once-ever would keep serving (and saving to) a stale path after a
+	// restart that reuses the process.
+	public static void Load()
+	{
+		path = Path.Combine(GamePaths.Config, "stratum-kits.json");
+		try
+		{
+			kits = File.Exists(path)
+				? JsonConvert.DeserializeObject<List<StratumKitDefinition>>(File.ReadAllText(path)) ?? new List<StratumKitDefinition>()
+				: new List<StratumKitDefinition>();
+		}
+		catch (Exception exception)
+		{
+			StratumRuntime.LogWarning("failed to load " + path + ": " + exception.Message);
+			kits = new List<StratumKitDefinition>();
+		}
+	}
+
+	// Defensive fallback only, for the unlikely case something reaches the store before
+	// CmdStratumKits's constructor has run Load().
+	private static void EnsureLoaded()
+	{
+		if (kits == null)
+		{
+			Load();
+		}
+	}
+
+	public static IReadOnlyList<StratumKitDefinition> All()
+	{
+		EnsureLoaded();
+		return kits;
+	}
+
+	public static StratumKitDefinition Find(string name)
+	{
+		if (string.IsNullOrWhiteSpace(name))
+		{
+			return null;
+		}
+
+		EnsureLoaded();
+		return kits.FirstOrDefault(kit => string.Equals(kit.Name, name, StringComparison.OrdinalIgnoreCase));
+	}
+
+	public static void Upsert(StratumKitDefinition kit)
+	{
+		EnsureLoaded();
+		kits.RemoveAll(existing => string.Equals(existing.Name, kit.Name, StringComparison.OrdinalIgnoreCase));
+		kits.Add(kit);
+		Save();
+	}
+
+	public static bool Delete(string name)
+	{
+		EnsureLoaded();
+		int removed = kits.RemoveAll(existing => string.Equals(existing.Name, name, StringComparison.OrdinalIgnoreCase));
+		if (removed > 0)
+		{
+			Save();
+		}
+
+		return removed > 0;
+	}
+
+	public static bool Rename(string name, string newName)
+	{
+		StratumKitDefinition kit = Find(name);
+		if (kit == null || Find(newName) != null)
+		{
+			return false;
+		}
+
+		kit.Name = newName;
+		Save();
+		return true;
+	}
+
+	public static void Save()
+	{
+		EnsureLoaded();
+		File.WriteAllText(path, JsonConvert.SerializeObject(kits, Formatting.Indented));
+	}
+}


### PR DESCRIPTION
## Summary

Kits editable in-game, live, via commands, with role assignment and configurable activation, closing #210. A UI isn't possible here (the issue's own scope checkbox says server-side only, no custom client), so this is a command surface, same as the rest of Stratum.

The issue's real complaint was having to know exact item codes and edit JSON by hand while the server is offline. Both `/kitedit create <name>` and `/kitedit additem <name>` solve that by snapshotting a live `ItemStack` straight off the caller (their whole inventory, or their active hotbar slot) instead of asking for a code anywhere.

**Giving items** (`StratumKitGiver`) reuses existing primitives rather than inventing new ones:
- Armor goes into the character inventory explicitly, matched by `ItemSlotCharacter`'s own dress-type compatibility check (`CanHold`); this doesn't duplicate that check, it just calls it.
- Everything else goes through `Entity.TryGiveItemStack`, the same entry point the existing `/giveitem` command already uses in production.
- A worn backpack's own contents already live inside its `ItemStack`'s attribute tree (`CollectibleBehaviorHeldBag` stores them under a `"backpack"` tree on the bag's own stack), so giving a filled backpack round-trips its contents in one piece. No separate "give backpack, then fill it" step needed.
- If nothing fits anywhere, the item drops at the player's feet rather than vanishing.

**Storage** (`StratumKitStore`): kits are global, staff-authored operational data, not tunable settings, so they get their own `stratum-kits.json` sidecar, loaded once at boot from `CmdStratumKits`'s constructor, rather than folding into `StratumRuntime`'s config load/save cycle the way `Commands`/`Performance` do.

**Commands** (`CmdStratumKits`): `/kit [name]` redeems a kit you're assigned (or lists what you can use); `/kitedit` covers `create`, `additem`, `removeitem`, `delete`, `rename`, `setrole` (toggles a role scope on/off), `setcooldown`, `onrespawn`, `oneperlife`, `preview`, `give`, `list`. `AssignedTo` is a general scope list (`"role:x"`) rather than a role-only field, so #203's later team kits shouldn't need a rewrite here.

**Give-on-respawn** polls for the player actually being revived before giving, rather than giving synchronously inside the respawn event handler. Vanilla's own handler for that event only starts an async teleport, calling `Entity.Revive()` later once the target chunk finishes loading, so giving immediately would race that revive and could lose the items.

## A real bug found writing test coverage

While writing Atlas scenarios for the drop-at-feet fallback, found that `PlayerInventoryManager.TryGiveItemstack` zeroes out whatever stack it was handed once its own internal transfer slot ends up empty, even when the overall give reports failure (a partial absorption elsewhere that doesn't count as a completed transfer). The original code reused that same stack reference for the drop-at-feet fallback, which would have silently discarded the item under exactly the circumstance that fallback exists to prevent. Fixed by giving a clone and dropping whatever it has left afterward.

## Type

- [x] New feature

## Checklist

- [x] `scripts/extract-patches.sh` ran clean. One intentional line in `ServerSystemCommands.cs.patch` registering the new command class, nothing else touched.
- [x] `dotnet build VintageStory.slnx -c Release` is green (0 errors, 0 new warnings; verified no warnings in any touched file).
- [x] Every vanilla edit has a `// Stratum` marker. The one vanilla-file line (`ServerSystemCommands.cs`) carries `// Stratum: issue #210 kit creator`.
- [x] No vanilla source committed.
- [x] Tested on a real server start, not just compilation (`make smoke`: PASS, reached `WorldReady`).

## Testing

Beyond build and smoke test, this got real functional coverage: 4 new Atlas scenarios (headless server-tick-driven tests, not just compile checks) covering armor placement into the character inventory, a filled backpack's contents surviving the give, the drop-at-feet fallback when every inventory is full, JSON persistence (upsert/rename/delete), the full `/kitedit` command surface end-to-end, and give-on-respawn with role-scope gating and the one-per-life marker. All 15 scenarios in the existing Atlas suite pass, no regressions. This is private tooling, not part of Stratum's own repo or CI, so it isn't part of this PR's diff, but it's what actually caught the `TryGiveItemstack` bug above.

## Related issues

Fixes #210
