### PR TITLE
Fixing allocations inside ScheduleReadyTasks

### DIFF
--- a/patches/VintagestoryLib/Vintagestory.Server/ChunkServerThread.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/ChunkServerThread.cs.patch
@@ -1,8 +1,8 @@
 diff --git a/VintagestoryLib/Vintagestory.Server/ChunkServerThread.cs b/VintagestoryLib/Vintagestory.Server/ChunkServerThread.cs
-index ee7d12d..a7b02bd 100644
+index ee7d12d..5baab55 100644
 --- a/VintagestoryLib/Vintagestory.Server/ChunkServerThread.cs
 +++ b/VintagestoryLib/Vintagestory.Server/ChunkServerThread.cs
-@@ -12,10 +12,23 @@ namespace Vintagestory.Server;
+@@ -12,10 +12,34 @@ namespace Vintagestory.Server;
  
  public class ChunkServerThread : ServerThread, IChunkProvider
  {
@@ -21,12 +21,23 @@ index ee7d12d..a7b02bd 100644
 +	// pin their shared neighbours twice and each releases its own.
 +	internal readonly System.Collections.Concurrent.ConcurrentDictionary<long, int> stratumPinnedColumns = new System.Collections.Concurrent.ConcurrentDictionary<long, int>();
 +
++	// Stratum: map-chunk indices that UnloadChunkColumns has committed to removing from
++	// server.loadedMapChunks. These are Done columns with no ChunkColumnLoadRequest left
++	// (the request is disposed once a column reaches Done), so they can't carry the
++	// per-request stratumDropping flag EnsureMinimumWorldgenPassAt already checks for
++	// still-generating columns. This is the same signal for the same purpose, keyed by
++	// index2d instead of hung off a request object, so a claim in the middle of pass
++	// 1/pass 2 can be refused instead of observing a column mid-removal as resident.
++	// See UnloadChunkColumns for the commit-then-recheck-pin handshake that sets it.
++	internal readonly System.Collections.Concurrent.ConcurrentDictionary<long, byte> stratumDroppingMapChunks = new System.Collections.Concurrent.ConcurrentDictionary<long, byte>();
++
++
  	internal ConcurrentIndexedFifoQueue<ChunkColumnLoadRequest> requestedChunkColumns;
  
  	internal IndexedFifoQueue<ChunkColumnLoadRequest> peekingChunkColumns;
  
  	internal Dictionary<long, ServerMapRegion> peekingMapRegions = new Dictionary<long, ServerMapRegion>(8);
-@@ -39,13 +52,13 @@ public class ChunkServerThread : ServerThread, IChunkProvider
+@@ -39,13 +63,13 @@ public class ChunkServerThread : ServerThread, IChunkProvider
  	public ILogger Logger => ServerMain.Logger;
  
  	public ChunkServerThread(ServerMain server, string threadname, CancellationToken cancellationToken)
@@ -43,7 +54,7 @@ index ee7d12d..a7b02bd 100644
  		}
  		if (additionalWorldGenThreadsCount < 0)
  		{
-@@ -101,15 +114,21 @@ public class ChunkServerThread : ServerThread, IChunkProvider
+@@ -101,15 +125,21 @@ public class ChunkServerThread : ServerThread, IChunkProvider
  		return peekingChunkColumns.GetByIndex(index);
  	}
  
@@ -67,7 +78,7 @@ index ee7d12d..a7b02bd 100644
  	}
  
  	internal ServerMapChunk GetMapChunk(long index2d)
-@@ -143,19 +162,19 @@ public class ChunkServerThread : ServerThread, IChunkProvider
+@@ -143,19 +173,19 @@ public class ChunkServerThread : ServerThread, IChunkProvider
  	IWorldChunk IChunkProvider.GetUnpackedChunkFast(int chunkX, int chunkY, int chunkZ, bool notRecentlyAccessed)
  	{
  		ServerChunk generatingChunk = GetGeneratingChunk(chunkX, chunkY, chunkZ);
@@ -89,38 +100,12 @@ index ee7d12d..a7b02bd 100644
  		});
  	}
  
-@@ -186,38 +205,125 @@ public class ChunkServerThread : ServerThread, IChunkProvider
+@@ -186,18 +216,142 @@ public class ChunkServerThread : ServerThread, IChunkProvider
  			requestedChunkColumns.EnqueueWithoutAddingToIndex(chunkRequest);
  		}
  		return !orAdd.Disposed;
  	}
  
--	internal bool EnsureMinimumWorldgenPassAt(long index2d, int chunkX, int chunkZ, int minPass, long requirorTime)
--	{
--		server.loadedMapChunks.TryGetValue(index2d, out var value);
--		if (value != null && value.CurrentIncompletePass == EnumWorldGenPass.Done)
--		{
--			return true;
--		}
--		ChunkColumnLoadRequest orAdd = requestedChunkColumns.elementsByIndex.GetOrAdd(index2d, (long index2d2) => new ChunkColumnLoadRequest(index2d2, chunkX, chunkZ, server.serverConsoleId, -1, server));
--		if (orAdd.CurrentIncompletePass_AsInt < minPass)
--		{
--			if (orAdd.untilPass < minPass)
--			{
--				if (orAdd.untilPass < 0)
--				{
--					requestedChunkColumns.EnqueueWithoutAddingToIndex(orAdd);
--				}
--				orAdd.untilPass = minPass;
--				if (orAdd.creationTime < requirorTime)
--				{
--					orAdd.creationTime = requirorTime;
--				}
--			}
--			return false;
--		}
--		return true;
--	}
 +    /// <summary>
 +    /// Stratum: holds the 3x3 neighbourhood of a column against unloading. Taken before the
 +    /// neighbour gate runs, released when the stage finishes or the gate refuses. Pins the
@@ -188,57 +173,87 @@ index ee7d12d..a7b02bd 100644
 +        return stratumPinnedColumns.ContainsKey(index2d);
 +    }
 +
-+    internal bool EnsureMinimumWorldgenPassAt(long index2d, int chunkX, int chunkZ, int minPass, long requirorTime)
++    /// <summary>
++    /// Stratum: marks a Done, request-less map chunk index as being dropped by
++    /// UnloadChunkColumns. Returns false if it's already marked (shouldn't happen -
++    /// mapChunkUnloadCandidates is a HashSet and UnloadChunkColumns runs one index at a
++    /// time - but TryAdd makes double-marking a no-op instead of silently overwriting).
++    /// </summary>
++    internal bool StratumTryMarkMapChunkDropping(long index2d)
 +    {
-+        // Stratum: a column the unload pass has committed to dropping is absent as far
-+        // as this gate is concerned, even while its map chunk is still in the registry.
-+        // Deciding to drop and finishing the drop are not one step, and granting a claim
-+        // in between is what let a generator read a column that vanished under it.
-+        if (requestedChunkColumns.elementsByIndex.TryGetValue(index2d, out var dropCheck) && Volatile.Read(ref dropCheck.stratumDropping) != 0)
-+        {
-+            return false;
-+        }
-+        server.loadedMapChunks.TryGetValue(index2d, out var value);
-+        if (value != null && value.CurrentIncompletePass == EnumWorldGenPass.Done)
-+        {
-+            return true;
-+        }
-+
-+        // Stratum start: avoiding Func<> + DisplayClass allocation for each call.
-+        // In the vast majority of cases, the entry already exists in the dictionary.
-+        if (!requestedChunkColumns.elementsByIndex.TryGetValue(index2d, out var orAdd))
-+        {
-+            orAdd = requestedChunkColumns.elementsByIndex.GetOrAdd(
-+                index2d,
-+                static (idx, arg) => new ChunkColumnLoadRequest(idx, arg.chunkX, arg.chunkZ, arg.consoleId, -1, arg.server),
-+                (chunkX, chunkZ, consoleId: server.serverConsoleId, server));
-+        }
-+
-+        if (orAdd.CurrentIncompletePass_AsInt < minPass)
-+        {
-+            if (orAdd.untilPass < minPass)
-+            {
-+                if (orAdd.untilPass < 0)
-+                {
-+                    requestedChunkColumns.EnqueueWithoutAddingToIndex(orAdd);
-+                }
-+                orAdd.untilPass = minPass;
-+                if (orAdd.creationTime < requirorTime)
-+                {
-+                    orAdd.creationTime = requirorTime;
-+                }
-+            }
-+            return false;
-+        }
-+
-+        // Stratum end
-+        return true;
++	    return stratumDroppingMapChunks.TryAdd(index2d, 0);
 +    }
