### PR TITLE
Skip server-side pose matrices until something reads them

### DIFF
--- a/patches/VintagestoryApi/Common/Model/Animation/AnimationManager.cs.patch
+++ b/patches/VintagestoryApi/Common/Model/Animation/AnimationManager.cs.patch
@@ -1,5 +1,5 @@
 diff --git a/VintagestoryApi/Common/Model/Animation/AnimationManager.cs b/VintagestoryApi/Common/Model/Animation/AnimationManager.cs
-index 573ec12..de0f300 100644
+index 573ec12..74acb9a 100644
 --- a/VintagestoryApi/Common/Model/Animation/AnimationManager.cs
 +++ b/VintagestoryApi/Common/Model/Animation/AnimationManager.cs
 @@ -27,11 +27,23 @@ namespace Vintagestory.API.Common
@@ -314,7 +314,7 @@ index 573ec12..de0f300 100644
                      val.Value.StartFrameOnce = anim.CurrentFrame;
                  }
  
-@@ -446,14 +595,16 @@ namespace Vintagestory.API.Common
+@@ -446,15 +595,28 @@ namespace Vintagestory.API.Common
          /// The event fired at each server tick.
          /// </summary>
          /// <param name="dt"></param>
@@ -327,14 +327,27 @@ index 573ec12..de0f300 100644
              {
 -                Animator.CalculateMatrices = !entity.Alive || entity.requirePosesOnServer;
 -                Animator.OnFrame(ActiveAnimationsByAnimCode, dt);
+-                AdjustCollisionBoxToAnimation = ActiveAnimationsByAnimCode.Any(anim => anim.Value.AdjustCollisionBox);
 +                stratumAnimator.CalculateMatrices = !entity.Alive || entity.requirePosesOnServer;
 +                stratumAnimator.OnFrame(ActiveAnimationsByAnimCode, dt);
-                 AdjustCollisionBoxToAnimation = ActiveAnimationsByAnimCode.Any(anim => anim.Value.AdjustCollisionBox);
++                // Stratum start: plain loop, the LINQ Any allocated an enumerator and a closure per entity per tick
++                bool stratumAdjustCollisionBox = false;
++                foreach (KeyValuePair<string, AnimationMetaData> stratumAnim in ActiveAnimationsByAnimCode)
++                {
++                    if (stratumAnim.Value.AdjustCollisionBox)
++                    {
++                        stratumAdjustCollisionBox = true;
++                        break;
++                    }
++                }
++                AdjustCollisionBoxToAnimation = stratumAdjustCollisionBox;
++                // Stratum end
              }
  
              runTriggers();
          }
-@@ -495,10 +646,11 @@ namespace Vintagestory.API.Common
+ 
+@@ -495,10 +657,11 @@ namespace Vintagestory.API.Common
              }
          }
  
@@ -346,7 +359,7 @@ index 573ec12..de0f300 100644
          }
  
          private void runTriggers()
-@@ -537,11 +689,11 @@ namespace Vintagestory.API.Common
+@@ -537,11 +700,11 @@ namespace Vintagestory.API.Common
              }
          }
  

--- a/patches/VintagestoryApi/Common/Model/Animation/AnimationManager.cs.patch
+++ b/patches/VintagestoryApi/Common/Model/Animation/AnimationManager.cs.patch
@@ -1,5 +1,5 @@
 diff --git a/VintagestoryApi/Common/Model/Animation/AnimationManager.cs b/VintagestoryApi/Common/Model/Animation/AnimationManager.cs
-index 573ec12..74acb9a 100644
+index 573ec12..21aa3dc 100644
 --- a/VintagestoryApi/Common/Model/Animation/AnimationManager.cs
 +++ b/VintagestoryApi/Common/Model/Animation/AnimationManager.cs
 @@ -27,11 +27,23 @@ namespace Vintagestory.API.Common
@@ -330,7 +330,7 @@ index 573ec12..74acb9a 100644
 -                AdjustCollisionBoxToAnimation = ActiveAnimationsByAnimCode.Any(anim => anim.Value.AdjustCollisionBox);
 +                stratumAnimator.CalculateMatrices = !entity.Alive || entity.requirePosesOnServer;
 +                stratumAnimator.OnFrame(ActiveAnimationsByAnimCode, dt);
