### PR TITLE
Caves delayed writes

### DIFF
--- a/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves.cs.patch
+++ b/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves.cs.patch
@@ -1,8 +1,8 @@
 diff --git a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves.cs b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves.cs
-index 30f034d..827cc28 100644
+index 30f034d..3cdcce8 100644
 --- a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves.cs
 +++ b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves.cs
-@@ -12,13 +12,18 @@ namespace Vintagestory.ServerMods
+@@ -12,17 +12,37 @@ namespace Vintagestory.ServerMods
      {
          protected override int chunkRange { get { return 5; } }
  
@@ -11,17 +11,36 @@ index 30f034d..827cc28 100644
 +        // Stratum: plain field, vanilla shape, because mods look it up by name.
 +        // Each worldgen thread gets its own GenCaves, so two columns never share it.
          internal LCGRandom caveRand;
++
++        // Stratum: set once via OnWorldGenBlockAccessor; workers get it copied in StratumCopyStateFrom.
          IWorldGenBlockAccessor worldgenBlockAccessor;
  
 +        // Stratum: one GenCaves per worldgen thread, made on first use.
 +        StratumWorkerInstances<GenCaves> stratumWorkers;
 +
++        // Immutable after initWorldGen(): safe to share between all workers.
          NormalizedSimplexNoise basaltNoise;
          NormalizedSimplexNoise heightvarNoise;
          int regionsize;
  
++        // Stratum start: sparse deferred writes. Instead of snapshotting 32768 ints and
++        // re-encoding the whole subchunk, we buffer (index3d, value) pairs and apply them
++        // with one batched SetBlocksUnsafe per touched subchunk at the end of each
++        // GeneratePartial. Per-instance => per-worker thread-confined. Lists are reused
++        // between calls.
++        List<int>[] stratumPendIdx;
++        List<int>[] stratumPendVal;
++        // Stratum end
++
++        // Stratum: reusable province weights buffer. Per-instance, never shared.
++        float[] stratumIndicesBuf;
++
          public override void StartServerSide(ICoreServerAPI api)
-@@ -30,18 +35,18 @@ namespace Vintagestory.ServerMods
+         {
+             base.StartServerSide(api);
+ 
+             if (TerraGenConfig.DoDecorationPass)
+@@ -30,18 +50,18 @@ namespace Vintagestory.ServerMods
                  api.Event.GetWorldgenBlockAccessor(OnWorldGenBlockAccessor);
  
                  api.ChatCommands.GetOrCreate("dev")
@@ -42,7 +61,7 @@ index 30f034d..827cc28 100644
          }
  
  
-@@ -51,10 +56,38 @@ namespace Vintagestory.ServerMods
+@@ -51,10 +71,44 @@ namespace Vintagestory.ServerMods
              caveRand = new LCGRandom(api.WorldManager.Seed + 123128);
              basaltNoise = NormalizedSimplexNoise.FromDefaultOctaves(2, 1f / 3.5f, 0.9f, api.World.Seed + 12);
              heightvarNoise = NormalizedSimplexNoise.FromDefaultOctaves(3, 1f / 20f, 0.9f, api.World.Seed + 12);
@@ -64,8 +83,8 @@ index 30f034d..827cc28 100644
 +            return worker;
 +        }
 +
-+        // Stratum: the noise fields and the block accessor are set once and never written again, so workers share them.
-+        // caveRand is per-column scratch, so each worker gets its own on the same seed.
++        // Stratum: copy immutable state and the accessor from source to worker.
++        // All mutable scratch (caveRand, pending write lists) is recreated per worker.
 +        protected override void StratumCopyStateFrom(GenPartial source)
 +        {
 +            base.StratumCopyStateFrom(source);
@@ -76,89 +95,364 @@ index 30f034d..827cc28 100644
 +            heightvarNoise = origin.heightvarNoise;
 +            regionsize = origin.regionsize;
 +            caveRand = new LCGRandom(api.WorldManager.Seed + 123128);
++
++            // Stratum start: reset per-worker mutable state.
++            stratumPendIdx = null;
++            stratumPendVal = null;
++            stratumIndicesBuf = null;
++            // Stratum end
          }
  
  
          private void OnMapChunkGen(IMapChunk mapChunk, int chunkX, int chunkZ)
          {
-@@ -74,19 +107,25 @@ namespace Vintagestory.ServerMods
+@@ -72,68 +126,96 @@ namespace Vintagestory.ServerMods
+                     mapChunk.CaveHeightDistort[dz * chunksize + dx] = (byte)(128 * val + 127);
+                 }
              }
          }
  
++        // Stratum: prevents two concurrent command invocations from racing each other.
++        private static readonly object cmdLock = new object();
++
          private TextCommandResult CmdCaveGenTest(TextCommandCallingArgs args)
          {
 -            caveRand = new LCGRandom(api.WorldManager.Seed + 123128);
 -            initWorldGen();
-+            initWorldGen(); // Stratum: this already reseeds caveRand with the same formula, no need to do it twice
++            // Stratum: do NOT call initWorldGen() here — it would rebuild stratumWorkers and
++            // noise fields while worldgen threads may already be reading them. The command runs
++            // on a dedicated thread-confined copy instead, leaving all shared state untouched.
++            if (heightvarNoise == null)
++            {
++                return TextCommandResult.Error("Worldgen is not initialized yet.");
++            }
  
-+            // Stratum start:
-+            // Adding light recalculation for caves
-+            // The cave generation command now works based on the player's coordinates.
++            lock (cmdLock)
++            {
++                // Stratum start:
++                // Adding light recalculation for caves
++                // The cave generation command now works based on the player's coordinates.
  
-+            // replace the air block with granite to generate inverted caves
-             airBlockId = api.World.GetBlock(new AssetLocation("rock-granite")).BlockId;
+-            airBlockId = api.World.GetBlock(new AssetLocation("rock-granite")).BlockId;
++                // Dedicated instance for this command invocation: all mutable state (airBlockId,
++                // caveRand, chunkRand, pending write lists) stays confined to the calling thread.
++                GenCaves cmd = new GenCaves();
++                cmd.StratumCopyStateFrom(this);
  
 -            int baseChunkX = api.World.BlockAccessor.MapSizeX / 2 / chunksize;
 -            int baseChunkZ = api.World.BlockAccessor.MapSizeZ / 2 / chunksize;
-+            // take the player as the center
-+            var player = args.Caller.Player as IServerPlayer;
-+            int baseChunkX = (int)player.Entity.Pos.X / chunksize;
-+            int baseChunkZ = (int)player.Entity.Pos.Z / chunksize;
++                // replace the air block with granite to generate inverted caves
++                cmd.airBlockId = api.World.GetBlock(new AssetLocation("rock-granite")).BlockId;
  
-+            // first check that all chunks are loaded
-             for (int dx = -5; dx <= 5; dx++)
-             {
-                 for (int dz = -5; dz <= 5; dz++)
+-            for (int dx = -5; dx <= 5; dx++)
+-            {
+-                for (int dz = -5; dz <= 5; dz++)
++                // take the player as the center
++                var player = args.Caller.Player as IServerPlayer;
++                int baseChunkX = (int)player.Entity.Pos.X / chunksize;
++                int baseChunkZ = (int)player.Entity.Pos.Z / chunksize;
++
++                // first check that all chunks are loaded
++                for (int dx = -5; dx <= 5; dx++)
                  {
-                     int chunkX = baseChunkX + dx;
-@@ -96,19 +135,19 @@ namespace Vintagestory.ServerMods
+-                    int chunkX = baseChunkX + dx;
+-                    int chunkZ = baseChunkZ + dz;
++                    for (int dz = -5; dz <= 5; dz++)
++                    {
++                        int chunkX = baseChunkX + dx;
++                        int chunkZ = baseChunkZ + dz;
  
-                     for (int i = 0; i < chunks.Length; i++)
-                     {
-                         if (chunks[i] == null)
+-                    IServerChunk[] chunks = GetChunkColumn(chunkX, chunkZ);
++                        IServerChunk[] chunks = GetChunkColumn(chunkX, chunkZ);
+ 
+-                    for (int i = 0; i < chunks.Length; i++)
+-                    {
+-                        if (chunks[i] == null)
++                        for (int i = 0; i < chunks.Length; i++)
                          {
 -                            return TextCommandResult.Success( "Cannot generate 10x10 area of caves, chunks are not loaded that far yet.");
-+                            return TextCommandResult.Success("Cannot generate 10x10 area of caves, chunks are not loaded that far yet.");
++                            if (chunks[i] == null)
++                            {
++                                return TextCommandResult.Success("Cannot generate 10x10 area of caves, chunks are not loaded that far yet.");
++                            }
                          }
-                     }
+-                    }
  
-                     OnMapChunkGen(chunks[0].MapChunk, chunkX, chunkZ);
+-                    OnMapChunkGen(chunks[0].MapChunk, chunkX, chunkZ);
++                        cmd.OnMapChunkGen(chunks[0].MapChunk, chunkX, chunkZ);
++                    }
                  }
-             }
+-            }
  
 -
-+            // clear all chunks and start cave generation
-             for (int dx = -5; dx <= 5; dx++)
-             {
-                 for (int dz = -5; dz <= 5; dz++)
+-            for (int dx = -5; dx <= 5; dx++)
+-            {
+-                for (int dz = -5; dz <= 5; dz++)
++                // clear all chunks and start cave generation
++                for (int dx = -5; dx <= 5; dx++)
                  {
-                     int chunkX = baseChunkX + dx;
-@@ -125,15 +164,24 @@ namespace Vintagestory.ServerMods
-                             chunkRand.InitPositionSeed(chunkX + gdx, chunkZ + gdz);
-                             GeneratePartial(chunks, chunkX, chunkZ, gdx, gdz);
+-                    int chunkX = baseChunkX + dx;
+-                    int chunkZ = baseChunkZ + dz;
+-
+-                    IServerChunk[] chunks = GetChunkColumn(chunkX, chunkZ);
+-                    ClearChunkColumn(chunks);
++                    for (int dz = -5; dz <= 5; dz++)
++                    {
++                        int chunkX = baseChunkX + dx;
++                        int chunkZ = baseChunkZ + dz;
+ 
++                        IServerChunk[] chunks = GetChunkColumn(chunkX, chunkZ);
++                        ClearChunkColumn(chunks);
+ 
+-                    for (int gdx = -chunkRange; gdx <= chunkRange; gdx++)
+-                    {
+-                        for (int gdz = -chunkRange; gdz <= chunkRange; gdz++)
++                        for (int gdx = -chunkRange; gdx <= chunkRange; gdx++)
+                         {
+-                            chunkRand.InitPositionSeed(chunkX + gdx, chunkZ + gdz);
+-                            GeneratePartial(chunks, chunkX, chunkZ, gdx, gdz);
++                            for (int gdz = -chunkRange; gdz <= chunkRange; gdz++)
++                            {
++                                cmd.chunkRand.InitPositionSeed(chunkX + gdx, chunkZ + gdz);
++                                cmd.GeneratePartial(chunks, chunkX, chunkZ, gdx, gdz);
++                            }
                          }
-                     }
+-                    }
  
-+                    // Run lighting recalculation (like in GenLightSurvival)
-+                    worldgenBlockAccessor.BeginColumn();
-+                    api.WorldManager.SunFloodChunkColumnForWorldGen(chunks, chunkX, chunkZ);
-+                    worldgenBlockAccessor.RunScheduledBlockLightUpdates(chunkX, chunkZ);
+-                    MarkDirty(chunkX, chunkZ, chunks);
++                        // Run lighting recalculation (like in GenLightSurvival)
++                        cmd.worldgenBlockAccessor.BeginColumn();
++                        api.WorldManager.SunFloodChunkColumnForWorldGen(chunks, chunkX, chunkZ);
++                        cmd.worldgenBlockAccessor.RunScheduledBlockLightUpdates(chunkX, chunkZ);
 +
-+
-                     MarkDirty(chunkX, chunkZ, chunks);
++                        MarkDirty(chunkX, chunkZ, chunks);
++                    }
                  }
-             }
+-            }
  
-+
-+            // restore the air block id back
-             airBlockId = 0;
-+            // Stratum end
+-            airBlockId = 0;
++                // no need to restore airBlockId: it lived on the local copy only
++                // Stratum end
++            }
  
              return TextCommandResult.Success("Generated and chunks force resend flags set");
          }
  
          private IServerChunk[] GetChunkColumn(int chunkX, int chunkZ)
-@@ -506,160 +554,225 @@ namespace Vintagestory.ServerMods
+@@ -148,11 +230,12 @@ namespace Vintagestory.ServerMods
+             return chunks;
+         }
+ 
+         private void MarkDirty(int chunkX, int chunkZ, IServerChunk[] chunks)
+         {
+-            for (int chunkY = 0; chunkY < chunks.Length; chunkY++) {
++            for (int chunkY = 0; chunkY < chunks.Length; chunkY++)
++            {
+                 chunks[chunkY].MarkModified();
+                 api.WorldManager.BroadcastChunk(chunkX, chunkY, chunkZ, true);
+             }
+         }
+ 
+@@ -183,11 +266,15 @@ namespace Vintagestory.ServerMods
+                 return;
+             }
+ 
+             worldgenBlockAccessor.BeginColumn();
+             LCGRandom chunkRand = this.chunkRand;
+-            int quantityCaves = chunkRand.NextInt(100) < TerraGenConfig.CavesPerChunkColumn*100 ? 1 : 0;
++            int quantityCaves = chunkRand.NextInt(100) < TerraGenConfig.CavesPerChunkColumn * 100 ? 1 : 0;
++
++            // Stratum start: clear pending-write buffers. No copying, no allocations.
++            StratumBeginColumn(chunks.Length);
++            // Stratum end
+ 
+             int rndSize = chunksize * chunksize * (worldheight - 20);
+             while (quantityCaves-- > 0)
+             {
+                 int rnd = chunkRand.NextInt(rndSize);
+@@ -229,11 +316,88 @@ namespace Vintagestory.ServerMods
+ 
+                 caveRand.SetWorldSeed(chunkRand.NextInt(10000000));
+                 caveRand.InitPositionSeed(chunkX + cdx, chunkZ + cdz);
+                 CarveTunnel(chunks, chunkX, chunkZ, posX, posY, posZ, horAngle, vertAngle, horizontalSize, verticalSize, 0, maxIterations, 0, extraBranchy, curviness, largeNearLavaLayer);
+             }
++
++            // Stratum start: apply buffered writes; one batched lock per touched subchunk.
++            StratumFlushPendingWrites(chunks);
++            // Stratum end
++        }
++
++        // Stratum start: (re)allocates the pending-write lists to match this column's chunk
++        // count and clears them. Cheap no-op after the first call for a given worker.
++        private void StratumBeginColumn(int numSubchunks)
++        {
++            if (stratumPendIdx == null || stratumPendIdx.Length != numSubchunks)
++            {
++                stratumPendIdx = new List<int>[numSubchunks];
++                stratumPendVal = new List<int>[numSubchunks];
++                for (int i = 0; i < numSubchunks; i++)
++                {
++                    stratumPendIdx[i] = new List<int>(1024);
++                    stratumPendVal[i] = new List<int>(1024);
++                }
++                return;
++            }
++            for (int i = 0; i < numSubchunks; i++)
++            {
++                stratumPendIdx[i].Clear();
++                stratumPendVal[i].Clear();
++            }
++        }
++
++        // Stratum start: buffer one block write; applied at the end of GeneratePartial.
++        private void StratumAppend(int chunkY, int index3D, int value)
++        {
++            stratumPendIdx[chunkY].Add(index3D);
++            stratumPendVal[chunkY].Add(value);
++        }
++
++        // Stratum start: one bulk write per touched subchunk; untouched ones cost nothing.
++        // Pairs are applied sequentially, so duplicate writes to the same cell fold into
++        // last-write-wins automatically.
++        private void StratumFlushPendingWrites(IServerChunk[] chunks)
++        {
++            for (int cy = 0; cy < stratumPendIdx.Length; cy++)
++            {
++                List<int> idx = stratumPendIdx[cy];
++                List<int> val = stratumPendVal[cy];
++                if (idx.Count == 0) continue;
++
++                IChunkBlocks data = chunks[cy].Data;
++
++                // Stratum: SetManyUnsafe is a fast path that assumes an initialized layer
++                // (palette + bit planes). A never-written subchunk (empty sky, or cleared
++                // by the dev command) has no palette and would NRE inside SetUnsafeCore.
++                // ClearBlocksAndPrepare() initializes palette/planes without destroying
++                // the fluids/light layers.
++                if (!data.HasBlocksLayer)
++                {
++                    // Writing air into a subchunk that never had blocks changes nothing: skip.
++                    bool anyNonZero = false;
++                    for (int i = 0; i < val.Count; i++)
++                    {
++                        if (val[i] != 0) { anyNonZero = true; break; }
++                    }
++                    if (!anyNonZero)
++                    {
++                        idx.Clear();
++                        val.Clear();
++                        continue;
++                    }
++
++                    // Real blocks into an empty subchunk: initialize palette lazily.
++                    data.ClearBlocksAndPrepare();
++                }
++
++                data.SetBlocksUnsafe(idx, val);
++                idx.Clear();
++                val.Clear();
++            }
+         }
++        // Stratum end
+ 
+         private void CarveTunnel(IServerChunk[] chunks, int chunkX, int chunkZ, double posX, double posY, double posZ, float horAngle, float vertAngle, float horizontalSize, float verticalSize, int currentIteration, int maxIterations, int branchLevel, bool extraBranchy = false, float curviness = 0.1f, bool largeNearLavaLayer = false)
+         {
+             LCGRandom caveRand = this.caveRand;
+ 
+@@ -289,14 +453,14 @@ namespace Vintagestory.ServerMods
+                 vertAngle *= 0.8f;
+ 
+                 int rrnd = caveRand.NextInt(800000);
+                 if (rrnd / 10000 == 0)   // chance 1/80
+                 {
+-                    sizeChangeSpeedGain = (caveRand.NextFloat() * caveRand.NextFloat())/2;
++                    sizeChangeSpeedGain = (caveRand.NextFloat() * caveRand.NextFloat()) / 2;
+                 }
+ 
+-                bool genHotSpring=false;
++                bool genHotSpring = false;
+ 
+                 int rnd = rrnd % 10000; // Calls to caveRand are not too cheap, so lets just use one for all those random variation changes
+                 // 1/330 * 10k = 30
+                 // 1/130 * 10k = 76
+                 // 1/100 * 10k = 100
+@@ -305,48 +469,55 @@ namespace Vintagestory.ServerMods
+ 
+                 // Rarely change direction
+                 if ((rnd -= 30) <= 0)
+                 {
+                     horAngle = caveRand.NextFloat() * GameMath.TWOPI;
+-                } else
++                }
++                else
+                 // Rarely change direction somewhat
+                 if ((rnd -= 76) <= 0)
+                 {
+                     horAngle += caveRand.NextFloat() * GameMath.PI - GameMath.PIHALF;
+-                } else
++                }
++                else
+                 // Rarely go pretty wide
+                 if ((rnd -= 60) <= 0)
+                 {
+                     horRadiusGain = caveRand.NextFloat() * caveRand.NextFloat() * 3.5f;
+-                } else
++                }
++                else
+                 // Rarely go thin
+                 if ((rnd -= 60) <= 0)
+                 {
+                     horRadiusLoss = caveRand.NextFloat() * caveRand.NextFloat() * 10;
+-                } else
++                }
++                else
+                 // Rarely go flat
+                 if ((rnd -= 50) <= 0)
+                 {
+                     if (posY < TerraGenConfig.seaLevel - 10)
+                     {
+                         verHeightLoss = caveRand.NextFloat() * caveRand.NextFloat() * 12f;
+                         horRadiusGain = Math.Max(horRadiusGain, caveRand.NextFloat() * caveRand.NextFloat() * 3f);
+                     }
+-                } else
++                }
++                else
+                 // Very rarely go really wide
+                 if ((rnd -= 9) <= 0)
+                 {
+                     if (posY < TerraGenConfig.seaLevel - 20)
+                     {
+                         horRadiusGain = 1 + caveRand.NextFloat() * caveRand.NextFloat() * 5f;
+                     }
+-                } else
++                }
++                else
+                 // Very rarely go really tall
+                 if ((rnd -= 9) <= 0)
+                 {
+                     verHeightGain = 2 + caveRand.NextFloat() * caveRand.NextFloat() * 7;
+-                } else
++                }
++                else
+                 // Rarely large lava caverns
+                 if ((rnd -= 100) <= 0)
+                 {
+                     if (posY < 19)
+                     {
+@@ -418,11 +589,11 @@ namespace Vintagestory.ServerMods
+                         horAngle + (caveRand.NextFloat() + caveRand.NextFloat() - 1) + GameMath.PI,
+                         -GameMath.PI / 2 - 0.1f + 0.2f * caveRand.NextFloat(),
+                         Math.Min(3.5f, horRadius - 1),
+                         verticalSize + verHeightGainAccum,
+                         currentIteration,
+-                        maxIterations - (int)(caveRand.NextFloat() * 0.5 * maxIterations) + (int)((posY/5) * (0.5f + 0.5f * caveRand.NextFloat())),
++                        maxIterations - (int)(caveRand.NextFloat() * 0.5 * maxIterations) + (int)((posY / 5) * (0.5f + 0.5f * caveRand.NextFloat())),
+                         branchLevel
+                     );
+ 
+                     branchLevel++;
+                 }
+@@ -506,155 +677,220 @@ namespace Vintagestory.ServerMods
  
  
  
@@ -169,11 +463,7 @@ index 30f034d..827cc28 100644
 -            // One extra size for checking if we run into water
 -            horRadius++;
 -            vertRadius+=2;
-+            // Stratum start:
-+            // Fixing incorrect cave generation in the /dev gencaves command mode
-+            // We sped up the algorithm, filtered out blocks that weren't within the ellipsoid's dimensions,
-+            // and checked for liquid in the same cycle as everything else.
- 
+-
 -            int mindx = (int)GameMath.Clamp(centerX - horRadius, 0, chunksize - 1);
 -            int maxdx = (int)GameMath.Clamp(centerX + horRadius + 1, 0, chunksize - 1);
 -            int mindy = (int)GameMath.Clamp(centerY - vertRadius * 0.7f, 1, worldheight - 1);
@@ -214,8 +504,10 @@ index 30f034d..827cc28 100644
 -                    }
 -                }
 -            }
-+            // Testing on 10,200 generation chunks:
-+            // Total method execution time: decreased from 9.2 s to 6.3 s;
++            // Stratum start:
++            // Fixing incorrect cave generation in the /dev gencaves command mode
++            // We sped up the algorithm, filtered out blocks that weren't within the ellipsoid's dimensions,
++            // and checked for liquid in the same cycle as everything else.
  
 +            IMapChunk mapchunk = chunks[0].MapChunk;
  