- 
--	public long ChunkIndex3D(int chunkX, int chunkY, int chunkZ)
-+    public long ChunkIndex3D(int chunkX, int chunkY, int chunkZ)
++
++    /// <summary>
++    /// Stratum: releases what StratumTryMarkMapChunkDropping took. Must run on every
++    /// exit from the removal it guards, success or failure, or the index stays
++    /// invisible to the neighbour gate forever.
++    /// </summary>
++    internal void StratumClearMapChunkDropping(long index2d)
++    {
++	    stratumDroppingMapChunks.TryRemove(index2d, out _);
++    }
++
++    /// <summary>
++    /// Stratum: true while UnloadChunkColumns is in the middle of dropping this index.
++    /// </summary>
++    internal bool StratumIsMapChunkDropping(long index2d)
++    {
++	    return stratumDroppingMapChunks.ContainsKey(index2d);
++    }
++
++
++
+ 	internal bool EnsureMinimumWorldgenPassAt(long index2d, int chunkX, int chunkZ, int minPass, long requirorTime)
  	{
- 		return ((long)chunkY * (long)server.WorldMap.index3dMulZ + chunkZ) * server.WorldMap.index3dMulX + chunkX;
++		// Stratum: a column the unload pass has committed to dropping is absent as far
++		// as this gate is concerned, even while its map chunk is still in the registry.
++		// Deciding to drop and finishing the drop are not one step, and granting a claim
++		// in between is what let a generator read a column that vanished under it.
++		if (requestedChunkColumns.elementsByIndex.TryGetValue(index2d, out var dropCheck) && Volatile.Read(ref dropCheck.stratumDropping) != 0)
++		{
++			return false;
++		}
++		// Stratum: same rule, for a neighbour that already finished generation and is
++		// now tracked only in loadedMapChunks (its ChunkColumnLoadRequest is long gone,
++		// so it can't carry the flag above). UnloadChunkColumns sets this before it
++		// touches loadedMapChunks for the index; see its own comment for the handshake.
++		if (StratumIsMapChunkDropping(index2d))
++		{
++			return false;
++		}
+ 		server.loadedMapChunks.TryGetValue(index2d, out var value);
+ 		if (value != null && value.CurrentIncompletePass == EnumWorldGenPass.Done)
+ 		{
+ 			return true;
+ 		}
+-		ChunkColumnLoadRequest orAdd = requestedChunkColumns.elementsByIndex.GetOrAdd(index2d, (long index2d2) => new ChunkColumnLoadRequest(index2d2, chunkX, chunkZ, server.serverConsoleId, -1, server));
++
++		// Stratum start: avoiding Func<> + DisplayClass allocation for each call.
++		// In the vast majority of cases, the entry already exists in the dictionary.
++		if (!requestedChunkColumns.elementsByIndex.TryGetValue(index2d, out var orAdd))
++		{
++			orAdd = requestedChunkColumns.elementsByIndex.GetOrAdd(
++				index2d,
++				static (idx, arg) => new ChunkColumnLoadRequest(idx, arg.chunkX, arg.chunkZ, arg.consoleId, -1, arg.server),
++				(chunkX, chunkZ, consoleId: server.serverConsoleId, server));
++		}
++
+ 		if (orAdd.CurrentIncompletePass_AsInt < minPass)
+ 		{
+ 			if (orAdd.untilPass < minPass)
+ 			{
+ 				if (orAdd.untilPass < 0)
+@@ -210,10 +364,12 @@ public class ChunkServerThread : ServerThread, IChunkProvider
+ 					orAdd.creationTime = requirorTime;
+ 				}
+ 			}
+ 			return false;
+ 		}
++
++		// Stratum end
+ 		return true;
  	}
  
- 	public long ChunkIndex3D(EntityPos pos)
+ 	public long ChunkIndex3D(int chunkX, int chunkY, int chunkZ)
+ 	{

--- a/patches/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs.patch
@@ -1,8 +1,8 @@
 diff --git a/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs b/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs
-index 159b06c..ac6145a 100644
+index 159b06c..381605a 100644
 --- a/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs
 +++ b/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs
-@@ -1,139 +1,1094 @@
+@@ -1,139 +1,1109 @@
  using System;
  using System.Collections.Generic;
  using System.Linq;
@@ -537,53 +537,46 @@ index 159b06c..ac6145a 100644
 +		// them. The checks below can THROW, not just return false:
 +		// ensurePrettyNeighbourhood reaches EnsureMinimumWorldgenPassAt, which
 +		// enqueues lagging neighbours and throws "Indexed Fifo Queue overflow" when
-+		// the request queue is full. Without this finally that exception escaped with
-+		// dispatchClaimed still 1 and the stage's active count still incremented,
-+		// which is unrecoverable rather than merely noisy: the column could never be
-+		// claimed again by anyone, and a stage whose cap is 1 lost its only slot
-+		// permanently, so worldgen wedged with every thread asleep and no watchdog on
-+		// the pregen path to notice.
++		// the request queue is full. Without this finally that exception escaped
++		// with dispatchClaimed still 1 and the stage's active count still
++		// incremented, which is unrecoverable rather than merely noisy.
 +		//
-+		// This finally makes the throw survivable. It does NOT stop the queue from
-+		// exhausting, and that distinction cost a full day to learn, so it is written
-+		// down here rather than rediscovered.
++		// Two-pass neighbour gate for gated stages. The old shape pinned the 3x3
++		// neighbourhood BEFORE running the gate, on every claim attempt, on the
++		// theory that holding must start before the residency check. Measured, that
++		// "free" pin on the refusing path was the single largest allocation source
++		// in the process: ~1e9 Node<Int64,Int32> (29 GB) in stratumPinnedColumns
++		// plus ~22s of CPU in ConcurrentDictionary.TryRemoveInternal, because every
++		// refused attempt paid 9 AddOrUpdate + 9 TryUpdate/Remove on a
++		// ConcurrentDictionary that allocates a fresh Node per mutation - and
++		// during pregen nearly all attempts refuse (neighbours lag), while the
++		// dispatcher spin and loadChunkAreaBlocking's wait loop retry the same
++		// gated columns hundreds of times a second.
 +		//
-+		// An earlier attempt guarded the two enqueues in EnsureMinimumWorldgenPassAt
-+		// so the throw could not be reached at all, reporting the neighbour as lagging
-+		// instead. It was rejected on measurement: it cost roughly a third of the wall
-+		// clock and introduced out-of-range block reads that neither clean indev nor
-+		// this fix produce. **That measurement was taken in configurations where the
-+		// queue never exhausts** — Terrain and TerrainLate are not neighbour-gated, so
-+		// ensurePrettyNeighbourhood returns true for them immediately and never
-+		// enqueues anything. All the guard did there was refuse work in a regime that
-+		// was already fine. Eight full radius-100 pregens produced zero overflows, so
-+		// the rejection looked safe.
++		// The pin only has to protect a stage that WILL run. A refused gate runs no
++		// stage, so it needs no pin. Hence:
 +		//
-+		// Raising TerrainFeatures' cap proved it was not the whole story. That pass IS
-+		// gated, so it really does enqueue lagging neighbours, and at cap 4 it produced
-+		// 3091 overflow throws and wedged at 7.8% of a radius-100 pregen. The claims
-+		// were released correctly every time — the finally works — but the outer catch
-+		// in ScheduleReadyTasks abandons the entire dispatch pass on any exception, so
-+		// a permanent wedge became a livelock instead. What actually fixed that was
-+		// raising RequestChunkColumnsQueueSize, see MagicNum.
++		//   Pass 1 runs the full gate unpinned, side effects included. The side
++		//   effects (enqueuing/bumping lagging neighbours) are exactly what drives
++		//   the neighbourhood forward and MUST stay on the refuse path - skipping
++		//   them would mean nothing ever requests those neighbours and worldgen
++		//   stalls.
 +		//
-+		// The lesson worth keeping: an optimisation measured only where its problem
-+		// does not occur will always look like pure cost. Before rejecting a guard on
-+		// this path again, check whether the configuration under test has a gated
-+		// stage running concurrently, because that is the only regime where the queue
-+		// is under real pressure.
++		//   Only if pass 1 accepted do we pin, then run pass 2 as the authoritative
++		//   gate under the pin. Pass 2 closes the race the old pre-gate pin existed
++		//   for: between pass 1's residency observation and the hold, the unload
++		//   pass can drop a neighbour; pass 2 re-establishes residency while it is
++		//   held, and refuses (the finally releases the pin) if it can't. On this
++		//   path pass 2 is a read-only re-check: EnsureMinimumWorldgenPassAt
++		//   mutates nothing for a neighbour already at pass or Done, so the double
++		//   gate adds no queue churn.
++		//
++		// Net: the refuse path (the overwhelming majority of attempts) never
++		// touches stratumPinnedColumns at all; pin/unpin now happens once per
++		// column per gated stage advance, which is what it was always meant to be.
 +		int claimedStage = stage;
 +		bool claimHeld = true;
-+		// Stratum: pin before the gate runs, not after it passes. The gate establishes
-+		// that the 8 neighbours are resident; holding them has to start before that
-+		// check, or the unload pass can drop one in the gap between the check and the
-+		// hold, which is the same check then use shape this pin exists to close. Pinning
-+		// first costs nothing when the gate then refuses, since the finally releases it.
-+		bool pinHeld = claimedStage > StratumWorldGenStages.TerrainLate;
-+		if (pinHeld)
-+		{
-+			chunkthread.StratumPinNeighbourhood(req.chunkX, req.chunkZ);
-+		}
++		bool pinHeld = false;
 +		try
 +		{
 +			// Re-verify: currentpass may have changed between the read and the CAS
@@ -600,11 +593,33 @@ index 159b06c..ac6145a 100644
 +				return false;
 +			}
 +
-+			if (!ensurePrettyNeighbourhood(req))
++			if (claimedStage > StratumWorldGenStages.TerrainLate)
 +			{
-+				stage = -1;
-+				return false;
++				// Pass 1: unpinned filter + neighbour driver. Refusing here costs
++				// a few dictionary reads per neighbour and zero pin mutations.
++				if (!ensurePrettyNeighbourhood(req))
++				{
++					stage = -1;
++					return false;
++				}
++
++				// Pass 1 accepted: neighbours looked resident. "Looked" - the
++				// unload pass can drop one between the check and the hold, the
++				// exact check-then-act shape the pin exists to close. Pin, then
++				// re-check.
++				chunkthread.StratumPinNeighbourhood(req.chunkX, req.chunkZ);
++				pinHeld = true;
++
++				// Pass 2: authoritative gate under the pin.
++				if (!ensurePrettyNeighbourhood(req))
++				{
++					stage = -1;
++					return false;
++				}
 +			}
++			// For stages at or below TerrainLate the gate is a no-op by definition
++			// (ensurePrettyNeighbourhood returns true immediately), so no pin and
++			// no gate call are needed here at all.
 +
 +			claimHeld = false;   // handed off to the caller, which owns the release
 +			pinHeld = false;     // the pin goes with it, released alongside the claim
@@ -771,7 +786,7 @@ index 159b06c..ac6145a 100644
 +			{
 +				// Channel completed (CompleteAdding) - exit
 +				return false;
-+			}
+ 			}
 +
 +			return dispatched > 0;
 +		}
