### PR TITLE
Release GenStructures' cached column state after the postpass

### DIFF
--- a/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/6.GenStructures/GenStructures.cs.patch
+++ b/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/6.GenStructures/GenStructures.cs.patch
@@ -1,5 +1,5 @@
 diff --git a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/6.GenStructures/GenStructures.cs b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/6.GenStructures/GenStructures.cs
-index 95025db..7c475dd 100644
+index 95025db..a7465d4 100644
 --- a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/6.GenStructures/GenStructures.cs
 +++ b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/6.GenStructures/GenStructures.cs
 @@ -46,19 +46,44 @@ namespace Vintagestory.ServerMods
@@ -48,7 +48,7 @@ index 95025db..7c475dd 100644
          WorldGenStructure[] shuffledStructures;
          private Dictionary<string, WorldGenStructure[]> StoryStructures;
  
-@@ -238,10 +263,47 @@ namespace Vintagestory.ServerMods
+@@ -238,13 +263,61 @@ namespace Vintagestory.ServerMods
              int chunkZ = request.ChunkZ;
  
              worldgenBlockAccessor.BeginColumn();
@@ -94,9 +94,23 @@ index 95025db..7c475dd 100644
  
              DoGenStructures(region, chunkX, chunkZ, true, structure?.Code, request.ChunkGenParams);
              TryGenVillages(region, chunkX, chunkZ, true, request.ChunkGenParams);
++
++            // Stratum: this column's structure generation is done on this thread once the
++            // postpass returns. Release the cached state rather than leaving it set until this
++            // thread happens to process another chunk's main pass (which may be much later, or
++            // never, once worldgen quiets down) - stratumStateOwner otherwise keeps the owning
++            // GenStructures instance, and everything it holds (WorldGenStructuresConfig's loaded
++            // schematic cache included), reachable from this thread for as long as the thread
++            // itself lives, well past the point this chunk's own data would otherwise be
++            // collectible.
++            stratumStateOwner = null;
++            stratumHeightmap = null;
          }
  