@@ -332,15 +624,18 @@ index 30f034d..827cc28 100644
 +                        if (dxSq / checkHorRadiusSq + checkYDistSq + dzSq / checkHorRadiusSq <= 1.0)
                          {
 -                            if (basaltNoise.Noise(chunkX * chunksize + lx, chunkZ * chunksize + lz) > 0.65)
--                            {
++                            // Fluid check — reads from live chunk data.
++                            // Correctness: caves only modify the blocks layer (air/basalt/lava),
++                            // never the fluids layer, so deferred block writes do not affect
++                            // fluid state visibility.
++                            if (!hasLiquidInCheckRadius && y >= 1 && y < worldheight)
+                             {
 -                                chunkBlockData[index3d] = gcfg.basaltBlockId;
 -                                terrainheightmap[lz * chunksize + lx] = Math.Max(terrainheightmap[lz * chunksize + lx], (ushort)11);
 -                                rainheightmap[lz * chunksize + lx] = Math.Max(rainheightmap[lz * chunksize + lx], (ushort)11);
 -                            }
 -                            else
-+                            // Fluid check
-+                            if (!hasLiquidInCheckRadius && y >= 1 && y < worldheight)
-                             {
+-                            {
 -                                chunkBlockData[index3d] = 0;
 -                                if (y > yLavaStart)
 +                                int chunkY = y / chunksize;
@@ -399,7 +694,9 @@ index 30f034d..827cc28 100644
 +                            int genMindy = (int)Math.Max(mindy, centerY - maxGenYDist);
 +                            int genMaxdy = (int)Math.Min(maxdy, centerY + maxGenYDist);
 +
-+                            // Generate blocks in the column
++                            // Generate blocks in the column — Stratum: writes are buffered as
++                            // (index3d, value) pairs and applied once per subchunk at the end of
++                            // GeneratePartial via SetBlocksUnsafe (one lock per batch).
 +                            for (int y = genMaxdy; y >= genMindy; y--)
                              {
 -                                chunkBlockData.SetFluid(index3d, gcfg.lavaBlockId);
@@ -413,7 +710,7 @@ index 30f034d..827cc28 100644
 +
 +                                if (y > worldheight - 1) continue;
 +
-+                                // Update heightmaps
++                                // Update heightmaps — these are local arrays, unchanged by Stratum pattern.
 +                                if (surfaceY == y)
 +                                {
 +                                    terrainheightmap[idx2d] = (ushort)(y - 1);
@@ -422,15 +719,13 @@ index 30f034d..827cc28 100644
 +
 +                                int chunkY = y / chunksize;
 +                                int localY = y % chunksize;
-+                                IChunkBlocks chunkBlockData = chunks[chunkY].Data;
-+                                int index3d = localY * chunksizeSq + idx2d;
++                                int index3D = (localY * chunksize + lz) * chunksize + lx;
 +
-+                                // Set block
 +                                if (y == 11)
 +                                {
 +                                    if (basaltNoise.Noise(chunkX * chunksize + lx, chunkZ * chunksize + lz) > 0.65)
 +                                    {
-+                                        chunkBlockData[index3d] = gcfg.basaltBlockId;
++                                        StratumAppend(chunkY, index3D, gcfg.basaltBlockId);
 +                                        terrainheightmap[idx2d] = Math.Max(terrainheightmap[idx2d], (ushort)11);
 +                                        rainheightmap[idx2d] = Math.Max(rainheightmap[idx2d], (ushort)11);
 +                                    }
@@ -438,11 +733,12 @@ index 30f034d..827cc28 100644
 +                                    {
 +                                        if (y > yLavaStart)
 +                                        {
-+                                            chunkBlockData[index3d] = gcfg.basaltBlockId;
++                                            StratumAppend(chunkY, index3D, gcfg.basaltBlockId);
 +                                        }
 +                                        else
 +                                        {
-+                                            chunkBlockData.SetFluid(index3d, gcfg.lavaBlockId);
++                                            // Stratum: fluids are NOT buffered — they remain live.
++                                            chunks[chunkY].Data.SetFluid(index3D, gcfg.lavaBlockId);
 +                                        }
 +
 +                                        if (y <= yLavaStart)
@@ -455,17 +751,18 @@ index 30f034d..827cc28 100644
 +                                {
 +                                    if (y > yLavaStart)
 +                                    {
-+                                        chunkBlockData[index3d] = gcfg.basaltBlockId;
++                                        StratumAppend(chunkY, index3D, gcfg.basaltBlockId);
 +                                    }
 +                                    else
 +                                    {
-+                                        chunkBlockData.SetFluid(index3d, gcfg.lavaBlockId);
++                                        chunks[chunkY].Data.SetFluid(index3D, gcfg.lavaBlockId);
 +                                    }
 +                                }
 +                                else
 +                                {
-+                                    chunkBlockData[index3d] = airBlockId != 0 ? (ushort)airBlockId : (ushort)0;
++                                    StratumAppend(chunkY, index3D, airBlockId != 0 ? airBlockId : 0);
 +                                }
++                                // Stratum end
                              }
                          }
 -                        else
@@ -477,10 +774,3 @@ index 30f034d..827cc28 100644
              }
  
              return true;
-+
-+            // Stratum end
-         }
- 
-         private int getGeologicActivity(int posx, int posz)
-         {
-             var climateMap = worldgenBlockAccessor.GetMapRegion(posx / regionsize, posz / regionsize)?.ClimateMap;

--- a/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves.cs.patch
+++ b/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves.cs.patch
@@ -1,8 +1,8 @@
 diff --git a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves.cs b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves.cs
-index 30f034d..90dcf8e 100644
+index 30f034d..3a7bbf3 100644
 --- a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves.cs
 +++ b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves.cs
-@@ -10,19 +10,55 @@ namespace Vintagestory.ServerMods
+@@ -10,19 +10,54 @@ namespace Vintagestory.ServerMods
  {
      public class GenCaves : GenPartial
      {
@@ -45,20 +45,19 @@ index 30f034d..90dcf8e 100644
 +        // Stratum: reusable province weights buffer. Per-instance, never shared.
 +        float[] stratumIndicesBuf;
 +
-+        // Stratum start: buffer light updates to flush them at the end of GeneratePartial.
-+        // ScheduleBlockLightUpdate is now thread-safe (protected by lightUpdatesLock inside
-+        // BlockAccessorWorldGen), so we don't need external locking here.
-+        List<BlockPos> stratumPendLightPos;
-+        List<int> stratumPendLightOld;
-+        List<int> stratumPendLightNew;
-+        // Stratum end
++        // Stratum start: buffered lava light updates for this column, packed exactly in
++        // the storage format (Vec4i = xyz + newBlockId). Old block id is not used by
++        // BlockAccessorWorldGen, so it is not buffered. Flushed in one batched call at
++        // the end of GeneratePartial.
++        List<Vec4i> stratumPendLight;
++        // Stratum end   
 +
          public override void StartServerSide(ICoreServerAPI api)
          {
              base.StartServerSide(api);
  
              if (TerraGenConfig.DoDecorationPass)
-@@ -30,33 +66,65 @@ namespace Vintagestory.ServerMods
+@@ -30,33 +65,63 @@ namespace Vintagestory.ServerMods
                  api.Event.GetWorldgenBlockAccessor(OnWorldGenBlockAccessor);
  
                  api.ChatCommands.GetOrCreate("dev")
@@ -117,9 +116,7 @@ index 30f034d..90dcf8e 100644
 +            stratumPendIdx = null;
 +            stratumPendVal = null;
 +            stratumIndicesBuf = null;
-+            stratumPendLightPos = null;
-+            stratumPendLightOld = null;
-+            stratumPendLightNew = null;
++            stratumPendLight = null;
 +            // Stratum end
 +        }
  
@@ -127,7 +124,7 @@ index 30f034d..90dcf8e 100644
          {
              if (heightvarNoise == null) return;
  
-@@ -72,70 +140,85 @@ namespace Vintagestory.ServerMods
+@@ -72,70 +137,85 @@ namespace Vintagestory.ServerMods
                      mapChunk.CaveHeightDistort[dz * chunksize + dx] = (byte)(128 * val + 127);
                  }
              }
@@ -251,7 +248,7 @@ index 30f034d..90dcf8e 100644
          private IServerChunk[] GetChunkColumn(int chunkX, int chunkZ)
          {
              int size = api.World.BlockAccessor.MapSizeY / chunksize;
-@@ -148,11 +231,12 @@ namespace Vintagestory.ServerMods
+@@ -148,11 +228,12 @@ namespace Vintagestory.ServerMods
              return chunks;
          }
  
@@ -265,7 +262,7 @@ index 30f034d..90dcf8e 100644
              }
          }
  
-@@ -181,13 +265,16 @@ namespace Vintagestory.ServerMods
+@@ -181,13 +262,16 @@ namespace Vintagestory.ServerMods
              if (GetIntersectingStructure(chunkX * chunksize + chunksize / 2, chunkZ * chunksize + chunksize / 2, CavesHashCode) != null)
              {
                  return;
@@ -284,7 +281,7 @@ index 30f034d..90dcf8e 100644
              while (quantityCaves-- > 0)
              {
                  int rnd = chunkRand.NextInt(rndSize);
-@@ -201,38 +288,115 @@ namespace Vintagestory.ServerMods
+@@ -201,38 +285,108 @@ namespace Vintagestory.ServerMods
                  float vertAngle = (chunkRand.NextFloat() - 0.5f) * 0.25f;
                  float horizontalSize = chunkRand.NextFloat() * 2 + chunkRand.NextFloat();
                  float verticalSize = 0.75f + chunkRand.NextFloat() * 0.4f;
@@ -330,17 +327,13 @@ index 30f034d..90dcf8e 100644
 +            // Stratum start: apply buffered writes; one batched lock per touched subchunk.
 +            StratumFlushPendingWrites(chunks);
 +
-+            // Stratum: flush buffered light updates. ScheduleBlockLightUpdate is now
-+            // thread-safe (protected by lightUpdatesLock inside BlockAccessorWorldGen),
-+            // so we can call it directly without external locking.
-+            if (stratumPendLightPos != null && stratumPendLightPos.Count > 0)
++            if (stratumPendLight != null && stratumPendLight.Count > 0)
 +            {
-+                for (int i = 0; i < stratumPendLightPos.Count; i++)
-+                {
-+                    worldgenBlockAccessor.ScheduleBlockLightUpdate(stratumPendLightPos[i], stratumPendLightOld[i], stratumPendLightNew[i]);
-+                }
++                // Stratum: ownership of the batch transfers to the map chunk (lock-free
++                // push). Never touch this list again.
++                worldgenBlockAccessor.ScheduleBlockLightUpdates(chunkX, chunkZ, stratumPendLight);
++                stratumPendLight = null;
 +            }
-+            // Stratum end
 +        }
 +
 +        private void StratumBeginColumn(int numSubchunks)
@@ -354,9 +347,6 @@ index 30f034d..90dcf8e 100644
 +                    stratumPendIdx[i] = new List<int>(1024);
 +                    stratumPendVal[i] = new List<int>(1024);
 +                }
-+                stratumPendLightPos = new List<BlockPos>(256);
-+                stratumPendLightOld = new List<int>(256);
-+                stratumPendLightNew = new List<int>(256);
 +                return;
 +            }
 +            for (int i = 0; i < numSubchunks; i++)
@@ -364,12 +354,12 @@ index 30f034d..90dcf8e 100644
 +                stratumPendIdx[i].Clear();
 +                stratumPendVal[i].Clear();
 +            }
-+            if (stratumPendLightPos != null)
-+            {
-+                stratumPendLightPos.Clear();
-+                stratumPendLightOld.Clear();
-+                stratumPendLightNew.Clear();
-+            }
++            // Stratum: the previous batch may have been handed over to the chunk.
++            if (stratumPendLight == null)
++                stratumPendLight = new List<Vec4i>(256);
++            else
++                stratumPendLight.Clear();
++
 +        }
 +
 +        private void StratumAppend(int chunkY, int index3D, int value)
@@ -408,7 +398,7 @@ index 30f034d..90dcf8e 100644
          private void CarveTunnel(IServerChunk[] chunks, int chunkX, int chunkZ, double posX, double posY, double posZ, float horAngle, float vertAngle, float horizontalSize, float verticalSize, int currentIteration, int maxIterations, int branchLevel, bool extraBranchy = false, float curviness = 0.1f, bool largeNearLavaLayer = false)
          {
              LCGRandom caveRand = this.caveRand;
-@@ -264,17 +428,16 @@ namespace Vintagestory.ServerMods
+@@ -264,17 +418,16 @@ namespace Vintagestory.ServerMods
                  relPos = (float)currentIteration / maxIterations;
  
                  float horRadius = 1.5f + GameMath.FastSin(relPos * GameMath.PI) * horizontalSize + horRadiusGainAccum;
@@ -427,7 +417,7 @@ index 30f034d..90dcf8e 100644
                      float factor = 1f + Math.Max(0f, 1f - (float)Math.Abs(posY - 12d) / 10f);
                      horRadius *= factor;
                      vertRadius *= factor;
-@@ -287,67 +450,61 @@ namespace Vintagestory.ServerMods
+@@ -287,67 +440,61 @@ namespace Vintagestory.ServerMods
                  posZ += GameMath.FastSin(horAngle) * advanceHor;
  
                  vertAngle *= 0.8f;
@@ -513,7 +503,7 @@ index 30f034d..90dcf8e 100644
                      if (posY < 19)
                      {
                          verHeightGain = 2 + caveRand.NextFloat() * caveRand.NextFloat() * 5;
-@@ -376,22 +533,19 @@ namespace Vintagestory.ServerMods
+@@ -376,22 +523,19 @@ namespace Vintagestory.ServerMods
                  verHeightLoss -= 0.4f;
  
                  horAngle += curviness * horAngleChange;
@@ -537,7 +527,7 @@ index 30f034d..90dcf8e 100644
                      CarveTunnel(
                          chunks,
                          chunkX,
-@@ -405,11 +559,10 @@ namespace Vintagestory.ServerMods
+@@ -405,11 +549,10 @@ namespace Vintagestory.ServerMods
                          maxIterations - (int)(caveRand.NextFloat() * 0.5 * maxIterations),
                          branchLevel + 1
                      );
@@ -549,7 +539,7 @@ index 30f034d..90dcf8e 100644
                      CarveShaft(
                          chunks,
                          chunkX,
-@@ -418,31 +571,25 @@ namespace Vintagestory.ServerMods
+@@ -418,31 +561,25 @@ namespace Vintagestory.ServerMods
                          horAngle + (caveRand.NextFloat() + caveRand.NextFloat() - 1) + GameMath.PI,
                          -GameMath.PI / 2 - 0.1f + 0.2f * caveRand.NextFloat(),
                          Math.Min(3.5f, horRadius - 1),
@@ -582,7 +572,7 @@ index 30f034d..90dcf8e 100644
              float vertAngleChange = 0;
  
              ushort[] terrainheightmap = chunks[0].MapChunk.WorldGenTerrainHeightMap;
-@@ -468,11 +615,10 @@ namespace Vintagestory.ServerMods
+@@ -468,11 +605,10 @@ namespace Vintagestory.ServerMods
                  posZ += GameMath.FastSin(horAngle) * advanceHor;
  
                  vertAngle += 0.1f * vertAngleChange;
@@ -594,7 +584,7 @@ index 30f034d..90dcf8e 100644
                      int num = 3 + caveRand.NextInt(4);
                      for (int i = 0; i < num; i++)
                      {
-@@ -493,168 +639,198 @@ namespace Vintagestory.ServerMods
+@@ -493,168 +629,196 @@ namespace Vintagestory.ServerMods
                      return;
                  }
  
@@ -660,26 +650,26 @@ index 30f034d..90dcf8e 100644
 -                }
 -            }
 -
-+            float genHorRadius = horRadius;
-+            float genVertRadius = vertRadius;
- 
+-
 -            horRadius--;
 -            vertRadius-=2;
-+            float checkHorRadius = horRadius + 1;
-+            float checkVertRadius = vertRadius + 2;
++            float genHorRadius = horRadius;
++            float genVertRadius = vertRadius;
  
 -            mindx = (int)GameMath.Clamp(centerX - horRadius, 0, chunksize - 1);
 -            maxdx = (int)GameMath.Clamp(centerX + horRadius + 1, 0, chunksize - 1);
 -            mindz = (int)GameMath.Clamp(centerZ - horRadius, 0, chunksize - 1);
 -            maxdz = (int)GameMath.Clamp(centerZ + horRadius + 1, 0, chunksize - 1);
++            float checkHorRadius = horRadius + 1;
++            float checkVertRadius = vertRadius + 2;
+ 
+-            mindy = (int)GameMath.Clamp(centerY - vertRadius * 0.7f, 1, worldheight - 1);
+-            maxdy = (int)GameMath.Clamp(centerY + vertRadius + 1, 1, worldheight - 1);
 +            int mindx = (int)GameMath.Clamp(centerX - checkHorRadius, 0, chunksize - 1);
 +            int maxdx = (int)GameMath.Clamp(centerX + checkHorRadius + 1, 0, chunksize - 1);
 +            int mindz = (int)GameMath.Clamp(centerZ - checkHorRadius, 0, chunksize - 1);
 +            int maxdz = (int)GameMath.Clamp(centerZ + checkHorRadius + 1, 0, chunksize - 1);
  
--            mindy = (int)GameMath.Clamp(centerY - vertRadius * 0.7f, 1, worldheight - 1);
--            maxdy = (int)GameMath.Clamp(centerY + vertRadius + 1, 1, worldheight - 1);
--
 -            hRadiusSq = horRadius * horRadius;
 -            vRadiusSq = vertRadius * vertRadius;
 +            int mindy = (int)GameMath.Clamp(centerY - checkVertRadius * 0.7f, 1, worldheight - 1);
@@ -770,14 +760,14 @@ index 30f034d..90dcf8e 100644
                              {
 -                                chunkBlockData[index3d] = 0;
 -                                if (y > yLavaStart)
--                                {
--                                    chunkBlockData[index3d] = gcfg.basaltBlockId;
--                                } else
 +                                int chunkY = y / chunksize;
 +                                int localY = y % chunksize;
 +                                var block = api.World.Blocks[chunks[chunkY].Data.GetFluid((localY * chunksize + lz) * chunksize + lx)];
 +                                if (block.LiquidCode != null)
                                  {
+-                                    chunkBlockData[index3d] = gcfg.basaltBlockId;
+-                                } else
+-                                {
 -                                    chunkBlockData.SetFluid(index3d, gcfg.lavaBlockId);
 +                                    return false;
                                  }
@@ -865,11 +855,9 @@ index 30f034d..90dcf8e 100644
 +
 +                                        if (y <= yLavaStart)
 +                                        {
-+                                            // Stratum: buffer light updates to flush them at the end of GeneratePartial.
-+                                            // ScheduleBlockLightUpdate is now thread-safe, so we just collect updates here.
-+                                            stratumPendLightPos.Add(new BlockPos(chunkX * chunksize + lx, y, chunkZ * chunksize + lz));
-+                                            stratumPendLightOld.Add(airBlockId);
-+                                            stratumPendLightNew.Add(gcfg.lavaBlockId);
++                                            // Stratum: buffer as Vec4i (storage format); flushed in one
++                                            // batched, single-lock call at the end of GeneratePartial.
++                                            stratumPendLight.Add(new Vec4i(new BlockPos(chunkX * chunksize + lx, y, chunkZ * chunksize + lz), gcfg.lavaBlockId));
 +                                        }
 +                                    }
 +                                }
@@ -899,7 +887,7 @@ index 30f034d..90dcf8e 100644
              }
  
              return true;
-@@ -669,8 +845,7 @@ namespace Vintagestory.ServerMods
+@@ -669,8 +833,7 @@ namespace Vintagestory.ServerMods
              int rlX = (posx / chunksize) % regionChunkSize;
              int rlZ = (posz / chunksize) % regionChunkSize;
  

--- a/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves.cs.patch
+++ b/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves.cs.patch
@@ -1,8 +1,8 @@
 diff --git a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves.cs b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves.cs
-index 30f034d..0583e33 100644
+index 30f034d..47dc4ad 100644
 --- a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves.cs
 +++ b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves.cs
-@@ -10,19 +10,47 @@ namespace Vintagestory.ServerMods
+@@ -10,19 +10,60 @@ namespace Vintagestory.ServerMods
  {
      public class GenCaves : GenPartial
      {
@@ -45,12 +45,25 @@ index 30f034d..0583e33 100644
 +        // Stratum: reusable province weights buffer. Per-instance, never shared.
 +        float[] stratumIndicesBuf;
 +
++        // Stratum start: serializes access to the shared worldgenBlockAccessor. Multiple
++        // TerrainLate workers can run GeneratePartial on neighboring chunks concurrently, so we
++        // must not let them concurrently mutate the shared accessor's cached state or the
++        // per-chunk light update lists.
++        private static readonly object accessorLock = new object();
++
++        // Stratum: buffer light updates to flush them under accessorLock at the end of
++        // GeneratePartial, avoiding concurrent List<T> mutations on the shared accessor.
++        List<BlockPos> stratumPendLightPos;
++        List<int> stratumPendLightOld;
++        List<int> stratumPendLightNew;
++        // Stratum end
++
          public override void StartServerSide(ICoreServerAPI api)
          {
              base.StartServerSide(api);
  
              if (TerraGenConfig.DoDecorationPass)
-@@ -30,18 +58,18 @@ namespace Vintagestory.ServerMods
+@@ -30,18 +71,18 @@ namespace Vintagestory.ServerMods
                  api.Event.GetWorldgenBlockAccessor(OnWorldGenBlockAccessor);
  
                  api.ChatCommands.GetOrCreate("dev")
@@ -71,7 +84,7 @@ index 30f034d..0583e33 100644
          }
  
  
-@@ -51,10 +79,44 @@ namespace Vintagestory.ServerMods
+@@ -51,10 +92,47 @@ namespace Vintagestory.ServerMods
              caveRand = new LCGRandom(api.WorldManager.Seed + 123128);
              basaltNoise = NormalizedSimplexNoise.FromDefaultOctaves(2, 1f / 3.5f, 0.9f, api.World.Seed + 12);
              heightvarNoise = NormalizedSimplexNoise.FromDefaultOctaves(3, 1f / 20f, 0.9f, api.World.Seed + 12);
@@ -110,13 +123,16 @@ index 30f034d..0583e33 100644
 +            stratumPendIdx = null;
 +            stratumPendVal = null;
 +            stratumIndicesBuf = null;
++            stratumPendLightPos = null;
++            stratumPendLightOld = null;
++            stratumPendLightNew = null;
 +            // Stratum end
          }
  
  
          private void OnMapChunkGen(IMapChunk mapChunk, int chunkX, int chunkZ)
          {
-@@ -72,68 +134,98 @@ namespace Vintagestory.ServerMods
+@@ -72,68 +150,102 @@ namespace Vintagestory.ServerMods
                      mapChunk.CaveHeightDistort[dz * chunksize + dx] = (byte)(128 * val + 127);
                  }
              }
@@ -205,38 +221,41 @@ index 30f034d..0583e33 100644
                  {
 -                    int chunkX = baseChunkX + dx;
 -                    int chunkZ = baseChunkZ + dz;
--
--                    IServerChunk[] chunks = GetChunkColumn(chunkX, chunkZ);
--                    ClearChunkColumn(chunks);
 +                    for (int dz = -5; dz <= 5; dz++)
 +                    {
 +                        int chunkX = baseChunkX + dx;
 +                        int chunkZ = baseChunkZ + dz;
  
+-                    IServerChunk[] chunks = GetChunkColumn(chunkX, chunkZ);
+-                    ClearChunkColumn(chunks);
 +                        IServerChunk[] chunks = GetChunkColumn(chunkX, chunkZ);
 +                        ClearChunkColumn(chunks);
  
--                    for (int gdx = -chunkRange; gdx <= chunkRange; gdx++)
--                    {
--                        for (int gdz = -chunkRange; gdz <= chunkRange; gdz++)
 +                        for (int gdx = -chunkRange; gdx <= chunkRange; gdx++)
-                         {
--                            chunkRand.InitPositionSeed(chunkX + gdx, chunkZ + gdz);
--                            GeneratePartial(chunks, chunkX, chunkZ, gdx, gdz);
++                        {
 +                            for (int gdz = -chunkRange; gdz <= chunkRange; gdz++)
 +                            {
 +                                cmd.chunkRand.InitPositionSeed(chunkX + gdx, chunkZ + gdz);
 +                                cmd.GeneratePartial(chunks, chunkX, chunkZ, gdx, gdz);
 +                            }
++                        }
+ 
+-                    for (int gdx = -chunkRange; gdx <= chunkRange; gdx++)
+-                    {
+-                        for (int gdz = -chunkRange; gdz <= chunkRange; gdz++)
++                        // Run lighting recalculation (like in GenLightSurvival)
++                        // Stratum: wrap in accessorLock to exclude concurrent worldgen workers from mutating the shared accessor.
++                        lock (accessorLock)
+                         {
+-                            chunkRand.InitPositionSeed(chunkX + gdx, chunkZ + gdz);
+-                            GeneratePartial(chunks, chunkX, chunkZ, gdx, gdz);
++                            cmd.worldgenBlockAccessor.BeginColumn();
++                            api.WorldManager.SunFloodChunkColumnForWorldGen(chunks, chunkX, chunkZ);
++                            cmd.worldgenBlockAccessor.RunScheduledBlockLightUpdates(chunkX, chunkZ);
                          }
 -                    }
  
 -                    MarkDirty(chunkX, chunkZ, chunks);
-+                        // Run lighting recalculation (like in GenLightSurvival)
-+                        cmd.worldgenBlockAccessor.BeginColumn();
-+                        api.WorldManager.SunFloodChunkColumnForWorldGen(chunks, chunkX, chunkZ);
-+                        cmd.worldgenBlockAccessor.RunScheduledBlockLightUpdates(chunkX, chunkZ);
-+
 +                        MarkDirty(chunkX, chunkZ, chunks);
 +                    }
                  }
@@ -251,7 +270,7 @@ index 30f034d..0583e33 100644
          }
  
          private IServerChunk[] GetChunkColumn(int chunkX, int chunkZ)
-@@ -148,11 +240,12 @@ namespace Vintagestory.ServerMods
+@@ -148,11 +260,12 @@ namespace Vintagestory.ServerMods
              return chunks;
          }
  
@@ -265,11 +284,15 @@ index 30f034d..0583e33 100644
              }
          }
  
-@@ -183,11 +276,15 @@ namespace Vintagestory.ServerMods
+@@ -181,13 +294,18 @@ namespace Vintagestory.ServerMods
+             if (GetIntersectingStructure(chunkX * chunksize + chunksize / 2, chunkZ * chunksize + chunksize / 2, CavesHashCode) != null)
+             {
                  return;
              }
  
-             worldgenBlockAccessor.BeginColumn();
+-            worldgenBlockAccessor.BeginColumn();
++            // Stratum: removed worldgenBlockAccessor.BeginColumn() from here. The shared accessor's
++            // cached state is now only mutated under accessorLock when flushing buffered light updates.
              LCGRandom chunkRand = this.chunkRand;
 -            int quantityCaves = chunkRand.NextInt(100) < TerraGenConfig.CavesPerChunkColumn*100 ? 1 : 0;
 +            int quantityCaves = chunkRand.NextInt(100) < TerraGenConfig.CavesPerChunkColumn * 100 ? 1 : 0;
@@ -282,7 +305,7 @@ index 30f034d..0583e33 100644
              while (quantityCaves-- > 0)
              {
                  int rnd = chunkRand.NextInt(rndSize);
-@@ -229,11 +326,83 @@ namespace Vintagestory.ServerMods
+@@ -229,11 +347,109 @@ namespace Vintagestory.ServerMods
  
                  caveRand.SetWorldSeed(chunkRand.NextInt(10000000));
                  caveRand.InitPositionSeed(chunkX + cdx, chunkZ + cdz);
@@ -291,6 +314,23 @@ index 30f034d..0583e33 100644
 +
 +            // Stratum start: apply buffered writes; one batched lock per touched subchunk.
 +            StratumFlushPendingWrites(chunks);
++
++            // Stratum: flush buffered light updates. We batched them to avoid locking the
++            // shared worldgenBlockAccessor inside the hot carving loop, and we flush them
++            // now under accessorLock. This ensures BeginColumn() sets the correct cached
++            // chunk right before ScheduleBlockLightUpdate mutates its List<Vec4i>, completely
++            // eliminating the race condition between neighboring workers.
++            if (stratumPendLightPos != null && stratumPendLightPos.Count > 0)
++            {
++                lock (accessorLock)
++                {
++                    worldgenBlockAccessor.BeginColumn();
++                    for (int i = 0; i < stratumPendLightPos.Count; i++)
++                    {
++                        worldgenBlockAccessor.ScheduleBlockLightUpdate(stratumPendLightPos[i], stratumPendLightOld[i], stratumPendLightNew[i]);
++                    }
++                }
++            }
 +            // Stratum end
 +        }
 +
@@ -307,12 +347,21 @@ index 30f034d..0583e33 100644
 +                    stratumPendIdx[i] = new List<int>(1024);
 +                    stratumPendVal[i] = new List<int>(1024);
 +                }
++                stratumPendLightPos = new List<BlockPos>(256);
++                stratumPendLightOld = new List<int>(256);
++                stratumPendLightNew = new List<int>(256);
 +                return;
 +            }
 +            for (int i = 0; i < numSubchunks; i++)
 +            {
 +                stratumPendIdx[i].Clear();
 +                stratumPendVal[i].Clear();
++            }
++            if (stratumPendLightPos != null)
++            {
++                stratumPendLightPos.Clear();
++                stratumPendLightOld.Clear();
++                stratumPendLightNew.Clear();
 +            }
 +        }
 +