@@ -783,9 +798,9 @@ index 159b06c..ac6145a 100644
 +		finally
 +		{
 +			Monitor.Exit(dispatcherLock);
-+		}
-+	}
-+
+ 		}
+ 	}
+ 
 +
 +
 +	/// <summary>
@@ -961,8 +976,8 @@ index 159b06c..ac6145a 100644
 +				// Closer than the farthest in top-K — replace
 +				stratumTopKHeap.Dequeue();
 +				stratumTopKHeap.Enqueue(r, -distSq);
- 			}
- 		}
++			}
++		}
 +
 +		// Extract from heap (farthest to nearest) and reverse
 +		while (stratumTopKHeap.Count > 0)
@@ -983,8 +998,8 @@ index 159b06c..ac6145a 100644
 +	{
 +		Volatile.Write(ref stratumPriorityListPublished, list);
 +		return list;
- 	}
- 
++	}
++
 +
 +
 +	/// <summary>
@@ -1119,7 +1134,7 @@ index 159b06c..ac6145a 100644
  			if (!tryLoadOrGenerateChunkColumnsInQueue())
  			{
  				break;
-@@ -143,39 +1098,59 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -143,39 +1113,59 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				break;
  			}
  		}
@@ -1181,7 +1196,7 @@ index 159b06c..ac6145a 100644
  				ServerChunk serverChunk = (ServerChunk)server.WorldMap.GetChunk(x, i, z);
  				if (serverChunk != null)
  				{
-@@ -183,11 +1158,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -183,11 +1173,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					for (int j = 0; j < entities.Length; j++)
  					{
  						Entity entity = entities[j];
@@ -1194,7 +1209,7 @@ index 159b06c..ac6145a 100644
  						{
  							if (j >= serverChunk.EntitiesCount)
  							{
-@@ -211,19 +1186,23 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -211,19 +1201,23 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				});
  			}
  			list2.Add(item);
@@ -1219,7 +1234,7 @@ index 159b06c..ac6145a 100644
  		{
  			ChunkPos item2 = server.WorldMap.MapRegionPosFromIndex2D(result2);
  			if (hashSet == null)
-@@ -237,28 +1216,46 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -237,28 +1231,46 @@ internal class ServerSystemSupplyChunks : ServerSystem
  		{
  			chunkthread.gameDatabase.DeleteMapRegions(hashSet);
  		}
@@ -1271,7 +1286,7 @@ index 159b06c..ac6145a 100644
  		ServerMapChunk orCreateMapChunk = chunkthread.loadsavechunks.GetOrCreateMapChunk(request);
  		if (orCreateMapChunk == null)
  		{
-@@ -267,94 +1264,203 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -267,94 +1279,203 @@ internal class ServerSystemSupplyChunks : ServerSystem
  		ServerChunk[] array = chunkthread.loadsavechunks.TryLoadChunkColumn(request);
  		if (array == null)
  		{
@@ -1481,7 +1496,7 @@ index 159b06c..ac6145a 100644
  				chunkRequest.Chunks = TryLoadChunkColumn(chunkRequest);
  				if (chunkRequest.Chunks != null)
  				{
-@@ -364,31 +1470,42 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -364,31 +1485,42 @@ internal class ServerSystemSupplyChunks : ServerSystem
  						obj.serverMapChunk = orCreateMapChunk;
  						obj.MarkFresh();
  					}
@@ -1524,7 +1539,7 @@ index 159b06c..ac6145a 100644
  				ServerEventAPI eventapi = server.api.eventapi;
  				ServerMapChunk mapChunk = orCreateMapChunk;
  				int chunkX = chunkRequest.chunkX;
-@@ -404,117 +1521,105 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -404,117 +1536,105 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					ServerMain.Logger.Error("Repair mode is enabled so will delete the entire chunk column.");
  					GenerateNewChunkColumn(orCreateMapChunk, chunkRequest);
  					return false;
@@ -1672,7 +1687,7 @@ index 159b06c..ac6145a 100644
  				try
  				{
  					serverChunk.Unpack();
-@@ -529,10 +1634,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -529,10 +1649,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
  						ServerMain.FrameProfiler.Leave();
  						return;
  					}
@@ -1685,7 +1700,7 @@ index 159b06c..ac6145a 100644
  			{
  				for (int j = 0; j < serverChunk.Entities.Length; j++)
  				{
-@@ -548,10 +1655,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -548,10 +1670,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					{
  						if (server.LoadEntity(entity, num2))
  						{
@@ -1697,7 +1712,7 @@ index 159b06c..ac6145a 100644
  						{
  							string text = "-";
  							try
-@@ -564,14 +1672,18 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -564,14 +1687,18 @@ internal class ServerSystemSupplyChunks : ServerSystem
  							ServerMain.Logger.Log(EnumLogType.Worldgen, "In " + server.WorldName + ", villager " + text + " removed at " + entity.Pos.AsBlockPos?.ToString() + " due to an exception on loading");
  						}
  					}
@@ -1716,7 +1731,7 @@ index 159b06c..ac6145a 100644
  			{
  				BlockEntity value = blockEntity.Value;
  				if (value == null)
-@@ -580,13 +1692,23 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -580,13 +1707,23 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				}
  				try
  				{
@@ -1742,7 +1757,7 @@ index 159b06c..ac6145a 100644
  					ServerMain.FrameProfiler.Leave();
  				}
  				catch (Exception ex3)
-@@ -594,23 +1716,33 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -594,23 +1731,33 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					ServerMain.Logger.Notification("Exception thrown when trying to initialize a block entity @{0}: {1}", value.Pos, ex3);
  					value.UnregisterAllTickListeners();
  				}
@@ -1776,7 +1791,7 @@ index 159b06c..ac6145a 100644
  		mapChunk.NeighboursLoaded = default(SmallBoolArray);
  		mapChunk.SelfLoaded = true;
  		for (int i = 0; i < Cardinal.ALL.Length; i++)
-@@ -623,20 +1755,26 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -623,20 +1770,26 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				serverMapChunk.NeighboursLoaded[cardinal.Opposite.Index] = true;
  			}
  		}
@@ -1803,7 +1818,7 @@ index 159b06c..ac6145a 100644
  			serverMapChunk.NeighboursLoaded[4] = false;
  		}
  		if (serverMapChunk2 != null)
-@@ -667,12 +1805,17 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -667,12 +1820,17 @@ internal class ServerSystemSupplyChunks : ServerSystem
  		{
  			serverMapChunk8.NeighboursLoaded[3] = false;
  		}
@@ -1821,7 +1836,7 @@ index 159b06c..ac6145a 100644
  			for (int j = -1; j <= 1; j++)
  			{
  				bool flag = false;
-@@ -682,19 +1825,24 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -682,19 +1840,24 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				}
  				if (!flag)
  				{
@@ -1846,7 +1861,7 @@ index 159b06c..ac6145a 100644
  		int num = 0;
  		for (int i = -1; i <= 1; i++)
  		{
-@@ -707,60 +1855,78 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -707,60 +1870,78 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			}
  		}
  		return num == 8;
@@ -1926,7 +1941,7 @@ index 159b06c..ac6145a 100644
  				dictionary = value.ModData;
  				dictionary2 = value.OreMaps;
  				intDataMap2D = value.GeologicProvinceMap;
-@@ -770,12 +1936,14 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -770,12 +1951,14 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			{
  				flag = false;
  				value.loadedTotalMs = server.ElapsedMilliseconds;
@@ -1941,7 +1956,7 @@ index 159b06c..ac6145a 100644
  			if (list != null)
  			{
  				value.GeneratedStructures = list;
-@@ -798,35 +1966,48 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -798,35 +1981,48 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			}
  		}
  		return value;
@@ -1990,7 +2005,7 @@ index 159b06c..ac6145a 100644
  		byte[] array = chunkGenParams?.GetBytes("GeneratedStructures");
  		if (array == null)
  		{
-@@ -836,44 +2017,60 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -836,44 +2032,60 @@ internal class ServerSystemSupplyChunks : ServerSystem
  		long key = server.api.WorldManager.MapRegionIndex2D(regionX, regionZ);
  		if (!dictionary.TryGetValue(key, out var value) || value == null)
  		{
@@ -2052,7 +2067,7 @@ index 159b06c..ac6145a 100644
  		long key = server.WorldMap.MapChunkIndex2D(chunkX, chunkZ);
  		server.loadedMapChunks.TryGetValue(key, out var value);
  		if (value != null)
-@@ -881,31 +2078,42 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -881,31 +2093,42 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			return value;
  		}
  		return TryLoadMapChunk(chunkX, chunkZ);
@@ -2095,7 +2110,7 @@ index 159b06c..ac6145a 100644
  			for (int j = 0; j < Cardinal.ALL.Length; j++)
  			{
  				Cardinal cardinal = Cardinal.ALL[j];
-@@ -918,47 +2126,111 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -918,47 +2141,111 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					}
  					chunkRequest.NeighbourTerrainHeight[j] = serverMapChunk.WorldGenTerrainHeightMap;
  				}
@@ -2223,7 +2238,7 @@ index 159b06c..ac6145a 100644
  			foreach (ServerChunk serverChunk in array)
  			{
  				if (serverChunk != null)
-@@ -967,10 +2239,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -967,10 +2254,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					serverChunk.MarkModified();
  					serverChunk.TryPackAndCommit();
  				}
@@ -2236,7 +2251,7 @@ index 159b06c..ac6145a 100644
  			ServerMain.Logger.Error("Loaded some but not all chunks of a column? Discarding whole column.");
  			return null;
  		}
-@@ -979,18 +2253,22 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -979,18 +2268,22 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			return null;
  		}
  		return array;
@@ -2259,7 +2274,7 @@ index 159b06c..ac6145a 100644
  					serverMapChunk.YMax = (ushort)(server.SaveGameData.MapSizeY - 1);
  				}
  				return serverMapChunk;