-@@ -268,24 +330,28 @@ namespace Vintagestory.ServerMods
+         private void OnChunkColumnGen(IChunkColumnGenerateRequest request)
+         {
+             if (!TerraGenConfig.GenerateStructures) return;
+@@ -268,24 +341,28 @@ namespace Vintagestory.ServerMods
              // rlX, rlZ goes from 0..16 pixel
              // facF = 16/16 = 1
              // Get 4 pixels for chunkx, chunkz, chunkx+1 and chunkz+1 inside the map
@@ -134,7 +148,7 @@ index 95025db..7c475dd 100644
              if (structure == null)
              {
                  TryGenVillages(region, chunkX, chunkZ, false, request.ChunkGenParams);
-@@ -294,27 +360,29 @@ namespace Vintagestory.ServerMods
+@@ -294,27 +371,29 @@ namespace Vintagestory.ServerMods
  
          private void DoGenStructures(IMapRegion region, int chunkX, int chunkZ, bool postPass, string locationCode, ITreeAttribute chunkGenParams = null)
          {
@@ -168,7 +182,7 @@ index 95025db..7c475dd 100644
              ITreeAttribute chanceModTree = null;
              ITreeAttribute maxQuantityModTree = null;
              StoryStructureLocation location = null;
-@@ -326,17 +394,31 @@ namespace Vintagestory.ServerMods
+@@ -326,17 +405,31 @@ namespace Vintagestory.ServerMods
              {
                  maxQuantityModTree = chunkGenParams["structureMaxCount"] as TreeAttribute;
              }
@@ -206,7 +220,7 @@ index 95025db..7c475dd 100644
                  float chance = struc.Chance * scfg.ChanceMultiplier;
                  int toGenerate = 9999;
                  if (chanceModTree != null)
-@@ -348,26 +430,26 @@ namespace Vintagestory.ServerMods
+@@ -348,26 +441,26 @@ namespace Vintagestory.ServerMods
                  {
                      toGenerate = maxQuantityModTree.GetInt(struc.Code, 9999);
                  }
@@ -239,7 +253,7 @@ index 95025db..7c475dd 100644
                      else
                      {
                          startPos.Set(chunkX * chunksize + dx, ySurface, chunkZ * chunksize + dz);
-@@ -382,61 +464,69 @@ namespace Vintagestory.ServerMods
+@@ -382,61 +475,69 @@ namespace Vintagestory.ServerMods
  
                      // check if in storylocation and if we can still generate this structure
                      if (locationCode != null)
@@ -272,14 +286,9 @@ index 95025db..7c475dd 100644
 +                        if (didGenerate)
                          {
 -                            if (location.SchematicsSpawned?.TryGetValue(struc.Group, out var spawnedSchematics) == true)
--                            {
--                                location.SchematicsSpawned[struc.Group] = spawnedSchematics + 1;
--                            }
--                            else
 +                            if(locationCode != null && location != null)
                              {
--                                location.SchematicsSpawned ??= new Dictionary<string, int>();
--                                location.SchematicsSpawned[struc.Group] = 1;
+-                                location.SchematicsSpawned[struc.Group] = spawnedSchematics + 1;
 +                                if (location.SchematicsSpawned?.TryGetValue(struc.Group, out var spawnedSchematics) == true)
 +                                {
 +                                    location.SchematicsSpawned[struc.Group] = spawnedSchematics + 1;
@@ -290,6 +299,11 @@ index 95025db..7c475dd 100644
 +                                    location.SchematicsSpawned[struc.Group] = 1;
 +                                }
                              }
+-                            else
+-                            {
+-                                location.SchematicsSpawned ??= new Dictionary<string, int>();
+-                                location.SchematicsSpawned[struc.Group] = 1;
+-                            }
 -                        }
 -                        Cuboidi loc = struc.LastPlacedSchematicLocation;
 +                            Cuboidi loc = struc.LastPlacedSchematicLocation;
@@ -344,7 +358,7 @@ index 95025db..7c475dd 100644
                  }
              }
          }
-@@ -444,89 +534,119 @@ namespace Vintagestory.ServerMods
+@@ -444,89 +545,119 @@ namespace Vintagestory.ServerMods
  
  
  


### PR DESCRIPTION
## Summary

Investigates #270 (BlockSchematicStructure objects never collected) by pulling and reading the actual profiler screenshots attached to the issue, then fixes the mechanism they point at.

Every retention chain in the screenshots ends the same way: `BlockSchematicStructure`/`BlockSchematicPartial` arrays reachable through `WorldGenStructuresConfig.LoadedSchematicsCache` via `GenStructures`, or through `GenDungeons` via a similar path, terminating at what looks like per-thread storage rather than a plain object reference. One screenshot names the exact field: `ServerEventManager.stratumCachedWorldSavedInvocations`.

That pointed at Stratum's own concurrency patch to `GenStructures.cs` (added to let TerrainFeatures generate multiple columns at once). It adds `[ThreadStatic]` fields (`stratumStateOwner`, `stratumHeightmap`, and a few siblings) so the postpass can reuse a chunk's already-computed heightmap and climate/forest values instead of recomputing them. The problem: that cached state is only ever overwritten when the same worker thread happens to process another chunk's main pass. Once worldgen quiets down, whatever a thread last touched (the owning `GenStructures` instance and its loaded schematic cache included) stays reachable from that thread for as long as the thread itself lives. Vanilla's own unpatched code doesn't have this property, since the equivalent state sits in plain instance fields tied to the `GenStructures` instance's own lifetime, not to a specific thread.

## Fix

Release `stratumStateOwner` and `stratumHeightmap` at the end of the postpass, the point at which a column's structure generation is actually finished. Both fields get set fresh by the main pass regardless of which branch runs, so clearing them right after the postpass reads them is always safe: the next chunk on that thread recomputes from scratch rather than reusing anything.

## Caveat

This is a real, demonstrable gap from vanilla's GC behavior, but a single heap snapshot can't distinguish "leaked forever" from "a worldgen thread that's mid-column right now." I can't reproduce a long-running server session with active generation followed by an idle period to directly confirm the counts stop growing. @tehtelev , since you filed this with the profiler already set up: if you get a chance to rerun the same capture after a while on this branch, that would close the loop for real.

## Type

- [x] Bug fix

## Checklist

- [x] `scripts/extract-patches.sh` ran clean. One file touched: `GenStructures.cs.patch`.
- [x] `dotnet build VintageStory.slnx -c Release` is green (0 errors, 0 new warnings).
- [x] Every vanilla edit has a `// Stratum` marker. The new lines carry one explaining why they're there.
- [x] No vanilla source committed.
- [x] Tested on a real server start, not just compilation (`make smoke`: PASS, reached `RunGame`).

## Related issues

Refs #270