@@ -366,7 +415,7 @@ index 30f034d..0583e33 100644
          {
              LCGRandom caveRand = this.caveRand;
  
-@@ -289,14 +458,14 @@ namespace Vintagestory.ServerMods
+@@ -289,14 +505,14 @@ namespace Vintagestory.ServerMods
                  vertAngle *= 0.8f;
  
                  int rrnd = caveRand.NextInt(800000);
@@ -383,7 +432,7 @@ index 30f034d..0583e33 100644
                  // 1/330 * 10k = 30
                  // 1/130 * 10k = 76
                  // 1/100 * 10k = 100
-@@ -305,48 +474,55 @@ namespace Vintagestory.ServerMods
+@@ -305,48 +521,55 @@ namespace Vintagestory.ServerMods
  
                  // Rarely change direction
                  if ((rnd -= 30) <= 0)
@@ -446,7 +495,7 @@ index 30f034d..0583e33 100644
                  {
                      if (posY < 19)
                      {
-@@ -418,11 +594,11 @@ namespace Vintagestory.ServerMods
+@@ -418,11 +641,11 @@ namespace Vintagestory.ServerMods
                          horAngle + (caveRand.NextFloat() + caveRand.NextFloat() - 1) + GameMath.PI,
                          -GameMath.PI / 2 - 0.1f + 0.2f * caveRand.NextFloat(),
                          Math.Min(3.5f, horRadius - 1),
@@ -459,7 +508,7 @@ index 30f034d..0583e33 100644
  
                      branchLevel++;
                  }
-@@ -506,155 +682,220 @@ namespace Vintagestory.ServerMods
+@@ -506,155 +729,224 @@ namespace Vintagestory.ServerMods
  
  
  
@@ -645,14 +694,14 @@ index 30f034d..0583e33 100644
                              {
 -                                chunkBlockData[index3d] = 0;
 -                                if (y > yLavaStart)
--                                {
--                                    chunkBlockData[index3d] = gcfg.basaltBlockId;
--                                } else
 +                                int chunkY = y / chunksize;
 +                                int localY = y % chunksize;
 +                                var block = api.World.Blocks[chunks[chunkY].Data.GetFluid((localY * chunksize + lz) * chunksize + lx)];
 +                                if (block.LiquidCode != null)
                                  {
+-                                    chunkBlockData[index3d] = gcfg.basaltBlockId;
+-                                } else
+-                                {
 -                                    chunkBlockData.SetFluid(index3d, gcfg.lavaBlockId);
 +                                    return false; // Found fluid - exit immediately
                                  }
@@ -660,13 +709,13 @@ index 30f034d..0583e33 100644
 -                                if (y <= yLavaStart) worldgenBlockAccessor.ScheduleBlockLightUpdate(new BlockPos(chunkX * chunksize + lx, y, chunkZ * chunksize + lz), airBlockId, gcfg.lavaBlockId);
                              }
 +                        }
- 
++
 +                        // Check inclusion in generation radius (for setting blocks)
 +                        if (!needsGenInGenRadius)
 +                        {
 +                            double heightOffFac = dy > 0 ? heightrnd * heightrnd * Math.Min(1, Math.Abs(y - surfaceY) / 10.0) : 0;
 +                            double genYDistSq = dySq / (genVertRadiusSq + heightOffFac);
-+
+ 
 +                            if (dxSq / genHorRadiusSq + genYDistSq + dzSq / genHorRadiusSq <= 1.0 && y < worldheight)
 +                            {
 +                                needsGenInGenRadius = true;
@@ -749,9 +798,13 @@ index 30f034d..0583e33 100644
 +                                        }
 +
 +                                        if (y <= yLavaStart)
-+                                            worldgenBlockAccessor.ScheduleBlockLightUpdate(
-+                                                new BlockPos(chunkX * chunksize + lx, y, chunkZ * chunksize + lz),
-+                                                airBlockId, gcfg.lavaBlockId);
++                                        {
++                                            // Stratum: buffer light updates to flush them under accessorLock at the
++                                            // end of GeneratePartial, avoiding concurrent List<T> mutations.
++                                            stratumPendLightPos.Add(new BlockPos(chunkX * chunksize + lx, y, chunkZ * chunksize + lz));
++                                            stratumPendLightOld.Add(airBlockId);
++                                            stratumPendLightNew.Add(gcfg.lavaBlockId);
++                                        }
 +                                    }
 +                                }
 +                                else if (y < 12)

--- a/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves.cs.patch
+++ b/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves.cs.patch
@@ -1,8 +1,8 @@
 diff --git a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves.cs b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves.cs
-index 30f034d..44e6a76 100644
+index 30f034d..c034eed 100644
 --- a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves.cs
 +++ b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves.cs
-@@ -10,19 +10,54 @@ namespace Vintagestory.ServerMods
+@@ -10,19 +10,51 @@ namespace Vintagestory.ServerMods
  {
      public class GenCaves : GenPartial
      {
@@ -42,9 +42,6 @@ index 30f034d..44e6a76 100644
 +        List<int>[] stratumPendVal;
 +        // Stratum end
 +
-+        // Stratum: reusable province weights buffer. Per-instance, never shared.
-+        float[] stratumIndicesBuf;
-+
 +        // Stratum start: buffered lava light updates for this column, packed exactly in
 +        // the storage format (Vec4i = xyz + newBlockId). Old block id is not used by
 +        // BlockAccessorWorldGen, so it is not buffered. Flushed in one batched call at
@@ -57,7 +54,7 @@ index 30f034d..44e6a76 100644
              base.StartServerSide(api);
  
              if (TerraGenConfig.DoDecorationPass)
-@@ -30,33 +65,63 @@ namespace Vintagestory.ServerMods
+@@ -30,33 +62,62 @@ namespace Vintagestory.ServerMods
                  api.Event.GetWorldgenBlockAccessor(OnWorldGenBlockAccessor);
  
                  api.ChatCommands.GetOrCreate("dev")
@@ -87,8 +84,8 @@ index 30f034d..44e6a76 100644
  
              regionsize = api.World.BlockAccessor.RegionSize;
 +            stratumWorkers = new StratumWorkerInstances<GenCaves>(StratumCreateWorker);
-+        }
-+
+         }
+ 
 +        private void StratumGenChunkColumnOnWorker(IChunkColumnGenerateRequest request)
 +        {
 +            stratumWorkers.Current.GenChunkColumn(request);
@@ -99,8 +96,8 @@ index 30f034d..44e6a76 100644
 +            GenCaves worker = new GenCaves();
 +            worker.StratumCopyStateFrom(this);
 +            return worker;
-         }
- 
++        }
++
 +        protected override void StratumCopyStateFrom(GenPartial source)
 +        {
 +            base.StratumCopyStateFrom(source);
@@ -115,7 +112,6 @@ index 30f034d..44e6a76 100644
 +            // Stratum start: reset per-worker mutable state.
 +            stratumPendIdx = null;
 +            stratumPendVal = null;
-+            stratumIndicesBuf = null;
 +            stratumPendLight = null;
 +            // Stratum end
 +        }
@@ -124,7 +120,7 @@ index 30f034d..44e6a76 100644
          {
              if (heightvarNoise == null) return;
  
-@@ -72,70 +137,90 @@ namespace Vintagestory.ServerMods
+@@ -72,70 +133,94 @@ namespace Vintagestory.ServerMods
                      mapChunk.CaveHeightDistort[dz * chunksize + dx] = (byte)(128 * val + 127);
                  }
              }
@@ -194,8 +190,8 @@ index 30f034d..44e6a76 100644
 +                    }
                  }
 -            }
--
  
+-
 -            for (int dx = -5; dx <= 5; dx++)
 -            {
 -                for (int dz = -5; dz <= 5; dz++)
@@ -232,6 +228,11 @@ index 30f034d..44e6a76 100644
 -                    MarkDirty(chunkX, chunkZ, chunks);
 -                }
 -            }
++                        // Stratum: reset the accessor's [ThreadStatic] chunk lookup cache before this
++                        // worker touches GetMapChunk again for lighting, mirroring GeneratePartial.
++                        cmd.worldgenBlockAccessor.BeginColumn();
+ 
+-            airBlockId = 0;
 +                        // Run lighting recalculation (like in GenLightSurvival)
 +                        // Stratum: ScheduleBlockLightUpdate and RunScheduledBlockLightUpdates are now
 +                        // thread-safe (protected by lightUpdatesLock inside BlockAccessorWorldGen),
@@ -239,12 +240,11 @@ index 30f034d..44e6a76 100644
 +                        api.WorldManager.SunFloodChunkColumnForWorldGen(chunks, chunkX, chunkZ);
 +                        cmd.worldgenBlockAccessor.RunScheduledBlockLightUpdates(chunkX, chunkZ);
  
--            airBlockId = 0;
+-            return TextCommandResult.Success("Generated and chunks force resend flags set");
 +                        MarkDirty(chunkX, chunkZ, chunks);
 +                    }
 +                }
- 
--            return TextCommandResult.Success("Generated and chunks force resend flags set");
++
 +                return TextCommandResult.Success("Generated and chunks force resend flags set");
 +            }
          }
@@ -266,7 +266,16 @@ index 30f034d..44e6a76 100644
              }
          }
  
-@@ -181,13 +267,16 @@ namespace Vintagestory.ServerMods
+@@ -176,18 +262,25 @@ namespace Vintagestory.ServerMods
+             worldgenBlockAccessor = chunkProvider.GetBlockAccessor(false);
+         }
+ 
+         public override void GeneratePartial(IServerChunk[] chunks, int chunkX, int chunkZ, int cdx, int cdz)
+         {
++            // Stratum: reset the accessor's [ThreadStatic] chunk lookup cache before this worker
++            // touches GetMapChunk again (see ScheduleBlockLightUpdates / RunScheduledBlockLightUpdates).
++            worldgenBlockAccessor.BeginColumn();
++
              if (GetIntersectingStructure(chunkX * chunksize + chunksize / 2, chunkZ * chunksize + chunksize / 2, CavesHashCode) != null)
              {
                  return;
@@ -285,7 +294,7 @@ index 30f034d..44e6a76 100644
              while (quantityCaves-- > 0)
              {
                  int rnd = chunkRand.NextInt(rndSize);
-@@ -201,38 +290,112 @@ namespace Vintagestory.ServerMods
+@@ -201,38 +294,112 @@ namespace Vintagestory.ServerMods
                  float vertAngle = (chunkRand.NextFloat() - 0.5f) * 0.25f;
                  float horizontalSize = chunkRand.NextFloat() * 2 + chunkRand.NextFloat();
                  float verticalSize = 0.75f + chunkRand.NextFloat() * 0.4f;
@@ -406,7 +415,7 @@ index 30f034d..44e6a76 100644
          private void CarveTunnel(IServerChunk[] chunks, int chunkX, int chunkZ, double posX, double posY, double posZ, float horAngle, float vertAngle, float horizontalSize, float verticalSize, int currentIteration, int maxIterations, int branchLevel, bool extraBranchy = false, float curviness = 0.1f, bool largeNearLavaLayer = false)
          {
              LCGRandom caveRand = this.caveRand;
-@@ -264,17 +427,16 @@ namespace Vintagestory.ServerMods
+@@ -264,17 +431,16 @@ namespace Vintagestory.ServerMods
                  relPos = (float)currentIteration / maxIterations;
  
                  float horRadius = 1.5f + GameMath.FastSin(relPos * GameMath.PI) * horizontalSize + horRadiusGainAccum;
@@ -425,7 +434,7 @@ index 30f034d..44e6a76 100644
                      float factor = 1f + Math.Max(0f, 1f - (float)Math.Abs(posY - 12d) / 10f);
                      horRadius *= factor;
                      vertRadius *= factor;
-@@ -287,67 +449,61 @@ namespace Vintagestory.ServerMods
+@@ -287,67 +453,61 @@ namespace Vintagestory.ServerMods
                  posZ += GameMath.FastSin(horAngle) * advanceHor;
  
                  vertAngle *= 0.8f;
@@ -511,7 +520,7 @@ index 30f034d..44e6a76 100644
                      if (posY < 19)
                      {
                          verHeightGain = 2 + caveRand.NextFloat() * caveRand.NextFloat() * 5;
-@@ -376,22 +532,19 @@ namespace Vintagestory.ServerMods
+@@ -376,22 +536,19 @@ namespace Vintagestory.ServerMods
                  verHeightLoss -= 0.4f;
  
                  horAngle += curviness * horAngleChange;
@@ -535,7 +544,7 @@ index 30f034d..44e6a76 100644
                      CarveTunnel(
                          chunks,
                          chunkX,
-@@ -405,11 +558,10 @@ namespace Vintagestory.ServerMods
+@@ -405,11 +562,10 @@ namespace Vintagestory.ServerMods
                          maxIterations - (int)(caveRand.NextFloat() * 0.5 * maxIterations),
                          branchLevel + 1
                      );
@@ -547,7 +556,7 @@ index 30f034d..44e6a76 100644
                      CarveShaft(
                          chunks,
                          chunkX,
-@@ -418,31 +570,25 @@ namespace Vintagestory.ServerMods
+@@ -418,31 +574,25 @@ namespace Vintagestory.ServerMods
                          horAngle + (caveRand.NextFloat() + caveRand.NextFloat() - 1) + GameMath.PI,
                          -GameMath.PI / 2 - 0.1f + 0.2f * caveRand.NextFloat(),
                          Math.Min(3.5f, horRadius - 1),
@@ -580,7 +589,7 @@ index 30f034d..44e6a76 100644
              float vertAngleChange = 0;
  
              ushort[] terrainheightmap = chunks[0].MapChunk.WorldGenTerrainHeightMap;
-@@ -468,11 +614,10 @@ namespace Vintagestory.ServerMods
+@@ -468,11 +618,10 @@ namespace Vintagestory.ServerMods
                  posZ += GameMath.FastSin(horAngle) * advanceHor;
  
                  vertAngle += 0.1f * vertAngleChange;
@@ -592,7 +601,7 @@ index 30f034d..44e6a76 100644
                      int num = 3 + caveRand.NextInt(4);
                      for (int i = 0; i < num; i++)
                      {
-@@ -493,168 +638,196 @@ namespace Vintagestory.ServerMods
+@@ -493,168 +642,196 @@ namespace Vintagestory.ServerMods
                      return;
                  }
  
@@ -645,10 +654,12 @@ index 30f034d..44e6a76 100644
 -                        double heightOffFac = yDist > 0 ? heightrnd * heightrnd : 0;
 -
 -                        ydistRel = yDist * yDist / (vRadiusSq + heightOffFac);
--
--                        if (xdistRel + ydistRel + zdistRel > 1.0 || y > worldheight - 1) continue;
 +            float genHorRadius = horRadius;
 +            float genVertRadius = vertRadius;
+ 
+-                        if (xdistRel + ydistRel + zdistRel > 1.0 || y > worldheight - 1) continue;
++            float checkHorRadius = horRadius + 1;
++            float checkVertRadius = vertRadius + 2;
  
 -                        int ly = y % chunksize;
 -                        var block = api.World.Blocks[chunks[y / chunksize].Data.GetFluid((ly * chunksize + lz) * chunksize + lx)];
@@ -659,13 +670,13 @@ index 30f034d..44e6a76 100644
 -                    }
 -                }
 -            }
-+            float checkHorRadius = horRadius + 1;
-+            float checkVertRadius = vertRadius + 2;
- 
 +            int mindx = (int)GameMath.Clamp(centerX - checkHorRadius, 0, chunksize - 1);
 +            int maxdx = (int)GameMath.Clamp(centerX + checkHorRadius + 1, 0, chunksize - 1);
 +            int mindz = (int)GameMath.Clamp(centerZ - checkHorRadius, 0, chunksize - 1);
 +            int maxdz = (int)GameMath.Clamp(centerZ + checkHorRadius + 1, 0, chunksize - 1);
+ 
++            int mindy = (int)GameMath.Clamp(centerY - checkVertRadius * 0.7f, 1, worldheight - 1);
++            int maxdy = (int)GameMath.Clamp(centerY + checkVertRadius + 1, 1, worldheight - 1);
  
 -            horRadius--;
 -            vertRadius-=2;
@@ -680,9 +691,7 @@ index 30f034d..44e6a76 100644
 -
 -            hRadiusSq = horRadius * horRadius;
 -            vRadiusSq = vertRadius * vertRadius;
-+            int mindy = (int)GameMath.Clamp(centerY - checkVertRadius * 0.7f, 1, worldheight - 1);
-+            int maxdy = (int)GameMath.Clamp(centerY + checkVertRadius + 1, 1, worldheight - 1);
- 
+-
 +            double genHorRadiusSq = genHorRadius * genHorRadius;
 +            double genVertRadiusSq = genVertRadius * genVertRadius;
 +            double checkHorRadiusSq = checkHorRadius * checkHorRadius;
@@ -768,14 +777,14 @@ index 30f034d..44e6a76 100644
                              {
 -                                chunkBlockData[index3d] = 0;
 -                                if (y > yLavaStart)
+-                                {
+-                                    chunkBlockData[index3d] = gcfg.basaltBlockId;
+-                                } else
 +                                int chunkY = y / chunksize;
 +                                int localY = y % chunksize;
 +                                var block = api.World.Blocks[chunks[chunkY].Data.GetFluid((localY * chunksize + lz) * chunksize + lx)];
 +                                if (block.LiquidCode != null)
                                  {
--                                    chunkBlockData[index3d] = gcfg.basaltBlockId;
--                                } else
--                                {
 -                                    chunkBlockData.SetFluid(index3d, gcfg.lavaBlockId);
 +                                    return false;
                                  }
@@ -895,7 +904,7 @@ index 30f034d..44e6a76 100644
              }
  
              return true;
-@@ -669,8 +842,7 @@ namespace Vintagestory.ServerMods
+@@ -669,8 +846,7 @@ namespace Vintagestory.ServerMods
              int rlX = (posx / chunksize) % regionChunkSize;
              int rlZ = (posz / chunksize) % regionChunkSize;
  

--- a/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves.cs.patch
+++ b/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves.cs.patch
@@ -1,8 +1,8 @@
 diff --git a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves.cs b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves.cs
-index 30f034d..47dc4ad 100644
+index 30f034d..90dcf8e 100644
 --- a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves.cs
 +++ b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves.cs
-@@ -10,19 +10,60 @@ namespace Vintagestory.ServerMods
+@@ -10,19 +10,55 @@ namespace Vintagestory.ServerMods
  {
      public class GenCaves : GenPartial
      {
@@ -45,14 +45,9 @@ index 30f034d..47dc4ad 100644
 +        // Stratum: reusable province weights buffer. Per-instance, never shared.
 +        float[] stratumIndicesBuf;
 +
-+        // Stratum start: serializes access to the shared worldgenBlockAccessor. Multiple
-+        // TerrainLate workers can run GeneratePartial on neighboring chunks concurrently, so we
-+        // must not let them concurrently mutate the shared accessor's cached state or the
-+        // per-chunk light update lists.
-+        private static readonly object accessorLock = new object();
-+
-+        // Stratum: buffer light updates to flush them under accessorLock at the end of
-+        // GeneratePartial, avoiding concurrent List<T> mutations on the shared accessor.
++        // Stratum start: buffer light updates to flush them at the end of GeneratePartial.
++        // ScheduleBlockLightUpdate is now thread-safe (protected by lightUpdatesLock inside
++        // BlockAccessorWorldGen), so we don't need external locking here.
 +        List<BlockPos> stratumPendLightPos;
 +        List<int> stratumPendLightOld;
 +        List<int> stratumPendLightNew;
@@ -63,14 +58,14 @@ index 30f034d..47dc4ad 100644
              base.StartServerSide(api);
  
              if (TerraGenConfig.DoDecorationPass)
-@@ -30,18 +71,18 @@ namespace Vintagestory.ServerMods
+@@ -30,33 +66,65 @@ namespace Vintagestory.ServerMods
                  api.Event.GetWorldgenBlockAccessor(OnWorldGenBlockAccessor);
  
                  api.ChatCommands.GetOrCreate("dev")
                      .BeginSubCommand("gencaves")
                      .WithDescription(
 -                        "Cave generator test tool. Deletes all chunks in the area and generates inverse caves around the world middle")
-+                        "Cave generator test tool. Deletes all chunks in the area 10х10 and generates inverse caves around the player.") // Stratum:
++                        "Cave generator test tool. Deletes all chunks in the area 10х10 and generates inverse caves around the player.")
                      .RequiresPrivilege(Privilege.controlserver)
                      .HandleWith(CmdCaveGenTest)
                      .EndSubCommand();
@@ -78,22 +73,23 @@ index 30f034d..47dc4ad 100644
                  api.Event.MapChunkGeneration(OnMapChunkGen, "standard");
                  api.Event.MapChunkGeneration(OnMapChunkGen, "superflat");
 -                api.Event.ChunkColumnGeneration(GenChunkColumn, EnumWorldGenPass.Terrain, "standard");
-+                StratumTerrainSplit.Register(api, GenChunkColumn, StratumGenChunkColumnOnWorker, "standard"); // Stratum: expose vanilla topology until the worker path is safe
++                StratumTerrainSplit.Register(api, GenChunkColumn, StratumGenChunkColumnOnWorker, "standard");
                  api.Event.InitWorldGenerator(initWorldGen, "superflat");
              }
          }
  
- 
-@@ -51,10 +92,47 @@ namespace Vintagestory.ServerMods
+-
+         public override void initWorldGen()
+         {
+             base.initWorldGen();
              caveRand = new LCGRandom(api.WorldManager.Seed + 123128);
              basaltNoise = NormalizedSimplexNoise.FromDefaultOctaves(2, 1f / 3.5f, 0.9f, api.World.Seed + 12);
              heightvarNoise = NormalizedSimplexNoise.FromDefaultOctaves(3, 1f / 20f, 0.9f, api.World.Seed + 12);
  
              regionsize = api.World.BlockAccessor.RegionSize;
-+            stratumWorkers = new StratumWorkerInstances<GenCaves>(StratumCreateWorker); // Stratum
++            stratumWorkers = new StratumWorkerInstances<GenCaves>(StratumCreateWorker);
 +        }
 +
-+        // Stratum: the registered handler. Runs on this thread's copy, never the shared one.
 +        private void StratumGenChunkColumnOnWorker(IChunkColumnGenerateRequest request)
 +        {
 +            stratumWorkers.Current.GenChunkColumn(request);
@@ -104,10 +100,8 @@ index 30f034d..47dc4ad 100644
 +            GenCaves worker = new GenCaves();
 +            worker.StratumCopyStateFrom(this);
 +            return worker;
-+        }
-+
-+        // Stratum: copy immutable state and the accessor from source to worker.
-+        // All mutable scratch (caveRand, pending write lists) is recreated per worker.
+         }
+ 
 +        protected override void StratumCopyStateFrom(GenPartial source)
 +        {
 +            base.StratumCopyStateFrom(source);
@@ -127,27 +121,24 @@ index 30f034d..47dc4ad 100644
 +            stratumPendLightOld = null;
 +            stratumPendLightNew = null;
 +            // Stratum end
-         }
- 
++        }
  
          private void OnMapChunkGen(IMapChunk mapChunk, int chunkX, int chunkZ)
          {
-@@ -72,68 +150,102 @@ namespace Vintagestory.ServerMods
+             if (heightvarNoise == null) return;
+ 
+@@ -72,70 +140,85 @@ namespace Vintagestory.ServerMods
                      mapChunk.CaveHeightDistort[dz * chunksize + dx] = (byte)(128 * val + 127);
                  }
              }
          }
  