-@@ -1011,10 +2289,13 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1011,10 +2304,13 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			}
  		}
  		return null;
@@ -2273,7 +2288,7 @@ index 159b06c..ac6145a 100644
  		byte[] mapRegion = chunkthread.gameDatabase.GetMapRegion(regionX, regionZ);
  		try
  		{
-@@ -1035,14 +2316,33 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1035,14 +2331,33 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			throw;
  		}
  		return null;
@@ -2307,7 +2322,7 @@ index 159b06c..ac6145a 100644
  			storyChunkSpawnEvents = new string[15]
  			{
  				Lang.Get("...the carved mountains"),
-@@ -1060,23 +2360,27 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1060,23 +2375,27 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				Lang.Get("...a misty sunrise"),
  				Lang.Get("...dew drops on a blade of grass"),
  				Lang.Get("...a soft breeze")
@@ -2335,7 +2350,7 @@ index 159b06c..ac6145a 100644
  					double value = random.NextDouble() * 6.2831854820251465;
  					double num7 = num6 * GameMath.Sin(value);
  					double num8 = num6 * GameMath.Cos(value);
-@@ -1096,10 +2400,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1096,10 +2415,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					server.api.Logger.Notification("Trying another spawn location ({0}/{1})...", i + 2, num3);
  				}
  			}
@@ -2347,7 +2362,7 @@ index 159b06c..ac6145a 100644
  				if (!server.blockAccessor.GetBlock(blockPos).SideSolid[BlockFacing.UP.Index])
  				{
  					server.blockAccessor.SetBlock(server.blockAccessor.GetBlock(new AssetLocation("planks-oak-we")).Id, blockPos);
-@@ -1107,13 +2412,16 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1107,13 +2427,16 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				blockPos.Y++;
  			}
  		}
@@ -2364,7 +2379,7 @@ index 159b06c..ac6145a 100644
  			x = blockPos.X,
  			y = blockPos.Y,
  			z = blockPos.Z
-@@ -1123,10 +2431,14 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1123,10 +2446,14 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			server.mapMiddleSpawnPos.y = null;
  		}
  		server.api.Logger.VerboseDebug("Done spawn chunk");
@@ -2379,7 +2394,7 @@ index 159b06c..ac6145a 100644
  		int num = 60;
  		int num2 = 0;
  		int num3 = 0;
-@@ -1137,36 +2449,47 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1137,36 +2464,47 @@ internal class ServerSystemSupplyChunks : ServerSystem
  		{
  			num4 = GameMath.Clamp(num2 + pos.X, 0, server.WorldMap.MapSizeX - 1);
  			num6 = GameMath.Clamp(num3 + pos.Z, 0, server.WorldMap.MapSizeZ - 1);
@@ -2428,7 +2443,7 @@ index 159b06c..ac6145a 100644
  		{
  			for (int k = -num2; k <= num2; k++)
  			{
-@@ -1174,18 +2497,22 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1174,18 +2512,22 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				{
  					long index2d = server.WorldMap.MapChunkIndex2D(x + j, y + k);
  					int regionX = (x + j) / MagicNum.ChunkRegionSizeInChunks;
@@ -2452,7 +2467,7 @@ index 159b06c..ac6145a 100644
  					};
  					chunkColumnLoadRequest.MapChunk = mapChunk;
  					GenerateNewChunkColumn(mapChunk, chunkColumnLoadRequest);
-@@ -1196,10 +2523,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1196,10 +2538,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
  						chunkthread.peekingChunkColumns.Enqueue(chunkColumnLoadRequest);
  					}
  				}
@@ -2465,7 +2480,7 @@ index 159b06c..ac6145a 100644
  		{
  			num4 = num - i;
  			for (int l = -num4; l <= num4; l++)
-@@ -1212,10 +2541,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1212,10 +2556,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
  						runGenerators(chunkRequest, i);
  					}
  				}
@@ -2478,7 +2493,7 @@ index 159b06c..ac6145a 100644
  		{
  			for (int n = -num2; n <= num2; n++)
  			{
-@@ -1232,61 +2563,111 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1232,61 +2578,111 @@ internal class ServerSystemSupplyChunks : ServerSystem
  						dictionary2[key] = chunks;
  					}
  				}
@@ -2592,7 +2607,7 @@ index 159b06c..ac6145a 100644
  				millisecondsSinceStart = server.totalUnpausedTime.ElapsedMilliseconds;
  				float num4 = 100f * ((float)server.loadedChunks.Count / (float)server.WorldMap.ChunkMapSizeY - (float)num) / (float)num2;
  				ServerMain.Logger.Event(num4.ToString("0.#") + "% ({0} in queue)", chunkthread.requestedChunkColumns.Count);
-@@ -1298,37 +2679,84 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1298,37 +2694,84 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				{
  					ServerMain.Logger.StoryEvent("...");
  				}
@@ -2680,7 +2695,7 @@ index 159b06c..ac6145a 100644
  				foreach (ChunkColumnLoadRequest requestedChunkColumn3 in chunkthread.requestedChunkColumns)
  				{
  					if (requestedChunkColumn3 != null)
-@@ -1340,16 +2768,25 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1340,16 +2783,25 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				throw new Exception("Somehow worldgen has become stuck in an endless loop, please report this as a bug!  Additional data in the server-main log");
  			}
  		}
@@ -2706,7 +2721,7 @@ index 159b06c..ac6145a 100644
  				if (chunkRequest.CurrentIncompletePass == EnumWorldGenPass.Terrain)
  				{
  					ushort sunLight = (ushort)server.sunBrightness;
-@@ -1359,32 +2796,62 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1359,32 +2811,62 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					}
  				}
  			}
@@ -2771,7 +2786,7 @@ index 159b06c..ac6145a 100644
  			return;
  		}
  		for (int i = 0; i < list.Count; i++)
-@@ -1396,89 +2863,119 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1396,89 +2878,119 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			catch (Exception ex)
  			{
  				ServerMain.Logger.Worldgen("An error was thrown in pass {5} when generating chunk column X={0},Z={1} in world '{3}' with seed {4}\nException {2}\n\n", chunkRequest.chunkX, chunkRequest.chunkZ, ex, server.SaveGameData.WorldName, server.SaveGameData.Seed, chunkRequest.CurrentIncompletePass.ToString());
@@ -2908,7 +2923,7 @@ index 159b06c..ac6145a 100644
  			chunkthread.requestedChunkColumns.Enqueue(curRequest);
  			return true;
  		}
-@@ -1490,13 +2987,19 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1490,13 +3002,19 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				ServerMain.Logger.VerboseDebug("Un-pausing all worldgen threads.");
  			}
  		}
@@ -2928,7 +2943,7 @@ index 159b06c..ac6145a 100644
  			if (requestedChunkColumn != null && !requestedChunkColumn.Disposed)
  			{
  				server.loadedMapChunks.Remove(requestedChunkColumn.mapIndex2d);
-@@ -1505,104 +3008,181 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1505,104 +3023,181 @@ internal class ServerSystemSupplyChunks : ServerSystem
  		}
  		chunkthread.requestedChunkColumns.Clear();
  		ServerMain.Logger.VerboseDebug("Incomplete chunks stored and wiped.");

--- a/patches/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs.patch
@@ -1,8 +1,8 @@
 diff --git a/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs b/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs
-index 159b06c..381605a 100644
+index 159b06c..d2610d0 100644
 --- a/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs
 +++ b/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs
-@@ -1,139 +1,1109 @@
+@@ -1,139 +1,1076 @@
  using System;
  using System.Collections.Generic;
  using System.Linq;
@@ -490,40 +490,20 @@ index 159b06c..381605a 100644
 +	}
 +
 +