-+                // Stratum start: plain loop, the LINQ Any allocated an enumerator and a closure per entity per tick
++                // Stratum start: plain loop, the LINQ Any boxed the dictionary enumerator per entity per tick
 +                bool stratumAdjustCollisionBox = false;
 +                foreach (KeyValuePair<string, AnimationMetaData> stratumAnim in ActiveAnimationsByAnimCode)
 +                {

--- a/patches/VintagestoryApi/Common/Model/Animation/AnimatorBase.cs.patch
+++ b/patches/VintagestoryApi/Common/Model/Animation/AnimatorBase.cs.patch
@@ -1,0 +1,26 @@
+diff --git a/VintagestoryApi/Common/Model/Animation/AnimatorBase.cs b/VintagestoryApi/Common/Model/Animation/AnimatorBase.cs
+index d2d4a4e..565c9bb 100644
+--- a/VintagestoryApi/Common/Model/Animation/AnimatorBase.cs
++++ b/VintagestoryApi/Common/Model/Animation/AnimatorBase.cs
+@@ -273,14 +273,21 @@ namespace Vintagestory.API.Common
+         protected abstract void calculateMatrices(float dt);
+         
+ 
+         public AttachmentPointAndPose GetAttachmentPointPose(string code)
+         {
++            StratumEnsurePosesFresh(); // Stratum: lazy server poses, see ServerAnimator
+             AttachmentPointByCode.TryGetValue(code, out AttachmentPointAndPose apap);
+             return apap;
+         }
+ 
++        // Stratum: ServerAnimator overrides this to recompute stale poses on the first read
++        // of a frame instead of on every tick. No-op on the client.
++        protected virtual void StratumEnsurePosesFresh()
++        {
++        }
++
+         public virtual ElementPose GetPosebyName(string name, StringComparison stringComparison = StringComparison.InvariantCultureIgnoreCase)
+         {
+             throw new NotImplementedException();
+         }
+ 

--- a/patches/VintagestoryApi/Common/Model/Animation/ClientAnimator.cs.patch
+++ b/patches/VintagestoryApi/Common/Model/Animation/ClientAnimator.cs.patch
@@ -1,0 +1,16 @@
+diff --git a/VintagestoryApi/Common/Model/Animation/ClientAnimator.cs b/VintagestoryApi/Common/Model/Animation/ClientAnimator.cs
+index 9636237..b9c0440 100644
+--- a/VintagestoryApi/Common/Model/Animation/ClientAnimator.cs
++++ b/VintagestoryApi/Common/Model/Animation/ClientAnimator.cs
+@@ -249,10 +249,11 @@ namespace Vintagestory.API.Common
+             return depth + 1;
+         }
+ 
+         public override ElementPose GetPosebyName(string name, StringComparison stringComparison = StringComparison.InvariantCultureIgnoreCase)
+         {
++            StratumEnsurePosesFresh(); // Stratum: lazy server poses, see ServerAnimator
+             return getPosebyName(RootPoses, name);
+         }
+ 
+         private ElementPose getPosebyName(List<ElementPose> poses, string name, StringComparison stringComparison = StringComparison.InvariantCultureIgnoreCase)
+         {

--- a/patches/VintagestoryApi/Common/Model/Animation/ServerAnimator.cs.patch
+++ b/patches/VintagestoryApi/Common/Model/Animation/ServerAnimator.cs.patch
@@ -1,0 +1,54 @@
+diff --git a/VintagestoryApi/Common/Model/Animation/ServerAnimator.cs b/VintagestoryApi/Common/Model/Animation/ServerAnimator.cs
+index c6363d0..f40583c 100644
+--- a/VintagestoryApi/Common/Model/Animation/ServerAnimator.cs
++++ b/VintagestoryApi/Common/Model/Animation/ServerAnimator.cs
+@@ -103,10 +103,49 @@ namespace Vintagestory.API.Common
+ 
+             LoadAttachmentPoints(RootPoses);
+             initFields();
+         }
+ 
++        // Stratum start: lazy server poses. Vanilla recomputes the whole skeleton every tick for
++        // every entity with requirePosesOnServer (that is every player) and for every dead entity,
++        // but the server only reads those poses through GetAttachmentPointPose and GetPosebyName,
++        // and only from a few places (boat seats, ropes, immersive first person eye position,
++        // pouring, fishing). Mark the poses stale each frame and recompute on the first read.
++        // With 40 seraph elements this is 5 to 7 microseconds per player per tick otherwise.
++        public static bool StratumLazyPoses = true;
++        private bool stratumPosesStale;
++        private float stratumLastDt;
++        private readonly object stratumPoseLock = new object();
++
++        protected override void calculateMatrices(float dt)
++        {
++            if (StratumLazyPoses && CalculateMatrices)
++            {
++                stratumPosesStale = true;
++                stratumLastDt = dt;
++                return;
++            }
++
++            base.calculateMatrices(dt);
++        }
++
++        protected override void StratumEnsurePosesFresh()
++        {
++            if (!stratumPosesStale) return;
++
++            // Readers can come from a physics thread while the main thread ticks the animation.
++            // Two readers must not recompute at the same time; the scratch matrices are thread
++            // static but jointsDone and the poses are shared.
++            lock (stratumPoseLock)
++            {
++                if (!stratumPosesStale) return;
++                base.calculateMatrices(stratumLastDt);
++                stratumPosesStale = false;
++            }
++        }
++        // Stratum end
++
+         protected override void LoadPosesAndAttachmentPoints(ShapeElement[] elements, List<ElementPose> intoPoses)
+         {
+             // Tyron Oct 3, 2024: We used to only load root poses and root attachment points here server side
+             // Its just not feasible anymore with the Center AP being at non-root elements and also its inconsistent with the Client side
+             // And also this optimization does not really help much i think. We only calculate matrices server side on dead creatures anyway

--- a/patches/VintagestoryApi/Common/Model/Animation/ServerAnimator.cs.patch
+++ b/patches/VintagestoryApi/Common/Model/Animation/ServerAnimator.cs.patch
@@ -1,8 +1,8 @@
 diff --git a/VintagestoryApi/Common/Model/Animation/ServerAnimator.cs b/VintagestoryApi/Common/Model/Animation/ServerAnimator.cs
-index c6363d0..f40583c 100644
+index c6363d0..e9f0c8b 100644
 --- a/VintagestoryApi/Common/Model/Animation/ServerAnimator.cs
 +++ b/VintagestoryApi/Common/Model/Animation/ServerAnimator.cs
-@@ -103,10 +103,49 @@ namespace Vintagestory.API.Common
+@@ -103,10 +103,60 @@ namespace Vintagestory.API.Common
  
              LoadAttachmentPoints(RootPoses);
              initFields();
@@ -19,6 +19,17 @@ index c6363d0..f40583c 100644
 +        private float stratumLastDt;
 +        private readonly object stratumPoseLock = new object();
 +
++        // The frame update (animation progress, active list, CurAnims) and the lazy recompute
++        // share one lock. A reader on a physics thread can otherwise recompute from animation
++        // state the main thread is in the middle of advancing.
++        public override void OnFrame(Dictionary<string, AnimationMetaData> activeAnimationsByAnimCode, float dt)
++        {
++            lock (stratumPoseLock)
++            {
++                base.OnFrame(activeAnimationsByAnimCode, dt);
++            }
++        }
++
 +        protected override void calculateMatrices(float dt)
 +        {
 +            if (StratumLazyPoses && CalculateMatrices)
@@ -29,15 +40,15 @@ index c6363d0..f40583c 100644
 +            }
 +
 +            base.calculateMatrices(dt);
++            // Eager path computed fresh poses, so a getter must not redo the work. Matters when
++            // lazy poses is switched off at runtime while an entity is still marked stale.
++            stratumPosesStale = false;
 +        }
 +
 +        protected override void StratumEnsurePosesFresh()
 +        {
 +            if (!stratumPosesStale) return;
 +
-+            // Readers can come from a physics thread while the main thread ticks the animation.
-+            // Two readers must not recompute at the same time; the scratch matrices are thread
-+            // static but jointsDone and the poses are shared.
 +            lock (stratumPoseLock)
 +            {
 +                if (!stratumPosesStale) return;

--- a/patches/VintagestoryApi/Common/Model/Animation/ServerAnimator.cs.patch
+++ b/patches/VintagestoryApi/Common/Model/Animation/ServerAnimator.cs.patch
@@ -1,8 +1,8 @@
 diff --git a/VintagestoryApi/Common/Model/Animation/ServerAnimator.cs b/VintagestoryApi/Common/Model/Animation/ServerAnimator.cs
-index c6363d0..e9f0c8b 100644
+index c6363d0..391ab4b 100644
 --- a/VintagestoryApi/Common/Model/Animation/ServerAnimator.cs
 +++ b/VintagestoryApi/Common/Model/Animation/ServerAnimator.cs
-@@ -103,10 +103,60 @@ namespace Vintagestory.API.Common
+@@ -103,10 +103,62 @@ namespace Vintagestory.API.Common
  
              LoadAttachmentPoints(RootPoses);
              initFields();
@@ -15,7 +15,9 @@ index c6363d0..e9f0c8b 100644
 +        // pouring, fishing). Mark the poses stale each frame and recompute on the first read.
 +        // With 40 seraph elements this is 5 to 7 microseconds per player per tick otherwise.
 +        public static bool StratumLazyPoses = true;
-+        private bool stratumPosesStale;
++        // Volatile: the first check in StratumEnsurePosesFresh runs outside the lock, and the
++        // writer sets this on the main thread while readers can be on physics threads.
++        private volatile bool stratumPosesStale;
 +        private float stratumLastDt;
 +        private readonly object stratumPoseLock = new object();
 +

--- a/patches/VintagestoryLib/Vintagestory.Server/ServerSystemEntitySimulation.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/ServerSystemEntitySimulation.cs.patch
@@ -1,5 +1,5 @@
 diff --git a/VintagestoryLib/Vintagestory.Server/ServerSystemEntitySimulation.cs b/VintagestoryLib/Vintagestory.Server/ServerSystemEntitySimulation.cs
-index ea1d5c0..7b3f2ad 100644
+index ea1d5c0..8c91c9d 100644
 --- a/VintagestoryLib/Vintagestory.Server/ServerSystemEntitySimulation.cs
 +++ b/VintagestoryLib/Vintagestory.Server/ServerSystemEntitySimulation.cs
 @@ -1,8 +1,13 @@
@@ -500,7 +500,7 @@ index ea1d5c0..7b3f2ad 100644
  		SendEntityDespawns();
  		int count = server.DelayedSpawnQueue.Count;
  		if (count <= 0)
-@@ -185,19 +542,150 @@ public class ServerSystemEntitySimulation : ServerSystem
+@@ -185,19 +542,151 @@ public class ServerSystemEntitySimulation : ServerSystem
  		}
  	}
  
