### PR TITLE
Fix /kitedit registration error, add snapshot scope, and document kit commands

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,7 +149,7 @@ Rules of thumb:
 Compilation is not enough. Before opening a PR:
 
 1. `dotnet build VintageStory.slnx -c Release` is green with zero warnings on files you touched.
-2. Run the smoke test: `make smoke` (or `bash scripts/smoke-test.sh` / `.\scripts\smoke-test.ps1`). It builds, boots the server, waits for RunGame, and checks for fatal errors.
+2. Run the smoke test: `make smoke` (or `bash scripts/smoke-test.sh` / `.\scripts\smoke-test.ps1`). It builds, boots the server, waits for RunGame, checks for fatal errors, and (bash only, set `SMOKE_TEST_PROBE=0` to skip) pipes a small set of console commands into the running server to cover command registration and argument handling end to end.
 3. If your change touches a hot path (entity ticking, chunk IO, packet handling), get a before/after measurement. Server timings, frame profiler output, or a sampling profiler are all fine. "Feels faster" is not.
 
 ## Commits

--- a/README.md
+++ b/README.md
@@ -99,6 +99,11 @@ changes.
 
 Anything else is forwarded to the server, such as `--port` or `--dataPath`.
 
+## Commands
+
+Stratum adds a set of in-game commands on top of vanilla. See
+[docs/commands/kits.md](docs/commands/kits.md) for `/kit` and `/kitedit`.
+
 ## Build
 
 Requires the .NET 10 SDK and `git`. Linux/macOS also need `bash`, `python3`, and `curl`.

--- a/docs/commands/kits.md
+++ b/docs/commands/kits.md
@@ -97,6 +97,7 @@ dropped, and failed.
 /kitedit rename <name> <newName>
 /kitedit setrole <name> <role>
 /kitedit setcooldown <name> <seconds>
+/kitedit setscope <name> all|hotbar
 /kitedit onrespawn <name> on|off
 /kitedit oneperlife <name> on|off
 /kitedit give <name> <player>
@@ -115,6 +116,7 @@ dropped, and failed.
 | `rename` | `<name> <newName>` | Renames a kit; fails if the new name is already taken. |
 | `setrole` | `<name> <role>` | Toggles a role assignment on the kit (see Assignment below). |
 | `setcooldown` | `<name> <seconds>` | Sets the per-kit redeem cooldown; `0` disables it. |
+| `setscope` | `<name> all\|hotbar` | Sets what a future `create` snapshots for this kit (see Item snapshot behavior below). |
 | `onrespawn` | `<name> on\|off` | Toggles give-on-respawn. |
 | `oneperlife` | `<name> on\|off` | Toggles the once-per-life redeem limit. |
 | `give` | `<name> <player>` | Gives the kit directly to an online player. |