-+	/// <summary>
-+	/// Stratum: everything TryDispatchRequest and TryRunOneReadyRequestInline
-+	/// share: claim the request itself first (req.dispatchClaimed), then a
-+	/// concurrency slot for its current stage, then run the checks that can
-+	/// still say no even after both are held (stage advanced under us,
-+	/// untilPass, neighbour readiness). On true the caller owns both claims and
-+	/// MUST release both exactly once (Interlocked.Decrement on
-+	/// stratumStageActiveCount[stage] AND Volatile.Write(req.dispatchClaimed, 0)),
-+	/// in a finally block, once it has either enqueued the request or finished
-+	/// running it. On false both claims have already been released internally;
-+	/// the caller does nothing further.
-+	/// </summary>
 +	private bool TryClaimStage(ChunkColumnLoadRequest req, out int stage)
 +	{
 +		stage = -1;
 +		if (req == null || req.Disposed) return false;
 +
-+		// Determine the current incomplete generation stage
 +		stage = req.CurrentIncompletePass_AsInt;
 +		if (stage < 1 || stage >= StratumWorldGenStages.Done) { stage = -1; return false; }
 +
-+		// Claim this specific request first. stratumStageActiveCount below only
-+		// caps how many claims are concurrently active *for the stage*; it does
-+		// nothing to stop this exact request being claimed a second time by
-+		// another concurrent caller before either claim has run PopulateChunk to
-+		// advance CurrentIncompletePass_AsInt. See dispatchClaimed's own comment
-+		// on ChunkColumnLoadRequest for what that double-claim does once it lands.
 +		if (Interlocked.CompareExchange(ref req.dispatchClaimed, 1, 0) != 0)
 +		{
 +			stage = -1;
 +			return false;
 +		}
 +
-+		// Atomically claim a concurrency slot for this stage, if one is free
 +		int cap = stratumStageMaxConcurrent[stage];
 +		if (Interlocked.Increment(ref stratumStageActiveCount[stage]) > cap)
 +		{
@@ -533,53 +513,11 @@ index 159b06c..381605a 100644
 +			return false;
 +		}
 +
-+		// Stratum: from here on both claims are held, so every exit has to release
-+		// them. The checks below can THROW, not just return false:
-+		// ensurePrettyNeighbourhood reaches EnsureMinimumWorldgenPassAt, which
-+		// enqueues lagging neighbours and throws "Indexed Fifo Queue overflow" when
-+		// the request queue is full. Without this finally that exception escaped
-+		// with dispatchClaimed still 1 and the stage's active count still
-+		// incremented, which is unrecoverable rather than merely noisy.
-+		//
-+		// Two-pass neighbour gate for gated stages. The old shape pinned the 3x3
-+		// neighbourhood BEFORE running the gate, on every claim attempt, on the
-+		// theory that holding must start before the residency check. Measured, that
-+		// "free" pin on the refusing path was the single largest allocation source
-+		// in the process: ~1e9 Node<Int64,Int32> (29 GB) in stratumPinnedColumns
-+		// plus ~22s of CPU in ConcurrentDictionary.TryRemoveInternal, because every
-+		// refused attempt paid 9 AddOrUpdate + 9 TryUpdate/Remove on a
-+		// ConcurrentDictionary that allocates a fresh Node per mutation - and
-+		// during pregen nearly all attempts refuse (neighbours lag), while the
-+		// dispatcher spin and loadChunkAreaBlocking's wait loop retry the same
-+		// gated columns hundreds of times a second.
-+		//
-+		// The pin only has to protect a stage that WILL run. A refused gate runs no
-+		// stage, so it needs no pin. Hence:
-+		//
-+		//   Pass 1 runs the full gate unpinned, side effects included. The side
-+		//   effects (enqueuing/bumping lagging neighbours) are exactly what drives
-+		//   the neighbourhood forward and MUST stay on the refuse path - skipping
-+		//   them would mean nothing ever requests those neighbours and worldgen
-+		//   stalls.
-+		//
-+		//   Only if pass 1 accepted do we pin, then run pass 2 as the authoritative
-+		//   gate under the pin. Pass 2 closes the race the old pre-gate pin existed
-+		//   for: between pass 1's residency observation and the hold, the unload
-+		//   pass can drop a neighbour; pass 2 re-establishes residency while it is
-+		//   held, and refuses (the finally releases the pin) if it can't. On this
-+		//   path pass 2 is a read-only re-check: EnsureMinimumWorldgenPassAt
-+		//   mutates nothing for a neighbour already at pass or Done, so the double
-+		//   gate adds no queue churn.
-+		//
-+		// Net: the refuse path (the overwhelming majority of attempts) never
-+		// touches stratumPinnedColumns at all; pin/unpin now happens once per
-+		// column per gated stage advance, which is what it was always meant to be.
 +		int claimedStage = stage;
 +		bool claimHeld = true;
 +		bool pinHeld = false;
 +		try
 +		{
-+			// Re-verify: currentpass may have changed between the read and the CAS
 +			if (req.CurrentIncompletePass_AsInt != stage)
 +			{
 +				stage = -1;
@@ -595,31 +533,60 @@ index 159b06c..381605a 100644
 +
 +			if (claimedStage > StratumWorldGenStages.TerrainLate)
 +			{
-+				// Pass 1: unpinned filter + neighbour driver. Refusing here costs
-+				// a few dictionary reads per neighbour and zero pin mutations.
++				// Stratum: ensurePrettyNeighbourhood's EnsureQueueSpace check (see its own
++				// comment) fires on exactly one call in this request's whole lifetime: its
++				// first-ever gate call, gated by req.prettified, which this claim is about
++				// to make if firstEverGateCall is true. On the queue-tight path that call
++				// pauses the workers and runs UnloadGeneratingChunkColumns, which already
++				// respects stratumPinnedColumns - but only for columns pinned BEFORE it
++				// runs. Nothing pins this request's neighbourhood until after pass 1
++				// normally accepts, so a request's very first attempt could still lose a
++				// neighbour (or itself) to that cleanup with no pin up yet. Pin first for
++				// this one call only; every later call, including pass 2 of this same
++				// attempt and every retry after it, has req.prettified already true, so
++				// EnsureQueueSpace no-ops there and the refuse path stays as cheap as
++				// before.
++				bool firstEverGateCall = !req.prettified;
++				if (firstEverGateCall)
++				{
++					chunkthread.StratumPinNeighbourhood(req.chunkX, req.chunkZ);
++					pinHeld = true;
++				}
++
++				// Pass 1: unpinned filter + neighbour driver (unpinned except on the very
++				// first call, above). Refusing here costs a few dictionary reads per
++				// neighbour and, past the first call, zero pin mutations.
 +				if (!ensurePrettyNeighbourhood(req))
 +				{
 +					stage = -1;
 +					return false;
 +				}
 +
-+				// Pass 1 accepted: neighbours looked resident. "Looked" - the
-+				// unload pass can drop one between the check and the hold, the
-+				// exact check-then-act shape the pin exists to close. Pin, then
-+				// re-check.
-+				chunkthread.StratumPinNeighbourhood(req.chunkX, req.chunkZ);
-+				pinHeld = true;
++				// Pass 1 accepted: neighbours looked resident. "Looked" - the unload pass
++				// can drop one between the check and the hold, the exact check-then-act
++				// shape the pin exists to close. Pin (if not already pinned above), then
++				// re-check under the hold.
++				if (!pinHeld)
++				{
++					chunkthread.StratumPinNeighbourhood(req.chunkX, req.chunkZ);
++					pinHeld = true;
++				}
 +
-+				// Pass 2: authoritative gate under the pin.
++				// Pass 2: authoritative gate under the pin. Not purely read-only: if a
++				// neighbour actually disappeared in the gap, EnsureMinimumWorldgenPassAt
++				// re-adds and re-enqueues it here, same as pass 1 would - that's the
++				// self-healing path for a genuinely vanished neighbour, and this refusal
++				// (plus the finally below releasing the pin) is what it looks like. The
++				// pin's job isn't to make this call allocation-free, it's to guarantee
++				// that when a neighbour IS still resident here, nothing pulls it out from
++				// under the claim between this check and PopulateChunk actually reading
++				// it.
 +				if (!ensurePrettyNeighbourhood(req))
 +				{
 +					stage = -1;
 +					return false;
 +				}
 +			}
-+			// For stages at or below TerrainLate the gate is a no-op by definition
-+			// (ensurePrettyNeighbourhood returns true immediately), so no pin and
-+			// no gate call are needed here at all.
 +
 +			claimHeld = false;   // handed off to the caller, which owns the release
 +			pinHeld = false;     // the pin goes with it, released alongside the claim
@@ -724,12 +691,12 @@ index 159b06c..381605a 100644
 +				}
 +				Volatile.Write(ref req.dispatchClaimed, 0);
 +				SignalDispatcher();
-+			}
+ 			}
 +			return true;
-+		}
+ 		}
 +		return false;
-+	}
-+
+ 	}
+ 
 +
 +	/// <summary>
 +	/// Dispatcher: scans the request queue and sends ready tasks to the worker channel.
@@ -786,7 +753,7 @@ index 159b06c..381605a 100644
 +			{
 +				// Channel completed (CompleteAdding) - exit
 +				return false;
- 			}
++			}
 +
 +			return dispatched > 0;
 +		}
@@ -798,9 +765,9 @@ index 159b06c..381605a 100644
 +		finally
 +		{
 +			Monitor.Exit(dispatcherLock);
- 		}
- 	}
- 
++		}
++	}
++
 +
 +
 +	/// <summary>
@@ -1134,7 +1101,7 @@ index 159b06c..381605a 100644
  			if (!tryLoadOrGenerateChunkColumnsInQueue())
  			{
  				break;
-@@ -143,39 +1113,59 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -143,39 +1080,59 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				break;
  			}
  		}