@@ -512,6 +512,7 @@ index ea1d5c0..7b3f2ad 100644
 +		list.Clear();
 +		StratumEntityTickingConfig stratumEntityTicking = StratumRuntime.Config.Performance.EntityTicking;
 +		StratumRegionTickingConfig stratumRegionTicking = StratumRuntime.Config.Performance.RegionTicking;
++		ServerAnimator.StratumLazyPoses = stratumEntityTicking.LazyServerPoses; // Stratum: lazy server poses, hot-reloadable
 +		BuildStratumPlayerPositions();
 +		if (stratumRegionTicking.Enabled)
 +		{
@@ -654,7 +655,7 @@ index ea1d5c0..7b3f2ad 100644
  				{
  					if (value is EntityPlayer entityPlayer)
  					{
-@@ -209,12 +697,17 @@ public class ServerSystemEntitySimulation : ServerSystem
+@@ -209,12 +698,17 @@ public class ServerSystemEntitySimulation : ServerSystem
  						ServerMain.Logger.Warning("Exception while ticking entity {0} ({1}) at {2}: ", value.GetName(), value.Properties?.Class, value.Pos);
  						ServerMain.Logger.Error(e);
  					}
@@ -672,7 +673,7 @@ index ea1d5c0..7b3f2ad 100644
  		}
  		ServerMain.FrameProfiler.Enter("despawning");
  		foreach (KeyValuePair<Entity, EntityDespawnData> item in list)
-@@ -222,27 +715,857 @@ public class ServerSystemEntitySimulation : ServerSystem
+@@ -222,27 +716,857 @@ public class ServerSystemEntitySimulation : ServerSystem
  			server.DespawnEntity(item.Key, item.Value);
  			ServerMain.FrameProfiler.Mark("despawned-", item.Key.Code.Path);
  		}