-+        // Stratum: prevents two concurrent command invocations from racing each other.
 +        private static readonly object cmdLock = new object();
 +
          private TextCommandResult CmdCaveGenTest(TextCommandCallingArgs args)
          {
 -            caveRand = new LCGRandom(api.WorldManager.Seed + 123128);
 -            initWorldGen();
-+            // Stratum: do NOT call initWorldGen() here — it would rebuild stratumWorkers and
-+            // noise fields while worldgen threads may already be reading them. The command runs
-+            // on a dedicated thread-confined copy instead, leaving all shared state untouched.
 +            if (heightvarNoise == null)
 +            {
 +                return TextCommandResult.Error("Worldgen is not initialized yet.");
@@ -155,47 +146,38 @@ index 30f034d..47dc4ad 100644
  
 +            lock (cmdLock)
 +            {
-+                // Stratum start:
-+                // Adding light recalculation for caves
-+                // The cave generation command now works based on the player's coordinates.
- 
--            airBlockId = api.World.GetBlock(new AssetLocation("rock-granite")).BlockId;
-+                // Dedicated instance for this command invocation: all mutable state (airBlockId,
-+                // caveRand, chunkRand, pending write lists) stays confined to the calling thread.
 +                GenCaves cmd = new GenCaves();
 +                cmd.StratumCopyStateFrom(this);
  
+-            airBlockId = api.World.GetBlock(new AssetLocation("rock-granite")).BlockId;
++                cmd.stratumLockedWrites = true;
+ 
 -            int baseChunkX = api.World.BlockAccessor.MapSizeX / 2 / chunksize;
 -            int baseChunkZ = api.World.BlockAccessor.MapSizeZ / 2 / chunksize;
-+                cmd.stratumLockedWrites = true; // Stratum: dev command touches live chunks -> locked writes
++                cmd.airBlockId = api.World.GetBlock(new AssetLocation("rock-granite")).BlockId;
  
 -            for (int dx = -5; dx <= 5; dx++)
 -            {
 -                for (int dz = -5; dz <= 5; dz++)
--                {
--                    int chunkX = baseChunkX + dx;
--                    int chunkZ = baseChunkZ + dz;
-+                // replace the air block with granite to generate inverted caves
-+                cmd.airBlockId = api.World.GetBlock(new AssetLocation("rock-granite")).BlockId;
- 
--                    IServerChunk[] chunks = GetChunkColumn(chunkX, chunkZ);
-+                // take the player as the center
 +                var player = args.Caller.Player as IServerPlayer;
 +                int baseChunkX = (int)player.Entity.Pos.X / chunksize;
 +                int baseChunkZ = (int)player.Entity.Pos.Z / chunksize;
- 
--                    for (int i = 0; i < chunks.Length; i++)
-+                // first check that all chunks are loaded
++
 +                for (int dx = -5; dx <= 5; dx++)
-+                {
+                 {
+-                    int chunkX = baseChunkX + dx;
+-                    int chunkZ = baseChunkZ + dz;
 +                    for (int dz = -5; dz <= 5; dz++)
-                     {
--                        if (chunks[i] == null)
++                    {
 +                        int chunkX = baseChunkX + dx;
 +                        int chunkZ = baseChunkZ + dz;
-+
+ 
+-                    IServerChunk[] chunks = GetChunkColumn(chunkX, chunkZ);
 +                        IServerChunk[] chunks = GetChunkColumn(chunkX, chunkZ);
-+
+ 
+-                    for (int i = 0; i < chunks.Length; i++)
+-                    {
+-                        if (chunks[i] == null)
 +                        for (int i = 0; i < chunks.Length; i++)
                          {
 -                            return TextCommandResult.Success( "Cannot generate 10x10 area of caves, chunks are not loaded that far yet.");
@@ -211,66 +193,65 @@ index 30f034d..47dc4ad 100644
 +                    }
                  }
 -            }
--
  
+-
 -            for (int dx = -5; dx <= 5; dx++)
 -            {
 -                for (int dz = -5; dz <= 5; dz++)
-+                // clear all chunks and start cave generation
 +                for (int dx = -5; dx <= 5; dx++)
                  {
 -                    int chunkX = baseChunkX + dx;
 -                    int chunkZ = baseChunkZ + dz;
+-
+-                    IServerChunk[] chunks = GetChunkColumn(chunkX, chunkZ);
+-                    ClearChunkColumn(chunks);
 +                    for (int dz = -5; dz <= 5; dz++)
 +                    {
 +                        int chunkX = baseChunkX + dx;
 +                        int chunkZ = baseChunkZ + dz;
  
--                    IServerChunk[] chunks = GetChunkColumn(chunkX, chunkZ);
--                    ClearChunkColumn(chunks);
 +                        IServerChunk[] chunks = GetChunkColumn(chunkX, chunkZ);
 +                        ClearChunkColumn(chunks);
  
+-                    for (int gdx = -chunkRange; gdx <= chunkRange; gdx++)
+-                    {
+-                        for (int gdz = -chunkRange; gdz <= chunkRange; gdz++)
 +                        for (int gdx = -chunkRange; gdx <= chunkRange; gdx++)
-+                        {
+                         {
+-                            chunkRand.InitPositionSeed(chunkX + gdx, chunkZ + gdz);
+-                            GeneratePartial(chunks, chunkX, chunkZ, gdx, gdz);
 +                            for (int gdz = -chunkRange; gdz <= chunkRange; gdz++)
 +                            {
 +                                cmd.chunkRand.InitPositionSeed(chunkX + gdx, chunkZ + gdz);
 +                                cmd.GeneratePartial(chunks, chunkX, chunkZ, gdx, gdz);
 +                            }
-+                        }
- 
--                    for (int gdx = -chunkRange; gdx <= chunkRange; gdx++)
--                    {
--                        for (int gdz = -chunkRange; gdz <= chunkRange; gdz++)
-+                        // Run lighting recalculation (like in GenLightSurvival)
-+                        // Stratum: wrap in accessorLock to exclude concurrent worldgen workers from mutating the shared accessor.
-+                        lock (accessorLock)
-                         {
--                            chunkRand.InitPositionSeed(chunkX + gdx, chunkZ + gdz);
--                            GeneratePartial(chunks, chunkX, chunkZ, gdx, gdz);
-+                            cmd.worldgenBlockAccessor.BeginColumn();
-+                            api.WorldManager.SunFloodChunkColumnForWorldGen(chunks, chunkX, chunkZ);
-+                            cmd.worldgenBlockAccessor.RunScheduledBlockLightUpdates(chunkX, chunkZ);
                          }
 -                    }
  
 -                    MarkDirty(chunkX, chunkZ, chunks);
-+                        MarkDirty(chunkX, chunkZ, chunks);
-+                    }
-                 }
+-                }
 -            }
++                        // Run lighting recalculation (like in GenLightSurvival)
++                        // Stratum: ScheduleBlockLightUpdate and RunScheduledBlockLightUpdates are now
++                        // thread-safe (protected by lightUpdatesLock inside BlockAccessorWorldGen),
++                        // so no external locking needed.
++                        api.WorldManager.SunFloodChunkColumnForWorldGen(chunks, chunkX, chunkZ);
++                        cmd.worldgenBlockAccessor.RunScheduledBlockLightUpdates(chunkX, chunkZ);
  
 -            airBlockId = 0;
-+                // no need to restore airBlockId: it lived on the local copy only
-+                // Stratum end
-+            }
++                        MarkDirty(chunkX, chunkZ, chunks);
++                    }
++                }
  
-             return TextCommandResult.Success("Generated and chunks force resend flags set");
+-            return TextCommandResult.Success("Generated and chunks force resend flags set");
++                return TextCommandResult.Success("Generated and chunks force resend flags set");
++            }
          }
  
          private IServerChunk[] GetChunkColumn(int chunkX, int chunkZ)
-@@ -148,11 +260,12 @@ namespace Vintagestory.ServerMods
+         {
+             int size = api.World.BlockAccessor.MapSizeY / chunksize;
+@@ -148,11 +231,12 @@ namespace Vintagestory.ServerMods
              return chunks;
          }
  
@@ -284,15 +265,13 @@ index 30f034d..47dc4ad 100644
              }
          }
  
-@@ -181,13 +294,18 @@ namespace Vintagestory.ServerMods
+@@ -181,13 +265,16 @@ namespace Vintagestory.ServerMods
              if (GetIntersectingStructure(chunkX * chunksize + chunksize / 2, chunkZ * chunksize + chunksize / 2, CavesHashCode) != null)
              {
                  return;
              }
  
 -            worldgenBlockAccessor.BeginColumn();
-+            // Stratum: removed worldgenBlockAccessor.BeginColumn() from here. The shared accessor's
-+            // cached state is now only mutated under accessorLock when flushing buffered light updates.
              LCGRandom chunkRand = this.chunkRand;
 -            int quantityCaves = chunkRand.NextInt(100) < TerraGenConfig.CavesPerChunkColumn*100 ? 1 : 0;
 +            int quantityCaves = chunkRand.NextInt(100) < TerraGenConfig.CavesPerChunkColumn * 100 ? 1 : 0;
@@ -305,7 +284,43 @@ index 30f034d..47dc4ad 100644
              while (quantityCaves-- > 0)
              {
                  int rnd = chunkRand.NextInt(rndSize);
-@@ -229,11 +347,109 @@ namespace Vintagestory.ServerMods
+@@ -201,38 +288,115 @@ namespace Vintagestory.ServerMods
+                 float vertAngle = (chunkRand.NextFloat() - 0.5f) * 0.25f;
+                 float horizontalSize = chunkRand.NextFloat() * 2 + chunkRand.NextFloat();
+                 float verticalSize = 0.75f + chunkRand.NextFloat() * 0.4f;
+ 
+                 rnd = chunkRand.NextInt(100 * 50 * 1000 * 100);
+-                if (rnd % 100 < 4)    // 4% chance
++                if (rnd % 100 < 4)
+                 {
+                     horizontalSize = chunkRand.NextFloat() * 2 + chunkRand.NextFloat() + chunkRand.NextFloat();
+                     verticalSize = 0.25f + chunkRand.NextFloat() * 0.2f;
+                 }
+                 else
+-                if (rnd % 100 == 4)   // 1% chance
++                if (rnd % 100 == 4)
+                 {
+                     horizontalSize = 0.75f + chunkRand.NextFloat();
+                     verticalSize = chunkRand.NextFloat() * 2 + chunkRand.NextFloat();
+                 }
+-                rnd /= 100;   // range of rnd is now 0 - 4,999,999
++                rnd /= 100;
+ 
+-                bool extraBranchy = (posY < TerraGenConfig.seaLevel / 2) ? rnd % 50 == 0 : false;     // 2% chance
+-                rnd /= 50;   // range of rnd is now 0 - 99,999
++                bool extraBranchy = (posY < TerraGenConfig.seaLevel / 2) ? rnd % 50 == 0 : false;
++                rnd /= 50;
+                 int rnd1000 = rnd % 1000;
+-                rnd /= 1000;  // range of rnd is  now 0 - 99
+-                bool largeNearLavaLayer = rnd1000 % 10 < 3;   // 0.3 chance
++                rnd /= 1000;
++                bool largeNearLavaLayer = rnd1000 % 10 < 3;
+ 
+-                float curviness = rnd == 0 ? 0.035f : (rnd1000 < 30 ? 0.5f : 0.1f);    // 0.01 chance;  0.03 chance)
++                float curviness = rnd == 0 ? 0.035f : (rnd1000 < 30 ? 0.5f : 0.1f);
+ 
+                 int maxIterations = chunkRange * chunksize - chunksize / 2;
+                 maxIterations = maxIterations - chunkRand.NextInt(maxIterations / 4);
  
                  caveRand.SetWorldSeed(chunkRand.NextInt(10000000));
                  caveRand.InitPositionSeed(chunkX + cdx, chunkZ + cdz);
@@ -315,27 +330,19 @@ index 30f034d..47dc4ad 100644
 +            // Stratum start: apply buffered writes; one batched lock per touched subchunk.
 +            StratumFlushPendingWrites(chunks);
 +
-+            // Stratum: flush buffered light updates. We batched them to avoid locking the
-+            // shared worldgenBlockAccessor inside the hot carving loop, and we flush them
-+            // now under accessorLock. This ensures BeginColumn() sets the correct cached
-+            // chunk right before ScheduleBlockLightUpdate mutates its List<Vec4i>, completely
-+            // eliminating the race condition between neighboring workers.
++            // Stratum: flush buffered light updates. ScheduleBlockLightUpdate is now
++            // thread-safe (protected by lightUpdatesLock inside BlockAccessorWorldGen),
++            // so we can call it directly without external locking.
 +            if (stratumPendLightPos != null && stratumPendLightPos.Count > 0)
 +            {
-+                lock (accessorLock)
++                for (int i = 0; i < stratumPendLightPos.Count; i++)
 +                {
-+                    worldgenBlockAccessor.BeginColumn();
-+                    for (int i = 0; i < stratumPendLightPos.Count; i++)
-+                    {
-+                        worldgenBlockAccessor.ScheduleBlockLightUpdate(stratumPendLightPos[i], stratumPendLightOld[i], stratumPendLightNew[i]);
-+                    }
++                    worldgenBlockAccessor.ScheduleBlockLightUpdate(stratumPendLightPos[i], stratumPendLightOld[i], stratumPendLightNew[i]);
 +                }
 +            }
 +            // Stratum end
 +        }
 +
-+        // Stratum start: (re)allocates the pending-write lists to match this column's chunk
-+        // count and clears them. Cheap no-op after the first call for a given worker.
 +        private void StratumBeginColumn(int numSubchunks)
 +        {
 +            if (stratumPendIdx == null || stratumPendIdx.Length != numSubchunks)
@@ -365,16 +372,12 @@ index 30f034d..47dc4ad 100644
 +            }
 +        }
 +
-+        // Stratum start: buffer one block write; applied at the end of GeneratePartial.
 +        private void StratumAppend(int chunkY, int index3D, int value)
 +        {
 +            stratumPendIdx[chunkY].Add(index3D);
 +            stratumPendVal[chunkY].Add(value);
 +        }
 +
-+        // Stratum start: one bulk write per touched subchunk; untouched ones cost nothing.
-+        // Pairs are applied sequentially, so duplicate writes to the same cell fold into
-+        // last-write-wins automatically.
 +        private void StratumFlushPendingWrites(IServerChunk[] chunks)
 +        {
 +            for (int cy = 0; cy < stratumPendIdx.Length; cy++)
@@ -387,11 +390,6 @@ index 30f034d..47dc4ad 100644
 +
 +                if (stratumLockedWrites)
 +                {
-+                    // Locked path: one readWriteLock per block, safe on live/published chunks. The
-+                    // indexer setter lazily creates the blocks layer and wraps each SetCore in
-+                    // readWriteLock.AcquireWriteLock()/ReleaseWriteLock() - exactly like the old
-+                    // chunkBlockData[index] = value path. Does NOT null out fluids/light layers, so lava
-+                    // written earlier this command run survives.
 +                    for (int i = 0; i < idx.Count; i++)
 +                    {
 +                        data[idx[i]] = val[i];
@@ -399,9 +397,6 @@ index 30f034d..47dc4ad 100644
 +                }
 +                else
 +                {
-+                    // Batched path: one lock per touched subchunk, only used during generation where
-+                    // chunks are not yet published. Self-initialises an empty blocks layer via
-+                    // PopulateWithAir without touching fluids/light layers (see ChunkData.SetBlocksUnsafe).
 +                    data.SetBlocksUnsafe(idx, val);
 +                }
 +
@@ -409,17 +404,37 @@ index 30f034d..47dc4ad 100644
 +                val.Clear();
 +            }
          }
-+        // Stratum end
  
          private void CarveTunnel(IServerChunk[] chunks, int chunkX, int chunkZ, double posX, double posY, double posZ, float horAngle, float vertAngle, float horizontalSize, float verticalSize, int currentIteration, int maxIterations, int branchLevel, bool extraBranchy = false, float curviness = 0.1f, bool largeNearLavaLayer = false)
          {
              LCGRandom caveRand = this.caveRand;
+@@ -264,17 +428,16 @@ namespace Vintagestory.ServerMods
+                 relPos = (float)currentIteration / maxIterations;
  
-@@ -289,14 +505,14 @@ namespace Vintagestory.ServerMods
+                 float horRadius = 1.5f + GameMath.FastSin(relPos * GameMath.PI) * horizontalSize + horRadiusGainAccum;
+                 horRadius = Math.Min(horRadius, Math.Max(1, horRadius - horRadiusLossAccum));
+ 
+-                float vertRadius = 1.5f + GameMath.FastSin(relPos * GameMath.PI) * (verticalSize + horRadiusLossAccum / 4f) + verHeightGainAccum; // - horRadiusGainAccum / 2
++                float vertRadius = 1.5f + GameMath.FastSin(relPos * GameMath.PI) * (verticalSize + horRadiusLossAccum / 4f) + verHeightGainAccum;
+                 vertRadius = Math.Min(vertRadius, Math.Max(0.6f, vertRadius - verHeightLossAccum));
+ 
+                 float advanceHor = GameMath.FastCos(vertAngle);
+                 float advanceVer = GameMath.FastSin(vertAngle);
+ 
+-                // Caves get bigger near y=12
+                 if (largeNearLavaLayer)
+                 {
+                     float factor = 1f + Math.Max(0f, 1f - (float)Math.Abs(posY - 12d) / 10f);
+                     horRadius *= factor;
+                     vertRadius *= factor;
+@@ -287,67 +450,61 @@ namespace Vintagestory.ServerMods
+                 posZ += GameMath.FastSin(horAngle) * advanceHor;
+ 
                  vertAngle *= 0.8f;
  
                  int rrnd = caveRand.NextInt(800000);
-                 if (rrnd / 10000 == 0)   // chance 1/80
+-                if (rrnd / 10000 == 0)   // chance 1/80
++                if (rrnd / 10000 == 0)
                  {
 -                    sizeChangeSpeedGain = (caveRand.NextFloat() * caveRand.NextFloat())/2;
 +                    sizeChangeSpeedGain = (caveRand.NextFloat() * caveRand.NextFloat()) / 2;
@@ -428,41 +443,43 @@ index 30f034d..47dc4ad 100644
 -                bool genHotSpring=false;
 +                bool genHotSpring = false;
  
-                 int rnd = rrnd % 10000; // Calls to caveRand are not too cheap, so lets just use one for all those random variation changes
-                 // 1/330 * 10k = 30
-                 // 1/130 * 10k = 76
-                 // 1/100 * 10k = 100
-@@ -305,48 +521,55 @@ namespace Vintagestory.ServerMods
+-                int rnd = rrnd % 10000; // Calls to caveRand are not too cheap, so lets just use one for all those random variation changes
+-                // 1/330 * 10k = 30
+-                // 1/130 * 10k = 76
+-                // 1/100 * 10k = 100
+-                // 1/120 * 10k = 83
+-                // 1/800 * 10k = 12
++                int rnd = rrnd % 10000;
  
-                 // Rarely change direction
+-                // Rarely change direction
                  if ((rnd -= 30) <= 0)
                  {
                      horAngle = caveRand.NextFloat() * GameMath.TWOPI;
 -                } else
+-                // Rarely change direction somewhat
 +                }
 +                else
-                 // Rarely change direction somewhat
                  if ((rnd -= 76) <= 0)
                  {
                      horAngle += caveRand.NextFloat() * GameMath.PI - GameMath.PIHALF;
 -                } else
+-                // Rarely go pretty wide
 +                }
 +                else
-                 // Rarely go pretty wide
                  if ((rnd -= 60) <= 0)
                  {
                      horRadiusGain = caveRand.NextFloat() * caveRand.NextFloat() * 3.5f;
 -                } else
+-                // Rarely go thin
 +                }
 +                else
-                 // Rarely go thin
                  if ((rnd -= 60) <= 0)
                  {
                      horRadiusLoss = caveRand.NextFloat() * caveRand.NextFloat() * 10;
 -                } else
+-                // Rarely go flat
 +                }
 +                else
-                 // Rarely go flat
                  if ((rnd -= 50) <= 0)
                  {
                      if (posY < TerraGenConfig.seaLevel - 10)
@@ -471,9 +488,9 @@ index 30f034d..47dc4ad 100644
                          horRadiusGain = Math.Max(horRadiusGain, caveRand.NextFloat() * caveRand.NextFloat() * 3f);
                      }
 -                } else
+-                // Very rarely go really wide
 +                }
 +                else
-                 // Very rarely go really wide
                  if ((rnd -= 9) <= 0)
                  {
                      if (posY < TerraGenConfig.seaLevel - 20)
@@ -481,21 +498,58 @@ index 30f034d..47dc4ad 100644
                          horRadiusGain = 1 + caveRand.NextFloat() * caveRand.NextFloat() * 5f;
                      }
 -                } else
+-                // Very rarely go really tall
 +                }
 +                else
-                 // Very rarely go really tall
                  if ((rnd -= 9) <= 0)
                  {
                      verHeightGain = 2 + caveRand.NextFloat() * caveRand.NextFloat() * 7;
 -                } else
+-                // Rarely large lava caverns
 +                }
 +                else
-                 // Rarely large lava caverns
                  if ((rnd -= 100) <= 0)
                  {
                      if (posY < 19)
                      {
-@@ -418,11 +641,11 @@ namespace Vintagestory.ServerMods
+                         verHeightGain = 2 + caveRand.NextFloat() * caveRand.NextFloat() * 5;
+@@ -376,22 +533,19 @@ namespace Vintagestory.ServerMods
+                 verHeightLoss -= 0.4f;
+ 
+                 horAngle += curviness * horAngleChange;
+                 vertAngle += curviness * vertAngleChange;
+ 
+-
+-                // somewhat costly
+                 vertAngleChange = 0.9f * vertAngleChange + caveRand.NextFloatMinusToPlusOne() * caveRand.NextFloat() * 3f;
+                 horAngleChange = 0.9f * horAngleChange + caveRand.NextFloatMinusToPlusOne() * caveRand.NextFloat();
+ 
+                 if (rrnd % 140 == 0)
+                 {
+                     horAngleChange *= caveRand.NextFloat() * 6;
+                 }
+ 
+-                // Horizontal branch
+-                int brand = branchRand + 2 * Math.Max(0, (int)posY - (TerraGenConfig.seaLevel - 20)); // Lower chance of branches above sealevel because Saraty does not like strongly cut out mountains
++                int brand = branchRand + 2 * Math.Max(0, (int)posY - (TerraGenConfig.seaLevel - 20));
+                 if (branchLevel < 3 && (vertRadius > 1f || horRadius > 1f) && caveRand.NextInt(brand) == 0)
+                 {
+                     CarveTunnel(
+                         chunks,
+                         chunkX,
+@@ -405,11 +559,10 @@ namespace Vintagestory.ServerMods
+                         maxIterations - (int)(caveRand.NextFloat() * 0.5 * maxIterations),
+                         branchLevel + 1
+                     );
+                 }
+ 
+-                // Vertical branch
+                 if (branchLevel < 1 && horRadius > 3f && posY > 60 && caveRand.NextInt(60) == 0)
+                 {
+                     CarveShaft(
+                         chunks,
+                         chunkX,
+@@ -418,31 +571,25 @@ namespace Vintagestory.ServerMods
                          horAngle + (caveRand.NextFloat() + caveRand.NextFloat() - 1) + GameMath.PI,
                          -GameMath.PI / 2 - 0.1f + 0.2f * caveRand.NextFloat(),
                          Math.Min(3.5f, horRadius - 1),
@@ -508,14 +562,59 @@ index 30f034d..47dc4ad 100644
  
                      branchLevel++;
                  }
-@@ -506,155 +729,224 @@ namespace Vintagestory.ServerMods
  
+-
+-
+                 if (horRadius >= 2 && rrnd % 5 == 0) continue;
  
+-                // Check just to prevent unnecessary calculations
+-                // As long as we are outside the currently generating chunk, we don't need to generate anything
+                 if (posX <= -horRadius * 2 || posX >= chunksize + horRadius * 2 || posZ <= -horRadius * 2 || posZ >= chunksize + horRadius * 2) continue;
  
+                 SetBlocks(chunks, horRadius, vertRadius + verHeightGainAccum, posX, posY + verHeightGainAccum / 2, posZ, terrainheightmap, rainheightmap, chunkX, chunkZ, genHotSpring);
+             }
+         }
+ 
+-
+-
+         private void CarveShaft(IServerChunk[] chunks, int chunkX, int chunkZ, double posX, double posY, double posZ, float horAngle, float vertAngle, float horizontalSize, float verticalSize, int caveCurrentIteration, int maxIterations, int branchLevel)
+         {
+             float vertAngleChange = 0;
+ 
+             ushort[] terrainheightmap = chunks[0].MapChunk.WorldGenTerrainHeightMap;
+@@ -468,11 +615,10 @@ namespace Vintagestory.ServerMods
+                 posZ += GameMath.FastSin(horAngle) * advanceHor;
+ 
+                 vertAngle += 0.1f * vertAngleChange;
+                 vertAngleChange = 0.9f * vertAngleChange + (caveRand.NextFloat() - caveRand.NextFloat()) * caveRand.NextFloat() / 3;
+ 
+-                // Horizontal branch
+                 if (maxIterations - currentIteration < 10)
+                 {
+                     int num = 3 + caveRand.NextInt(4);
+                     for (int i = 0; i < num; i++)
+                     {
+@@ -493,168 +639,198 @@ namespace Vintagestory.ServerMods
+                     return;
+                 }
+ 
+                 if (caveRand.NextInt(5) == 0 && horRadius >= 2) continue;
+ 
+-                // Check just to prevent unnecessary calculations
+-                // As long as we are outside the currently generating chunk, we don't need to generate anything
+                 if (posX <= -horRadius * 2 || posX >= chunksize + horRadius * 2 || posZ <= -horRadius * 2 || posZ >= chunksize + horRadius * 2) continue;
+ 
+                 SetBlocks(chunks, horRadius, vertRadius, posX, posY, posZ, terrainheightmap, rainheightmap, chunkX, chunkZ, false);
+             }
+         }
+ 
+-
+-
+-
          private bool SetBlocks(IServerChunk[] chunks, float horRadius, float vertRadius, double centerX, double centerY, double centerZ, ushort[] terrainheightmap, ushort[] rainheightmap, int chunkX, int chunkZ, bool genHotSpring)
          {
--            IMapChunk mapchunk = chunks[0].MapChunk;
--
+             IMapChunk mapchunk = chunks[0].MapChunk;
+ 
 -            // One extra size for checking if we run into water
 -            horRadius++;
 -            vertRadius+=2;
@@ -560,48 +659,37 @@ index 30f034d..47dc4ad 100644
 -                    }
 -                }
 -            }
-+            // Stratum start:
-+            // Fixing incorrect cave generation in the /dev gencaves command mode
-+            // We sped up the algorithm, filtered out blocks that weren't within the ellipsoid's dimensions,
-+            // and checked for liquid in the same cycle as everything else.
- 
-+            IMapChunk mapchunk = chunks[0].MapChunk;
+-
++            float genHorRadius = horRadius;
++            float genVertRadius = vertRadius;
  
 -            horRadius--;
 -            vertRadius-=2;
-+            // Regular generation radius
-+            float genHorRadius = horRadius;
-+            float genVertRadius = vertRadius;
++            float checkHorRadius = horRadius + 1;
++            float checkVertRadius = vertRadius + 2;
  
 -            mindx = (int)GameMath.Clamp(centerX - horRadius, 0, chunksize - 1);
 -            maxdx = (int)GameMath.Clamp(centerX + horRadius + 1, 0, chunksize - 1);
 -            mindz = (int)GameMath.Clamp(centerZ - horRadius, 0, chunksize - 1);
 -            maxdz = (int)GameMath.Clamp(centerZ + horRadius + 1, 0, chunksize - 1);
-+            // Increased radius for fluid checks
-+            float checkHorRadius = horRadius + 1;
-+            float checkVertRadius = vertRadius + 2;
- 
--            mindy = (int)GameMath.Clamp(centerY - vertRadius * 0.7f, 1, worldheight - 1);
--            maxdy = (int)GameMath.Clamp(centerY + vertRadius + 1, 1, worldheight - 1);
-+            // Compute common bounds for both radii
 +            int mindx = (int)GameMath.Clamp(centerX - checkHorRadius, 0, chunksize - 1);
 +            int maxdx = (int)GameMath.Clamp(centerX + checkHorRadius + 1, 0, chunksize - 1);
 +            int mindz = (int)GameMath.Clamp(centerZ - checkHorRadius, 0, chunksize - 1);
 +            int maxdz = (int)GameMath.Clamp(centerZ + checkHorRadius + 1, 0, chunksize - 1);
  
+-            mindy = (int)GameMath.Clamp(centerY - vertRadius * 0.7f, 1, worldheight - 1);
+-            maxdy = (int)GameMath.Clamp(centerY + vertRadius + 1, 1, worldheight - 1);
+-
 -            hRadiusSq = horRadius * horRadius;
 -            vRadiusSq = vertRadius * vertRadius;
-+            // For Y use the check radius because it is larger
 +            int mindy = (int)GameMath.Clamp(centerY - checkVertRadius * 0.7f, 1, worldheight - 1);
 +            int maxdy = (int)GameMath.Clamp(centerY + checkVertRadius + 1, 1, worldheight - 1);
  
-+            // Precompute squared radii for fast comparisons
 +            double genHorRadiusSq = genHorRadius * genHorRadius;
 +            double genVertRadiusSq = genVertRadius * genVertRadius;
 +            double checkHorRadiusSq = checkHorRadius * checkHorRadius;
 +            double checkVertRadiusSq = checkVertRadius * checkVertRadius;
  
-+            // Get geologic activity once
              int geoActivity = getGeologicActivity(chunkX * chunksize + (int)centerX, chunkZ * chunksize + (int)centerZ);
              genHotSpring &= geoActivity > 128;
  
@@ -615,10 +703,8 @@ index 30f034d..47dc4ad 100644
              }
  
              int yLavaStart = (geoActivity * 16) / 128;
-+            int chunksizeSq = chunksize * chunksize;
  
 -