@@ -1196,7 +1163,7 @@ index 159b06c..381605a 100644
  				ServerChunk serverChunk = (ServerChunk)server.WorldMap.GetChunk(x, i, z);
  				if (serverChunk != null)
  				{
-@@ -183,11 +1173,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -183,11 +1140,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					for (int j = 0; j < entities.Length; j++)
  					{
  						Entity entity = entities[j];
@@ -1209,7 +1176,7 @@ index 159b06c..381605a 100644
  						{
  							if (j >= serverChunk.EntitiesCount)
  							{
-@@ -211,19 +1201,23 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -211,19 +1168,23 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				});
  			}
  			list2.Add(item);
@@ -1234,7 +1201,7 @@ index 159b06c..381605a 100644
  		{
  			ChunkPos item2 = server.WorldMap.MapRegionPosFromIndex2D(result2);
  			if (hashSet == null)
-@@ -237,28 +1231,46 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -237,28 +1198,46 @@ internal class ServerSystemSupplyChunks : ServerSystem
  		{
  			chunkthread.gameDatabase.DeleteMapRegions(hashSet);
  		}
@@ -1286,7 +1253,7 @@ index 159b06c..381605a 100644
  		ServerMapChunk orCreateMapChunk = chunkthread.loadsavechunks.GetOrCreateMapChunk(request);
  		if (orCreateMapChunk == null)
  		{
-@@ -267,94 +1279,203 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -267,94 +1246,203 @@ internal class ServerSystemSupplyChunks : ServerSystem
  		ServerChunk[] array = chunkthread.loadsavechunks.TryLoadChunkColumn(request);
  		if (array == null)
  		{
@@ -1496,7 +1463,7 @@ index 159b06c..381605a 100644
  				chunkRequest.Chunks = TryLoadChunkColumn(chunkRequest);
  				if (chunkRequest.Chunks != null)
  				{
-@@ -364,31 +1485,42 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -364,31 +1452,42 @@ internal class ServerSystemSupplyChunks : ServerSystem
  						obj.serverMapChunk = orCreateMapChunk;
  						obj.MarkFresh();
  					}
@@ -1539,7 +1506,7 @@ index 159b06c..381605a 100644
  				ServerEventAPI eventapi = server.api.eventapi;
  				ServerMapChunk mapChunk = orCreateMapChunk;
  				int chunkX = chunkRequest.chunkX;
-@@ -404,117 +1536,105 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -404,117 +1503,105 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					ServerMain.Logger.Error("Repair mode is enabled so will delete the entire chunk column.");
  					GenerateNewChunkColumn(orCreateMapChunk, chunkRequest);
  					return false;
@@ -1687,7 +1654,7 @@ index 159b06c..381605a 100644
  				try
  				{
  					serverChunk.Unpack();
-@@ -529,10 +1649,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -529,10 +1616,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
  						ServerMain.FrameProfiler.Leave();
  						return;
  					}
@@ -1700,7 +1667,7 @@ index 159b06c..381605a 100644
  			{
  				for (int j = 0; j < serverChunk.Entities.Length; j++)
  				{
-@@ -548,10 +1670,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -548,10 +1637,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					{
  						if (server.LoadEntity(entity, num2))
  						{
@@ -1712,7 +1679,7 @@ index 159b06c..381605a 100644
  						{
  							string text = "-";
  							try
-@@ -564,14 +1687,18 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -564,14 +1654,18 @@ internal class ServerSystemSupplyChunks : ServerSystem
  							ServerMain.Logger.Log(EnumLogType.Worldgen, "In " + server.WorldName + ", villager " + text + " removed at " + entity.Pos.AsBlockPos?.ToString() + " due to an exception on loading");
  						}
  					}
@@ -1731,7 +1698,7 @@ index 159b06c..381605a 100644
  			{
  				BlockEntity value = blockEntity.Value;
  				if (value == null)
-@@ -580,13 +1707,23 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -580,13 +1674,23 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				}
  				try
  				{
@@ -1757,7 +1724,7 @@ index 159b06c..381605a 100644
  					ServerMain.FrameProfiler.Leave();
  				}
  				catch (Exception ex3)
-@@ -594,23 +1731,33 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -594,23 +1698,33 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					ServerMain.Logger.Notification("Exception thrown when trying to initialize a block entity @{0}: {1}", value.Pos, ex3);
  					value.UnregisterAllTickListeners();
  				}
@@ -1791,7 +1758,7 @@ index 159b06c..381605a 100644
  		mapChunk.NeighboursLoaded = default(SmallBoolArray);
  		mapChunk.SelfLoaded = true;
  		for (int i = 0; i < Cardinal.ALL.Length; i++)
-@@ -623,20 +1770,26 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -623,20 +1737,26 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				serverMapChunk.NeighboursLoaded[cardinal.Opposite.Index] = true;
  			}
  		}
@@ -1818,7 +1785,7 @@ index 159b06c..381605a 100644
  			serverMapChunk.NeighboursLoaded[4] = false;
  		}
  		if (serverMapChunk2 != null)
-@@ -667,12 +1820,17 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -667,12 +1787,17 @@ internal class ServerSystemSupplyChunks : ServerSystem
  		{
  			serverMapChunk8.NeighboursLoaded[3] = false;
  		}
@@ -1836,7 +1803,7 @@ index 159b06c..381605a 100644
  			for (int j = -1; j <= 1; j++)
  			{
  				bool flag = false;
-@@ -682,19 +1840,24 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -682,19 +1807,24 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				}
  				if (!flag)
  				{
@@ -1861,7 +1828,7 @@ index 159b06c..381605a 100644
  		int num = 0;
  		for (int i = -1; i <= 1; i++)
  		{
-@@ -707,60 +1870,78 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -707,60 +1837,78 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			}
  		}
  		return num == 8;
@@ -1941,7 +1908,7 @@ index 159b06c..381605a 100644
  				dictionary = value.ModData;
  				dictionary2 = value.OreMaps;
  				intDataMap2D = value.GeologicProvinceMap;
-@@ -770,12 +1951,14 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -770,12 +1918,14 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			{
  				flag = false;
  				value.loadedTotalMs = server.ElapsedMilliseconds;
@@ -1956,7 +1923,7 @@ index 159b06c..381605a 100644
  			if (list != null)
  			{
  				value.GeneratedStructures = list;
-@@ -798,35 +1981,48 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -798,35 +1948,48 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			}
  		}
  		return value;
@@ -2005,7 +1972,7 @@ index 159b06c..381605a 100644
  		byte[] array = chunkGenParams?.GetBytes("GeneratedStructures");
  		if (array == null)
  		{
-@@ -836,44 +2032,60 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -836,44 +1999,60 @@ internal class ServerSystemSupplyChunks : ServerSystem
  		long key = server.api.WorldManager.MapRegionIndex2D(regionX, regionZ);
  		if (!dictionary.TryGetValue(key, out var value) || value == null)
  		{
@@ -2067,7 +2034,7 @@ index 159b06c..381605a 100644
  		long key = server.WorldMap.MapChunkIndex2D(chunkX, chunkZ);
  		server.loadedMapChunks.TryGetValue(key, out var value);
  		if (value != null)
-@@ -881,31 +2093,42 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -881,31 +2060,42 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			return value;
  		}
  		return TryLoadMapChunk(chunkX, chunkZ);
@@ -2110,7 +2077,7 @@ index 159b06c..381605a 100644
  			for (int j = 0; j < Cardinal.ALL.Length; j++)
  			{
  				Cardinal cardinal = Cardinal.ALL[j];
-@@ -918,47 +2141,111 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -918,47 +2108,111 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					}
  					chunkRequest.NeighbourTerrainHeight[j] = serverMapChunk.WorldGenTerrainHeightMap;
  				}
@@ -2238,7 +2205,7 @@ index 159b06c..381605a 100644
  			foreach (ServerChunk serverChunk in array)
  			{
  				if (serverChunk != null)
-@@ -967,10 +2254,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -967,10 +2221,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					serverChunk.MarkModified();
  					serverChunk.TryPackAndCommit();
  				}
@@ -2251,7 +2218,7 @@ index 159b06c..381605a 100644
  			ServerMain.Logger.Error("Loaded some but not all chunks of a column? Discarding whole column.");
  			return null;
  		}
-@@ -979,18 +2268,22 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -979,18 +2235,22 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			return null;
  		}
  		return array;
@@ -2274,7 +2241,7 @@ index 159b06c..381605a 100644
  					serverMapChunk.YMax = (ushort)(server.SaveGameData.MapSizeY - 1);
  				}
  				return serverMapChunk;
-@@ -1011,10 +2304,13 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1011,10 +2271,13 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			}
  		}
  		return null;
@@ -2288,7 +2255,7 @@ index 159b06c..381605a 100644
  		byte[] mapRegion = chunkthread.gameDatabase.GetMapRegion(regionX, regionZ);
  		try
  		{
-@@ -1035,14 +2331,33 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1035,14 +2298,33 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			throw;
  		}
  		return null;
@@ -2322,7 +2289,7 @@ index 159b06c..381605a 100644
  			storyChunkSpawnEvents = new string[15]
  			{
  				Lang.Get("...the carved mountains"),
-@@ -1060,23 +2375,27 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1060,23 +2342,27 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				Lang.Get("...a misty sunrise"),
  				Lang.Get("...dew drops on a blade of grass"),
  				Lang.Get("...a soft breeze")
@@ -2350,7 +2317,7 @@ index 159b06c..381605a 100644
  					double value = random.NextDouble() * 6.2831854820251465;
  					double num7 = num6 * GameMath.Sin(value);
  					double num8 = num6 * GameMath.Cos(value);
-@@ -1096,10 +2415,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1096,10 +2382,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					server.api.Logger.Notification("Trying another spawn location ({0}/{1})...", i + 2, num3);
  				}
  			}
@@ -2362,7 +2329,7 @@ index 159b06c..381605a 100644
  				if (!server.blockAccessor.GetBlock(blockPos).SideSolid[BlockFacing.UP.Index])
  				{
  					server.blockAccessor.SetBlock(server.blockAccessor.GetBlock(new AssetLocation("planks-oak-we")).Id, blockPos);
-@@ -1107,13 +2427,16 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1107,13 +2394,16 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				blockPos.Y++;
  			}
  		}
@@ -2379,7 +2346,7 @@ index 159b06c..381605a 100644
  			x = blockPos.X,
  			y = blockPos.Y,
  			z = blockPos.Z
-@@ -1123,10 +2446,14 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1123,10 +2413,14 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			server.mapMiddleSpawnPos.y = null;
  		}
  		server.api.Logger.VerboseDebug("Done spawn chunk");