@@ -124,15 +126,34 @@ Action words are lowercase and matched case-sensitively (the game's own
 
 ### Item snapshot behavior
 
-`create` walks only the hotbar and character inventories. A worn backpack's
-contents live inside the backpack's own item stack already, so walking the
-backpack's inventory too would capture its contents a second time; it is
-skipped deliberately. Each item is stored as a `JsonItemStack` (type, code,
+`create`'s scope controls which of your inventories it walks:
+
+- `all` (the default): hotbar and character inventory. This includes worn
+  armor and clothing, and a worn backpack (as a single item; see below) —
+  everything visually equipped on your character, not just what you are
+  holding.
+- `hotbar`: only the hotbar, which already includes the offhand slot.
+  Nothing worn or equipped is captured. Use this when a kit should only
+  ever hand out consumables or tools, never gear the recipient is
+  currently wearing.
+
+Set the scope with `/kitedit setscope <name> all|hotbar` before running
+`create`; scope is a property of the kit, not an argument to `create`
+itself, and it only affects what a *future* `create` captures — it does not
+retroactively filter a kit's existing item list. To reduce an existing
+`all`-scope kit down to `hotbar`, run `setscope` and then run `create`
+again.
+
+A worn backpack's contents (when scope is `all`) live inside the backpack's
+own item stack already, so walking the backpack's separate inventory too
+would capture its contents a second time; that inventory is always skipped
+regardless of scope. Each item is stored as a `JsonItemStack` (type, code,
 stack size, and attributes), with a human-readable code and quantity mirror
 kept alongside it. A kit is a point-in-time snapshot, not a live link to any
 item definition: running `create` again on an existing name replaces the
-item list but keeps the kit's assignment, cooldown, and flags. `additem`
-captures only the item currently in your active hotbar slot.
+item list but keeps the kit's assignment, cooldown, flags, and scope.
+`additem` always captures only the item currently in your active hotbar
+slot, regardless of scope.
 
 ### Assignment
 
@@ -165,8 +186,8 @@ Each action takes exactly the argument count in the table above:
   rejected by the game's own command parser before Stratum ever sees it.
 - An unknown action: `Unknown /kitedit action '<action>'. Actions: list,
   create, additem, removeitem, preview, delete, rename, setrole,
-  setcooldown, onrespawn, oneperlife, give. Run /kitedit list to see
-  existing kits.`
+  setcooldown, setscope, onrespawn, oneperlife, give. Run /kitedit list to
+  see existing kits.`
 
 ### Where changes are saved
 
@@ -176,7 +197,12 @@ Every mutating action writes `stratum-kits.json` immediately. `create` and
 ## Typical workflow
 
 1. Put the exact items you want in the kit into your inventory.
-2. `/kitedit create <name>` to snapshot them.
+2. `/kitedit create <name>` to snapshot them. `setscope` needs the kit to
+   already exist, so this first `create` always captures with the default
+   `all` scope.
+3. If the kit should never include worn armor or clothing, run `/kitedit
+   setscope <name> hotbar`, then run `/kitedit create <name>` again to
+   re-snapshot under the new scope.
 3. Use `additem` / `removeitem` to adjust the item list as needed.
 4. `/kitedit preview <name>` to verify the result.
 5. `/kitedit setrole <name> <role>` if the kit should be limited to a role.
@@ -232,7 +258,7 @@ edit:
 | Registration, privileges, in-game descriptions | `CmdStratumKits` constructor |
 | Action list and argument counts | `CmdStratumKits.KitEditActions`, `CmdStratumKits.ActionShape` |
 | Argument rejection wording | `CmdStratumKits.CheckActionArgs`, `CmdStratumKits.UnknownAction` |
-| Inventory snapshot scope | `CmdStratumKits.SnapshotInventory`, `CmdStratumKits.EncodeStack` |
+| Inventory snapshot scope | `CmdStratumKits.SnapshotInventory`, `CmdStratumKits.EncodeStack`, `CmdStratumKits.SetScope`, `StratumKitDefinition.Scope` |
 | Assignment matching | `CmdStratumKits.IsAssignedTo` |
 | Cooldown and staff bypass | `StratumCommandCooldowns.TryUse` |
 | Once per life | `CmdStratumKits.HasRedeemedThisLife`, `MarkRedeemedThisLife`, `OnPlayerRespawn` |
@@ -244,4 +270,10 @@ edit:
 `scripts/smoke-test.sh` asserts the exact usage and error strings documented
 above by piping the corresponding `/kitedit` and `/kit` commands into a
 running server's console. A wording change here that is not mirrored there
-(or vice versa) fails the smoke test.
+(or vice versa) fails the smoke test. The scope behavior specifically (a
+worn armor piece included under `all`, excluded under `hotbar`) is proven
+against a real connected player's real inventory by the private Atlas
+regression suite (`research/atlas-tests/stratum-pr-validation/KitScenarios.cs`,
+`Create_scope_all_includes_worn_armor_hotbar_excludes_it`), not by the public
+smoke test, since that requires a real player entity a console caller does
+not have.

--- a/docs/commands/kits.md
+++ b/docs/commands/kits.md
@@ -1,0 +1,247 @@
+# Kit commands
+
+Stratum ships two commands for staff-authored, in-game item kits: `/kit` for
+players and `/kitedit` for staff. Both are server side only and stay
+compatible with the stock client: there is no custom UI, so every `/kitedit`
+step that would otherwise need a typed item code instead snapshots a live
+`ItemStack` off the caller. Implementation:
+[`CmdStratumKits.cs`](../../sources/VintagestoryLib/Vintagestory.Server/CmdStratumKits.cs).
+
+## At a glance
+
+| Command | Audience | Access config key | Default privilege | Storage |
+| --- | --- | --- | --- | --- |
+| `/kit` | Players | `Commands.Kits` | `stratum.kits` | `stratum-kits.json` |
+| `/kitedit` | Staff | `Commands.KitEdit` | `stratum.kitedit` | `stratum-kits.json` |
+
+## Prerequisites
+
+- `Commands.Enabled`, `Commands.Kits.Enabled`, and `Commands.KitEdit.Enabled`
+  all default to `true`. Setting one to `false` skips registering that
+  command entirely; the change takes effect on the next server restart,
+  since registration happens once when the server boots.
+- `stratum.kits` and `stratum.kitedit` are **not** granted to any default
+  role, including `admin`. Grant them with `/roles grant <role>
+  stratum.kitedit` (see the roles command reference) or by editing
+  `serverroles.json` directly.
+- The server console always passes Stratum's own access check (see
+  `StratumCommandAccessCatalog.CallerHasAccess`), so both commands can be run
+  from the console for diagnostics. A console caller has no player entity,
+  so `create`, `additem`, and `/kit` itself (which needs a connected player)
+  will report that instead of doing anything.
+- Kit definitions live in a `stratum-kits.json` sidecar in the server's data
+  path, written on every mutation.
+
+## `/kit`
+
+```
+/kit
+/kit <name>
+```
+
+| Argument | Required | Meaning |
+| --- | --- | --- |
+| `name` | No | The kit to redeem. Omit it to list the kits assigned to you. |
+
+Running `/kit` with no argument lists every kit you are assigned, each with
+its item count, cooldown (if any), and a "once per life" marker, followed by
+a reminder of the redeem syntax. Running `/kit <name>` redeems that kit
+immediately if you are allowed to.
+
+**Assignment.** A kit with an empty assignment list is available to every
+player with kit access. A kit assigned to one or more roles is available
+only to players currently holding one of those roles.
+
+**Cooldowns.** Each kit has its own `CooldownSeconds` (`0` disables it),
+tracked per player per kit, in memory only — it resets when the server
+restarts. Staff holding the `Commands.StaffChat` access also bypass every
+per-kit cooldown, the same rule `/kit` and `/kitedit` themselves use for
+their own command-level cooldown (`Commands.Kits.CooldownSeconds` /
+`Commands.KitEdit.CooldownSeconds`), which is checked separately, before the
+per-kit one. The server console bypasses cooldowns entirely.
+
+**Once per life.** A kit flagged `oneperlife` can only be redeemed once
+between respawns; a second attempt is rejected until you die and respawn.
+
+**Give on respawn.** A kit flagged `onrespawn` is handed out automatically
+after you respawn, once your entity is actually alive again (Stratum polls
+for that, giving up after roughly 10 seconds if it never happens), and
+counts as redeemed for that life the same as a manual `/kit <name>` would.
+
+**Delivery.** Armor pieces are placed directly into a compatible, empty
+character inventory slot. Everything else is given through the same
+`Entity.TryGiveItemStack` path the `/giveitem` command uses; anything that
+does not fit is dropped at your feet instead of being discarded, and an item
+whose original definition no longer resolves is reported as failed rather
+than silently skipped. The result message says how many items were given,
+dropped, and failed.
+
+| Situation | Message |
+| --- | --- |
+| Not assigned the kit | `You are not assigned the kit '<name>'.` |
+| No such kit | `No kit named '<name>'. Run /kit to see the kits you can redeem.` |
+| Command or per-kit cooldown active | `Wait <N>s before ...` |
+| Already redeemed this life | `You have already redeemed '<name>' this life.` |
+| Not a connected player (e.g. console) | `Only a connected player can use /kit.` |
+| More than one argument | rejected by the game's own command parser |
+
+## `/kitedit`
+
+```
+/kitedit list
+/kitedit create <name>
+/kitedit additem <name>
+/kitedit removeitem <name> <index>
+/kitedit preview <name>
+/kitedit delete <name>
+/kitedit rename <name> <newName>
+/kitedit setrole <name> <role>
+/kitedit setcooldown <name> <seconds>
+/kitedit onrespawn <name> on|off
+/kitedit oneperlife <name> on|off
+/kitedit give <name> <player>
+```
+
+### Actions
+
+| Action | Arguments | Effect |
+| --- | --- | --- |
+| `list` | none | Lists every kit and its assignment summary. |
+| `create` | `<name>` | Snapshots your whole inventory into a kit, creating it or replacing its item list if it already exists. |
+| `additem` | `<name>` | Adds the item in your active hotbar slot to the kit. |
+| `removeitem` | `<name> <index>` | Removes one item by its 1-based `preview` index. |
+| `preview` | `<name>` | Shows assignment, cooldown, flags, and numbered items. |
+| `delete` | `<name>` | Deletes the kit. |
+| `rename` | `<name> <newName>` | Renames a kit; fails if the new name is already taken. |
+| `setrole` | `<name> <role>` | Toggles a role assignment on the kit (see Assignment below). |
+| `setcooldown` | `<name> <seconds>` | Sets the per-kit redeem cooldown; `0` disables it. |
+| `onrespawn` | `<name> on\|off` | Toggles give-on-respawn. |
+| `oneperlife` | `<name> on\|off` | Toggles the once-per-life redeem limit. |
+| `give` | `<name> <player>` | Gives the kit directly to an online player. |
+
+Action words are lowercase and matched case-sensitively (the game's own
+`WordRange` parser behavior). Kit names are matched case-insensitively.
+
+### Item snapshot behavior
+
+`create` walks only the hotbar and character inventories. A worn backpack's
+contents live inside the backpack's own item stack already, so walking the
+backpack's inventory too would capture its contents a second time; it is
+skipped deliberately. Each item is stored as a `JsonItemStack` (type, code,
+stack size, and attributes), with a human-readable code and quantity mirror
+kept alongside it. A kit is a point-in-time snapshot, not a live link to any
+item definition: running `create` again on an existing name replaces the
+item list but keeps the kit's assignment, cooldown, and flags. `additem`
+captures only the item currently in your active hotbar slot.
+
+### Assignment
+
+`AssignedTo` holds a list of scope strings; today the only scope shape is
+`role:<code>`. An empty list means every player with kit access can redeem
+the kit. `setrole` toggles: running it with a role the kit does not have
+adds it, running it again with the same role removes it. Multiple roles can
+be assigned to the same kit. Matching is against the player's current role
+code at redeem time.
+
+### Flags
+
+`onrespawn` and `oneperlife` each accept only `on` or `off`; anything else
+returns the usage line for that action. See `/kit` above for what each flag
+does at redeem time.
+
+### Cooldowns
+
+Per-kit cooldowns are set with `setcooldown`. They share the same in-memory,
+per-player-per-kit tracking and staff bypass rule described under `/kit`.
+
+### Argument rules
+
+Each action takes exactly the argument count in the table above:
+
+- Too few arguments: the usage line for that action, e.g. `Usage: /kitedit
+  create <name>`.
+- Too many arguments (three when the action takes fewer): `/kitedit <action>
+  takes N argument(s). Usage: ...`. A fourth word on the command line is
+  rejected by the game's own command parser before Stratum ever sees it.
+- An unknown action: `Unknown /kitedit action '<action>'. Actions: list,
+  create, additem, removeitem, preview, delete, rename, setrole,
+  setcooldown, onrespawn, oneperlife, give. Run /kitedit list to see
+  existing kits.`
+
+### Where changes are saved
+
+Every mutating action writes `stratum-kits.json` immediately. `create` and
+`additem` are also written to the audit log.
+
+## Typical workflow
+
+1. Put the exact items you want in the kit into your inventory.
+2. `/kitedit create <name>` to snapshot them.
+3. Use `additem` / `removeitem` to adjust the item list as needed.
+4. `/kitedit preview <name>` to verify the result.
+5. `/kitedit setrole <name> <role>` if the kit should be limited to a role.
+6. `/kitedit setcooldown`, `onrespawn`, and `oneperlife` as needed.
+7. Test with `/kit <name>` yourself, or hand it to someone with `/kitedit
+   give <name> <player>`.
+
+## Examples
+
+```
+/kitedit create starter_kit 1     # rejected: create takes 1 argument
+/kitedit create starter_kit       # correct: snapshots your inventory
+/kitedit preview starter_kit
+/kitedit setrole starter_kit newplayer
+/kit starter_kit
+```
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| `Programming error: Incomplete command - no name or required privilege has been set` | Running a Stratum build older than this fix | Upgrade; `/kitedit` was missing its base command privilege and could not run at all. |
+| `You do not have permission to use /kitedit.` | Your role does not hold the configured privilege | Grant `stratum.kitedit` (or your configured privilege) to the role. |
+| `/kitedit is disabled.` | `Commands.KitEdit.Enabled` is `false` | Enable it and restart the server. |
+| `Your inventory is empty; nothing to snapshot.` | `create` with nothing in the hotbar or character inventory | Pick up items first. |
+| `... partially given: N given, M dropped at feet (inventory full)` | The recipient's inventory could not hold every item | Free up space, or accept the drop at their feet. |
+
+## Configuration reference
+
+| Key | Default | Effect |
+| --- | --- | --- |
+| `Commands.Enabled` | `true` | Master switch for every Stratum command, including these two. |
+| `Commands.Kits.Enabled` | `true` | Registers `/kit`. |
+| `Commands.Kits.Privilege` | `stratum.kits` | Privilege required to use `/kit`. |
+| `Commands.Kits.CooldownSeconds` | `0` | Command-level cooldown for `/kit`, checked before any per-kit cooldown. |
+| `Commands.Kits.CooldownBypassForStaff` | `true` | Staff with `Commands.StaffChat` access skip the command-level cooldown. |
+| `Commands.KitEdit.Enabled` | `true` | Registers `/kitedit`. |
+| `Commands.KitEdit.Privilege` | `stratum.kitedit` | Privilege required to use `/kitedit`. |
+| `Commands.KitEdit.CooldownSeconds` | `0` | Command-level cooldown for `/kitedit`. |
+| `Commands.KitEdit.CooldownBypassForStaff` | `true` | Staff with `Commands.StaffChat` access skip it. |
+
+Use `/stratum access command kit` (or `kitedit`) to see the effective
+privilege and cooldown for either command on a running server.
+
+## Keeping this page in sync
+
+This page documents behavior owned by specific symbols in
+`CmdStratumKits.cs`. If one of these changes, this page needs a matching
+edit:
+
+| Documented behavior | Owning symbol |
+| --- | --- |
+| Registration, privileges, in-game descriptions | `CmdStratumKits` constructor |
+| Action list and argument counts | `CmdStratumKits.KitEditActions`, `CmdStratumKits.ActionShape` |
+| Argument rejection wording | `CmdStratumKits.CheckActionArgs`, `CmdStratumKits.UnknownAction` |
+| Inventory snapshot scope | `CmdStratumKits.SnapshotInventory`, `CmdStratumKits.EncodeStack` |
+| Assignment matching | `CmdStratumKits.IsAssignedTo` |
+| Cooldown and staff bypass | `StratumCommandCooldowns.TryUse` |
+| Once per life | `CmdStratumKits.HasRedeemedThisLife`, `MarkRedeemedThisLife`, `OnPlayerRespawn` |
+| Give on respawn | `CmdStratumKits.GiveAssignedRespawnKits` |
+| Item delivery and drop-at-feet | `StratumKitGiver.Give`, `TryGiveOne` |
+| Storage file and shape | `StratumKitStore` |
+| Config defaults | `StratumConfig.StratumCommandsConfig.Kits` / `.KitEdit` |
+
+`scripts/smoke-test.sh` asserts the exact usage and error strings documented
+above by piping the corresponding `/kitedit` and `/kit` commands into a
+running server's console. A wording change here that is not mirrored there
+(or vice versa) fails the smoke test.

--- a/scripts/smoke-test.ps1
+++ b/scripts/smoke-test.ps1
@@ -5,6 +5,10 @@ monitors progress through startup phases, and verifies it reaches RunGame
 without fatal errors. Detects stalls by checking log growth rather than a
 hard timeout.
 
+Does not yet pipe the console command probe scripts/smoke-test.sh runs on
+Linux/macOS (registration and argument-handling coverage for commands like
+/kitedit); this script is boot-only for now.
+
 .PARAMETER Patience
 Seconds without log output before declaring a stall. Default: 60.
 

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -10,6 +10,7 @@ set -euo pipefail
 #   SMOKE_TEST_PATIENCE - seconds without progress before declaring stall (default: 60)
 #   SMOKE_TEST_PORT     - server port (default: random ephemeral)
 #   SMOKE_TEST_DATA     - server dataPath (default: temp dir, cleaned on exit)
+#   SMOKE_TEST_PROBE    - set to 0 to skip the console command probe (default: 1)
 
 script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd -- "$script_dir/.." && pwd)"
@@ -31,6 +32,33 @@ fi
 patience="${SMOKE_TEST_PATIENCE:-60}"
 port="${SMOKE_TEST_PORT:-0}"
 
+# Console command probe. After the server reaches RunGame these lines are piped into
+# its stdin one at a time; the server runs them as console chat commands (a caller
+# that always passes Stratum's own access check, see StratumCommandAccessCatalog) and
+# writes each result to the log, so command registration and argument handling are
+# covered without a game client. probe_expect is index-matched; an empty entry only
+# asserts that the command was dispatched and did not trip the registration error.
+probe_commands=(
+  "/kitedit list"
+  "/kitedit create starter_kit 1"
+  "/kitedit create starter_kit"
+  "/kitedit preview starter_kit"
+  "/kitedit rename starter_kit"
+  "/kitedit list extra"
+  "/kitedit create starter_kit 1 2"
+  "/kit"
+)
+probe_expect=(
+  "No kits exist yet."
+  "/kitedit create takes 1 argument."
+  "Only a connected player can snapshot a kit from their own inventory."
+  "No kit named 'starter_kit'."
+  "Usage: /kitedit rename"
+  "/kitedit list takes no arguments."
+  ""
+  "Only a connected player can use /kit."
+)
+
 # Data path handling.
 own_data=1
 if [[ -n "${SMOKE_TEST_DATA:-}" ]]; then
@@ -42,6 +70,8 @@ fi
 mkdir -p "$data_path"
 
 cleanup() {
+  exec 3>&- 2>/dev/null || true
+  rm -f "$data_path/console.fifo" 2>/dev/null || true
   if [[ "$own_data" == "1" && -d "$data_path" ]]; then
     rm -rf "$data_path"
   fi
@@ -77,8 +107,19 @@ fi
 
 echo "Smoke test: port=$port patience=${patience}s data=$data_path"
 
+# The server's console reader executes whatever a single stdin read returns as one
+# command, so the probe needs a live pipe it can write to one line at a time.
+# Opened read-write so neither open() blocks on the other end.
+console_fifo="$data_path/console.fifo"
+mkfifo "$console_fifo"
+exec 3<>"$console_fifo"
+
 log_file="$data_path/smoke-test.log"
-"$server_bin" --dataPath "$data_path" --port "$port" >"$log_file" 2>&1 &
+# Run from the server's own directory, not repo_root: Mono.Cecil's default assembly
+# resolver searches the process's current directory, and modinfo scanning at boot
+# fails to resolve VintagestoryAPI (silently dropping every mod, "game" included)
+# when launched from anywhere else.
+(cd "$server_dir" && exec "$server_bin" --dataPath "$data_path" --port "$port" <"$console_fifo" >"$log_file" 2>&1) &
 server_pid=$!
 
 last_line_count=0
@@ -125,6 +166,43 @@ while true; do
   fi
 done
 
+log_contains() {
+  grep -qF -- "$1" "$log_file" 2>/dev/null
+}
+
+probe_failures=""
+probe_ran=0
+if [[ "${SMOKE_TEST_PROBE:-1}" == "1" ]] \
+  && kill -0 "$server_pid" 2>/dev/null \
+  && grep -q "Entering runphase RunGame" "$log_file" 2>/dev/null; then
+  probe_ran=1
+  echo "Probing ${#probe_commands[@]} console command(s)..."
+  for cmd in "${probe_commands[@]}"; do
+    printf '%s\n' "$cmd" >&3
+    # One second between writes: two lines that land in the same read would be
+    # submitted to the server as a single bogus command.
+    sleep 1
+  done
+  # Let the results reach the log before grepping.
+  sleep 5
+
+  for i in "${!probe_commands[@]}"; do
+    cmd="${probe_commands[$i]}"
+    if ! log_contains "Handling Console Command $cmd"; then
+      probe_failures+="    not dispatched: $cmd"$'\n'
+      continue
+    fi
+    expected="${probe_expect[$i]}"
+    if [[ -n "$expected" ]] && ! log_contains "$expected"; then
+      probe_failures+="    $cmd -> missing expected output: $expected"$'\n'
+    fi
+  done
+
+  if log_contains "Incomplete command"; then
+    probe_failures+="    command registration incomplete: \"Incomplete command\" appeared in the log"$'\n'
+  fi
+fi
+
 # Shut down.
 if kill -0 "$server_pid" 2>/dev/null; then
   kill -TERM "$server_pid" 2>/dev/null || true
@@ -142,8 +220,12 @@ if grep -qi "Fatal\|Unhandled exception" "$log_file" 2>/dev/null; then
   has_fatal=1
 fi
 
-if [[ "$reached_rungame" == "1" && "$has_fatal" == "0" ]]; then
-  echo "PASS: server reached RunGame, no fatal errors. (last phase: $last_phase)"
+if [[ "$reached_rungame" == "1" && "$has_fatal" == "0" && -z "$probe_failures" ]]; then
+  if [[ "$probe_ran" == "1" ]]; then
+    echo "PASS: server reached RunGame, no fatal errors, ${#probe_commands[@]} console command(s) verified. (last phase: $last_phase)"
+  else
+    echo "PASS: server reached RunGame, no fatal errors. (last phase: $last_phase)"
+  fi
   exit 0
 fi
 
@@ -154,6 +236,10 @@ fi
 if [[ "$has_fatal" == "1" ]]; then
   echo "  Fatal errors:" >&2
   grep -i "Fatal\|Unhandled exception" "$log_file" | head -3 | sed 's/^/    /' >&2
+fi
+if [[ -n "$probe_failures" ]]; then
+  echo "  Console command probe failures:" >&2
+  printf '%s' "$probe_failures" >&2
 fi
 echo "  Log: $log_file" >&2
 exit 1

--- a/sources/VintagestoryLib/Vintagestory.Server/CmdStratumKits.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/CmdStratumKits.cs
@@ -23,6 +23,13 @@ internal class CmdStratumKits
 {
 	private const string RedeemedThisLifeKey = "stratum.kit.redeemed-this-life.v1";
 
+	// Single source of truth for the /kitedit action words: drives the WordRange parser, the
+	// unknown-action message, and ActionShape below. Ordered the way an operator uses them.
+	private static readonly string[] KitEditActions =
+	{
+		"list", "create", "additem", "removeitem", "preview", "delete", "rename", "setrole", "setcooldown", "onrespawn", "oneperlife", "give"
+	};
+
 	private readonly ServerMain server;
 
 	public CmdStratumKits(ServerMain server)
@@ -40,7 +47,8 @@ internal class CmdStratumKits
 		if (StratumCommandRegistration.ShouldRegister(kitAccess, "/kit", "Commands.Kits"))
 		{
 			server.api.commandapi.Create("kit")
-				.WithDescription("Redeem a kit you have been assigned, or list the ones you can use: /kit [name]")
+				.WithDescription("Redeem a kit you have been assigned, or list the kits you can redeem")
+				.WithAdditionalInformation("/kit lists the kits assigned to you. /kit &lt;name&gt; redeems one. A kit with no role assignment is available to every player with kit access.")
 				.WithArgs(parsers.OptionalWord("name"))
 				.RequiresPrivilege(Privilege.chat)
 				.HandleWith(HandleKit);
@@ -50,11 +58,13 @@ internal class CmdStratumKits
 		if (StratumCommandRegistration.ShouldRegister(kitEditAccess, "/kitedit", "Commands.KitEdit"))
 		{
 			server.api.commandapi.Create("kitedit")
-				.WithDescription("Create and manage kits: /kitedit create|additem|removeitem|delete|rename|setrole|setcooldown|onrespawn|oneperlife|preview|give|list <...>")
+				.WithDescription("Create and manage kits")
+				.WithAdditionalInformation("Actions: list, create &lt;name&gt;, additem &lt;name&gt;, removeitem &lt;name&gt; &lt;index&gt;, preview &lt;name&gt;, delete &lt;name&gt;, rename &lt;name&gt; &lt;newName&gt;, setrole &lt;name&gt; &lt;role&gt;, setcooldown &lt;name&gt; &lt;seconds&gt;, onrespawn &lt;name&gt; on|off, oneperlife &lt;name&gt; on|off, give &lt;name&gt; &lt;player&gt;. create snapshots your whole inventory, additem snapshots your active hotbar slot.")
 				.WithArgs(
-					parsers.WordRange("action", "create", "additem", "removeitem", "delete", "rename", "setrole", "setcooldown", "onrespawn", "oneperlife", "preview", "give", "list"),
+					parsers.WordRange("action", KitEditActions),
 					parsers.OptionalWord("name"),
 					parsers.OptionalWord("value"))
+				.RequiresPrivilege(Privilege.chat)
 				.HandleWith(HandleKitEdit);
 		}
 	}
@@ -131,7 +141,7 @@ internal class CmdStratumKits
 		StratumKitDefinition kit = StratumKitStore.Find(name);
 		if (kit == null)
 		{
-			return TextCommandResult.Error("No kit named '" + name + "'.");
+			return TextCommandResult.Error("No kit named '" + name + "'. Run /kit to see the kits you can redeem.");
 		}
 
 		if (!IsAssignedTo(kit, caller.ServerData))
@@ -195,6 +205,11 @@ internal class CmdStratumKits
 		string name = args.Parsers[1].IsMissing ? null : args[1] as string;
 		string value = args.Parsers[2].IsMissing ? null : args[2] as string;
 
+		if (!CheckActionArgs(action, name, value, out TextCommandResult usage))
+		{
+			return usage;
+		}
+
 		return action switch
 		{
 			"create" => CreateKit(name, args.Caller),
@@ -209,15 +224,82 @@ internal class CmdStratumKits
 			"preview" => PreviewKit(name),
 			"give" => GiveKit(name, value),
 			"list" => ListAllKits(),
-			_ => TextCommandResult.Error("Unknown /kitedit action '" + action + "'.")
+			_ => UnknownAction(action)
 		};
+	}
+
+	// Argument shape per /kitedit action: how many words follow the action, and the usage line to
+	// show when the caller gets it wrong. Angle brackets are written escaped because command
+	// results render as VTML in chat, where a raw <name> is parsed as an unknown tag and dropped.
+	private static (int ArgCount, string Usage) ActionShape(string action)
+	{
+		return action switch
+		{
+			"list" => (0, "/kitedit list"),
+			"create" => (1, "/kitedit create &lt;name&gt;"),
+			"additem" => (1, "/kitedit additem &lt;name&gt;"),
+			"removeitem" => (2, "/kitedit removeitem &lt;name&gt; &lt;index&gt;"),
+			"preview" => (1, "/kitedit preview &lt;name&gt;"),
+			"delete" => (1, "/kitedit delete &lt;name&gt;"),
+			"rename" => (2, "/kitedit rename &lt;name&gt; &lt;newName&gt;"),
+			"setrole" => (2, "/kitedit setrole &lt;name&gt; &lt;role&gt;"),
+			"setcooldown" => (2, "/kitedit setcooldown &lt;name&gt; &lt;seconds&gt;"),
+			"onrespawn" => (2, "/kitedit onrespawn &lt;name&gt; on|off"),
+			"oneperlife" => (2, "/kitedit oneperlife &lt;name&gt; on|off"),
+			"give" => (2, "/kitedit give &lt;name&gt; &lt;player&gt;"),
+			_ => (-1, null)
+		};
+	}
+
+	// The command is registered with two optional word parsers, so vanilla only rejects a fourth
+	// word. An argument the action itself does not take has to be caught here or it is silently
+	// ignored, which is how /kitedit create starter_kit 1 in #293 looked like it had worked.
+	private static bool CheckActionArgs(string action, string name, string value, out TextCommandResult failure)
+	{
+		failure = null;
+		(int expected, string usage) = ActionShape(action);
+		if (usage == null)
+		{
+			failure = UnknownAction(action);
+			return false;
+		}
+
+		int provided = (string.IsNullOrWhiteSpace(name) ? 0 : 1) + (string.IsNullOrWhiteSpace(value) ? 0 : 1);
+		if (provided < expected)
+		{
+			failure = TextCommandResult.Error("Usage: " + usage);
+			return false;
+		}
+
+		if (provided > expected)
+		{
+			failure = TextCommandResult.Error("/kitedit " + action + " takes " + DescribeArgCount(expected) + ". Usage: " + usage);
+			return false;
+		}
+
+		return true;
+	}
+
+	private static string DescribeArgCount(int count)
+	{
+		return count switch
+		{
+			0 => "no arguments",
+			1 => "1 argument",
+			_ => count + " arguments"
+		};
+	}
+
+	private static TextCommandResult UnknownAction(string action)
+	{
+		return TextCommandResult.Error("Unknown /kitedit action '" + action + "'. Actions: " + string.Join(", ", KitEditActions) + ". Run /kitedit list to see existing kits.");
 	}
 
 	private TextCommandResult CreateKit(string name, Caller caller)
 	{
 		if (string.IsNullOrWhiteSpace(name))
 		{
-			return TextCommandResult.Error("Usage: /kitedit create <name>");
+			return TextCommandResult.Error("Usage: /kitedit create &lt;name&gt;");
 		}
 
 		IPlayer player = caller.Player;
@@ -277,7 +359,7 @@ internal class CmdStratumKits
 
 		if (!int.TryParse(indexText, out int index) || index < 1 || index > kit.Items.Count)
 		{
-			return TextCommandResult.Error("Usage: /kitedit removeitem <name> <index 1-" + kit.Items.Count + ">. See /kitedit preview " + kit.Name + ".");
+			return TextCommandResult.Error("Usage: /kitedit removeitem &lt;name&gt; &lt;index 1-" + kit.Items.Count + "&gt;. See /kitedit preview " + kit.Name + ".");
 		}
 
 		StratumKitItem removed = kit.Items[index - 1];
@@ -300,7 +382,7 @@ internal class CmdStratumKits
 	{
 		if (string.IsNullOrWhiteSpace(newName))
 		{
-			return TextCommandResult.Error("Usage: /kitedit rename <name> <newName>");
+			return TextCommandResult.Error("Usage: /kitedit rename &lt;name&gt; &lt;newName&gt;");
 		}
 
 		if (!StratumKitStore.Rename(name, newName))
@@ -324,7 +406,7 @@ internal class CmdStratumKits
 
 		if (string.IsNullOrWhiteSpace(roleCode))
 		{
-			return TextCommandResult.Error("Usage: /kitedit setrole <name> <role>");
+			return TextCommandResult.Error("Usage: /kitedit setrole &lt;name&gt; &lt;role&gt;");
 		}
 
 		if (!server.Config.RolesByCode.ContainsKey(roleCode))
@@ -353,7 +435,7 @@ internal class CmdStratumKits
 
 		if (!int.TryParse(secondsText, out int seconds) || seconds < 0)
 		{
-			return TextCommandResult.Error("Usage: /kitedit setcooldown <name> <seconds>=0");
+			return TextCommandResult.Error("Usage: /kitedit setcooldown &lt;name&gt; &lt;seconds&gt;, 0 disables the cooldown");
 		}
 
 		kit.CooldownSeconds = seconds;
@@ -374,7 +456,7 @@ internal class CmdStratumKits
 			: (bool?)null;
 		if (on == null)
 		{
-			return TextCommandResult.Error("Usage: /kitedit " + flag + " <name> on|off");
+			return TextCommandResult.Error("Usage: /kitedit " + flag + " &lt;name&gt; on|off");
 		}
 
 		if (flag == "onrespawn")

--- a/sources/VintagestoryLib/Vintagestory.Server/CmdStratumKits.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/CmdStratumKits.cs
@@ -27,7 +27,7 @@ internal class CmdStratumKits
 	// unknown-action message, and ActionShape below. Ordered the way an operator uses them.
 	private static readonly string[] KitEditActions =
 	{
-		"list", "create", "additem", "removeitem", "preview", "delete", "rename", "setrole", "setcooldown", "onrespawn", "oneperlife", "give"
+		"list", "create", "additem", "removeitem", "preview", "delete", "rename", "setrole", "setcooldown", "setscope", "onrespawn", "oneperlife", "give"
 	};
 
 	private readonly ServerMain server;
@@ -59,7 +59,7 @@ internal class CmdStratumKits
 		{
 			server.api.commandapi.Create("kitedit")
 				.WithDescription("Create and manage kits")
-				.WithAdditionalInformation("Actions: list, create &lt;name&gt;, additem &lt;name&gt;, removeitem &lt;name&gt; &lt;index&gt;, preview &lt;name&gt;, delete &lt;name&gt;, rename &lt;name&gt; &lt;newName&gt;, setrole &lt;name&gt; &lt;role&gt;, setcooldown &lt;name&gt; &lt;seconds&gt;, onrespawn &lt;name&gt; on|off, oneperlife &lt;name&gt; on|off, give &lt;name&gt; &lt;player&gt;. create snapshots your whole inventory, additem snapshots your active hotbar slot.")
+				.WithAdditionalInformation("Actions: list, create &lt;name&gt;, additem &lt;name&gt;, removeitem &lt;name&gt; &lt;index&gt;, preview &lt;name&gt;, delete &lt;name&gt;, rename &lt;name&gt; &lt;newName&gt;, setrole &lt;name&gt; &lt;role&gt;, setcooldown &lt;name&gt; &lt;seconds&gt;, setscope &lt;name&gt; all|hotbar, onrespawn &lt;name&gt; on|off, oneperlife &lt;name&gt; on|off, give &lt;name&gt; &lt;player&gt;. create snapshots your whole inventory (or only your hotbar and offhand, if scope is hotbar), additem snapshots your active hotbar slot.")
 				.WithArgs(
 					parsers.WordRange("action", KitEditActions),
 					parsers.OptionalWord("name"),
@@ -219,6 +219,7 @@ internal class CmdStratumKits
 			"rename" => RenameKit(name, value),
 			"setrole" => SetRole(name, value),
 			"setcooldown" => SetCooldown(name, value),
+			"setscope" => SetScope(name, value),
 			"onrespawn" => SetFlag(name, value, "onrespawn"),
 			"oneperlife" => SetFlag(name, value, "oneperlife"),
 			"preview" => PreviewKit(name),
@@ -244,6 +245,7 @@ internal class CmdStratumKits
 			"rename" => (2, "/kitedit rename &lt;name&gt; &lt;newName&gt;"),
 			"setrole" => (2, "/kitedit setrole &lt;name&gt; &lt;role&gt;"),
 			"setcooldown" => (2, "/kitedit setcooldown &lt;name&gt; &lt;seconds&gt;"),
+			"setscope" => (2, "/kitedit setscope &lt;name&gt; all|hotbar"),
 			"onrespawn" => (2, "/kitedit onrespawn &lt;name&gt; on|off"),
 			"oneperlife" => (2, "/kitedit oneperlife &lt;name&gt; on|off"),
 			"give" => (2, "/kitedit give &lt;name&gt; &lt;player&gt;"),
@@ -308,13 +310,16 @@ internal class CmdStratumKits
 			return TextCommandResult.Error("Only a connected player can snapshot a kit from their own inventory.");
 		}
 
-		List<StratumKitItem> items = SnapshotInventory(player);
+		StratumKitDefinition existing = StratumKitStore.Find(name);
+		// A re-create keeps whatever scope /kitedit setscope already put on the kit; a brand new
+		// kit defaults to "all", matching the snapshot behavior this command always had.
+		string scope = existing?.Scope ?? "all";
+		List<StratumKitItem> items = SnapshotInventory(player, scope);
 		if (items.Count == 0)
 		{
 			return TextCommandResult.Error("Your inventory is empty; nothing to snapshot.");
 		}
 
-		StratumKitDefinition existing = StratumKitStore.Find(name);
 		StratumKitDefinition kit = existing ?? new StratumKitDefinition
 		{
 			Name = name,
@@ -443,6 +448,27 @@ internal class CmdStratumKits
 		return TextCommandResult.Success(StratumCommandText.Confirm("Cooldown set", kit.Name + " = " + seconds + "s"));
 	}
 
+	// Changes what a future create/re-create captures; does not retroactively filter Items already
+	// stored on the kit. Re-run create afterward to apply the new scope to the item list itself.
+	private TextCommandResult SetScope(string name, string scope)
+	{
+		StratumKitDefinition kit = StratumKitStore.Find(name);
+		if (kit == null)
+		{
+			return TextCommandResult.Error("No kit named '" + name + "'.");
+		}
+
+		string normalized = scope?.ToLowerInvariant();
+		if (normalized != "all" && normalized != "hotbar")
+		{
+			return TextCommandResult.Error("Usage: /kitedit setscope &lt;name&gt; all|hotbar");
+		}
+
+		kit.Scope = normalized;
+		StratumKitStore.Save();
+		return TextCommandResult.Success(StratumCommandText.Confirm("Scope set", kit.Name + " = " + normalized + ". Run /kitedit create " + kit.Name + " again to apply it to the item list."));
+	}
+
 	private TextCommandResult SetFlag(string name, string onOff, string flag)
 	{
 		StratumKitDefinition kit = StratumKitStore.Find(name);
@@ -482,6 +508,7 @@ internal class CmdStratumKits
 
 		StringBuilder output = new StringBuilder(StratumCommandText.Title("Kit: " + kit.Name));
 		output.Append(StratumCommandText.Row("Assigned to", kit.AssignedTo.Count == 0 ? "everyone with stratum.kits" : string.Join(", ", kit.AssignedTo)));
+		output.Append(StratumCommandText.Row("Scope", string.IsNullOrEmpty(kit.Scope) ? "all" : kit.Scope));
 		output.Append(StratumCommandText.Row("Cooldown", kit.CooldownSeconds + "s"));
 		output.Append(StratumCommandText.Row("One per life", kit.OnePerLife ? "yes" : "no"));
 		output.Append(StratumCommandText.Row("Give on respawn", kit.GiveOnRespawn ? "yes" : "no"));
@@ -548,15 +575,21 @@ internal class CmdStratumKits
 			: TextCommandResult.Success(StratumCommandText.Warning("Kit '" + kit.Name + "' partially given: " + summary));
 	}
 
-	private static List<StratumKitItem> SnapshotInventory(IPlayer player)
+	// "all" walks hotbar and character (worn armor and a worn backpack's own stack included);
+	// "hotbar" walks only the hotbar, which already includes the offhand slot, so nothing worn or
+	// stored in a character equipment slot is captured. A worn backpack's contents are stored in
+	// the backpack stack itself, inside the character inventory; walking the backpack inventory
+	// too would add every content item a second time, so it is never walked directly here either
+	// way.
+	private static List<StratumKitItem> SnapshotInventory(IPlayer player, string scope)
 	{
+		bool hotbarOnly = string.Equals(scope, "hotbar", StringComparison.OrdinalIgnoreCase);
 		List<StratumKitItem> items = new List<StratumKitItem>();
 		foreach (InventoryBase inventory in player.InventoryManager.InventoriesOrdered)
 		{
-			// A worn backpack's contents are stored in the backpack stack in the character inventory.
-			// Walking the backpack inventory too would add every content item a second time.
-			if (inventory.ClassName != GlobalConstants.hotBarInvClassName
-				&& inventory.ClassName != GlobalConstants.characterInvClassName)
+			bool included = inventory.ClassName == GlobalConstants.hotBarInvClassName
+				|| (!hotbarOnly && inventory.ClassName == GlobalConstants.characterInvClassName);
+			if (!included)
 			{
 				continue;
 			}

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumKitStore.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumKitStore.cs
@@ -44,6 +44,11 @@ internal sealed class StratumKitDefinition
 
 	public bool GiveOnRespawn { get; set; }
 
+	// "all" (default) snapshots hotbar and character inventory, worn armor and backpack included.
+	// "hotbar" snapshots only the hotbar (which already includes the offhand slot). Set with
+	// /kitedit setscope; applied on the next create, not retroactively to Items already stored.
+	public string Scope { get; set; } = "all";
+
 	public string CreatedByUid { get; set; }
 
 	public string CreatedByName { get; set; }


### PR DESCRIPTION
## Summary

Two related fixes to the kit commands:

1. `/kitedit` was registered without a base command privilege, so Vintage Story's command API rejected every invocation before Stratum's own handler ever ran. Fixes #293.
2. `create`'s snapshot always included worn armor/clothing with no way to opt out. Adds a per-kit `/kitedit setscope <name> all|hotbar` so an operator can limit `create` to the hotbar only. Addresses #295.

Also adds a public command reference for `/kit` and `/kitedit`, and a console-driven regression probe in `scripts/smoke-test.sh`.

## Part 1 — #293: registration error

### Problem

Reported repro:

```
/kitedit create starter_kit 1
```

Server response:

```
Programming error: Incomplete command - no name or required privilege has been set
```

### Baseline reproduction

Confirmed directly against the pre-fix source by piping the reported command (and several others) into a running server's console:

```
4.9.2026 14:05:46 [Server Notification] Handling Console Command /kitedit list
4.9.2026 14:05:46 [Server Error] Exception: Programming error: Incomplete command - no name or required privilege has been set
4.9.2026 14:05:47 [Server Notification] Handling Console Command /kitedit create starter_kit 1
4.9.2026 14:05:47 [Server Error] Exception: Programming error: Incomplete command - no name or required privilege has been set
```

Every `/kitedit` invocation failed the same way, regardless of action or arguments — the command never reached `HandleKitEdit` at all.

### Root cause

Vintage Story's command builder throws "Incomplete command - no name or required privilege has been set" when a registered command has no base privilege set. `/kit` in the same file ends its registration with `.RequiresPrivilege(Privilege.chat)`; `/kitedit` did not have that call. Checked every other Stratum command registration in `CmdStratumKits.cs`, `CmdStratumStaffCommands.cs`, and `CmdStratumRoles.cs`: `/kitedit` was the only one missing it.

Secondary issues found while fixing this:

- The command was registered with two optional word parsers (`name`, `value`), so a third word on a one-argument action (e.g. the reported `1` after `create starter_kit`) was silently accepted and ignored instead of rejected.
- Several usage strings wrote raw `<name>` inside `TextCommandResult.Error(...)`; the client's chat renderer treats that as an unknown VTML tag and drops it silently, so the usage hint was invisible.

### Fix

`sources/VintagestoryLib/Vintagestory.Server/CmdStratumKits.cs`:

- Add `.RequiresPrivilege(Privilege.chat)` to the `/kitedit` registration. This is the actual fix. The real, configurable gate (`Commands.KitEdit` / `stratum.kitedit`, enforced in `CheckAccess`) is unchanged.
- Add `CheckActionArgs`/`ActionShape`, a per-action argument-count table with a usage line, so an action rejects too few or too many arguments with a clear message instead of silently ignoring extras.
- Add `UnknownAction`, listing valid actions.
- Escape `<`/`>` as `&lt;`/`&gt;` in every usage string so it renders in chat.
- Improve both commands' `.WithDescription` and add `.WithAdditionalInformation` (shown by `/help kit` / `/help kitedit`) with real usage text.

### Regression proof

`scripts/smoke-test.sh` now pipes 8 console commands into the running server after it reaches `RunGame` and asserts each was dispatched and produced the expected message — including the literal reported command. A console caller always passes Stratum's own access check and has no player entity, so this exercises registration, parsing, and argument handling end to end without a game client.

After the fix:

```
4.9.2026 14:09:57 [Server Notification] Handling Console Command /kitedit list
4.9.2026 14:09:57 [Server Notification] No kits exist yet. Create one with /kitedit create <name>.
4.9.2026 14:09:58 [Server Notification] Handling Console Command /kitedit create starter_kit 1
4.9.2026 14:09:58 [Server Notification] /kitedit create takes 1 argument. Usage: /kitedit create <name>
4.9.2026 14:09:59 [Server Notification] Handling Console Command /kitedit create starter_kit
4.9.2026 14:09:59 [Server Notification] Only a connected player can snapshot a kit from their own inventory.
4.9.2026 14:10:00 [Server Notification] Handling Console Command /kitedit preview starter_kit
4.9.2026 14:10:00 [Server Notification] No kit named 'starter_kit'.
4.9.2026 14:10:01 [Server Notification] Handling Console Command /kitedit rename starter_kit
4.9.2026 14:10:01 [Server Notification] Usage: /kitedit rename <name> <newName>
4.9.2026 14:10:02 [Server Notification] Handling Console Command /kitedit list extra
4.9.2026 14:10:02 [Server Notification] /kitedit list takes no arguments. Usage: /kitedit list
4.9.2026 14:10:03 [Server Notification] Handling Console Command /kitedit create starter_kit 1 2
4.9.2026 14:10:03 [Server Notification] Command /kitedit, too many arguments
4.9.2026 14:10:04 [Server Notification] Handling Console Command /kit
4.9.2026 14:10:04 [Server Notification] Only a connected player can use /kit.
```

```
PASS: server reached RunGame, no fatal errors, 8 console command(s) verified. (last phase: WorldReady)
```

Also fixed en route: `smoke-test.sh` launched the server with `cwd=repo root`. Mono.Cecil's default assembly resolver searches the process's current directory when resolving mod references; from repo root it failed to resolve `VintagestoryAPI`, which silently dropped every mod (including the base `game` content mod) and made the server crash before `RunGame` on every run, independent of this fix. Now launches from the server's own directory.

### Manual verification (done)

Ran a real Stratum server locally, connected with the stock client using the maintainer's normal account, and exercised the full command surface by hand: `/kitedit create`, `preview`, `additem`, `removeitem`, `/kit`, `/kit <name>`, and `/help kitedit`. Create, preview, item add/remove, redeem, and the give-back all worked end to end with a real inventory.

This manual pass is what surfaced the #295 follow-up below: the maintainer noticed `create` picked up worn armor/clothing along with the hotbar contents. That is correct per the original #210/#269 design (`StratumKitGiver`'s own comments confirm armor placement was always intentional), just not something an operator could opt out of before this PR.

## Part 2 — #295: snapshot scope

### Problem

`create` always walks hotbar + character inventory together, so worn armor/clothing is captured with no way to opt out. Confirmed by manual testing above.

### Fix

`sources/VintagestoryLib/Vintagestory.Server/CmdStratumKits.cs`, `StratumKitStore.cs`:

- `StratumKitDefinition.Scope` (`"all"` default, or `"hotbar"`).
- `/kitedit setscope <name> all|hotbar`, added to the action table and argument validation the same way every other action is.
- `SnapshotInventory` takes the kit's scope: `all` walks hotbar + character (current behavior, unchanged), `hotbar` walks only the hotbar (offhand included, since it's the same inventory).
- `create` reads `existing?.Scope ?? "all"` so a brand-new kit keeps today's default and a re-`create` respects whatever `setscope` set.
- `preview` shows the current scope.

Scope is a kit property applied on the *next* `create`, not retroactive to an already-stored item list — same model as `setrole`/`setcooldown`/the on/off flags.

### Regression proof

A console caller has no player entity, so this path cannot be exercised by the public smoke test (which is console-driven). Instead, added `Create_scope_all_includes_worn_armor_hotbar_excludes_it` to the private Atlas regression suite (`research/atlas-tests/stratum-pr-validation/KitScenarios.cs`, not part of this public repo): a real test player is given a hotbar item and has armor equipped into a real character inventory slot, then:

- `/kitedit create` with default scope `all` → resulting kit's items include both the hotbar item and the armor.
- `/kitedit setscope <name> hotbar` → `Find(...).Scope == "hotbar"`.
- `/kitedit create` again → resulting kit's items include the hotbar item, **not** the armor.
- `/kitedit preview` output contains `"hotbar"`.
- `/kitedit setscope <name> everything` (invalid value) → rejected with the usage line.

```
Passed!  - Failed: 0, Passed: 1, Skipped: 0, Total: 1, Duration: 575 ms
```

Ran the full `KitScenarios` class alongside it: 4 passed (including this new one), 1 pre-existing failure (`Respawn_gives_assigned_kits_skips_unassigned_and_marks_one_per_life`) — a real-time polling scenario on a code path this PR does not touch (`OnPlayerRespawn` / `GiveAssignedRespawnKits`), timing out at 600 ticks in this sandboxed environment. Not a regression from either change here.

## Documentation

`docs/commands/kits.md`: full reference for `/kit` and `/kitedit`, including `setscope`, the scope's effect on `create`, and a symbol-to-behavior sync table so a future implementation change is easy to spot as needing a doc update.

## Gates run

- `dotnet build VintageStory.slnx -c Release -p:EmbedPatchedFiles=true` — 0 errors, 0 new warnings on touched files.
- `bash scripts/smoke-test.sh` — `PASS` (log above), covers #293.
- Atlas `KitScenarios` (private suite) — covers #295's scope behavior against a real player/inventory.
- Manual verification with a real connected client — done (see Part 1).
- `git diff --check` clean.

## Limitations

- `scripts/smoke-test.ps1` was not extended with the console command probe and not re-verified on Windows; it now has a note pointing to the bash probe. The coverage for #293 is bash-only for now.
- Noticed independently, not fixed here: `smoke-test.ps1` prefers `VintagestoryServer.exe` over `StratumServer.exe`, the opposite of `smoke-test.sh`'s (correct) preference — likely boot-tests unpatched vanilla on Windows. Worth its own issue.
- Noticed independently, not fixed here: the same raw-angle-bracket usage-string defect this PR fixes in `CmdStratumKits.cs` also exists in `CmdStratumStaffCommands.cs` and `CmdStratumRoles.cs`. Left out to keep this PR scoped.
- Also noticed: `dotnet build VintageStory.slnx -p:EmbedPatchedFiles=true` needs to be run twice, and `StratumServer` needs to actually be launched once, for its embedded/overlaid `VintagestoryLib.dll` to pick up a same-session code change. Not fixed here (build/overlay pipeline issue, outside this file's scope) but worth knowing when verifying any patch through `StratumServer` locally.
- `setscope` does not retroactively filter an existing kit's stored items; documented, not a bug.

## Risk

Low. `sources/`-only changes, no vanilla patch touched. `.RequiresPrivilege(Privilege.chat)` is the loosest possible base gate and matches every sibling command; no player loses access they had. The new scope defaults to `all`, so no existing kit's behavior changes unless an operator explicitly opts it into `hotbar`.

## Type

- [x] Bug fix
- [x] New feature
- [x] Docs or build

## Checklist

- [x] `scripts/extract-patches.sh` ran clean (unrelated pre-existing working-tree drift in this environment was discarded before committing; only the intended files are in this diff).
- [x] `dotnet build VintageStory.slnx -c Release` is green.
- [x] Every vanilla edit has a `// Stratum` marker. (N/A — no vanilla file touched; `CmdStratumKits.cs`/`StratumKitStore.cs` are Stratum-only under `sources/`.)
- [x] No vanilla source committed.
- [x] Tested on a real server start, not just compilation.

## Related issues

Fixes #293
Fixes #295

Related: #210 (original feature request), #269 (original implementation).