-+            // Main loop - single pass
              for (int lx = mindx; lx <= maxdx; lx++)
              {
 -                xdistRel = (lx - centerX) * (lx - centerX) / hRadiusSq;
@@ -639,18 +725,15 @@ index 30f034d..47dc4ad 100644
 -                    {
 -                        double yDist = y - centerY;
 -                        double heightOffFac = yDist > 0 ? heightrnd * heightrnd * Math.Min(1, Math.Abs(y - surfaceY) /10.0) : 0;
-+                    // Compute distortion once for the column
 +                    double distortStrength = GameMath.Clamp(genVertRadius / 4.0, 0, 0.1);
 +                    double heightrnd = (mapchunk.CaveHeightDistort[idx2d] - 127) * distortStrength;
 +                    int surfaceY = terrainheightmap[idx2d];
  
 -                        ydistRel = yDist * yDist / (vRadiusSq + heightOffFac);
-+                    // Compute maximum XZ distance for the check radius
 +                    double checkXZDist = dxSq / checkHorRadiusSq + dzSq / checkHorRadiusSq;
 +                    if (checkXZDist > 1.0) continue;
  
 -                        if (y > worldheight - 1 || xdistRel + ydistRel + zdistRel > 1.0) continue;
-+                    // Compute Y range for the check radius
 +                    double maxCheckDist = 1.0 - checkXZDist;
 +                    double maxCheckYDist = Math.Sqrt(maxCheckDist * checkVertRadiusSq);
 +                    int checkMindy = (int)Math.Max(mindy, centerY - maxCheckYDist);
@@ -661,21 +744,18 @@ index 30f034d..47dc4ad 100644
 -                            terrainheightmap[lz * chunksize + lx] = (ushort)(y - 1);
 -                            rainheightmap[lz * chunksize + lx]--;
 -                        }
-+                    // Variables for tracking state
 +                    bool hasLiquidInCheckRadius = false;
 +                    bool needsGenInGenRadius = false;
 +                    int firstGenY = -1;
  
 -                        IChunkBlocks chunkBlockData = chunks[y / chunksize].Data;
 -                        int index3d = ((y % chunksize) * chunksize + lz) * chunksize + lx;
-+                    // Walk Y once from top down
 +                    for (int y = checkMaxdy; y >= checkMindy; y--)
 +                    {
 +                        double dy = y - centerY;
 +                        double dySq = dy * dy;
  
 -                        if (y == 11)
-+                        // Check inclusion in check radius (for fluids)
 +                        double checkYDistSq = dySq / checkVertRadiusSq;
 +                        if (dxSq / checkHorRadiusSq + checkYDistSq + dzSq / checkHorRadiusSq <= 1.0)
                          {
@@ -686,31 +766,26 @@ index 30f034d..47dc4ad 100644
 -                                rainheightmap[lz * chunksize + lx] = Math.Max(rainheightmap[lz * chunksize + lx], (ushort)11);
 -                            }
 -                            else
-+                            // Fluid check — reads from live chunk data.
-+                            // Correctness: caves only modify the blocks layer (air/basalt/lava),
-+                            // never the fluids layer, so deferred block writes do not affect
-+                            // fluid state visibility.
 +                            if (!hasLiquidInCheckRadius && y >= 1 && y < worldheight)
                              {
 -                                chunkBlockData[index3d] = 0;
 -                                if (y > yLavaStart)
+-                                {
+-                                    chunkBlockData[index3d] = gcfg.basaltBlockId;
+-                                } else
 +                                int chunkY = y / chunksize;
 +                                int localY = y % chunksize;
 +                                var block = api.World.Blocks[chunks[chunkY].Data.GetFluid((localY * chunksize + lz) * chunksize + lx)];
 +                                if (block.LiquidCode != null)
                                  {
--                                    chunkBlockData[index3d] = gcfg.basaltBlockId;
--                                } else
--                                {
 -                                    chunkBlockData.SetFluid(index3d, gcfg.lavaBlockId);
-+                                    return false; // Found fluid - exit immediately
++                                    return false;
                                  }
 -
 -                                if (y <= yLavaStart) worldgenBlockAccessor.ScheduleBlockLightUpdate(new BlockPos(chunkX * chunksize + lx, y, chunkZ * chunksize + lz), airBlockId, gcfg.lavaBlockId);
                              }
 +                        }
 +
-+                        // Check inclusion in generation radius (for setting blocks)
 +                        if (!needsGenInGenRadius)
 +                        {
 +                            double heightOffFac = dy > 0 ? heightrnd * heightrnd * Math.Min(1, Math.Abs(y - surfaceY) / 10.0) : 0;
@@ -725,10 +800,8 @@ index 30f034d..47dc4ad 100644
 -                        else if (y < 12)
 +                    }
 +
-+                    // If we need to generate in this column
 +                    if (needsGenInGenRadius)
 +                    {
-+                        // Compute precise range for generation
 +                        double genXZDist = dxSq / genHorRadiusSq + dzSq / genHorRadiusSq;
 +                        double maxGenDist = 1.0 - genXZDist;
 +
@@ -736,7 +809,6 @@ index 30f034d..47dc4ad 100644
                          {
 -                            chunkBlockData[index3d] = 0;
 -                            if (y > yLavaStart)
-+                            // For positive Y account for distortion
 +                            double vertRadiusSqWithDistort = genVertRadiusSq;
 +                            if (firstGenY > centerY)
                              {
@@ -750,23 +822,18 @@ index 30f034d..47dc4ad 100644
 +                            int genMindy = (int)Math.Max(mindy, centerY - maxGenYDist);
 +                            int genMaxdy = (int)Math.Min(maxdy, centerY + maxGenYDist);
 +
-+                            // Generate blocks in the column — Stratum: writes are buffered as
-+                            // (index3d, value) pairs and applied once per subchunk at the end of
-+                            // GeneratePartial via SetBlocksUnsafe (one lock per batch).
 +                            for (int y = genMaxdy; y >= genMindy; y--)
                              {
 -                                chunkBlockData.SetFluid(index3d, gcfg.lavaBlockId);
 +                                double dy = y - centerY;
 +                                double dySq = dy * dy;
 +
-+                                // Check inclusion in ellipsoid with distortion
 +                                double heightOffFac = dy > 0 ? heightrnd * heightrnd * Math.Min(1, Math.Abs(y - surfaceY) / 10.0) : 0;
 +                                if (dxSq / genHorRadiusSq + dySq / (genVertRadiusSq + heightOffFac) + dzSq / genHorRadiusSq > 1.0)
 +                                    continue;
 +
 +                                if (y > worldheight - 1) continue;
 +
-+                                // Update heightmaps — these are local arrays, unchanged by Stratum pattern.
 +                                if (surfaceY == y)
 +                                {
 +                                    terrainheightmap[idx2d] = (ushort)(y - 1);
@@ -793,14 +860,13 @@ index 30f034d..47dc4ad 100644
 +                                        }
 +                                        else
 +                                        {
-+                                            // Stratum: fluids are NOT buffered — they remain live.
 +                                            chunks[chunkY].Data.SetFluid(index3D, gcfg.lavaBlockId);
 +                                        }
 +
 +                                        if (y <= yLavaStart)
 +                                        {
-+                                            // Stratum: buffer light updates to flush them under accessorLock at the
-+                                            // end of GeneratePartial, avoiding concurrent List<T> mutations.
++                                            // Stratum: buffer light updates to flush them at the end of GeneratePartial.
++                                            // ScheduleBlockLightUpdate is now thread-safe, so we just collect updates here.
 +                                            stratumPendLightPos.Add(new BlockPos(chunkX * chunksize + lx, y, chunkZ * chunksize + lz));
 +                                            stratumPendLightOld.Add(airBlockId);
 +                                            stratumPendLightNew.Add(gcfg.lavaBlockId);
@@ -822,7 +888,6 @@ index 30f034d..47dc4ad 100644
 +                                {
 +                                    StratumAppend(chunkY, index3D, airBlockId != 0 ? airBlockId : 0);
 +                                }
-+                                // Stratum end
                              }
                          }
 -                        else
@@ -834,3 +899,12 @@ index 30f034d..47dc4ad 100644
              }
  
              return true;
+@@ -669,8 +845,7 @@ namespace Vintagestory.ServerMods
+             int rlX = (posx / chunksize) % regionChunkSize;
+             int rlZ = (posz / chunksize) % regionChunkSize;
+ 
+             return climateMap.GetUnpaddedInt((int)(rlX * fac), (int)(rlZ * fac)) & 0xff;
+         }
+-
+     }
+ }

--- a/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves.cs.patch
+++ b/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves.cs.patch
@@ -1,5 +1,5 @@
 diff --git a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves.cs b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves.cs
-index 30f034d..3a7bbf3 100644
+index 30f034d..44e6a76 100644
 --- a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves.cs
 +++ b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves.cs
 @@ -10,19 +10,54 @@ namespace Vintagestory.ServerMods
@@ -124,7 +124,7 @@ index 30f034d..3a7bbf3 100644
          {
              if (heightvarNoise == null) return;
  
-@@ -72,70 +137,85 @@ namespace Vintagestory.ServerMods
+@@ -72,70 +137,90 @@ namespace Vintagestory.ServerMods
                      mapChunk.CaveHeightDistort[dz * chunksize + dx] = (byte)(128 * val + 127);
                  }
              }
@@ -156,25 +156,29 @@ index 30f034d..3a7bbf3 100644
 -            for (int dx = -5; dx <= 5; dx++)
 -            {
 -                for (int dz = -5; dz <= 5; dz++)
-+                var player = args.Caller.Player as IServerPlayer;
-+                int baseChunkX = (int)player.Entity.Pos.X / chunksize;
-+                int baseChunkZ = (int)player.Entity.Pos.Z / chunksize;
-+
-+                for (int dx = -5; dx <= 5; dx++)
++                IServerPlayer player = args.Caller.Player as IServerPlayer;
++                if (player == null)
                  {
 -                    int chunkX = baseChunkX + dx;
 -                    int chunkZ = baseChunkZ + dz;
-+                    for (int dz = -5; dz <= 5; dz++)
-+                    {
-+                        int chunkX = baseChunkX + dx;
-+                        int chunkZ = baseChunkZ + dz;
++                    return TextCommandResult.Error("This command can only be run by an in-game player, not the server console.");
++                }
  
 -                    IServerChunk[] chunks = GetChunkColumn(chunkX, chunkZ);
-+                        IServerChunk[] chunks = GetChunkColumn(chunkX, chunkZ);
++                int baseChunkX = (int)player.Entity.Pos.X / chunksize;
++                int baseChunkZ = (int)player.Entity.Pos.Z / chunksize;
  
 -                    for (int i = 0; i < chunks.Length; i++)
--                    {
++                for (int dx = -5; dx <= 5; dx++)
++                {
++                    for (int dz = -5; dz <= 5; dz++)
+                     {
 -                        if (chunks[i] == null)
++                        int chunkX = baseChunkX + dx;
++                        int chunkZ = baseChunkZ + dz;
++
++                        IServerChunk[] chunks = GetChunkColumn(chunkX, chunkZ);
++
 +                        for (int i = 0; i < chunks.Length; i++)
                          {
 -                            return TextCommandResult.Success( "Cannot generate 10x10 area of caves, chunks are not loaded that far yet.");
@@ -190,8 +194,8 @@ index 30f034d..3a7bbf3 100644
 +                    }
                  }
 -            }
- 
 -
+ 
 -            for (int dx = -5; dx <= 5; dx++)
 -            {
 -                for (int dz = -5; dz <= 5; dz++)
@@ -248,7 +252,7 @@ index 30f034d..3a7bbf3 100644
          private IServerChunk[] GetChunkColumn(int chunkX, int chunkZ)
          {
              int size = api.World.BlockAccessor.MapSizeY / chunksize;
-@@ -148,11 +228,12 @@ namespace Vintagestory.ServerMods
+@@ -148,11 +233,12 @@ namespace Vintagestory.ServerMods
              return chunks;
          }
  
@@ -262,7 +266,7 @@ index 30f034d..3a7bbf3 100644
              }
          }
  
-@@ -181,13 +262,16 @@ namespace Vintagestory.ServerMods
+@@ -181,13 +267,16 @@ namespace Vintagestory.ServerMods
              if (GetIntersectingStructure(chunkX * chunksize + chunksize / 2, chunkZ * chunksize + chunksize / 2, CavesHashCode) != null)
              {
                  return;
@@ -281,7 +285,7 @@ index 30f034d..3a7bbf3 100644
              while (quantityCaves-- > 0)
              {
                  int rnd = chunkRand.NextInt(rndSize);
-@@ -201,38 +285,108 @@ namespace Vintagestory.ServerMods
+@@ -201,38 +290,112 @@ namespace Vintagestory.ServerMods
                  float vertAngle = (chunkRand.NextFloat() - 0.5f) * 0.25f;
                  float horizontalSize = chunkRand.NextFloat() * 2 + chunkRand.NextFloat();
                  float verticalSize = 0.75f + chunkRand.NextFloat() * 0.4f;
@@ -347,6 +351,10 @@ index 30f034d..3a7bbf3 100644
 +                    stratumPendIdx[i] = new List<int>(1024);
 +                    stratumPendVal[i] = new List<int>(1024);
 +                }
++
++                // Stratum: initialize the light buffer on the first column too, before returning.
++                if (stratumPendLight == null)
++                    stratumPendLight = new List<Vec4i>(256);
 +                return;
 +            }
 +            for (int i = 0; i < numSubchunks; i++)
@@ -354,12 +362,12 @@ index 30f034d..3a7bbf3 100644
 +                stratumPendIdx[i].Clear();
 +                stratumPendVal[i].Clear();
 +            }
++
 +            // Stratum: the previous batch may have been handed over to the chunk.
 +            if (stratumPendLight == null)
 +                stratumPendLight = new List<Vec4i>(256);
 +            else
 +                stratumPendLight.Clear();
-+
 +        }
 +
 +        private void StratumAppend(int chunkY, int index3D, int value)
@@ -398,7 +406,7 @@ index 30f034d..3a7bbf3 100644
          private void CarveTunnel(IServerChunk[] chunks, int chunkX, int chunkZ, double posX, double posY, double posZ, float horAngle, float vertAngle, float horizontalSize, float verticalSize, int currentIteration, int maxIterations, int branchLevel, bool extraBranchy = false, float curviness = 0.1f, bool largeNearLavaLayer = false)
          {
              LCGRandom caveRand = this.caveRand;
-@@ -264,17 +418,16 @@ namespace Vintagestory.ServerMods
+@@ -264,17 +427,16 @@ namespace Vintagestory.ServerMods
                  relPos = (float)currentIteration / maxIterations;
  
                  float horRadius = 1.5f + GameMath.FastSin(relPos * GameMath.PI) * horizontalSize + horRadiusGainAccum;
@@ -417,7 +425,7 @@ index 30f034d..3a7bbf3 100644
                      float factor = 1f + Math.Max(0f, 1f - (float)Math.Abs(posY - 12d) / 10f);
                      horRadius *= factor;
                      vertRadius *= factor;
-@@ -287,67 +440,61 @@ namespace Vintagestory.ServerMods
+@@ -287,67 +449,61 @@ namespace Vintagestory.ServerMods
                  posZ += GameMath.FastSin(horAngle) * advanceHor;
  
                  vertAngle *= 0.8f;
@@ -503,7 +511,7 @@ index 30f034d..3a7bbf3 100644
                      if (posY < 19)
                      {
                          verHeightGain = 2 + caveRand.NextFloat() * caveRand.NextFloat() * 5;
-@@ -376,22 +523,19 @@ namespace Vintagestory.ServerMods
+@@ -376,22 +532,19 @@ namespace Vintagestory.ServerMods
                  verHeightLoss -= 0.4f;
  
                  horAngle += curviness * horAngleChange;
@@ -527,7 +535,7 @@ index 30f034d..3a7bbf3 100644
                      CarveTunnel(
                          chunks,
                          chunkX,
-@@ -405,11 +549,10 @@ namespace Vintagestory.ServerMods
+@@ -405,11 +558,10 @@ namespace Vintagestory.ServerMods
                          maxIterations - (int)(caveRand.NextFloat() * 0.5 * maxIterations),
                          branchLevel + 1
                      );
@@ -539,7 +547,7 @@ index 30f034d..3a7bbf3 100644
                      CarveShaft(
                          chunks,
                          chunkX,
-@@ -418,31 +561,25 @@ namespace Vintagestory.ServerMods
+@@ -418,31 +570,25 @@ namespace Vintagestory.ServerMods
                          horAngle + (caveRand.NextFloat() + caveRand.NextFloat() - 1) + GameMath.PI,
                          -GameMath.PI / 2 - 0.1f + 0.2f * caveRand.NextFloat(),
                          Math.Min(3.5f, horRadius - 1),
@@ -572,7 +580,7 @@ index 30f034d..3a7bbf3 100644
              float vertAngleChange = 0;
  
              ushort[] terrainheightmap = chunks[0].MapChunk.WorldGenTerrainHeightMap;
-@@ -468,11 +605,10 @@ namespace Vintagestory.ServerMods
+@@ -468,11 +614,10 @@ namespace Vintagestory.ServerMods
                  posZ += GameMath.FastSin(horAngle) * advanceHor;
  
                  vertAngle += 0.1f * vertAngleChange;
@@ -584,7 +592,7 @@ index 30f034d..3a7bbf3 100644
                      int num = 3 + caveRand.NextInt(4);
                      for (int i = 0; i < num; i++)
                      {
-@@ -493,168 +629,196 @@ namespace Vintagestory.ServerMods
+@@ -493,168 +638,196 @@ namespace Vintagestory.ServerMods
                      return;
                  }
  
@@ -639,7 +647,9 @@ index 30f034d..3a7bbf3 100644
 -                        ydistRel = yDist * yDist / (vRadiusSq + heightOffFac);
 -
 -                        if (xdistRel + ydistRel + zdistRel > 1.0 || y > worldheight - 1) continue;
--
++            float genHorRadius = horRadius;
++            float genVertRadius = vertRadius;
+ 
 -                        int ly = y % chunksize;
 -                        var block = api.World.Blocks[chunks[y / chunksize].Data.GetFluid((ly * chunksize + lz) * chunksize + lx)];
 -                        if (block.LiquidCode != null)
@@ -649,27 +659,25 @@ index 30f034d..3a7bbf3 100644
 -                    }
 -                }
 -            }
--
--
--            horRadius--;
--            vertRadius-=2;
-+            float genHorRadius = horRadius;
-+            float genVertRadius = vertRadius;
- 
--            mindx = (int)GameMath.Clamp(centerX - horRadius, 0, chunksize - 1);
--            maxdx = (int)GameMath.Clamp(centerX + horRadius + 1, 0, chunksize - 1);
--            mindz = (int)GameMath.Clamp(centerZ - horRadius, 0, chunksize - 1);
--            maxdz = (int)GameMath.Clamp(centerZ + horRadius + 1, 0, chunksize - 1);
 +            float checkHorRadius = horRadius + 1;
 +            float checkVertRadius = vertRadius + 2;
  
--            mindy = (int)GameMath.Clamp(centerY - vertRadius * 0.7f, 1, worldheight - 1);
--            maxdy = (int)GameMath.Clamp(centerY + vertRadius + 1, 1, worldheight - 1);
 +            int mindx = (int)GameMath.Clamp(centerX - checkHorRadius, 0, chunksize - 1);
 +            int maxdx = (int)GameMath.Clamp(centerX + checkHorRadius + 1, 0, chunksize - 1);
 +            int mindz = (int)GameMath.Clamp(centerZ - checkHorRadius, 0, chunksize - 1);
 +            int maxdz = (int)GameMath.Clamp(centerZ + checkHorRadius + 1, 0, chunksize - 1);
  
+-            horRadius--;
+-            vertRadius-=2;
+-
+-            mindx = (int)GameMath.Clamp(centerX - horRadius, 0, chunksize - 1);
+-            maxdx = (int)GameMath.Clamp(centerX + horRadius + 1, 0, chunksize - 1);
+-            mindz = (int)GameMath.Clamp(centerZ - horRadius, 0, chunksize - 1);
+-            maxdz = (int)GameMath.Clamp(centerZ + horRadius + 1, 0, chunksize - 1);
+-
+-            mindy = (int)GameMath.Clamp(centerY - vertRadius * 0.7f, 1, worldheight - 1);
+-            maxdy = (int)GameMath.Clamp(centerY + vertRadius + 1, 1, worldheight - 1);
+-
 -            hRadiusSq = horRadius * horRadius;
 -            vRadiusSq = vertRadius * vertRadius;
 +            int mindy = (int)GameMath.Clamp(centerY - checkVertRadius * 0.7f, 1, worldheight - 1);
@@ -887,7 +895,7 @@ index 30f034d..3a7bbf3 100644
              }
  
              return true;
-@@ -669,8 +833,7 @@ namespace Vintagestory.ServerMods
+@@ -669,8 +842,7 @@ namespace Vintagestory.ServerMods
              int rlX = (posx / chunksize) % regionChunkSize;
              int rlZ = (posz / chunksize) % regionChunkSize;
  

--- a/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves.cs.patch
+++ b/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves.cs.patch
@@ -1,11 +1,21 @@
 diff --git a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves.cs b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves.cs
-index 30f034d..3cdcce8 100644
+index 30f034d..0583e33 100644
 --- a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves.cs
 +++ b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves.cs
-@@ -12,17 +12,37 @@ namespace Vintagestory.ServerMods
+@@ -10,19 +10,47 @@ namespace Vintagestory.ServerMods
+ {
+     public class GenCaves : GenPartial
      {
          protected override int chunkRange { get { return 5; } }
  
++        // Stratum: when true (only set for the isolated /dev gencaves instance), buffered writes
++        // go through the readWriteLock-locked Set() path instead of the batched SetManyUnsafe. The
++        // command runs against live/published chunks any player can be standing in, so a concurrent
++        // reader or the save/compression thread must never observe a torn bit-plane update; SetManyUnsafe's
++        // stratumWriteLock alone does not exclude readers. Normal worldgen keeps the fast batched path
++        // because its chunks are not published until generation finishes.
++        bool stratumLockedWrites;
++
          public override double ExecuteOrder() { return 0.3; }
  
 +        // Stratum: plain field, vanilla shape, because mods look it up by name.
@@ -40,7 +50,7 @@ index 30f034d..3cdcce8 100644
              base.StartServerSide(api);
  
              if (TerraGenConfig.DoDecorationPass)
-@@ -30,18 +50,18 @@ namespace Vintagestory.ServerMods
+@@ -30,18 +58,18 @@ namespace Vintagestory.ServerMods
                  api.Event.GetWorldgenBlockAccessor(OnWorldGenBlockAccessor);
  
                  api.ChatCommands.GetOrCreate("dev")
@@ -61,7 +71,7 @@ index 30f034d..3cdcce8 100644
          }
  
  
-@@ -51,10 +71,44 @@ namespace Vintagestory.ServerMods
+@@ -51,10 +79,44 @@ namespace Vintagestory.ServerMods
              caveRand = new LCGRandom(api.WorldManager.Seed + 123128);
              basaltNoise = NormalizedSimplexNoise.FromDefaultOctaves(2, 1f / 3.5f, 0.9f, api.World.Seed + 12);
              heightvarNoise = NormalizedSimplexNoise.FromDefaultOctaves(3, 1f / 20f, 0.9f, api.World.Seed + 12);
@@ -106,7 +116,7 @@ index 30f034d..3cdcce8 100644
  
          private void OnMapChunkGen(IMapChunk mapChunk, int chunkX, int chunkZ)
          {
-@@ -72,68 +126,96 @@ namespace Vintagestory.ServerMods
+@@ -72,68 +134,98 @@ namespace Vintagestory.ServerMods
                      mapChunk.CaveHeightDistort[dz * chunksize + dx] = (byte)(128 * val + 127);
                  }
              }
@@ -141,33 +151,35 @@ index 30f034d..3cdcce8 100644
  
 -            int baseChunkX = api.World.BlockAccessor.MapSizeX / 2 / chunksize;
 -            int baseChunkZ = api.World.BlockAccessor.MapSizeZ / 2 / chunksize;