@@ -2394,7 +2361,7 @@ index 159b06c..381605a 100644
  		int num = 60;
  		int num2 = 0;
  		int num3 = 0;
-@@ -1137,36 +2464,47 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1137,36 +2431,47 @@ internal class ServerSystemSupplyChunks : ServerSystem
  		{
  			num4 = GameMath.Clamp(num2 + pos.X, 0, server.WorldMap.MapSizeX - 1);
  			num6 = GameMath.Clamp(num3 + pos.Z, 0, server.WorldMap.MapSizeZ - 1);
@@ -2443,7 +2410,7 @@ index 159b06c..381605a 100644
  		{
  			for (int k = -num2; k <= num2; k++)
  			{
-@@ -1174,18 +2512,22 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1174,18 +2479,22 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				{
  					long index2d = server.WorldMap.MapChunkIndex2D(x + j, y + k);
  					int regionX = (x + j) / MagicNum.ChunkRegionSizeInChunks;
@@ -2467,7 +2434,7 @@ index 159b06c..381605a 100644
  					};
  					chunkColumnLoadRequest.MapChunk = mapChunk;
  					GenerateNewChunkColumn(mapChunk, chunkColumnLoadRequest);
-@@ -1196,10 +2538,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1196,10 +2505,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
  						chunkthread.peekingChunkColumns.Enqueue(chunkColumnLoadRequest);
  					}
  				}
@@ -2480,7 +2447,7 @@ index 159b06c..381605a 100644
  		{
  			num4 = num - i;
  			for (int l = -num4; l <= num4; l++)
-@@ -1212,10 +2556,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1212,10 +2523,12 @@ internal class ServerSystemSupplyChunks : ServerSystem
  						runGenerators(chunkRequest, i);
  					}
  				}
@@ -2493,7 +2460,7 @@ index 159b06c..381605a 100644
  		{
  			for (int n = -num2; n <= num2; n++)
  			{
-@@ -1232,61 +2578,111 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1232,61 +2545,111 @@ internal class ServerSystemSupplyChunks : ServerSystem
  						dictionary2[key] = chunks;
  					}
  				}
@@ -2607,7 +2574,7 @@ index 159b06c..381605a 100644
  				millisecondsSinceStart = server.totalUnpausedTime.ElapsedMilliseconds;
  				float num4 = 100f * ((float)server.loadedChunks.Count / (float)server.WorldMap.ChunkMapSizeY - (float)num) / (float)num2;
  				ServerMain.Logger.Event(num4.ToString("0.#") + "% ({0} in queue)", chunkthread.requestedChunkColumns.Count);
-@@ -1298,37 +2694,84 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1298,37 +2661,84 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				{
  					ServerMain.Logger.StoryEvent("...");
  				}
@@ -2695,7 +2662,7 @@ index 159b06c..381605a 100644
  				foreach (ChunkColumnLoadRequest requestedChunkColumn3 in chunkthread.requestedChunkColumns)
  				{
  					if (requestedChunkColumn3 != null)
-@@ -1340,16 +2783,25 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1340,16 +2750,25 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				throw new Exception("Somehow worldgen has become stuck in an endless loop, please report this as a bug!  Additional data in the server-main log");
  			}
  		}
@@ -2721,7 +2688,7 @@ index 159b06c..381605a 100644
  				if (chunkRequest.CurrentIncompletePass == EnumWorldGenPass.Terrain)
  				{
  					ushort sunLight = (ushort)server.sunBrightness;
-@@ -1359,32 +2811,62 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1359,32 +2778,62 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					}
  				}
  			}
@@ -2786,7 +2753,7 @@ index 159b06c..381605a 100644
  			return;
  		}
  		for (int i = 0; i < list.Count; i++)
-@@ -1396,89 +2878,119 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1396,89 +2845,119 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			catch (Exception ex)
  			{
  				ServerMain.Logger.Worldgen("An error was thrown in pass {5} when generating chunk column X={0},Z={1} in world '{3}' with seed {4}\nException {2}\n\n", chunkRequest.chunkX, chunkRequest.chunkZ, ex, server.SaveGameData.WorldName, server.SaveGameData.Seed, chunkRequest.CurrentIncompletePass.ToString());
@@ -2923,7 +2890,7 @@ index 159b06c..381605a 100644
  			chunkthread.requestedChunkColumns.Enqueue(curRequest);
  			return true;
  		}
-@@ -1490,13 +3002,19 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1490,13 +2969,19 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				ServerMain.Logger.VerboseDebug("Un-pausing all worldgen threads.");
  			}
  		}
@@ -2943,7 +2910,7 @@ index 159b06c..381605a 100644
  			if (requestedChunkColumn != null && !requestedChunkColumn.Disposed)
  			{
  				server.loadedMapChunks.Remove(requestedChunkColumn.mapIndex2d);
-@@ -1505,104 +3023,181 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1505,104 +2990,181 @@ internal class ServerSystemSupplyChunks : ServerSystem
  		}
  		chunkthread.requestedChunkColumns.Clear();
  		ServerMain.Logger.VerboseDebug("Incomplete chunks stored and wiped.");

--- a/patches/VintagestoryLib/Vintagestory.Server/ServerSystemUnloadChunks.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/ServerSystemUnloadChunks.cs.patch
@@ -1,5 +1,5 @@
 diff --git a/VintagestoryLib/Vintagestory.Server/ServerSystemUnloadChunks.cs b/VintagestoryLib/Vintagestory.Server/ServerSystemUnloadChunks.cs
-index 642722c..9b46a7c 100644
+index 642722c..a933fe2 100644
 --- a/VintagestoryLib/Vintagestory.Server/ServerSystemUnloadChunks.cs
 +++ b/VintagestoryLib/Vintagestory.Server/ServerSystemUnloadChunks.cs
 @@ -34,15 +34,30 @@ internal class ServerSystemUnloadChunks : ServerSystem
@@ -86,7 +86,7 @@ index 642722c..9b46a7c 100644
  			list3.Add(new DbChunk
  			{
  				Position = item.pos,
-@@ -271,12 +292,14 @@ internal class ServerSystemUnloadChunks : ServerSystem
+@@ -271,47 +292,85 @@ internal class ServerSystemUnloadChunks : ServerSystem
  		server.readyToAutoSave = true;
  	}
  
@@ -103,7 +103,100 @@ index 642722c..9b46a7c 100644
  		{
  			if (server.forceLoadedChunkColumns.Contains(mapChunkUnloadCandidate))
  			{
-@@ -354,132 +377,225 @@ internal class ServerSystemUnloadChunks : ServerSystem
+ 				continue;
+ 			}
+-			ChunkPos ret = server.WorldMap.ChunkPosFromChunkIndex2D(mapChunkUnloadCandidate);
+-			ServerSystemSupplyChunks.UpdateLoadedNeighboursFlags(server.WorldMap, ret.X, ret.Z);
+-			server.api.eventapi.TriggerChunkColumnUnloaded(ret.ToVec3i());
+-			for (int i = 0; i < server.WorldMap.ChunkMapSizeY; i++)
++
++			// Stratum: FindUnloadableChunkColumnCandidates checked the pin when it built
++			// this set, up to 3s ago - that check is a fast pre-filter, not authoritative.
++			// A neighbour gate can pin this column at any point since, including after
++			// that scan and before this loop reaches it, which is exactly the residency
++			// window the pin exists to protect once a claim has accepted both its passes.
++			// Commit to the drop first, then look at the pin once more: a pin taken
++			// before this point wins (we see it here and back off); a pin taken after
++			// this point loses, because EnsureMinimumWorldgenPassAt checks the same flag
++			// we set below and refuses to grant residency over a column already
++			// committed to removal. One of the two always happens, so no claim can be
++			// granted over a column this pass is mid-removal on, and this pass never
++			// removes a column a claim is holding. Mirrors the handshake
++			// UnloadGeneratingChunkColumns already uses for requestedChunkColumns
++			// entries; this is the equivalent for Done columns that no longer have a
++			// ChunkColumnLoadRequest to hang a flag on.
++			if (!chunkthread.StratumTryMarkMapChunkDropping(mapChunkUnloadCandidate))
+ 			{
+-				ret.Y = i;
+-				long num2 = server.WorldMap.ChunkIndex3D(ret.X, i, ret.Z);
+-				ServerChunk loadedChunk = server.GetLoadedChunk(num2);
+-				if (loadedChunk != null && TryUnloadChunk(num2, ret, loadedChunk, list, server))
+-				{
+-					num++;
+-				}
++				continue; // already being dropped by another concurrent call - skip
++			}
++			if (chunkthread.StratumIsColumnPinned(mapChunkUnloadCandidate))
++			{
++				chunkthread.StratumClearMapChunkDropping(mapChunkUnloadCandidate);
++				continue;
+ 			}
+-			server.loadedMapChunks.TryGetValue(mapChunkUnloadCandidate, out var value);
+-			if (value != null)
++
++			try
+ 			{
+-				if (value.DirtyForSaving)
++				ChunkPos ret = server.WorldMap.ChunkPosFromChunkIndex2D(mapChunkUnloadCandidate);
++				ServerSystemSupplyChunks.UpdateLoadedNeighboursFlags(server.WorldMap, ret.X, ret.Z);
++				server.api.eventapi.TriggerChunkColumnUnloaded(ret.ToVec3i());
++				for (int i = 0; i < server.WorldMap.ChunkMapSizeY; i++)
+ 				{
+-					list2.Add(new ServerMapChunkWithCoord
++					ret.Y = i;
++					long num2 = server.WorldMap.ChunkIndex3D(ret.X, i, ret.Z);
++					ServerChunk loadedChunk = server.GetLoadedChunk(num2);
++					if (loadedChunk != null && TryUnloadChunk(num2, ret, loadedChunk, list, server))
+ 					{
+-						chunkX = ret.X,
+-						chunkZ = ret.Z,
+-						index2d = mapChunkUnloadCandidate,
+-						mapchunk = value
+-					});
++						num++;
++					}
+ 				}
+-				value.DirtyForSaving = false;
+-				server.loadedMapChunks.Remove(mapChunkUnloadCandidate);
++				server.loadedMapChunks.TryGetValue(mapChunkUnloadCandidate, out var value);
++				if (value != null)
++				{
++					if (value.DirtyForSaving)
++					{
++						list2.Add(new ServerMapChunkWithCoord
++						{
++							chunkX = ret.X,
++							chunkZ = ret.Z,
++							index2d = mapChunkUnloadCandidate,
++							mapchunk = value
++						});
++					}
++					value.DirtyForSaving = false;
++					server.loadedMapChunks.Remove(mapChunkUnloadCandidate);
++				}
++			}
++			finally
++			{
++				// Stratum: out of loadedMapChunks (or never was in it), the flag has no
++				// further job - clear it on every path, success or exception, so it can
++				// never permanently blind the neighbour gate to this index.
++				chunkthread.StratumClearMapChunkDropping(mapChunkUnloadCandidate);
+ 			}
+ 		}
+ 		lock (dirtyChunksLock)
+ 		{
+ 			dirtyUnloadedChunks.AddRange(list);
+@@ -354,132 +413,225 @@ internal class ServerSystemUnloadChunks : ServerSystem
  			chunk.Dispose();
  		}
  		return flag;