@@ -1534,7 +1535,7 @@ index ea1d5c0..7b3f2ad 100644
  		ItemStack itemStack = client.Player.InventoryManager?.ActiveHotbarSlot?.Itemstack;
  		float num = itemStack?.Collectible.GetAttackRange(itemStack) ?? GlobalConstants.DefaultAttackRange;
  		double x = pos.X + client.Entityplayer.LocalEyePos.X;
-@@ -257,10 +1580,16 @@ public class ServerSystemEntitySimulation : ServerSystem
+@@ -257,10 +1581,16 @@ public class ServerSystemEntitySimulation : ServerSystem
  		if (server.Config.AntiAbuse >= EnumProtectionLevel.Basic && !player.IsInInteractionRangeOf(entity))
  		{
  			ServerMain.Logger.Audit("{0} tried to interact with an entity out of range.", player.PlayerName);
@@ -1551,7 +1552,7 @@ index ea1d5c0..7b3f2ad 100644
  			player.Entity.EntitySelection = new EntitySelection
  			{
  				Entity = entity,
-@@ -279,14 +1608,46 @@ public class ServerSystemEntitySimulation : ServerSystem
+@@ -279,14 +1609,46 @@ public class ServerSystemEntitySimulation : ServerSystem
  		{
  			entity.OnInteract(player.Entity, player.InventoryManager.ActiveHotbarSlot, vec3d, (p.MouseButton != 0) ? EnumInteractMode.Interact : EnumInteractMode.Attack);
  		}
@@ -1600,7 +1601,7 @@ index ea1d5c0..7b3f2ad 100644
  			server.EventManager.TriggerPlayerRespawn(client.Player);
  		}
  		else
-@@ -384,16 +1745,24 @@ public class ServerSystemEntitySimulation : ServerSystem
+@@ -384,16 +1746,24 @@ public class ServerSystemEntitySimulation : ServerSystem
  	{
  		if (deathMessagesCache == null)
  		{
@@ -1627,7 +1628,7 @@ index ea1d5c0..7b3f2ad 100644
  			item.Entityplayer.DeadNotify = false;
  			item.WorldData.Deaths++;
  			server.EventManager.TriggerPlayerDeath(item.Player, item.Entityplayer.DeathReason);
-@@ -401,13 +1770,17 @@ public class ServerSystemEntitySimulation : ServerSystem
+@@ -401,13 +1771,17 @@ public class ServerSystemEntitySimulation : ServerSystem
  			{
  				Id = 45,
  				PlayerDeath = new Packet_PlayerDeath
@@ -1646,7 +1647,7 @@ index ea1d5c0..7b3f2ad 100644
  			string text = "";
  			if (num2)
  			{
-@@ -422,10 +1795,11 @@ public class ServerSystemEntitySimulation : ServerSystem
+@@ -422,10 +1796,11 @@ public class ServerSystemEntitySimulation : ServerSystem
  			else
  			{
  				ServerMain.Logger.Audit(Lang.Get("{0} died. Death message: {1}", item.PlayerName, text));

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumConfig.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumConfig.cs
@@ -1266,6 +1266,13 @@ internal class StratumEntityTickingConfig
 
 	public double MovingEntitySpeedThreshold { get; set; } = 0.01;
 
+	// Recompute server-side entity poses (skeleton matrices) only when something reads them
+	// instead of on every tick. Vanilla recomputes them every tick for every player and every
+	// dead entity; the server reads them rarely (boat seats, ropes, immersive first person eye
+	// position, pouring, fishing). Turn off if a mod reads animator poses directly from the
+	// RootPoses field on the server and misbehaves.
+	public bool LazyServerPoses { get; set; } = true;
+
 	// Hard cap on creature entities ticked per server tick (round-robin fairness via accumulated dt).
 	// 0 = unlimited. Recommended ~ (target tick ms) * (ticks-per-ms creature budget).
 	public int MaxCreatureTicksPerTick { get; set; } = 0;


### PR DESCRIPTION
## Summary

`ServerAnimator` no longer recomputes the whole skeleton (`calculateMatrices`) on every tick. It marks the poses stale in `calculateMatrices` and recomputes them on the first read through `GetAttachmentPointPose` or `GetPosebyName`. New config switch `Performance.EntityTicking.LazyServerPoses` (default `true`, hot-reloadable via `/stratum set`) turns it off. `AnimationManager.OnServerTick` also drops a LINQ `Any` that allocated an enumerator and a closure per entity per tick.

Why: every player has `requirePosesOnServer = true`, so vanilla walks all 40 seraph elements, blends every active animation, and multiplies matrices for every player on every server tick, plus for every dead entity. The server only reads those poses in a handful of places (boat seats, rope points, immersive first person eye position, pouring, fishing pole), and only on the tick something happens.

Compatibility:

- Stock client, server-only change.
- Mods that call `GetAttachmentPointPose` or `GetPosebyName` on the server get fresh poses. Checked Overhaullib / CombatOverhaul: its server hit detection goes through `GetAttachmentPointPose`; its `RootPoses` reads are client-only and structural.
- A mod that reads `AnimatorBase.RootPoses` element matrices directly on the server without calling a getter first would see stale poses. `LazyServerPoses: false` restores vanilla behaviour.
- Readers on a physics thread take a lock for the recompute; the vanilla scratch matrices are already thread static.

## Type

- [ ] Bug fix
- [x] Performance
- [ ] New feature
- [ ] Refactor or cleanup
- [ ] Docs or build

## Checklist

- [x] `.\scripts\extract-patches.ps1` ran clean.
- [x] `dotnet build VintageStory.slnx -c Release` is green.
- [x] Every vanilla edit has a `// Stratum` marker.
- [x] No vanilla source committed.
- [x] Tested on a real server start, not just compilation.

## Performance numbers

Micro-benchmark on the real `seraph.json` against `VintagestoryAPI.dll` 1.22.7 (desktop CPU, .NET 10, 30000 frames per case after warm up):

| active animations | with matrices | without | 650 players, per tick |
| --- | --- | --- | --- |
| none | 7.24 us | 0.01 us | 4.7 ms |
| idle1 | 5.51 us | 0.05 us | 3.6 ms |
| walk + idle1 | 6.96 us | 0.08 us | 4.5 ms |
| walk + idle1 + held item | 7.41 us | 0.14 us | 4.8 ms |

The 650-bot timings report from two months ago had `entity.tick.players` at 13.1 ms per tick average. This is 30 to 40 percent of that, on a machine that is probably faster than the server.

Equivalence check: eager and lazy animators ticked with the same random animation set for 6000 frames, attachment points read on random frames: 1842 reads, maximum absolute matrix difference 0.0, 6000 computes eager vs 614 lazy.

Real server (this branch, launcher with the built assemblies overlaid), one player, same spot, standing still, same machine state. Absolute numbers are high because the desktop had other work running; the comparison is A against B:

| run | LazyServerPoses | ticks | entity.type.player avg | max |
| --- | --- | --- | --- | --- |
| A | true | 5457 | 0.233 ms | 3.8 ms |
| B | false | 12694 | 0.290 ms | 8.4 ms |

57 us less per player per tick with lazy poses, about 20 percent of the player entity tick on that machine. Run B was otherwise the lighter run (creature tick 0.36 vs 0.41 ms, physics 5.9 vs 6.5 ms), so the difference is not the world getting busier. The bot swarm is still the number that matters for the 650-player case: compare `entity.type.player` in `/stratum timings report` with `Performance.EntityTicking.LazyServerPoses` true vs false.

Functional check on the same session: creative flight loading chunks, spawned and killed mobs, corpse harvesting, normal play, both settings; no exceptions in the server log.

## Related issues

Related to #262 (entity tick cost), not a fix for it.

Side note: `scripts/smoke-test.ps1` prefers `StratumServer/bin/Release/net10.0/VintagestoryServer.exe` when it exists. After the launcher's first run that file is the vanilla server it downloaded, so from then on the smoke test boots vanilla, not Stratum, and on a dev build (`EmbedPatchedFiles=false`) the launcher overlays nothing either. Worth pointing the smoke test at `StratumServer.exe` after a `StratumDeploy` overlay, or checking for the Stratum banner in the log.