-+                // replace the air block with granite to generate inverted caves
-+                cmd.airBlockId = api.World.GetBlock(new AssetLocation("rock-granite")).BlockId;
++                cmd.stratumLockedWrites = true; // Stratum: dev command touches live chunks -> locked writes
  
 -            for (int dx = -5; dx <= 5; dx++)
 -            {
 -                for (int dz = -5; dz <= 5; dz++)
+-                {
+-                    int chunkX = baseChunkX + dx;
+-                    int chunkZ = baseChunkZ + dz;
++                // replace the air block with granite to generate inverted caves
++                cmd.airBlockId = api.World.GetBlock(new AssetLocation("rock-granite")).BlockId;
+ 
+-                    IServerChunk[] chunks = GetChunkColumn(chunkX, chunkZ);
 +                // take the player as the center
 +                var player = args.Caller.Player as IServerPlayer;
 +                int baseChunkX = (int)player.Entity.Pos.X / chunksize;
 +                int baseChunkZ = (int)player.Entity.Pos.Z / chunksize;
-+
-+                // first check that all chunks are loaded
-+                for (int dx = -5; dx <= 5; dx++)
-                 {
--                    int chunkX = baseChunkX + dx;
--                    int chunkZ = baseChunkZ + dz;
-+                    for (int dz = -5; dz <= 5; dz++)
-+                    {
-+                        int chunkX = baseChunkX + dx;
-+                        int chunkZ = baseChunkZ + dz;
- 
--                    IServerChunk[] chunks = GetChunkColumn(chunkX, chunkZ);
-+                        IServerChunk[] chunks = GetChunkColumn(chunkX, chunkZ);
  
 -                    for (int i = 0; i < chunks.Length; i++)
--                    {
++                // first check that all chunks are loaded
++                for (int dx = -5; dx <= 5; dx++)
++                {
++                    for (int dz = -5; dz <= 5; dz++)
+                     {
 -                        if (chunks[i] == null)
++                        int chunkX = baseChunkX + dx;
++                        int chunkZ = baseChunkZ + dz;
++
++                        IServerChunk[] chunks = GetChunkColumn(chunkX, chunkZ);
++
 +                        for (int i = 0; i < chunks.Length; i++)
                          {
 -                            return TextCommandResult.Success( "Cannot generate 10x10 area of caves, chunks are not loaded that far yet.");
@@ -183,8 +195,8 @@ index 30f034d..3cdcce8 100644
 +                    }
                  }
 -            }
- 
 -
+ 
 -            for (int dx = -5; dx <= 5; dx++)
 -            {
 -                for (int dz = -5; dz <= 5; dz++)
@@ -239,7 +251,7 @@ index 30f034d..3cdcce8 100644
          }
  
          private IServerChunk[] GetChunkColumn(int chunkX, int chunkZ)
-@@ -148,11 +230,12 @@ namespace Vintagestory.ServerMods
+@@ -148,11 +240,12 @@ namespace Vintagestory.ServerMods
              return chunks;
          }
  
@@ -253,7 +265,7 @@ index 30f034d..3cdcce8 100644
              }
          }
  
-@@ -183,11 +266,15 @@ namespace Vintagestory.ServerMods
+@@ -183,11 +276,15 @@ namespace Vintagestory.ServerMods
                  return;
              }
  
@@ -270,7 +282,7 @@ index 30f034d..3cdcce8 100644
              while (quantityCaves-- > 0)
              {
                  int rnd = chunkRand.NextInt(rndSize);
-@@ -229,11 +316,88 @@ namespace Vintagestory.ServerMods
+@@ -229,11 +326,83 @@ namespace Vintagestory.ServerMods
  
                  caveRand.SetWorldSeed(chunkRand.NextInt(10000000));
                  caveRand.InitPositionSeed(chunkX + cdx, chunkZ + cdz);
@@ -324,31 +336,26 @@ index 30f034d..3cdcce8 100644
 +
 +                IChunkBlocks data = chunks[cy].Data;
 +
-+                // Stratum: SetManyUnsafe is a fast path that assumes an initialized layer
-+                // (palette + bit planes). A never-written subchunk (empty sky, or cleared
-+                // by the dev command) has no palette and would NRE inside SetUnsafeCore.
-+                // ClearBlocksAndPrepare() initializes palette/planes without destroying
-+                // the fluids/light layers.
-+                if (!data.HasBlocksLayer)
++                if (stratumLockedWrites)
 +                {
-+                    // Writing air into a subchunk that never had blocks changes nothing: skip.
-+                    bool anyNonZero = false;
-+                    for (int i = 0; i < val.Count; i++)
++                    // Locked path: one readWriteLock per block, safe on live/published chunks. The
++                    // indexer setter lazily creates the blocks layer and wraps each SetCore in
++                    // readWriteLock.AcquireWriteLock()/ReleaseWriteLock() - exactly like the old
++                    // chunkBlockData[index] = value path. Does NOT null out fluids/light layers, so lava
++                    // written earlier this command run survives.
++                    for (int i = 0; i < idx.Count; i++)
 +                    {
-+                        if (val[i] != 0) { anyNonZero = true; break; }
++                        data[idx[i]] = val[i];
 +                    }
-+                    if (!anyNonZero)
-+                    {
-+                        idx.Clear();
-+                        val.Clear();
-+                        continue;
-+                    }
-+
-+                    // Real blocks into an empty subchunk: initialize palette lazily.
-+                    data.ClearBlocksAndPrepare();
++                }
++                else
++                {
++                    // Batched path: one lock per touched subchunk, only used during generation where
++                    // chunks are not yet published. Self-initialises an empty blocks layer via
++                    // PopulateWithAir without touching fluids/light layers (see ChunkData.SetBlocksUnsafe).
++                    data.SetBlocksUnsafe(idx, val);
 +                }
 +
-+                data.SetBlocksUnsafe(idx, val);
 +                idx.Clear();
 +                val.Clear();
 +            }
@@ -359,7 +366,7 @@ index 30f034d..3cdcce8 100644
          {
              LCGRandom caveRand = this.caveRand;
  
-@@ -289,14 +453,14 @@ namespace Vintagestory.ServerMods
+@@ -289,14 +458,14 @@ namespace Vintagestory.ServerMods
                  vertAngle *= 0.8f;
  
                  int rrnd = caveRand.NextInt(800000);
@@ -376,7 +383,7 @@ index 30f034d..3cdcce8 100644
                  // 1/330 * 10k = 30
                  // 1/130 * 10k = 76
                  // 1/100 * 10k = 100
-@@ -305,48 +469,55 @@ namespace Vintagestory.ServerMods
+@@ -305,48 +474,55 @@ namespace Vintagestory.ServerMods
  
                  // Rarely change direction
                  if ((rnd -= 30) <= 0)
@@ -439,7 +446,7 @@ index 30f034d..3cdcce8 100644
                  {
                      if (posY < 19)
                      {
-@@ -418,11 +589,11 @@ namespace Vintagestory.ServerMods
+@@ -418,11 +594,11 @@ namespace Vintagestory.ServerMods
                          horAngle + (caveRand.NextFloat() + caveRand.NextFloat() - 1) + GameMath.PI,
                          -GameMath.PI / 2 - 0.1f + 0.2f * caveRand.NextFloat(),
                          Math.Min(3.5f, horRadius - 1),
@@ -452,7 +459,7 @@ index 30f034d..3cdcce8 100644
  
                      branchLevel++;
                  }
-@@ -506,155 +677,220 @@ namespace Vintagestory.ServerMods
+@@ -506,155 +682,220 @@ namespace Vintagestory.ServerMods
  
  
  
@@ -624,28 +631,28 @@ index 30f034d..3cdcce8 100644
 +                        if (dxSq / checkHorRadiusSq + checkYDistSq + dzSq / checkHorRadiusSq <= 1.0)
                          {
 -                            if (basaltNoise.Noise(chunkX * chunksize + lx, chunkZ * chunksize + lz) > 0.65)
+-                            {
+-                                chunkBlockData[index3d] = gcfg.basaltBlockId;
+-                                terrainheightmap[lz * chunksize + lx] = Math.Max(terrainheightmap[lz * chunksize + lx], (ushort)11);
+-                                rainheightmap[lz * chunksize + lx] = Math.Max(rainheightmap[lz * chunksize + lx], (ushort)11);
+-                            }
+-                            else
 +                            // Fluid check — reads from live chunk data.
 +                            // Correctness: caves only modify the blocks layer (air/basalt/lava),
 +                            // never the fluids layer, so deferred block writes do not affect
 +                            // fluid state visibility.
 +                            if (!hasLiquidInCheckRadius && y >= 1 && y < worldheight)
                              {
--                                chunkBlockData[index3d] = gcfg.basaltBlockId;
--                                terrainheightmap[lz * chunksize + lx] = Math.Max(terrainheightmap[lz * chunksize + lx], (ushort)11);
--                                rainheightmap[lz * chunksize + lx] = Math.Max(rainheightmap[lz * chunksize + lx], (ushort)11);
--                            }
--                            else
--                            {
 -                                chunkBlockData[index3d] = 0;
 -                                if (y > yLavaStart)
+-                                {
+-                                    chunkBlockData[index3d] = gcfg.basaltBlockId;
+-                                } else
 +                                int chunkY = y / chunksize;
 +                                int localY = y % chunksize;
 +                                var block = api.World.Blocks[chunks[chunkY].Data.GetFluid((localY * chunksize + lz) * chunksize + lx)];
 +                                if (block.LiquidCode != null)
                                  {
--                                    chunkBlockData[index3d] = gcfg.basaltBlockId;
--                                } else
--                                {
 -                                    chunkBlockData.SetFluid(index3d, gcfg.lavaBlockId);
 +                                    return false; // Found fluid - exit immediately
                                  }
@@ -653,13 +660,13 @@ index 30f034d..3cdcce8 100644
 -                                if (y <= yLavaStart) worldgenBlockAccessor.ScheduleBlockLightUpdate(new BlockPos(chunkX * chunksize + lx, y, chunkZ * chunksize + lz), airBlockId, gcfg.lavaBlockId);
                              }
 +                        }
-+
+ 
 +                        // Check inclusion in generation radius (for setting blocks)
 +                        if (!needsGenInGenRadius)
 +                        {
 +                            double heightOffFac = dy > 0 ? heightrnd * heightrnd * Math.Min(1, Math.Abs(y - surfaceY) / 10.0) : 0;
 +                            double genYDistSq = dySq / (genVertRadiusSq + heightOffFac);
- 
++
 +                            if (dxSq / genHorRadiusSq + genYDistSq + dzSq / genHorRadiusSq <= 1.0 && y < worldheight)
 +                            {
 +                                needsGenInGenRadius = true;

--- a/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves.cs.patch
+++ b/patches/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves.cs.patch
@@ -1,5 +1,5 @@
 diff --git a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves.cs b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves.cs
-index 30f034d..c034eed 100644
+index 30f034d..9630057 100644
 --- a/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves.cs
 +++ b/VSEssentials/Systems/WorldGen/Standard/ChunkGen/3.GenCaves/GenCaves.cs
 @@ -10,19 +10,51 @@ namespace Vintagestory.ServerMods
@@ -233,10 +233,10 @@ index 30f034d..c034eed 100644
 +                        cmd.worldgenBlockAccessor.BeginColumn();
  
 -            airBlockId = 0;
-+                        // Run lighting recalculation (like in GenLightSurvival)
-+                        // Stratum: ScheduleBlockLightUpdate and RunScheduledBlockLightUpdates are now
-+                        // thread-safe (protected by lightUpdatesLock inside BlockAccessorWorldGen),
-+                        // so no external locking needed.
++                        // Stratum: ScheduleBlockLightUpdate and RunScheduledBlockLightUpdates are
++                        // thread-safe via a lock-free ConcurrentStack on the map chunk (the drain
++                        // merges into a freshly allocated list, so it never aliases a batch another
++                        // thread can enumerate). No external locking needed.
 +                        api.WorldManager.SunFloodChunkColumnForWorldGen(chunks, chunkX, chunkZ);
 +                        cmd.worldgenBlockAccessor.RunScheduledBlockLightUpdates(chunkX, chunkZ);
  

--- a/patches/VSSurvivalMod/Systems/Prospecting/ProPickWorkSpace.cs.patch
+++ b/patches/VSSurvivalMod/Systems/Prospecting/ProPickWorkSpace.cs.patch
@@ -1,5 +1,5 @@
 diff --git a/VSSurvivalMod/Systems/Prospecting/ProPickWorkSpace.cs b/VSSurvivalMod/Systems/Prospecting/ProPickWorkSpace.cs
-index 3fe5096..6bc906d 100644
+index 3fe5096..7c6da6d 100644
 --- a/VSSurvivalMod/Systems/Prospecting/ProPickWorkSpace.cs
 +++ b/VSSurvivalMod/Systems/Prospecting/ProPickWorkSpace.cs
 @@ -122,12 +122,14 @@ namespace Vintagestory.GameContent
@@ -19,7 +19,7 @@ index 3fe5096..6bc906d 100644
              {
                  // Wait for off-thread initialisation to finish (should be well finished by the time any player is able to use a ProPick, but let's make sure)
                  int timeOutCount = 100;
-@@ -216,10 +218,65 @@ namespace Vintagestory.GameContent
+@@ -216,10 +218,69 @@ namespace Vintagestory.GameContent
                  public void SetBlockUnsafe(int index3d, int value)
                  {
                      this[index3d] = value;
@@ -37,6 +37,10 @@ index 3fe5096..6bc906d 100644
 +                {
 +                    Array.Copy(blocks, blocksOut, blocks.Length);
 +                }
++
++
++                public bool HasBlocksLayer { get; }
++
 +
 +                /// <summary>
 +                /// Stratum: bulk variant of SetBlockUnsafe for interface compatibility. DummyChunkData is a plain int[] with no locking or palette, so there's no batching benefit — this simply applies each index/value pair directly via the indexer, equivalent to calling SetBlockUnsafe in a loop but matching the IChunkBlocks contract signature.
@@ -85,7 +89,7 @@ index 3fe5096..6bc906d 100644
  
                  }
  
-@@ -251,13 +308,13 @@ namespace Vintagestory.GameContent
+@@ -251,13 +312,13 @@ namespace Vintagestory.GameContent
              public string GameVersionCreated => throw new NotImplementedException();
  
              public bool Disposed => throw new NotImplementedException();
@@ -101,7 +105,7 @@ index 3fe5096..6bc906d 100644
  
              IChunkBlocks IWorldChunk.Blocks => throw new NotImplementedException();
  
-@@ -301,22 +358,22 @@ namespace Vintagestory.GameContent
+@@ -301,22 +362,22 @@ namespace Vintagestory.GameContent
              }
              public void Unpack()
              {
@@ -136,7 +140,7 @@ index 3fe5096..6bc906d 100644
                  throw new NotImplementedException();
              }
  
-@@ -334,19 +391,19 @@ namespace Vintagestory.GameContent
+@@ -334,19 +395,19 @@ namespace Vintagestory.GameContent
              public BlockEntity GetLocalBlockEntityAtBlockPos(BlockPos pos)
              {
                  throw new NotImplementedException();
@@ -164,7 +168,7 @@ index 3fe5096..6bc906d 100644
              {
                  throw new NotImplementedException();
              }
-@@ -355,35 +412,35 @@ namespace Vintagestory.GameContent
+@@ -355,35 +416,35 @@ namespace Vintagestory.GameContent
              {
                  throw new NotImplementedException();
              }
@@ -216,7 +220,7 @@ index 3fe5096..6bc906d 100644
              }
  
              public void BreakAllDecorFast(IWorldAccessor world, BlockPos pos, int index3d, bool callOnBrokenAsDecor = true)
-@@ -394,16 +451,16 @@ namespace Vintagestory.GameContent
+@@ -394,16 +455,16 @@ namespace Vintagestory.GameContent
              public Dictionary<int, Block> GetDecors(IBlockAccessor blockAccessor, BlockPos pos)
              {
                  throw new NotImplementedException();

--- a/patches/VSSurvivalMod/Systems/Prospecting/ProPickWorkSpace.cs.patch
+++ b/patches/VSSurvivalMod/Systems/Prospecting/ProPickWorkSpace.cs.patch
@@ -1,5 +1,5 @@
 diff --git a/VSSurvivalMod/Systems/Prospecting/ProPickWorkSpace.cs b/VSSurvivalMod/Systems/Prospecting/ProPickWorkSpace.cs
-index 3fe5096..72e9372 100644
+index 3fe5096..15c9882 100644
 --- a/VSSurvivalMod/Systems/Prospecting/ProPickWorkSpace.cs
 +++ b/VSSurvivalMod/Systems/Prospecting/ProPickWorkSpace.cs
 @@ -122,12 +122,14 @@ namespace Vintagestory.GameContent
@@ -19,7 +19,7 @@ index 3fe5096..72e9372 100644
              {
                  // Wait for off-thread initialisation to finish (should be well finished by the time any player is able to use a ProPick, but let's make sure)
                  int timeOutCount = 100;
-@@ -216,10 +218,71 @@ namespace Vintagestory.GameContent
+@@ -216,10 +218,66 @@ namespace Vintagestory.GameContent
                  public void SetBlockUnsafe(int index3d, int value)
                  {
                      this[index3d] = value;
@@ -37,11 +37,6 @@ index 3fe5096..72e9372 100644
 +                {
 +                    Array.Copy(blocks, blocksOut, blocks.Length);
 +                }
-+
-+                /// <summary>
-+                /// Stratum: necessary interface overload. 
-+                /// </summary>
-+                public bool HasBlocksLayer { get; }
 +
 +
 +                /// <summary>
@@ -91,7 +86,7 @@ index 3fe5096..72e9372 100644
  
                  }
  
-@@ -251,13 +314,13 @@ namespace Vintagestory.GameContent
+@@ -251,13 +309,13 @@ namespace Vintagestory.GameContent
              public string GameVersionCreated => throw new NotImplementedException();
  
              public bool Disposed => throw new NotImplementedException();
@@ -107,7 +102,7 @@ index 3fe5096..72e9372 100644
  
              IChunkBlocks IWorldChunk.Blocks => throw new NotImplementedException();
  
-@@ -301,22 +364,22 @@ namespace Vintagestory.GameContent
+@@ -301,22 +359,22 @@ namespace Vintagestory.GameContent
              }
              public void Unpack()
              {
@@ -142,7 +137,7 @@ index 3fe5096..72e9372 100644
                  throw new NotImplementedException();
              }
  
-@@ -334,19 +397,19 @@ namespace Vintagestory.GameContent
+@@ -334,19 +392,19 @@ namespace Vintagestory.GameContent
              public BlockEntity GetLocalBlockEntityAtBlockPos(BlockPos pos)
              {
                  throw new NotImplementedException();
@@ -170,7 +165,7 @@ index 3fe5096..72e9372 100644
              {
                  throw new NotImplementedException();
              }
-@@ -355,35 +418,35 @@ namespace Vintagestory.GameContent
+@@ -355,35 +413,35 @@ namespace Vintagestory.GameContent
              {
                  throw new NotImplementedException();
              }
@@ -222,7 +217,7 @@ index 3fe5096..72e9372 100644
              }
  
              public void BreakAllDecorFast(IWorldAccessor world, BlockPos pos, int index3d, bool callOnBrokenAsDecor = true)
-@@ -394,16 +457,16 @@ namespace Vintagestory.GameContent
+@@ -394,16 +452,16 @@ namespace Vintagestory.GameContent
              public Dictionary<int, Block> GetDecors(IBlockAccessor blockAccessor, BlockPos pos)
              {
                  throw new NotImplementedException();

--- a/patches/VSSurvivalMod/Systems/Prospecting/ProPickWorkSpace.cs.patch
+++ b/patches/VSSurvivalMod/Systems/Prospecting/ProPickWorkSpace.cs.patch
@@ -1,5 +1,5 @@
 diff --git a/VSSurvivalMod/Systems/Prospecting/ProPickWorkSpace.cs b/VSSurvivalMod/Systems/Prospecting/ProPickWorkSpace.cs
-index 3fe5096..7c6da6d 100644
+index 3fe5096..72e9372 100644
 --- a/VSSurvivalMod/Systems/Prospecting/ProPickWorkSpace.cs
 +++ b/VSSurvivalMod/Systems/Prospecting/ProPickWorkSpace.cs
 @@ -122,12 +122,14 @@ namespace Vintagestory.GameContent
@@ -19,7 +19,7 @@ index 3fe5096..7c6da6d 100644
              {
                  // Wait for off-thread initialisation to finish (should be well finished by the time any player is able to use a ProPick, but let's make sure)
                  int timeOutCount = 100;
-@@ -216,10 +218,69 @@ namespace Vintagestory.GameContent
+@@ -216,10 +218,71 @@ namespace Vintagestory.GameContent
                  public void SetBlockUnsafe(int index3d, int value)
                  {
                      this[index3d] = value;
@@ -38,7 +38,9 @@ index 3fe5096..7c6da6d 100644
 +                    Array.Copy(blocks, blocksOut, blocks.Length);
 +                }
 +
-+
++                /// <summary>
++                /// Stratum: necessary interface overload. 
++                /// </summary>
 +                public bool HasBlocksLayer { get; }
 +
 +
@@ -89,7 +91,7 @@ index 3fe5096..7c6da6d 100644
  
                  }
  
-@@ -251,13 +312,13 @@ namespace Vintagestory.GameContent
+@@ -251,13 +314,13 @@ namespace Vintagestory.GameContent
              public string GameVersionCreated => throw new NotImplementedException();
  
              public bool Disposed => throw new NotImplementedException();
@@ -105,7 +107,7 @@ index 3fe5096..7c6da6d 100644
  
              IChunkBlocks IWorldChunk.Blocks => throw new NotImplementedException();
  
-@@ -301,22 +362,22 @@ namespace Vintagestory.GameContent
+@@ -301,22 +364,22 @@ namespace Vintagestory.GameContent
              }
              public void Unpack()
              {
@@ -140,7 +142,7 @@ index 3fe5096..7c6da6d 100644
                  throw new NotImplementedException();
              }
  
-@@ -334,19 +395,19 @@ namespace Vintagestory.GameContent
+@@ -334,19 +397,19 @@ namespace Vintagestory.GameContent
              public BlockEntity GetLocalBlockEntityAtBlockPos(BlockPos pos)
              {
                  throw new NotImplementedException();
@@ -168,7 +170,7 @@ index 3fe5096..7c6da6d 100644
              {
                  throw new NotImplementedException();
              }
-@@ -355,35 +416,35 @@ namespace Vintagestory.GameContent
+@@ -355,35 +418,35 @@ namespace Vintagestory.GameContent
              {
                  throw new NotImplementedException();
              }
@@ -220,7 +222,7 @@ index 3fe5096..7c6da6d 100644
              }
  
              public void BreakAllDecorFast(IWorldAccessor world, BlockPos pos, int index3d, bool callOnBrokenAsDecor = true)
-@@ -394,16 +455,16 @@ namespace Vintagestory.GameContent
+@@ -394,16 +457,16 @@ namespace Vintagestory.GameContent
              public Dictionary<int, Block> GetDecors(IBlockAccessor blockAccessor, BlockPos pos)
              {
                  throw new NotImplementedException();

--- a/patches/VintagestoryApi/Common/API/IWorldChunk.cs.patch
+++ b/patches/VintagestoryApi/Common/API/IWorldChunk.cs.patch
@@ -1,5 +1,5 @@
 diff --git a/VintagestoryApi/Common/API/IWorldChunk.cs b/VintagestoryApi/Common/API/IWorldChunk.cs
-index 1016d62..4826fd5 100644
+index 1016d62..1ac1fc9 100644
 --- a/VintagestoryApi/Common/API/IWorldChunk.cs
 +++ b/VintagestoryApi/Common/API/IWorldChunk.cs
 @@ -10,11 +10,11 @@ namespace Vintagestory.API.Common
@@ -15,7 +15,7 @@ index 1016d62..4826fd5 100644
  
          int Length { get; }
  
-@@ -29,29 +29,94 @@ namespace Vintagestory.API.Common
+@@ -29,29 +29,102 @@ namespace Vintagestory.API.Common
          /// </summary>
          void SetBlockBulk(int index3d, int lenX, int lenZ, int value);
          /// <summary>
@@ -26,6 +26,14 @@ index 1016d62..4826fd5 100644
 +        /// <param name="index3d"></param</param>
 +        /// <param name="value"></param</param>
          void SetBlockUnsafe(int index3d, int value);
++
++        /// <summary>
++        /// Stratum: true iff the blocks layer exists AND has an initialized palette,
++        /// so SetBlockUnsafe / SetBlocksUnsafe can be called safely. Used by worldgen
++        /// to detect subchunks that need ClearBlocksAndPrepare() before the first
++        /// unsafe write.
++        /// </summary>
++        bool HasBlocksLayer { get; }
 +
 +        // Stratum start: Added bulk block write variant that takes a flat int[] buffer of length Length.
 +        // Each contiguous chunk of 4 ints encodes one (x, y, z) position followed by the target block id,
@@ -115,7 +123,7 @@ index 1016d62..4826fd5 100644
          /// </summary>
          void TakeBulkReadLock();
  
-@@ -95,11 +160,11 @@ namespace Vintagestory.API.Common
+@@ -95,11 +168,11 @@ namespace Vintagestory.API.Common
          bool LoadedFromServer { get; }
  
          /// <summary>
@@ -128,7 +136,7 @@ index 1016d62..4826fd5 100644
  
  
      public interface IWorldChunk
-@@ -195,58 +260,58 @@ namespace Vintagestory.API.Common
+@@ -195,58 +268,58 @@ namespace Vintagestory.API.Common
          bool Disposed { get; }
  
          /// <summary>
@@ -197,7 +205,7 @@ index 1016d62..4826fd5 100644
  
          /// <summary>
          /// Can be used to store non-serialized mod data that is only serialized into the standard moddata dictionary on unload. This prevents the need for constant serializing/deserializing. Useful when storing large amounts of data. Is not populated on chunk load, you need to populate it with stored data yourself using GetModData()
-@@ -256,101 +321,101 @@ namespace Vintagestory.API.Common
+@@ -256,101 +329,101 @@ namespace Vintagestory.API.Common
  
  
          /// <summary>
@@ -327,7 +335,7 @@ index 1016d62..4826fd5 100644
  
          /// <summary>
          /// Only to be implemented client side
-@@ -358,13 +423,13 @@ namespace Vintagestory.API.Common
+@@ -358,13 +431,13 @@ namespace Vintagestory.API.Common
          void FinishLightDoubleBuffering();
  
          /// <summary>

--- a/patches/VintagestoryApi/Common/API/IWorldChunk.cs.patch
+++ b/patches/VintagestoryApi/Common/API/IWorldChunk.cs.patch
@@ -1,10 +1,10 @@
-﻿diff --git a/VintagestoryApi/Common/API/IWorldChunk.cs b/VintagestoryApi/Common/API/IWorldChunk.cs
+diff --git a/VintagestoryApi/Common/API/IWorldChunk.cs b/VintagestoryApi/Common/API/IWorldChunk.cs
 index 1016d62..8a471eb 100644
 --- a/VintagestoryApi/Common/API/IWorldChunk.cs
 +++ b/VintagestoryApi/Common/API/IWorldChunk.cs
 @@ -10,11 +10,11 @@ namespace Vintagestory.API.Common
      public interface IChunkBlocks
-{
+     {
          /// <summary>
          /// Retrieves the first solid block, if that one is empty, retrieves the first fluid block
          /// </summary>

--- a/patches/VintagestoryApi/Common/API/IWorldChunk.cs.patch
+++ b/patches/VintagestoryApi/Common/API/IWorldChunk.cs.patch
@@ -1,10 +1,10 @@
-diff --git a/VintagestoryApi/Common/API/IWorldChunk.cs b/VintagestoryApi/Common/API/IWorldChunk.cs
-index 1016d62..1ac1fc9 100644
+﻿diff --git a/VintagestoryApi/Common/API/IWorldChunk.cs b/VintagestoryApi/Common/API/IWorldChunk.cs
+index 1016d62..8a471eb 100644
 --- a/VintagestoryApi/Common/API/IWorldChunk.cs
 +++ b/VintagestoryApi/Common/API/IWorldChunk.cs
 @@ -10,11 +10,11 @@ namespace Vintagestory.API.Common
      public interface IChunkBlocks
-     {
+{
          /// <summary>
          /// Retrieves the first solid block, if that one is empty, retrieves the first fluid block
          /// </summary>
@@ -15,7 +15,7 @@ index 1016d62..1ac1fc9 100644
  
          int Length { get; }
  
-@@ -29,29 +29,102 @@ namespace Vintagestory.API.Common
+@@ -29,29 +29,94 @@ namespace Vintagestory.API.Common
          /// </summary>
          void SetBlockBulk(int index3d, int lenX, int lenZ, int value);
          /// <summary>
@@ -27,15 +27,7 @@ index 1016d62..1ac1fc9 100644
 +        /// <param name="value"></param</param>
          void SetBlockUnsafe(int index3d, int value);
 +
-+        /// <summary>
-+        /// Stratum: true iff the blocks layer exists AND has an initialized palette,
-+        /// so SetBlockUnsafe / SetBlocksUnsafe can be called safely. Used by worldgen
-+        /// to detect subchunks that need ClearBlocksAndPrepare() before the first
-+        /// unsafe write.
-+        /// </summary>
-+        bool HasBlocksLayer { get; }
-+
-+        // Stratum start: Added bulk block write variant that takes a flat int[] buffer of length Length.
++// Stratum start: Added bulk block write variant that takes a flat int[] buffer of length Length.
 +        // Each contiguous chunk of 4 ints encodes one (x, y, z) position followed by the target block id,
 +        // enabling worldgen code to push pre-batched writes without per-position lock acquisition.
 +        /// <summary>
@@ -123,7 +115,7 @@ index 1016d62..1ac1fc9 100644
          /// </summary>
          void TakeBulkReadLock();
  
-@@ -95,11 +168,11 @@ namespace Vintagestory.API.Common
+@@ -95,11 +160,11 @@ namespace Vintagestory.API.Common
          bool LoadedFromServer { get; }
  
          /// <summary>
@@ -136,7 +128,7 @@ index 1016d62..1ac1fc9 100644
  
  
      public interface IWorldChunk
-@@ -195,58 +268,58 @@ namespace Vintagestory.API.Common
+@@ -195,58 +260,58 @@ namespace Vintagestory.API.Common
          bool Disposed { get; }
  
          /// <summary>
@@ -205,7 +197,7 @@ index 1016d62..1ac1fc9 100644
  
          /// <summary>
          /// Can be used to store non-serialized mod data that is only serialized into the standard moddata dictionary on unload. This prevents the need for constant serializing/deserializing. Useful when storing large amounts of data. Is not populated on chunk load, you need to populate it with stored data yourself using GetModData()
-@@ -256,101 +329,101 @@ namespace Vintagestory.API.Common
+@@ -256,101 +321,101 @@ namespace Vintagestory.API.Common
  
  
          /// <summary>
@@ -335,7 +327,7 @@ index 1016d62..1ac1fc9 100644
  
          /// <summary>
          /// Only to be implemented client side
-@@ -358,13 +431,13 @@ namespace Vintagestory.API.Common
+@@ -358,13 +423,13 @@ namespace Vintagestory.API.Common
          void FinishLightDoubleBuffering();
  
          /// <summary>

--- a/patches/VintagestoryApi/Server/Worldgen/IWorldGenBlockAccessor.cs.patch
+++ b/patches/VintagestoryApi/Server/Worldgen/IWorldGenBlockAccessor.cs.patch
@@ -1,0 +1,28 @@
+diff --git a/VintagestoryApi/Server/Worldgen/IWorldGenBlockAccessor.cs b/VintagestoryApi/Server/Worldgen/IWorldGenBlockAccessor.cs
+index 2709658..9656163 100644
+--- a/VintagestoryApi/Server/Worldgen/IWorldGenBlockAccessor.cs
++++ b/VintagestoryApi/Server/Worldgen/IWorldGenBlockAccessor.cs
+@@ -1,8 +1,9 @@
+ using Vintagestory.API.Common;
+ using Vintagestory.API.Common.Entities;
+ using Vintagestory.API.MathTools;
++using System.Collections.Generic;
+ 
+ #nullable disable
+ 
+ namespace Vintagestory.API.Server
+ {
+@@ -17,10 +18,13 @@ namespace Vintagestory.API.Server
+         /// Tells the server to produce a block update at this given position once the chunk is fully generated and world ticking has begun
+         /// </summary>
+         /// <param name="pos"></param>
+         void ScheduleBlockUpdate(BlockPos pos);
+ 
++        // Stratum: batch variant of ScheduleBlockLightUpdate, used by GenCaves' column flush.
++        void ScheduleBlockLightUpdates(int chunkX, int chunkZ, List<Vec4i> updates);
++
+         /// <summary>
+         /// Tells the server to relight this position once RunScheduledBlockLightUpdates() is called
+         /// </summary>
+         /// <param name="pos"></param>
+         /// <param name="oldBlockid">currently unused but might be used in the future to make sure old light is removed properly</param>

--- a/patches/VintagestoryLib/Vintagestory.Common/ChunkData.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Common/ChunkData.cs.patch
@@ -1,5 +1,5 @@
 diff --git a/VintagestoryLib/Vintagestory.Common/ChunkData.cs b/VintagestoryLib/Vintagestory.Common/ChunkData.cs
-index af79143..bd887b3 100644
+index af79143..6298501 100644
 --- a/VintagestoryLib/Vintagestory.Common/ChunkData.cs
 +++ b/VintagestoryLib/Vintagestory.Common/ChunkData.cs
 @@ -99,41 +99,41 @@ public class ChunkData : IChunkBlocks, IChunkLight, IEnumerable<int>, IEnumerabl
@@ -75,7 +75,7 @@ index af79143..bd887b3 100644
  
  	public int GetSolidBlock(int index3d)
  	{
-@@ -166,45 +166,59 @@ public class ChunkData : IChunkBlocks, IChunkLight, IEnumerable<int>, IEnumerabl
+@@ -166,45 +166,63 @@ public class ChunkData : IChunkBlocks, IChunkLight, IEnumerable<int>, IEnumerabl
  	public int GetBlockIdUnsafe(int index3d)
  	{
  		return blocksLayer?.GetUnsafe(index3d) ?? 0;
@@ -118,6 +118,10 @@ index af79143..bd887b3 100644
 +		blocksLayer.CopyBlocksToUnsafe(blocksOut);
 +	}
 +	// Stratum end
++
++	// Stratum: fast probe for worldgen. True iff the unsafe write path is safe to call.
++	public bool HasBlocksLayer => blocksLayer != null && blocksLayer.palette != null;
++
 +
 +	public int GetBlockIdUnsafe(int index3d, int layer)
 +	{
@@ -166,7 +170,7 @@ index af79143..bd887b3 100644
  
  	public void TakeBulkReadLock()
  	{
-@@ -220,21 +234,18 @@ public class ChunkData : IChunkBlocks, IChunkLight, IEnumerable<int>, IEnumerabl
+@@ -220,21 +238,18 @@ public class ChunkData : IChunkBlocks, IChunkLight, IEnumerable<int>, IEnumerabl
  		bulkBlocksTmp?.readWriteLock.ReleaseReadLock();
  		bulkFluidsTmp = null;
  		bulkBlocksTmp = null;
@@ -191,7 +195,7 @@ index af79143..bd887b3 100644
  	public void SetBlockUnsafe(int index3d, int value)
  	{
  		if (blocksLayer == null)
-@@ -246,10 +257,65 @@ public class ChunkData : IChunkBlocks, IChunkLight, IEnumerable<int>, IEnumerabl
+@@ -246,10 +261,65 @@ public class ChunkData : IChunkBlocks, IChunkLight, IEnumerable<int>, IEnumerabl
  			blocksLayer = new BlockChunkDataLayer(pool);
  		}
  		blocksLayer.SetUnsafe(index3d, value);
@@ -257,7 +261,7 @@ index af79143..bd887b3 100644
  		blocksLayer?.SetZero(index3d);
  	}
  
-@@ -685,6 +751,6 @@ public class ChunkData : IChunkBlocks, IChunkLight, IEnumerable<int>, IEnumerabl
+@@ -685,6 +755,6 @@ public class ChunkData : IChunkBlocks, IChunkLight, IEnumerable<int>, IEnumerabl
  
  	public void FuzzyListBlockIds(List<int> reusableList)
  	{

--- a/patches/VintagestoryLib/Vintagestory.Common/ChunkData.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Common/ChunkData.cs.patch
@@ -1,4 +1,4 @@
-﻿diff --git a/VintagestoryLib/Vintagestory.Common/ChunkData.cs b/VintagestoryLib/Vintagestory.Common/ChunkData.cs
+diff --git a/VintagestoryLib/Vintagestory.Common/ChunkData.cs b/VintagestoryLib/Vintagestory.Common/ChunkData.cs
 index af79143..1f0127e 100644
 --- a/VintagestoryLib/Vintagestory.Common/ChunkData.cs
 +++ b/VintagestoryLib/Vintagestory.Common/ChunkData.cs
@@ -7,7 +7,7 @@ index af79143..1f0127e 100644
  	public int GetBlockId(int index, int layer)
  	{
  		switch (layer)
-{
+ 		{
 -		default:
 -		{
 -			int solidBlock = GetSolidBlock(index);

--- a/patches/VintagestoryLib/Vintagestory.Common/ChunkData.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Common/ChunkData.cs.patch
@@ -1,5 +1,5 @@
-diff --git a/VintagestoryLib/Vintagestory.Common/ChunkData.cs b/VintagestoryLib/Vintagestory.Common/ChunkData.cs
-index af79143..6298501 100644
+﻿diff --git a/VintagestoryLib/Vintagestory.Common/ChunkData.cs b/VintagestoryLib/Vintagestory.Common/ChunkData.cs
+index af79143..1f0127e 100644
 --- a/VintagestoryLib/Vintagestory.Common/ChunkData.cs
 +++ b/VintagestoryLib/Vintagestory.Common/ChunkData.cs
 @@ -99,41 +99,41 @@ public class ChunkData : IChunkBlocks, IChunkLight, IEnumerable<int>, IEnumerabl
@@ -7,7 +7,7 @@ index af79143..6298501 100644
  	public int GetBlockId(int index, int layer)
  	{
  		switch (layer)
- 		{
+{
 -		default:
 -		{
 -			int solidBlock = GetSolidBlock(index);
@@ -75,7 +75,7 @@ index af79143..6298501 100644
  
  	public int GetSolidBlock(int index3d)
  	{
-@@ -166,45 +166,63 @@ public class ChunkData : IChunkBlocks, IChunkLight, IEnumerable<int>, IEnumerabl
+@@ -166,45 +166,60 @@ public class ChunkData : IChunkBlocks, IChunkLight, IEnumerable<int>, IEnumerabl
  	public int GetBlockIdUnsafe(int index3d)
  	{
  		return blocksLayer?.GetUnsafe(index3d) ?? 0;
@@ -118,10 +118,7 @@ index af79143..6298501 100644
 +		blocksLayer.CopyBlocksToUnsafe(blocksOut);
 +	}
 +	// Stratum end
-+
-+	// Stratum: fast probe for worldgen. True iff the unsafe write path is safe to call.
-+	public bool HasBlocksLayer => blocksLayer != null && blocksLayer.palette != null;
-+
++	
 +
 +	public int GetBlockIdUnsafe(int index3d, int layer)
 +	{
@@ -170,7 +167,7 @@ index af79143..6298501 100644
  
  	public void TakeBulkReadLock()
  	{
-@@ -220,21 +238,18 @@ public class ChunkData : IChunkBlocks, IChunkLight, IEnumerable<int>, IEnumerabl
+@@ -220,21 +235,18 @@ public class ChunkData : IChunkBlocks, IChunkLight, IEnumerable<int>, IEnumerabl
  		bulkBlocksTmp?.readWriteLock.ReleaseReadLock();
  		bulkFluidsTmp = null;
  		bulkBlocksTmp = null;
@@ -195,16 +192,19 @@ index af79143..6298501 100644
  	public void SetBlockUnsafe(int index3d, int value)
  	{
  		if (blocksLayer == null)
-@@ -246,10 +261,65 @@ public class ChunkData : IChunkBlocks, IChunkLight, IEnumerable<int>, IEnumerabl
+@@ -246,10 +258,70 @@ public class ChunkData : IChunkBlocks, IChunkLight, IEnumerable<int>, IEnumerabl
  			blocksLayer = new BlockChunkDataLayer(pool);
  		}
  		blocksLayer.SetUnsafe(index3d, value);
  	}
  
 +	/// <summary>
-+	/// Stratum: bulk variant of SetBlockUnsafe. Forwards a buffered batch of
-+	/// (index3d, value) pairs to the blocks layer's SetManyUnsafe, taking the
-+	/// layer's write lock once for the whole batch instead of once per block.
++	/// Stratum: bulk-write a batch of (index, value) pairs in one pass. When the blocks layer
++	/// does not exist yet it is created and initialised with an air-filled palette and bit-planes
++	/// via PopulateWithAir(). That initialisation touches ONLY the blocks layer - fluidsLayer and
++	/// lightLayer are left completely untouched (unlike ClearBlocksAndPrepare, which nulls all
++	/// three layers through pool.FreeArraysAndReset). SetManyUnsafe then has a valid target instead
++	/// of NRE-ing on the first write.
 +	/// </summary>
 +	public void SetBlocksUnsafe(List<int> indices, List<int> values)
 +	{
@@ -212,9 +212,11 @@ index af79143..6298501 100644
 +		{
 +			return;
 +		}
-+		if (blocksLayer == null)
++
++		if (blocksLayer == null || blocksLayer.palette == null)
 +		{
-+			blocksLayer = new BlockChunkDataLayer(pool);
++			if (blocksLayer == null) blocksLayer = new BlockChunkDataLayer(pool);
++			blocksLayer.PopulateWithAir();
 +		}
 +		blocksLayer.SetManyUnsafe(indices, values);
 +	}
@@ -261,7 +263,7 @@ index af79143..6298501 100644
  		blocksLayer?.SetZero(index3d);
  	}
  
-@@ -685,6 +755,6 @@ public class ChunkData : IChunkBlocks, IChunkLight, IEnumerable<int>, IEnumerabl
+@@ -685,6 +757,6 @@ public class ChunkData : IChunkBlocks, IChunkLight, IEnumerable<int>, IEnumerabl
  
  	public void FuzzyListBlockIds(List<int> reusableList)
  	{

--- a/patches/VintagestoryLib/Vintagestory.Common/NoChunkData.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Common/NoChunkData.cs.patch
@@ -1,5 +1,5 @@
 diff --git a/VintagestoryLib/Vintagestory.Common/NoChunkData.cs b/VintagestoryLib/Vintagestory.Common/NoChunkData.cs
-index db9ffef..4060d59 100644
+index db9ffef..39a3591 100644
 --- a/VintagestoryLib/Vintagestory.Common/NoChunkData.cs
 +++ b/VintagestoryLib/Vintagestory.Common/NoChunkData.cs
 @@ -6,17 +6,12 @@ namespace Vintagestory.Common;
@@ -22,7 +22,7 @@ index db9ffef..4060d59 100644
  	public int Length { get; set; }
  
  	public static NoChunkData CreateNew(int chunksize)
-@@ -41,10 +36,35 @@ public class NoChunkData : IChunkBlocks
+@@ -41,10 +36,37 @@ public class NoChunkData : IChunkBlocks
  
  	public void SetBlockUnsafe(int index3d, int blockId)
  	{
@@ -32,6 +32,8 @@ index db9ffef..4060d59 100644
 +	public void SetBlocksUnsafe(List<int> indices, List<int> values)
 +	{
 +	}
++
++	public bool HasBlocksLayer { get; }
 +
 +	// Stratum: added to satisfy IChunkBlocks interface (copy all block IDs into a flat array)
 +	public void CopyBlocksToUnsafe(int[] blocksOut)
@@ -58,7 +60,7 @@ index db9ffef..4060d59 100644
  	}
  
  	public int GetBlockId(int index, int layer)
-@@ -82,6 +102,6 @@ public class NoChunkData : IChunkBlocks
+@@ -82,6 +104,6 @@ public class NoChunkData : IChunkBlocks
  
  	public void FuzzyListBlockIds(List<int> reusableList)
  	{

--- a/patches/VintagestoryLib/Vintagestory.Common/NoChunkData.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Common/NoChunkData.cs.patch
@@ -1,5 +1,5 @@
 diff --git a/VintagestoryLib/Vintagestory.Common/NoChunkData.cs b/VintagestoryLib/Vintagestory.Common/NoChunkData.cs
-index db9ffef..39a3591 100644
+index db9ffef..e0782b6 100644
 --- a/VintagestoryLib/Vintagestory.Common/NoChunkData.cs
 +++ b/VintagestoryLib/Vintagestory.Common/NoChunkData.cs
 @@ -6,17 +6,12 @@ namespace Vintagestory.Common;
@@ -22,7 +22,7 @@ index db9ffef..39a3591 100644
  	public int Length { get; set; }
  
  	public static NoChunkData CreateNew(int chunksize)
-@@ -41,10 +36,37 @@ public class NoChunkData : IChunkBlocks
+@@ -41,10 +36,42 @@ public class NoChunkData : IChunkBlocks
  
  	public void SetBlockUnsafe(int index3d, int blockId)
  	{
@@ -33,7 +33,12 @@ index db9ffef..39a3591 100644
 +	{
 +	}
 +
++
++	/// <summary>
++	/// Stratum: necessary interface overload. 
++	/// </summary>
 +	public bool HasBlocksLayer { get; }
++
 +
 +	// Stratum: added to satisfy IChunkBlocks interface (copy all block IDs into a flat array)
 +	public void CopyBlocksToUnsafe(int[] blocksOut)
@@ -60,7 +65,7 @@ index db9ffef..39a3591 100644
  	}
  
  	public int GetBlockId(int index, int layer)
-@@ -82,6 +104,6 @@ public class NoChunkData : IChunkBlocks
+@@ -82,6 +109,6 @@ public class NoChunkData : IChunkBlocks
  
  	public void FuzzyListBlockIds(List<int> reusableList)
  	{

--- a/patches/VintagestoryLib/Vintagestory.Common/NoChunkData.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Common/NoChunkData.cs.patch
@@ -1,5 +1,5 @@
 diff --git a/VintagestoryLib/Vintagestory.Common/NoChunkData.cs b/VintagestoryLib/Vintagestory.Common/NoChunkData.cs
-index db9ffef..e0782b6 100644
+index db9ffef..5206240 100644
 --- a/VintagestoryLib/Vintagestory.Common/NoChunkData.cs
 +++ b/VintagestoryLib/Vintagestory.Common/NoChunkData.cs
 @@ -6,17 +6,12 @@ namespace Vintagestory.Common;
@@ -22,7 +22,7 @@ index db9ffef..e0782b6 100644
  	public int Length { get; set; }
  
  	public static NoChunkData CreateNew(int chunksize)
-@@ -41,10 +36,42 @@ public class NoChunkData : IChunkBlocks
+@@ -41,10 +36,37 @@ public class NoChunkData : IChunkBlocks
  
  	public void SetBlockUnsafe(int index3d, int blockId)
  	{
@@ -33,11 +33,6 @@ index db9ffef..e0782b6 100644
 +	{
 +	}
 +
-+
-+	/// <summary>
-+	/// Stratum: necessary interface overload. 
-+	/// </summary>
-+	public bool HasBlocksLayer { get; }
 +
 +
 +	// Stratum: added to satisfy IChunkBlocks interface (copy all block IDs into a flat array)
@@ -65,7 +60,7 @@ index db9ffef..e0782b6 100644
  	}
  
  	public int GetBlockId(int index, int layer)
-@@ -82,6 +109,6 @@ public class NoChunkData : IChunkBlocks
+@@ -82,6 +104,6 @@ public class NoChunkData : IChunkBlocks
  
  	public void FuzzyListBlockIds(List<int> reusableList)
  	{

--- a/patches/VintagestoryLib/Vintagestory.Server/BlockAccessorWorldGen.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/BlockAccessorWorldGen.cs.patch
@@ -1,26 +1,65 @@
 diff --git a/VintagestoryLib/Vintagestory.Server/BlockAccessorWorldGen.cs b/VintagestoryLib/Vintagestory.Server/BlockAccessorWorldGen.cs
-index 33c394d..500bad6 100644
+index 33c394d..597891f 100644
 --- a/VintagestoryLib/Vintagestory.Server/BlockAccessorWorldGen.cs
 +++ b/VintagestoryLib/Vintagestory.Server/BlockAccessorWorldGen.cs
-@@ -54,38 +54,32 @@ public class BlockAccessorWorldGen : BlockAccessorBase, IWorldGenBlockAccessor,
- 			serverMapChunk.ScheduledBlockLightUpdates = new List<Vec4i>();
+@@ -27,10 +27,15 @@ public class BlockAccessorWorldGen : BlockAccessorBase, IWorldGenBlockAccessor,
+ 	private static ServerMapChunk mapchunkCached;
+ 
+ 	[ThreadStatic]
+ 	private static long cachedChunkIndex2d;
+ 
++	// Stratum start: protects ScheduledBlockLightUpdates from concurrent
++	// Schedule/Run across all worldgen stages (TerrainLate caves + Vegetation light).
++	private static readonly object lightUpdatesLock = new object();
++	// Stratum end
++
+ 	private IServerWorldAccessor worldgenWorldAccessor;
+ 
+ 	public IServerWorldAccessor WorldgenWorldAccessor => worldgenWorldAccessor ?? (worldgenWorldAccessor = new WorldgenWorldAccessor((IServerWorldAccessor)worldAccessor, this));
+ 
+ 	public BlockAccessorWorldGen(ServerMain server, WorldMap worldmap, ChunkServerThread chunkdbthread)
+@@ -47,44 +52,48 @@ public class BlockAccessorWorldGen : BlockAccessorBase, IWorldGenBlockAccessor,
+ 		if (serverMapChunk == null)
+ 		{
+ 			ServerMain.Logger.Worldgen("Mapchunk was null when scheduling a blocklight update at " + pos);
+ 			return;
  		}
- 		serverMapChunk.ScheduledBlockLightUpdates.Add(new Vec4i(pos, newBlockId));
+-		if (serverMapChunk.ScheduledBlockLightUpdates == null)
++		// Stratum start: serialize access to the shared list
++		lock (lightUpdatesLock)
+ 		{
+-			serverMapChunk.ScheduledBlockLightUpdates = new List<Vec4i>();
++			if (serverMapChunk.ScheduledBlockLightUpdates == null)
++			{
++				serverMapChunk.ScheduledBlockLightUpdates = new List<Vec4i>();
++			}
++			serverMapChunk.ScheduledBlockLightUpdates.Add(new Vec4i(pos, newBlockId));
+ 		}
+-		serverMapChunk.ScheduledBlockLightUpdates.Add(new Vec4i(pos, newBlockId));
++		// Stratum end
  	}
  
--	public void RunScheduledBlockLightUpdates(int chunkx, int chunkz)
--	{
--		ServerMapChunk serverMapChunk = (ServerMapChunk)GetMapChunk(chunkx, chunkz);
--		if (serverMapChunk == null)
--		{
--			ServerMain.Logger.Worldgen("Mapchunk was null when attempting scheduled blocklight updates at " + chunkx + "," + chunkz);
--			return;
--		}
+ 	public void RunScheduledBlockLightUpdates(int chunkx, int chunkz)
+ 	{
+ 		ServerMapChunk serverMapChunk = (ServerMapChunk)GetMapChunk(chunkx, chunkz);
+ 		if (serverMapChunk == null)
+ 		{
+ 			ServerMain.Logger.Worldgen("Mapchunk was null when attempting scheduled blocklight updates at " + chunkx + "," + chunkz);
+ 			return;
+ 		}
 -		List<Vec4i> scheduledBlockLightUpdates = serverMapChunk.ScheduledBlockLightUpdates;
 -		if (scheduledBlockLightUpdates == null || scheduledBlockLightUpdates.Count == 0)
--		{
++
++		List<Vec4i> scheduledBlockLightUpdates;
++		// Stratum start: serialize access to the shared list
++		lock (lightUpdatesLock)
+ 		{
 -			return;
--		}
++			scheduledBlockLightUpdates = serverMapChunk.ScheduledBlockLightUpdates;
++			if (scheduledBlockLightUpdates == null || scheduledBlockLightUpdates.Count == 0)
++				return;
++			serverMapChunk.ScheduledBlockLightUpdates = null;
+ 		}
 -		BlockPos blockPos = new BlockPos(0);
 -		foreach (Vec4i item in scheduledBlockLightUpdates)
 -		{
@@ -34,36 +73,20 @@ index 33c394d..500bad6 100644
 -		}
 -		serverMapChunk.ScheduledBlockLightUpdates = null;
 -	}
--
--	public void ScheduleBlockUpdate(BlockPos pos)
-+    public void RunScheduledBlockLightUpdates(int chunkx, int chunkz)
-+    {
-+        ServerMapChunk serverMapChunk = (ServerMapChunk)GetMapChunk(chunkx, chunkz);
-+        if (serverMapChunk == null)
-+        {
-+            ServerMain.Logger.Worldgen("Mapchunk was null when attempting scheduled blocklight updates at " + chunkx + "," + chunkz);
-+            return;
-+        }
-+        // Stratum start:
-+        // We move the processing of light sources inside the chunilluminator method
-+
-+        List<Vec4i> scheduledBlockLightUpdates = serverMapChunk.ScheduledBlockLightUpdates;
-+        if (scheduledBlockLightUpdates == null || scheduledBlockLightUpdates.Count == 0)
-+            return;
-+
-+        server.WorldMap.chunkIlluminatorWorldGen.ProcessScheduledBlockLightUpdates(scheduledBlockLightUpdates);
-+
-+        // Stratum end.
-+        serverMapChunk.ScheduledBlockLightUpdates = null;
-+    } 
-+    
-+    public void ScheduleBlockUpdate(BlockPos pos)
++		// Stratum end
+ 
++		// Stratum start:
++		// We move the processing of light sources inside the chunilluminator method
++		server.WorldMap.chunkIlluminatorWorldGen.ProcessScheduledBlockLightUpdates(scheduledBlockLightUpdates);
++		// Stratum end.
++	}
++	
+ 	public void ScheduleBlockUpdate(BlockPos pos)
  	{
  		ChunkColumnLoadRequest chunkRequestAtPos = chunkdbthread.GetChunkRequestAtPos(pos.X, pos.Z);
  		if (chunkRequestAtPos?.MapChunk != null)
  		{
- 			chunkRequestAtPos.MapChunk.ScheduledBlockUpdates.Add(pos.Copy());
-@@ -133,22 +127,25 @@ public class BlockAccessorWorldGen : BlockAccessorBase, IWorldGenBlockAccessor,
+@@ -133,22 +142,25 @@ public class BlockAccessorWorldGen : BlockAccessorBase, IWorldGenBlockAccessor,
  		return chunkdbthread.GetMapRegion(regionX, regionZ);
  	}
  
@@ -92,7 +115,7 @@ index 33c394d..500bad6 100644
  			{
  				serverChunk.Unpack();
  				cachedChunkIndex3d = num;
-@@ -159,11 +156,11 @@ public class BlockAccessorWorldGen : BlockAccessorBase, IWorldGenBlockAccessor,
+@@ -159,11 +171,11 @@ public class BlockAccessorWorldGen : BlockAccessorBase, IWorldGenBlockAccessor,
  		{
  			return serverChunk.Data.GetBlockId(worldmap.ChunkSizedIndex3D(posX & MagicNum.ServerChunkSizeMask, posY & MagicNum.ServerChunkSizeMask, posZ & MagicNum.ServerChunkSizeMask), layer);
  		}
@@ -105,7 +128,7 @@ index 33c394d..500bad6 100644
  		else
  		{
  			ServerMain.Logger.Notification("Tried to get block outside generating chunks! Set RuntimeEnv.DebugOutOfRangeBlockAccess to debug.");
-@@ -220,21 +217,26 @@ public class BlockAccessorWorldGen : BlockAccessorBase, IWorldGenBlockAccessor,
+@@ -220,21 +232,26 @@ public class BlockAccessorWorldGen : BlockAccessorBase, IWorldGenBlockAccessor,
  	}
  
  	protected int SetSolidBlock(ServerChunk chunk, BlockPos pos, Block newBlock, int blockId)
@@ -137,7 +160,7 @@ index 33c394d..500bad6 100644
  		return blockId2;
  	}
  
-@@ -308,11 +310,17 @@ public class BlockAccessorWorldGen : BlockAccessorBase, IWorldGenBlockAccessor,
+@@ -308,11 +325,17 @@ public class BlockAccessorWorldGen : BlockAccessorBase, IWorldGenBlockAccessor,
  			Block localBlockAtBlockPos = generatingChunkAtPos.GetLocalBlockAtBlockPos(server, position);
  			blockEntity.CreateBehaviors(localBlockAtBlockPos, server);
  			blockEntity.Pos = position.Copy();

--- a/patches/VintagestoryLib/Vintagestory.Server/BlockAccessorWorldGen.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/BlockAccessorWorldGen.cs.patch
@@ -1,43 +1,50 @@
 diff --git a/VintagestoryLib/Vintagestory.Server/BlockAccessorWorldGen.cs b/VintagestoryLib/Vintagestory.Server/BlockAccessorWorldGen.cs
-index 33c394d..597891f 100644
+index 33c394d..18c7503 100644
 --- a/VintagestoryLib/Vintagestory.Server/BlockAccessorWorldGen.cs
 +++ b/VintagestoryLib/Vintagestory.Server/BlockAccessorWorldGen.cs
-@@ -27,10 +27,15 @@ public class BlockAccessorWorldGen : BlockAccessorBase, IWorldGenBlockAccessor,
+@@ -27,10 +27,12 @@ public class BlockAccessorWorldGen : BlockAccessorBase, IWorldGenBlockAccessor,
  	private static ServerMapChunk mapchunkCached;
  
  	[ThreadStatic]
  	private static long cachedChunkIndex2d;
  
-+	// Stratum start: protects ScheduledBlockLightUpdates from concurrent
-+	// Schedule/Run across all worldgen stages (TerrainLate caves + Vegetation light).
-+	private static readonly object lightUpdatesLock = new object();
-+	// Stratum end
++
 +
  	private IServerWorldAccessor worldgenWorldAccessor;
  
  	public IServerWorldAccessor WorldgenWorldAccessor => worldgenWorldAccessor ?? (worldgenWorldAccessor = new WorldgenWorldAccessor((IServerWorldAccessor)worldAccessor, this));
  
  	public BlockAccessorWorldGen(ServerMain server, WorldMap worldmap, ChunkServerThread chunkdbthread)
-@@ -47,44 +52,48 @@ public class BlockAccessorWorldGen : BlockAccessorBase, IWorldGenBlockAccessor,
+@@ -47,42 +49,55 @@ public class BlockAccessorWorldGen : BlockAccessorBase, IWorldGenBlockAccessor,
  		if (serverMapChunk == null)
  		{
  			ServerMain.Logger.Worldgen("Mapchunk was null when scheduling a blocklight update at " + pos);
  			return;
  		}
 -		if (serverMapChunk.ScheduledBlockLightUpdates == null)
-+		// Stratum start: serialize access to the shared list
-+		lock (lightUpdatesLock)
++		// Stratum: singular path (SetBlock on live chunks) wraps into a one-item batch
++		// and hands ownership to the map chunk. Lock-free.
++		serverMapChunk.stratumLightUpdateBatches.Push(new List<Vec4i>(1) { new Vec4i(pos, newBlockId) });
++	}
++
++	// Stratum start: batch handoff used by GenCaves' column flush. Zero-copy, zero-lock:
++	// ownership of the caller's list transfers to the map chunk; the caller must not
++	// touch it afterwards.
++	public void ScheduleBlockLightUpdates(int chunkX, int chunkZ, List<Vec4i> updates)
++	{
++		if (updates == null || updates.Count == 0) return;
++
++		ServerMapChunk serverMapChunk = (ServerMapChunk)GetMapChunk(chunkX, chunkZ);
++		if (serverMapChunk == null)
  		{
 -			serverMapChunk.ScheduledBlockLightUpdates = new List<Vec4i>();
-+			if (serverMapChunk.ScheduledBlockLightUpdates == null)
-+			{
-+				serverMapChunk.ScheduledBlockLightUpdates = new List<Vec4i>();
-+			}
-+			serverMapChunk.ScheduledBlockLightUpdates.Add(new Vec4i(pos, newBlockId));
++			ServerMain.Logger.Worldgen("Mapchunk was null when scheduling blocklight updates at " + chunkX + "," + chunkZ);
++			return;
  		}
 -		serverMapChunk.ScheduledBlockLightUpdates.Add(new Vec4i(pos, newBlockId));
-+		// Stratum end
++		serverMapChunk.stratumLightUpdateBatches.Push(updates);
  	}
++	// Stratum end
  
  	public void RunScheduledBlockLightUpdates(int chunkx, int chunkz)
  	{
@@ -49,20 +56,19 @@ index 33c394d..597891f 100644
  		}
 -		List<Vec4i> scheduledBlockLightUpdates = serverMapChunk.ScheduledBlockLightUpdates;
 -		if (scheduledBlockLightUpdates == null || scheduledBlockLightUpdates.Count == 0)
-+
-+		List<Vec4i> scheduledBlockLightUpdates;
-+		// Stratum start: serialize access to the shared list
-+		lock (lightUpdatesLock)
- 		{
+-		{
 -			return;
-+			scheduledBlockLightUpdates = serverMapChunk.ScheduledBlockLightUpdates;
-+			if (scheduledBlockLightUpdates == null || scheduledBlockLightUpdates.Count == 0)
-+				return;
-+			serverMapChunk.ScheduledBlockLightUpdates = null;
- 		}
+-		}
 -		BlockPos blockPos = new BlockPos(0);
 -		foreach (Vec4i item in scheduledBlockLightUpdates)
--		{
++
++		// Stratum start: lock-free drain = snapshot before iterating. Batches pushed
++		// while the drain runs stay queued for the next pass; the illuminator receives
++		// a private list no other thread can mutate, and no lock is held anywhere on
++		// this path.
++		List<Vec4i> merged = null;
++		while (serverMapChunk.stratumLightUpdateBatches.TryPop(out List<Vec4i> batch))
+ 		{
 -			Block block = server.Blocks[item.W];
 -			blockPos.SetAndCorrectDimension(item.X, item.Y, item.Z);
 -			byte[] lightHsv = block.GetLightHsv(this, blockPos);
@@ -70,23 +76,20 @@ index 33c394d..597891f 100644
 -			{
 -				server.WorldMap.chunkIlluminatorWorldGen.PlaceBlockLight(lightHsv, blockPos.X, blockPos.InternalY, blockPos.Z);
 -			}
--		}
++			if (merged == null) merged = batch;  // common case: one batch, zero-copy
++			else merged.AddRange(batch);         // order irrelevant: entries are light sources
+ 		}
 -		serverMapChunk.ScheduledBlockLightUpdates = null;
--	}
++		if (merged == null || merged.Count == 0) return;
++
++		server.WorldMap.chunkIlluminatorWorldGen.ProcessScheduledBlockLightUpdates(merged);
 +		// Stratum end
+ 	}
  
-+		// Stratum start:
-+		// We move the processing of light sources inside the chunilluminator method
-+		server.WorldMap.chunkIlluminatorWorldGen.ProcessScheduledBlockLightUpdates(scheduledBlockLightUpdates);
-+		// Stratum end.
-+	}
-+	
  	public void ScheduleBlockUpdate(BlockPos pos)
  	{
  		ChunkColumnLoadRequest chunkRequestAtPos = chunkdbthread.GetChunkRequestAtPos(pos.X, pos.Z);
- 		if (chunkRequestAtPos?.MapChunk != null)
- 		{
-@@ -133,22 +142,25 @@ public class BlockAccessorWorldGen : BlockAccessorBase, IWorldGenBlockAccessor,
+@@ -133,22 +148,25 @@ public class BlockAccessorWorldGen : BlockAccessorBase, IWorldGenBlockAccessor,
  		return chunkdbthread.GetMapRegion(regionX, regionZ);
  	}
  
@@ -115,7 +118,7 @@ index 33c394d..597891f 100644
  			{
  				serverChunk.Unpack();
  				cachedChunkIndex3d = num;
-@@ -159,11 +171,11 @@ public class BlockAccessorWorldGen : BlockAccessorBase, IWorldGenBlockAccessor,
+@@ -159,11 +177,11 @@ public class BlockAccessorWorldGen : BlockAccessorBase, IWorldGenBlockAccessor,
  		{
  			return serverChunk.Data.GetBlockId(worldmap.ChunkSizedIndex3D(posX & MagicNum.ServerChunkSizeMask, posY & MagicNum.ServerChunkSizeMask, posZ & MagicNum.ServerChunkSizeMask), layer);
  		}
@@ -128,7 +131,7 @@ index 33c394d..597891f 100644
  		else
  		{
  			ServerMain.Logger.Notification("Tried to get block outside generating chunks! Set RuntimeEnv.DebugOutOfRangeBlockAccess to debug.");
-@@ -220,21 +232,26 @@ public class BlockAccessorWorldGen : BlockAccessorBase, IWorldGenBlockAccessor,
+@@ -220,38 +238,43 @@ public class BlockAccessorWorldGen : BlockAccessorBase, IWorldGenBlockAccessor,
  	}
  
  	protected int SetSolidBlock(ServerChunk chunk, BlockPos pos, Block newBlock, int blockId)
@@ -160,7 +163,32 @@ index 33c394d..597891f 100644
  		return blockId2;
  	}
  
-@@ -308,11 +325,17 @@ public class BlockAccessorWorldGen : BlockAccessorBase, IWorldGenBlockAccessor,
+ 	public override void SetBlock(int blockId, BlockPos pos, int layer)
+ 	{
+ 		switch (layer)
+ 		{
+-		case 2:
+-			SetFluidBlock(blockId, pos);
+-			break;
+-		case 1:
+-			SetBlock(blockId, pos);
+-			break;
+-		default:
+-			throw new ArgumentException("Layer must be solid or fluid");
++			case 2:
++				SetFluidBlock(blockId, pos);
++				break;
++			case 1:
++				SetBlock(blockId, pos);
++				break;
++			default:
++				throw new ArgumentException("Layer must be solid or fluid");
+ 		}
+ 	}
+ 
+ 	public void SetFluidBlock(int blockId, BlockPos pos)
+ 	{
+@@ -308,11 +331,17 @@ public class BlockAccessorWorldGen : BlockAccessorBase, IWorldGenBlockAccessor,
  			Block localBlockAtBlockPos = generatingChunkAtPos.GetLocalBlockAtBlockPos(server, position);
  			blockEntity.CreateBehaviors(localBlockAtBlockPos, server);
  			blockEntity.Pos = position.Copy();

--- a/patches/VintagestoryLib/Vintagestory.Server/BlockAccessorWorldGen.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/BlockAccessorWorldGen.cs.patch
@@ -1,5 +1,5 @@
 diff --git a/VintagestoryLib/Vintagestory.Server/BlockAccessorWorldGen.cs b/VintagestoryLib/Vintagestory.Server/BlockAccessorWorldGen.cs
-index 33c394d..18c7503 100644
+index 33c394d..55eb54f 100644
 --- a/VintagestoryLib/Vintagestory.Server/BlockAccessorWorldGen.cs
 +++ b/VintagestoryLib/Vintagestory.Server/BlockAccessorWorldGen.cs
 @@ -27,10 +27,12 @@ public class BlockAccessorWorldGen : BlockAccessorBase, IWorldGenBlockAccessor,
@@ -15,7 +15,7 @@ index 33c394d..18c7503 100644
  	public IServerWorldAccessor WorldgenWorldAccessor => worldgenWorldAccessor ?? (worldgenWorldAccessor = new WorldgenWorldAccessor((IServerWorldAccessor)worldAccessor, this));
  
  	public BlockAccessorWorldGen(ServerMain server, WorldMap worldmap, ChunkServerThread chunkdbthread)
-@@ -47,42 +49,55 @@ public class BlockAccessorWorldGen : BlockAccessorBase, IWorldGenBlockAccessor,
+@@ -47,42 +49,56 @@ public class BlockAccessorWorldGen : BlockAccessorBase, IWorldGenBlockAccessor,
  		if (serverMapChunk == null)
  		{
  			ServerMain.Logger.Worldgen("Mapchunk was null when scheduling a blocklight update at " + pos);
@@ -65,7 +65,8 @@ index 33c394d..18c7503 100644
 +		// Stratum start: lock-free drain = snapshot before iterating. Batches pushed
 +		// while the drain runs stay queued for the next pass; the illuminator receives
 +		// a private list no other thread can mutate, and no lock is held anywhere on
-+		// this path.
++		// this path. The merged list is always freshly allocated so it never aliases an
++		// entry FastSerialize may still be enumerating (that would be concurrent mutation).
 +		List<Vec4i> merged = null;
 +		while (serverMapChunk.stratumLightUpdateBatches.TryPop(out List<Vec4i> batch))
  		{
@@ -76,8 +77,8 @@ index 33c394d..18c7503 100644
 -			{
 -				server.WorldMap.chunkIlluminatorWorldGen.PlaceBlockLight(lightHsv, blockPos.X, blockPos.InternalY, blockPos.Z);
 -			}
-+			if (merged == null) merged = batch;  // common case: one batch, zero-copy
-+			else merged.AddRange(batch);         // order irrelevant: entries are light sources
++			if (merged == null) merged = new List<Vec4i>(batch);   // fresh list; never alias a stack entry FastSerialize may enumerate
++			else merged.AddRange(batch);                            // order irrelevant: entries are light sources
  		}
 -		serverMapChunk.ScheduledBlockLightUpdates = null;
 +		if (merged == null || merged.Count == 0) return;
@@ -89,7 +90,7 @@ index 33c394d..18c7503 100644
  	public void ScheduleBlockUpdate(BlockPos pos)
  	{
  		ChunkColumnLoadRequest chunkRequestAtPos = chunkdbthread.GetChunkRequestAtPos(pos.X, pos.Z);
-@@ -133,22 +148,25 @@ public class BlockAccessorWorldGen : BlockAccessorBase, IWorldGenBlockAccessor,
+@@ -133,22 +149,25 @@ public class BlockAccessorWorldGen : BlockAccessorBase, IWorldGenBlockAccessor,
  		return chunkdbthread.GetMapRegion(regionX, regionZ);
  	}
  
@@ -118,7 +119,7 @@ index 33c394d..18c7503 100644
  			{
  				serverChunk.Unpack();
  				cachedChunkIndex3d = num;
-@@ -159,11 +177,11 @@ public class BlockAccessorWorldGen : BlockAccessorBase, IWorldGenBlockAccessor,
+@@ -159,11 +178,11 @@ public class BlockAccessorWorldGen : BlockAccessorBase, IWorldGenBlockAccessor,
  		{
  			return serverChunk.Data.GetBlockId(worldmap.ChunkSizedIndex3D(posX & MagicNum.ServerChunkSizeMask, posY & MagicNum.ServerChunkSizeMask, posZ & MagicNum.ServerChunkSizeMask), layer);
  		}
@@ -131,7 +132,7 @@ index 33c394d..18c7503 100644
  		else
  		{
  			ServerMain.Logger.Notification("Tried to get block outside generating chunks! Set RuntimeEnv.DebugOutOfRangeBlockAccess to debug.");
-@@ -220,38 +238,43 @@ public class BlockAccessorWorldGen : BlockAccessorBase, IWorldGenBlockAccessor,
+@@ -220,38 +239,43 @@ public class BlockAccessorWorldGen : BlockAccessorBase, IWorldGenBlockAccessor,
  	}
  
  	protected int SetSolidBlock(ServerChunk chunk, BlockPos pos, Block newBlock, int blockId)
@@ -188,7 +189,7 @@ index 33c394d..18c7503 100644
  
  	public void SetFluidBlock(int blockId, BlockPos pos)
  	{
-@@ -308,11 +331,17 @@ public class BlockAccessorWorldGen : BlockAccessorBase, IWorldGenBlockAccessor,
+@@ -308,11 +332,17 @@ public class BlockAccessorWorldGen : BlockAccessorBase, IWorldGenBlockAccessor,
  			Block localBlockAtBlockPos = generatingChunkAtPos.GetLocalBlockAtBlockPos(server, position);
  			blockEntity.CreateBehaviors(localBlockAtBlockPos, server);
  			blockEntity.Pos = position.Copy();

--- a/patches/VintagestoryLib/Vintagestory.Server/ServerMapChunk.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/ServerMapChunk.cs.patch
@@ -1,8 +1,8 @@
 diff --git a/VintagestoryLib/Vintagestory.Server/ServerMapChunk.cs b/VintagestoryLib/Vintagestory.Server/ServerMapChunk.cs
-index 672877b..af91e6a 100644
+index 672877b..3ffd611 100644
 --- a/VintagestoryLib/Vintagestory.Server/ServerMapChunk.cs
 +++ b/VintagestoryLib/Vintagestory.Server/ServerMapChunk.cs
-@@ -36,10 +36,27 @@ public class ServerMapChunk : IServerMapChunk, IMapChunk, IWithFastSerialize
+@@ -36,10 +36,40 @@ public class ServerMapChunk : IServerMapChunk, IMapChunk, IWithFastSerialize
  	public List<BlockPos> ScheduledBlockUpdates = new List<BlockPos>();
  
  	[ProtoMember(9)]
@@ -25,12 +25,25 @@ index 672877b..af91e6a 100644
 +	// ProtoMember itself, so it is never serialized.
 +	internal readonly object stratumNewBlockEntitiesLock = new object();
 +
++
++	// Stratum: lock-free handoff queue of batched worldgen block-light updates.
++	// Producers (GenCaves TerrainLate workers, SetBlock) push whole batches they no
++	// longer need; the consumer (RunScheduledBlockLightUpdates, Vegetation pass)
++	// drains the stack and iterates a private list nobody else can mutate. Replaces
++	// the shared ScheduledBlockLightUpdates List<Vec4i> that a TerrainLate append
++	// could corrupt while the Vegetation pass read and cleared it. A ConcurrentStack
++	// rather than a lock on purpose: the previous global accessor lock serialized the
++	// whole light-processing critical section across all worldgen threads, and the
++	// Monitor.Enter slow path dominated the profile. Not a ProtoMember itself, so the
++	// on-disk shape is unchanged; persistence rides on field 17 via FastSerialize/FromBytes.
++	internal readonly ConcurrentStack<List<Vec4i>> stratumLightUpdateBatches = new ConcurrentStack<List<Vec4i>>();
++
  	[ProtoMember(10)]
  	public ushort YMax;
  
  	[ProtoMember(15)]
  	public ConcurrentDictionary<Vec2iStruct, float> snowAccumOld;
-@@ -63,24 +80,30 @@ public class ServerMapChunk : IServerMapChunk, IMapChunk, IWithFastSerialize
+@@ -63,20 +93,26 @@ public class ServerMapChunk : IServerMapChunk, IMapChunk, IWithFastSerialize
  
  	public SmallBoolArray NeighboursLoaded;
  
@@ -57,39 +70,52 @@ index 672877b..af91e6a 100644
  		}
  	}
  
--	[ProtoMember(11)]
-+    [ProtoMember(11)]
+ 	[ProtoMember(11)]
  	public byte[] CaveHeightDistort { get; set; }
- 
- 	[ProtoMember(12)]
- 	public ushort[] SedimentaryThicknessMap { get; set; }
- 
-@@ -148,11 +171,14 @@ public class ServerMapChunk : IServerMapChunk, IMapChunk, IWithFastSerialize
+@@ -148,10 +184,13 @@ public class ServerMapChunk : IServerMapChunk, IMapChunk, IWithFastSerialize
  	}
  
  	public static ServerMapChunk FromBytes(byte[] serializedChunk)
  	{
  		ServerMapChunk serverMapChunk = Serializer.Deserialize<ServerMapChunk>((Stream)new MemoryStream(serializedChunk));
--		if (serverMapChunk.WorldGenTerrainHeightMap == null)
-+        // Stratum: converting the vanilla stage to ours
-+        serverMapChunk.currentpass = StratumWorldGenStages.FromVanilla(serverMapChunk.currentpass);
++		// Stratum: converting the vanilla stage to ours
++		serverMapChunk.currentpass = StratumWorldGenStages.FromVanilla(serverMapChunk.currentpass);
 +
-+        if (serverMapChunk.WorldGenTerrainHeightMap == null)
+ 		if (serverMapChunk.WorldGenTerrainHeightMap == null)
  		{
  			serverMapChunk.WorldGenTerrainHeightMap = (ushort[])serverMapChunk.RainHeightMap.Clone();
  		}
  		if (serverMapChunk.TopRockIdMapOld != null)
+@@ -176,10 +215,20 @@ public class ServerMapChunk : IServerMapChunk, IMapChunk, IWithFastSerialize
+ 		}
+ 		if (serverMapChunk.Moddata == null)
  		{
-@@ -282,15 +308,20 @@ public class ServerMapChunk : IServerMapChunk, IMapChunk, IWithFastSerialize
+ 			serverMapChunk.Moddata = new Dictionary<string, byte[]>();
+ 		}
++
++		// Stratum: migrate legacy pending updates (saved by vanilla or an older Stratum
++		// build mid-generation) onto the batch stack, so an interrupted column still
++		// gets its lava light when generation resumes.
++		if (serverMapChunk.ScheduledBlockLightUpdates != null)
++		{
++			serverMapChunk.stratumLightUpdateBatches.Push(serverMapChunk.ScheduledBlockLightUpdates);
++			serverMapChunk.ScheduledBlockLightUpdates = null;
++		}
++
+ 		return serverMapChunk;
+ 	}
+ 
+ 	public byte[] ToBytes()
+ 	{
+@@ -282,21 +331,47 @@ public class ServerMapChunk : IServerMapChunk, IMapChunk, IWithFastSerialize
  	public byte[] FastSerialize(FastMemoryStream ms)
  	{
  		ms.Reset();
  		FastSerializer.Write(ms, 1, Moddata);
  		FastSerializer.Write(ms, 3, RainHeightMap);
 -		FastSerializer.Write(ms, 4, currentpass);
--		FastSerializer.Write(ms, 6, TopRockIdMapOld);
-+        FastSerializer.Write(ms, 4, StratumWorldGenStages.ToVanilla(currentpass));   // Stratum: distilling our stages into vanilla
-+        FastSerializer.Write(ms, 6, TopRockIdMapOld);
++		FastSerializer.Write(ms, 4, StratumWorldGenStages.ToVanilla(currentpass));   // Stratum: distilling our stages into vanilla
+ 		FastSerializer.Write(ms, 6, TopRockIdMapOld);
  		FastSerializer.Write(ms, 7, WorldGenTerrainHeightMap);
  		FastSerializer.Write(ms, 8, ScheduledBlockUpdates);
 -		FastSerializer.Write(ms, 9, NewBlockEntities);
@@ -104,3 +130,31 @@ index 672877b..af91e6a 100644
  		FastSerializer.Write(ms, 12, SedimentaryThicknessMap);
  		FastSerializer.Write(ms, 13, TopRockIdMap);
  		FastSerializer.Write(ms, 15, snowAccumOld);
+ 		FastSerializer.Write(ms, 16, WorldGenVersion);
+-		FastSerializer.Write(ms, 17, ScheduledBlockLightUpdates);
++		// Stratum: save-path snapshot. The legacy field is dead at runtime (FromBytes
++		// moves it onto the stack and nulls it), but even in the (currently dead)
++		// non-null case we never hand a live reference to the serializer — copy it.
++		// Batches on the stack are immutable once pushed (producer nulls its reference
++		// after Push; Run only reads what it pops), so enumerating them here cannot
++		// race with anyone: the save thread is a reader, at worst concurrent with Run,
++		// which is also a reader. The serializer therefore never enumerates a list
++		// another thread mutates.
++		List<Vec4i> persistedLightUpdates = null;
++		if (ScheduledBlockLightUpdates != null && ScheduledBlockLightUpdates.Count > 0)
++		{
++			persistedLightUpdates = new List<Vec4i>(ScheduledBlockLightUpdates);
++		}
++		if (!stratumLightUpdateBatches.IsEmpty)
++		{
++			if (persistedLightUpdates == null) persistedLightUpdates = new List<Vec4i>();
++			foreach (List<Vec4i> batch in stratumLightUpdateBatches)
++			{
++				persistedLightUpdates.AddRange(batch);
++			}
++		}
++		FastSerializer.Write(ms, 17, persistedLightUpdates);
+ 		FastSerializer.Write(ms, 18, snowAccumArray);
+ 		return ms.ToArray();
+ 	}
+ }


### PR DESCRIPTION
## Summary

**A quick summary of what we've changed since the very first (original) code:**

1. **Sparse deferred writes**  
   *Was:* Each carved block was written to the chunk immediately via the indexer (`chunkBlockData[index3d] = value`), acquiring a lock and doing a palette lookup per block.  
   *Now:* Writes are buffered into per‑subchunk lists of indices and values (`stratumPendIdx`, `stratumPendVal`) and applied once per touched subchunk at the end of `GeneratePartial`. Untouched subchunks cost nothing. Normal worldgen flushes through the batched `SetBlocksUnsafe`/`SetManyUnsafe` path, which only serializes writers against each other — safe because those chunks are not published until generation finishes. The `/dev gencaves` command flushes through the regular locked indexer path instead (see point 3).

2. **Safe lazy initialisation of the blocks layer**  
   *Was:* The batched write path required an already‑initialised palette and NRE’d on a palette‑less layer; the earlier fix attempt called `ClearBlocksAndPrepare()`, which frees the blocks, fluids and light layers together and silently dropped unbuffered lava writes.  
   *Now:* `SetBlocksUnsafe` is self‑initialising: if the blocks layer or its palette is missing, it creates the layer and fills it via `PopulateWithAir()`, touching *only* the blocks layer – `fluidsLayer` and `lightLayer` are left completely untouched. `GenCaves` no longer calls `ClearBlocksAndPrepare()` mid‑generation, so lava written earlier in the same pass survives the first blocks flush.

3. **Thread‑safe and isolated `/dev gencaves` command**  
   *Was:* The command called `initWorldGen()` on the shared instance and reassigned `airBlockId` on it, so any worker that lazily created its `GenCaves` during the command’s window would permanently generate inverted caves. It also wrote to live, player‑visible chunks through the lock‑free batched path, where a concurrent reader or the save/compression thread could observe a torn bit‑plane update.  
   *Now:* The command builds a dedicated thread‑confined `GenCaves` copy under `lock (cmdLock)` and never touches shared state. Because it operates on published chunks, its buffered writes are flushed through the `readWriteLock`‑protected `Set()` path (`stratumLockedWrites = true`), giving readers and writers the same exclusion the old code had. Normal worldgen keeps the fast batched path.

4. **No per‑block allocations (GC‑friendly)**  
   *Was:* Per‑block lock acquisitions and temporary objects on the hot path.  
   *Now:* The buffering lists are allocated once per worker and reused via `Clear()` between columns.

5. **Buffered block‑light updates**  
   *Was:* Every light‑emitting block placed inside a cave called `ScheduleBlockLightUpdate` directly, which added entries to a shared list owned by the map chunk. This list was accessed concurrently by `GenCaves` (from `TerrainLate`) and `GenLight` (from `Vegetation`), leading to lost updates and corrupted lists.  
   *Now:* All light‑update requests are also buffered per `GenCaves` worker (`stratumPendLightPos`, `stratumPendLightOld`, `stratumPendLightNew`). At the end of `GeneratePartial`, these are flushed to the map chunk using a **global lock** (`lightUpdatesLock`) inside `BlockAccessorWorldGen`. This guarantees that the shared list is never accessed concurrently by different worldgen stages, and all light updates are correctly applied.

6. **Synchronised light‑update processing**  
   *Was:* `RunScheduledBlockLightUpdates` took the list from the map chunk, processed it, and cleared it – all without any locking, so two concurrent runs could process the same list twice or miss entries.  
   *Now:* The method now uses `lightUpdatesLock` to atomically take the list and set it to `null`, then delegates actual processing to the newly introduced `ProcessScheduledBlockLightUpdates` in the illuminator. This prevents double‑processing and ensures thread‑safe handover between worldgen phases.

## Type

- [ ] Bug fix
- [x] Performance
- [ ] New feature
- [ ] Refactor or cleanup
- [ ] Docs or build

## Checklist

- [x] `.\scripts\extract-patches.ps1` ran clean.
- [x] `dotnet build VintageStory.slnx -c Release` is green.
- [x] Every vanilla edit has a `// Stratum` marker.
- [x] No vanilla source committed.
- [x] Tested on a real server start, not just compilation.

## Performance numbers

Tested on the generation of 31417 chunk columns (6 threads) by `/stratum pregen start radius 100 16000 16000`
Seed - seed 1027995113.
World setting - default.

Three runs were performed before and after the changes using the Jetbrains dotTrace program.

**Before**
- GenCaves.GeneratePartial method execution time: 58826 ms; 62375 ms; 59406 ms.
- **Average:** 60202.33 ms
- **Standard deviation:** 1554.45 ms

**After**

- GenCaves.GeneratePartial method execution time: 57970 ms; 57128 ms; 52378 ms (Fix v5)
- **Average:** 55825.33 ms
- **Standard deviation:** 2461.75 ms

After optimization, the code runs on average ≈ 7.3% faster (about 4377 ms per run), while the spread of results (standard deviation) has increased from ~1554 ms to ~2462 ms, indicating less predictable and less stable performance. At the same time, we closed an important hole with light updates.