@@ -248,11 +341,7 @@ index 642722c..9b46a7c 100644
 -		List<ChunkColumnLoadRequest> list = new List<ChunkColumnLoadRequest>();
 -		int num = 0;
 -		foreach (ChunkColumnLoadRequest item in chunkthread.requestedChunkColumns.Snapshot())
-+		private readonly int x;
-+		private readonly int z;
-+
-+		public StratumUnloadChunkPosition(int x, int z)
- 		{
+-		{
 -			if (item.Chunks == null || item.Disposed)
 -			{
 -				continue;
@@ -279,21 +368,24 @@ index 642722c..9b46a7c 100644
 -			{
 -				list.Add(item);
 -			}
-+			this.x = x;
-+			this.z = z;
- 		}
+-		}
 -		if (list.Count == 0)
++		private readonly int x;
++		private readonly int z;
 +
-+		public bool Equals(StratumUnloadChunkPosition other)
++		public StratumUnloadChunkPosition(int x, int z)
  		{
 -			return;
-+			return x == other.x && z == other.z;
++			this.x = x;
++			this.z = z;
  		}
 -		List<DbChunk> list2 = new List<DbChunk>();
 -		List<DbChunk> list3 = new List<DbChunk>();
 -		using FastMemoryStream ms = new FastMemoryStream();
 -		foreach (ChunkColumnLoadRequest item2 in list)
--		{
++
++		public bool Equals(StratumUnloadChunkPosition other)
+ 		{
 -			item2.generatingLock.AcquireReadLock();
 -			try
 -			{
@@ -334,7 +426,8 @@ index 642722c..9b46a7c 100644
 -			}
 -			server.ChunkColumnRequested.Remove(item2.mapIndex2d);
 -			num++;
--		}
++			return x == other.x && z == other.z;
+ 		}
 -		if (list2.Count > 0)
 +
 +		public override bool Equals(object obj)
@@ -366,7 +459,11 @@ index 642722c..9b46a7c 100644
  		{
 -			if (value2.State != EnumClientState.Queued)
 +			if (value2.State == EnumClientState.Queued)
-+			{
+ 			{
+-				int allowedChunkRadius = server.GetAllowedChunkRadius(value2);
+-				int x = ((value2.Position == null) ? (server.WorldMap.MapSizeX / 2) : ((int)value2.Position.X)) / MagicNum.ServerChunkSize;
+-				int y = ((value2.Position == null) ? (server.WorldMap.MapSizeZ / 2) : ((int)value2.Position.Z)) / MagicNum.ServerChunkSize;
+-				for (int i = 0; i <= allowedChunkRadius; i++)
 +				continue;
 +			}
 +			int allowedChunkRadius = server.GetAllowedChunkRadius(value2);
@@ -375,11 +472,7 @@ index 642722c..9b46a7c 100644
 +			StratumUnloadChunkPosition positionKey = new StratumUnloadChunkPosition(x, y);
 +			int startRadius = 0;
 +			if (seenPositions.TryGetValue(positionKey, out int seenRadius))
- 			{
--				int allowedChunkRadius = server.GetAllowedChunkRadius(value2);
--				int x = ((value2.Position == null) ? (server.WorldMap.MapSizeX / 2) : ((int)value2.Position.X)) / MagicNum.ServerChunkSize;
--				int y = ((value2.Position == null) ? (server.WorldMap.MapSizeZ / 2) : ((int)value2.Position.Z)) / MagicNum.ServerChunkSize;
--				for (int i = 0; i <= allowedChunkRadius; i++)
++			{
 +				if (seenRadius >= allowedChunkRadius)
  				{
 -					ShapeUtil.LoadOctagonIndices(list, x, y, i, server.WorldMap.ChunkMapSizeX);
@@ -419,7 +512,7 @@ index 642722c..9b46a7c 100644
  					if (value.IsOld())
  					{
  						mapChunkUnloadCandidates.Add(mapChunkIndex);
-@@ -497,14 +613,16 @@ internal class ServerSystemUnloadChunks : ServerSystem
+@@ -497,14 +649,16 @@ internal class ServerSystemUnloadChunks : ServerSystem
  	{
  		if (server.unloadedChunks.IsEmpty)
  		{
@@ -438,7 +531,7 @@ index 642722c..9b46a7c 100644
  			list2.Clear();
  			foreach (long item in list)
  			{
-@@ -545,12 +663,14 @@ internal class ServerSystemUnloadChunks : ServerSystem
+@@ -545,12 +699,14 @@ internal class ServerSystemUnloadChunks : ServerSystem
  		}
  	}
  


### PR DESCRIPTION
## Summary

In `TryClaimStage`, for stages with a neighbor gate, a 3×3 environment pin (`stratumPinnedColumns`) was set before the neighbor readiness check — for each claim attempt. Each pin/unpin is a mutation of `ConcurrentDictionary`, and each mutation allocates a new node. During pregen, the vast majority of claims are rejected by the gate (neighbors are still lagging behind), while the dispatcher and the `loadChunkAreaBlocking` wait loop repeatedly retry the same columns in a tight loop. The result: a "free" pin on the rejection path turned into an avalanche of short-lived dictionary nodes and CPU inside `ConcurrentDictionary` — even though a rejected claim doesn't start any stage and isn't required to protect residency at all.

**Bugfix.** The gate is split into two passes:

- **Pass 1** — full `ensurePrettyNeighbourhood` without a pin. Its side effects (requesting lagging neighbors, bumping `untilPass`) are preserved: they are what move the environment forward and are needed, among other things, in the failure path.

- The pin is set only if pass 1 has passed, that is, only when the stage is actually launched. Then **pass 2** — an authoritative re-gate under the pin: it closes the same race for which the pin existed (unloading can drop a neighbor between the residency check and holding). If the environment has changed, we fail and the pin is removed in `finally`.

The failure path now completely ignores `stratumPinnedColumns`; pin/unpin occurs once per column per stage transition, as intended. On the accepted path, pass 2 is mostly read-only: if the environment hasn't changed, `EnsureMinimumWorldgenPassAt` doesn't mutate anything. However, if a neighbor vanished in the gap between pass 1 and pass 2, pass 2 acts as a self-healing mechanism by re-adding and re-enqueuing the neighbor's request (the new comment in the diff documents this explicitly). The pin's job is not to make this call allocation-free, but to guarantee that when a neighbor IS still resident, nothing pulls it out from under the claim between the check and `PopulateChunk` actually reading it. The contract with the dispatcher and workers remains unchanged: on success, the pin is passed out along with the claim; on failure, both are released in `finally`.

## Type

- [ ] Bug fix
- [x] Performance
- [ ] New feature
- [ ] Refactor or cleanup
- [ ] Docs or build

## Checklist

- [x] `.\scripts\extract-patches.ps1` ran clean.
- [x] `dotnet build VintageStory.slnx -c Release` is green.
- [x] Every vanilla edit has a `// Stratum` marker.
- [x] No vanilla source committed.
- [x] Tested on a real server start, not just compilation.

## Performance numbers

**Before**
<img width="828" height="466" alt="image" src="https://github.com/user-attachments/assets/f63eff0c-6426-4298-871f-5e6380cd9531" />
<img width="846" height="539" alt="image" src="https://github.com/user-attachments/assets/40a59137-ac25-4d32-ae58-ffcb6f0f7c8c" />
<img width="1417" height="488" alt="image" src="https://github.com/user-attachments/assets/db95e849-c56f-483e-906e-d35139a1ccc7" />


**After**
<img width="838" height="436" alt="image" src="https://github.com/user-attachments/assets/474d513b-a564-40b8-9a20-e7bb1b35dcbb" />
<img width="850" height="519" alt="image" src="https://github.com/user-attachments/assets/95ab641b-65a1-4854-9eb9-bae5accacf1c" />

<img width="1443" height="444" alt="image" src="https://github.com/user-attachments/assets/2c1b27a0-d71a-4faf-ac32-c5cafd4fe235" />



