### PR TITLE
Vectorizing SetLightBulkUnsafe

### DIFF
--- a/patches/VintagestoryLib/Vintagestory.Common/ChunkDataLayer.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Common/ChunkDataLayer.cs.patch
@@ -1,5 +1,5 @@
 diff --git a/VintagestoryLib/Vintagestory.Common/ChunkDataLayer.cs b/VintagestoryLib/Vintagestory.Common/ChunkDataLayer.cs
-index 4d0bf91..8360927 100644
+index 4d0bf91..0fd873d 100644
 --- a/VintagestoryLib/Vintagestory.Common/ChunkDataLayer.cs
 +++ b/VintagestoryLib/Vintagestory.Common/ChunkDataLayer.cs
 @@ -1,9 +1,13 @@
@@ -83,7 +83,7 @@ index 4d0bf91..8360927 100644
 +	// scheduler grows a real per-chunk ownership model, at which point option 2 makes
 +	// this deletable.
 +	private readonly object stratumWriteLock = new object();
-+	// Stratum end.
++	// Stratum end
 +
  	public Func<int, int> Get;
  
@@ -119,14 +119,14 @@ index 4d0bf91..8360927 100644
 +	protected int[] dataBit11;
 +	protected int[] dataBit12;
 +	protected int[] dataBit13;
-+	// Stratum end.
++	// Stratum end
 +
  	private int setBlockIndexCached;
  
  	private int setBlockValueCached;
  
  	protected ChunkDataPool pool;
-@@ -49,149 +142,533 @@ public class ChunkDataLayer
+@@ -49,149 +142,546 @@ public class ChunkDataLayer
  	private static int[] paletteBitmap;
  
  	[ThreadStatic]
@@ -145,7 +145,11 @@ index 4d0bf91..8360927 100644
  	protected int GetGeneralCase(int index3d)
  	{
 -		int num = (index3d & 0x7FFF) / 32;
-+		// Stratum: integer division by 32 replaced with a right shift by 5. Identical result for positive values, and the operation is negligible in cost.
++		// Stratum: (1) [MethodImpl(AggressiveInlining)] added on the method to encourage inlining on the read path;
++		// Stratum: (2) integer division `index3d / 32` → right shift `(index3d & 0x7FFF) >> 5` — identical result for positive indices, cheaper;
++		// Stratum: (3) removed the per-call read lock that vanilla held across the plane loop. Deliberate and consistent: every fast-path getter
++		//          (GetFromBits1..14) also dropped its read lock in this rewrite, so reads are now lock-free on the hot path — correctness is
++		//          provided by writers holding stratumWriteLock + the write lock whenever a plane changes.
 +		int num = (index3d & 0x7FFF) >> 5;
  		int num2 = 1;
  		int num3 = 0;
@@ -188,7 +192,7 @@ index 4d0bf91..8360927 100644
 +		ref int base0 = ref MemoryMarshal.GetArrayDataReference(dataBit0);
 +		return palette[(Unsafe.Add(ref base0, arrayIndex) >> index3d) & 1];
  	}
-+	// Stratum end.
++	// Stratum end
  
 +	/// <summary>Stratum: Fast-path read for bit depth of 2. Extracts the two least significant bits from the first two planes.</summary>
 +	[MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -297,8 +301,8 @@ index 4d0bf91..8360927 100644
 +		int b3 = (Unsafe.Add(ref base3, arrayIndex) >> shift) & 1;
 +		int b4 = (Unsafe.Add(ref base4, arrayIndex) >> shift) & 1;
 +		return palette[b0 | (b1 << 1) | (b2 << 2) | (b3 << 3) | (b4 << 4)];
-+	}
-+
+ 	}
+ 
 +	/// <summary>Stratum: Fast-path read for bit depth of 6. Extracts the six least significant bits from the first six planes.</summary>
 +	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 +	private int GetFromBits6(int index3d)
@@ -310,6 +314,7 @@ index 4d0bf91..8360927 100644
 +		ref int base2 = ref MemoryMarshal.GetArrayDataReference(dataBit2);
 +		ref int base3 = ref MemoryMarshal.GetArrayDataReference(dataBit3);
 +		ref int base4 = ref MemoryMarshal.GetArrayDataReference(dataBit4);
++		// Stratum: added dataBit5 — previously read through the array-of-arrays (dataBits[5][num]). Now hoisted to a dedicated field.
 +		ref int base5 = ref MemoryMarshal.GetArrayDataReference(dataBit5);
 +		int b0 = (Unsafe.Add(ref base0, arrayIndex) >> shift) & 1;
 +		int b1 = (Unsafe.Add(ref base1, arrayIndex) >> shift) & 1;
@@ -332,6 +337,7 @@ index 4d0bf91..8360927 100644
 +		ref int base3 = ref MemoryMarshal.GetArrayDataReference(dataBit3);
 +		ref int base4 = ref MemoryMarshal.GetArrayDataReference(dataBit4);
 +		ref int base5 = ref MemoryMarshal.GetArrayDataReference(dataBit5);
++		// Stratum: added dataBit6 — previously read through the array-of-arrays (dataBits[6][num]). Now hoisted to a dedicated field.
 +		ref int base6 = ref MemoryMarshal.GetArrayDataReference(dataBit6);
 +		int b0 = (Unsafe.Add(ref base0, arrayIndex) >> shift) & 1;
 +		int b1 = (Unsafe.Add(ref base1, arrayIndex) >> shift) & 1;
@@ -356,6 +362,7 @@ index 4d0bf91..8360927 100644
 +		ref int base4 = ref MemoryMarshal.GetArrayDataReference(dataBit4);
 +		ref int base5 = ref MemoryMarshal.GetArrayDataReference(dataBit5);
 +		ref int base6 = ref MemoryMarshal.GetArrayDataReference(dataBit6);
++		// Stratum: added dataBit7 — previously read through the array-of-arrays (dataBits[7][num]). Now hoisted to a dedicated field.
 +		ref int base7 = ref MemoryMarshal.GetArrayDataReference(dataBit7);
 +		int b0 = (Unsafe.Add(ref base0, arrayIndex) >> shift) & 1;
 +		int b1 = (Unsafe.Add(ref base1, arrayIndex) >> shift) & 1;
@@ -382,6 +389,7 @@ index 4d0bf91..8360927 100644
 +		ref int base5 = ref MemoryMarshal.GetArrayDataReference(dataBit5);
 +		ref int base6 = ref MemoryMarshal.GetArrayDataReference(dataBit6);
 +		ref int base7 = ref MemoryMarshal.GetArrayDataReference(dataBit7);
++		// Stratum: added dataBit8 — previously read through the array-of-arrays (dataBits[8][num]). Now hoisted to a dedicated field.
 +		ref int base8 = ref MemoryMarshal.GetArrayDataReference(dataBit8);
 +		int b0 = (Unsafe.Add(ref base0, arrayIndex) >> shift) & 1;
 +		int b1 = (Unsafe.Add(ref base1, arrayIndex) >> shift) & 1;
@@ -393,8 +401,8 @@ index 4d0bf91..8360927 100644
 +		int b7 = (Unsafe.Add(ref base7, arrayIndex) >> shift) & 1;
 +		int b8 = (Unsafe.Add(ref base8, arrayIndex) >> shift) & 1;
 +		return palette[b0 | (b1 << 1) | (b2 << 2) | (b3 << 3) | (b4 << 4) | (b5 << 5) | (b6 << 6) | (b7 << 7) | (b8 << 8)];
- 	}
- 
++	}
++
 +	/// <summary>Stratum: Fast-path read for bit depth of 10. Extracts the ten least significant bits from the first ten planes.</summary>
 +	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 +	private int GetFromBits10(int index3d)
@@ -410,6 +418,7 @@ index 4d0bf91..8360927 100644
 +		ref int base6 = ref MemoryMarshal.GetArrayDataReference(dataBit6);
 +		ref int base7 = ref MemoryMarshal.GetArrayDataReference(dataBit7);
 +		ref int base8 = ref MemoryMarshal.GetArrayDataReference(dataBit8);
++		// Stratum: added dataBit9 — previously read through the array-of-arrays (dataBits[9][num]). Now hoisted to a dedicated field.
 +		ref int base9 = ref MemoryMarshal.GetArrayDataReference(dataBit9);
 +		int b0 = (Unsafe.Add(ref base0, arrayIndex) >> shift) & 1;
 +		int b1 = (Unsafe.Add(ref base1, arrayIndex) >> shift) & 1;
@@ -440,6 +449,7 @@ index 4d0bf91..8360927 100644
 +		ref int base7 = ref MemoryMarshal.GetArrayDataReference(dataBit7);
 +		ref int base8 = ref MemoryMarshal.GetArrayDataReference(dataBit8);
 +		ref int base9 = ref MemoryMarshal.GetArrayDataReference(dataBit9);
++		// Stratum: added dataBit10 — previously read through the array-of-arrays (dataBits[10][num]). Now hoisted to a dedicated field.
 +		ref int base10 = ref MemoryMarshal.GetArrayDataReference(dataBit10);
 +		int b0 = (Unsafe.Add(ref base0, arrayIndex) >> shift) & 1;
 +		int b1 = (Unsafe.Add(ref base1, arrayIndex) >> shift) & 1;
@@ -472,6 +482,7 @@ index 4d0bf91..8360927 100644
 +		ref int base8 = ref MemoryMarshal.GetArrayDataReference(dataBit8);
 +		ref int base9 = ref MemoryMarshal.GetArrayDataReference(dataBit9);
 +		ref int base10 = ref MemoryMarshal.GetArrayDataReference(dataBit10);
++		// Stratum: added dataBit11 — previously read through the array-of-arrays (dataBits[11][num]). Now hoisted to a dedicated field.
 +		ref int base11 = ref MemoryMarshal.GetArrayDataReference(dataBit11);
 +		int b0 = (Unsafe.Add(ref base0, arrayIndex) >> shift) & 1;
 +		int b1 = (Unsafe.Add(ref base1, arrayIndex) >> shift) & 1;
@@ -506,6 +517,7 @@ index 4d0bf91..8360927 100644
 +		ref int base9 = ref MemoryMarshal.GetArrayDataReference(dataBit9);
 +		ref int base10 = ref MemoryMarshal.GetArrayDataReference(dataBit10);
 +		ref int base11 = ref MemoryMarshal.GetArrayDataReference(dataBit11);
++		// Stratum: added dataBit12 — previously read through the array-of-arrays (dataBits[12][num]). Now hoisted to a dedicated field.
 +		ref int base12 = ref MemoryMarshal.GetArrayDataReference(dataBit12);
 +		int b0 = (Unsafe.Add(ref base0, arrayIndex) >> shift) & 1;
 +		int b1 = (Unsafe.Add(ref base1, arrayIndex) >> shift) & 1;
@@ -542,6 +554,7 @@ index 4d0bf91..8360927 100644
 +		ref int base10 = ref MemoryMarshal.GetArrayDataReference(dataBit10);
 +		ref int base11 = ref MemoryMarshal.GetArrayDataReference(dataBit11);
 +		ref int base12 = ref MemoryMarshal.GetArrayDataReference(dataBit12);
++		// Stratum: added dataBit13 — previously read through the array-of-arrays (dataBits[13][num]). Now hoisted to a dedicated field.
 +		ref int base13 = ref MemoryMarshal.GetArrayDataReference(dataBit13);
 +		int b0 = (Unsafe.Add(ref base0, arrayIndex) >> shift) & 1;
 +		int b1 = (Unsafe.Add(ref base1, arrayIndex) >> shift) & 1;
@@ -751,7 +764,7 @@ index 4d0bf91..8360927 100644
  		readWriteLock.AcquireReadLock();
  		int[][] array = new int[bitsize][];
  		try
-@@ -215,82 +692,602 @@ public class ChunkDataLayer
+@@ -215,82 +705,591 @@ public class ChunkDataLayer
  		{
  			readWriteLock.ReleaseReadLock();
  		}
@@ -775,12 +788,14 @@ index 4d0bf91..8360927 100644
 +
 +		int num = bitsize > 15 ? 15 : bitsize;
 +
-+		// Stratum: AVX2 path — reuses the same bit-plane → palette decode as CopyBlocksToUnsafe.
++		// Stratum: AVX path — reuses the same bit-plane → palette decode as CopyBlocksToUnsafe.
++
 +		if (Avx512F.IsSupported)
 +		{
 +			DecodePlanesAvx512(blocksOut, dataBits, palette, num);
 +			return;
 +		}
++
 +		if (Avx2.IsSupported)
 +		{
 +			DecodePlanesAvx2(blocksOut, dataBits, palette, num);
@@ -886,21 +901,19 @@ index 4d0bf91..8360927 100644
 +		Vector256<byte> P1 = Vector256<byte>.Zero;
 +		for (int k = 0; k < nLow; k++)
 +		{
-+			int v0 = w0[k];
-+			if (v0 != 0) P0 = Avx2.Or(P0, Avx2.Shuffle(Vector256.Create(v0).AsByte(), PackCtl[k]));
-+			int v1 = w1[k];
-+			if (v1 != 0) P1 = Avx2.Or(P1, Avx2.Shuffle(Vector256.Create(v1).AsByte(), PackCtl[k]));
++			// Stratum: removed the `if (v != 0)` branch. Shuffling a zero vector by any mask (including PackCtl bytes of 0x80) yields zero, so OR-ing it in is a no-op. The branch was purely an optimization heuristic relying on data-dependent branch prediction, which is poor on mixed words — only mixed words reach here (mixed != 0). Replacing it with an unconditional shuffle+or gives the same result at a fixed, rather than probabilistic, cost per iteration.
++			P0 = Avx2.Or(P0, Avx2.Shuffle(Vector256.Create(w0[k]).AsByte(), PackCtl[k]));
++			P1 = Avx2.Or(P1, Avx2.Shuffle(Vector256.Create(w1[k]).AsByte(), PackCtl[k]));
 +		}
 +
 +		Vector512<ulong> L512 = Transpose8x8_512(Vector512.Create(P0, P1).AsUInt64());
 +		Vector256<ulong> L0 = L512.GetLower();
 +		Vector256<ulong> L1 = L512.GetUpper();
 +
-+		// Sequentially: first all of word 0, then all of word 1.
-+		idx0 = Vector512.Create(ExtractGroup(L0, 0), ExtractGroup(L0, 1)); // word0: 0..15
-+		idx1 = Vector512.Create(ExtractGroup(L0, 2), ExtractGroup(L0, 3)); // word0: 16..31
-+		idx2 = Vector512.Create(ExtractGroup(L1, 0), ExtractGroup(L1, 1)); // word1: 0..15
-+		idx3 = Vector512.Create(ExtractGroup(L1, 2), ExtractGroup(L1, 3)); // word1: 16..31
++		idx0 = Vector512.Create(ExtractGroup(L0, 0), ExtractGroup(L0, 1));
++		idx1 = Vector512.Create(ExtractGroup(L0, 2), ExtractGroup(L0, 3));
++		idx2 = Vector512.Create(ExtractGroup(L1, 0), ExtractGroup(L1, 1));
++		idx3 = Vector512.Create(ExtractGroup(L1, 2), ExtractGroup(L1, 3));
 +
 +		if (num > 8)
 +		{
@@ -908,10 +921,9 @@ index 4d0bf91..8360927 100644
 +			Vector256<byte> Q1 = Vector256<byte>.Zero;
 +			for (int k = 8; k < num; k++)
 +			{
-+				int v0 = w0[k];
-+				if (v0 != 0) Q0 = Avx2.Or(Q0, Avx2.Shuffle(Vector256.Create(v0).AsByte(), PackCtl[k - 8]));
-+				int v1 = w1[k];
-+				if (v1 != 0) Q1 = Avx2.Or(Q1, Avx2.Shuffle(Vector256.Create(v1).AsByte(), PackCtl[k - 8]));
++				// Stratum: same branchless simplification for the upper plane group (8..num-1).
++				Q0 = Avx2.Or(Q0, Avx2.Shuffle(Vector256.Create(w0[k]).AsByte(), PackCtl[k - 8]));
++				Q1 = Avx2.Or(Q1, Avx2.Shuffle(Vector256.Create(w1[k]).AsByte(), PackCtl[k - 8]));
 +			}
 +
 +			Vector512<ulong> H512 = Transpose8x8_512(Vector512.Create(Q0, Q1).AsUInt64());
@@ -1107,7 +1119,6 @@ index 4d0bf91..8360927 100644
 +	private static unsafe void DecodeWordAvx2_LE8(
 +		int* w, int num, int* pPalette, int palLen, int* pOut, int mixed, int uniIdx)
 +	{
-+		// Fast path: all planes are 0 or -1.
 +		if (mixed == 0)
 +		{
 +			uint ui = (uint)uniIdx;
@@ -1120,13 +1131,11 @@ index 4d0bf91..8360927 100644
 +			return;
 +		}
 +
-+		// Pack byte groups of 8 planes (num <= 8).
++		// Stratum: removed `if (v == 0) continue;` — same branchless argument as in BuildIndices512 (AVX512): shuffling a zero vector by PackCtl yields zero, so OR-ing it in is a no-op. The branch relied on data-dependent prediction, which is poor here since only mixed words reach this point (mixed != 0).
 +		Vector256<byte> P = Vector256<byte>.Zero;
 +		for (int k = 0; k < num; k++)
 +		{
-+			int v = w[k];
-+			if (v == 0) continue;
-+			P = Avx2.Or(P, Avx2.Shuffle(Vector256.Create(v).AsByte(), PackCtl[k]));
++			P = Avx2.Or(P, Avx2.Shuffle(Vector256.Create(w[k]).AsByte(), PackCtl[k]));
 +		}
 +		Vector256<ulong> L = Transpose8x8(P.AsUInt64());
 +
@@ -1135,7 +1144,6 @@ index 4d0bf91..8360927 100644
 +		Vector256<int> idx2 = ExtractGroup(L, 2);
 +		Vector256<int> idx3 = ExtractGroup(L, 3);
 +
-+		// Palette lookup via gather with mask.
 +		Vector256<int> palLenVec = Vector256.Create(palLen);
 +		Vector256<int> zero = Vector256<int>.Zero;
 +		Unsafe.WriteUnaligned(pOut, Avx2.GatherMaskVector256(zero, pPalette, idx0, Avx2.CompareGreaterThan(palLenVec, idx0), 4));
@@ -1205,7 +1213,6 @@ index 4d0bf91..8360927 100644
 +	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 +	private static unsafe void DecodeWordAvx2(int* w, int num, int* pPalette, int palLen, int* pOut, int mixed, int uniIdx)
 +	{
-+		// Fast path: all planes are 0 or -1 => 32 identical blocks (covers fully-zero word too).
 +		if (mixed == 0)
 +		{
 +			uint ui = (uint)uniIdx;
@@ -1218,14 +1225,12 @@ index 4d0bf91..8360927 100644
 +			return;
 +		}
 +
-+		// Mixed: pack byte groups of 8 planes into 4x64-bit lanes + butterfly.
++		// Stratum: same branchless simplification for the lower plane group (0..7).
 +		int nLow = num < 8 ? num : 8;
 +		Vector256<byte> P = Vector256<byte>.Zero;
 +		for (int k = 0; k < nLow; k++)
 +		{
-+			int v = w[k];
-+			if (v == 0) continue;
-+			P = Avx2.Or(P, Avx2.Shuffle(Vector256.Create(v).AsByte(), PackCtl[k]));
++			P = Avx2.Or(P, Avx2.Shuffle(Vector256.Create(w[k]).AsByte(), PackCtl[k]));
 +		}
 +		Vector256<ulong> L = Transpose8x8(P.AsUInt64());
 +
@@ -1236,12 +1241,11 @@ index 4d0bf91..8360927 100644
 +
 +		if (num > 8)
 +		{
++			// Stratum: same branchless simplification for the upper plane group (8..num-1).
 +			Vector256<byte> Q = Vector256<byte>.Zero;
 +			for (int k = 8; k < num; k++)
 +			{
-+				int v = w[k];
-+				if (v == 0) continue;
-+				Q = Avx2.Or(Q, Avx2.Shuffle(Vector256.Create(v).AsByte(), PackCtl[k - 8]));
++				Q = Avx2.Or(Q, Avx2.Shuffle(Vector256.Create(w[k]).AsByte(), PackCtl[k - 8]));
 +			}
 +			Vector256<ulong> H = Transpose8x8(Q.AsUInt64());
 +			idx0 = Avx2.Or(idx0, Avx2.ShiftLeftLogical(ExtractGroup(H, 0), 8));
@@ -1250,8 +1254,6 @@ index 4d0bf91..8360927 100644
 +			idx3 = Avx2.Or(idx3, Avx2.ShiftLeftLogical(ExtractGroup(H, 3), 8));
 +		}
 +
-+		// Palette lookup: vpcmpgtd (palLen > idx == idx < palLen) + vpgatherdd with mask —
-+		// exact semantics of the old bounds check; does not read past palette.
 +		Vector256<int> palLenVec = Vector256.Create(palLen);
 +		Vector256<int> zero = Vector256<int>.Zero;
 +		Unsafe.WriteUnaligned(pOut, Avx2.GatherMaskVector256(zero, pPalette, idx0, Avx2.CompareGreaterThan(palLenVec, idx0), 4));
@@ -1278,7 +1280,7 @@ index 4d0bf91..8360927 100644
  	{
  		try
  		{
--			int num = index3d / 32;
+ 			int num = index3d / 32;
 -			switch (bitsize)
 -			{
 -			case 0:
@@ -1294,7 +1296,6 @@ index 4d0bf91..8360927 100644
 -			case 5:
 -				return palette[((dataBit0[num] >> index3d) & 1) + 2 * ((dataBit1[num] >> index3d) & 1) + 4 * ((dataBit2[num] >> index3d) & 1) + 8 * ((dataBit3[num] >> index3d) & 1) + 16 * ((dataBits[4][num] >> index3d) & 1)];
 -			default:
-+			int num = index3d / 32;
 +
 +			switch (bitsize)
  			{
@@ -1403,7 +1404,7 @@ index 4d0bf91..8360927 100644
  		{
  			int num;
  			if (palette != null)
-@@ -314,19 +1311,19 @@ public class ChunkDataLayer
+@@ -314,19 +1313,19 @@ public class ChunkDataLayer
  									break;
  								}
  								num++;
@@ -1430,13 +1431,13 @@ index 4d0bf91..8360927 100644
  						setBlockIndexCached = num;
  						setBlockValueCached = value;
  					}
-@@ -376,11 +1373,47 @@ public class ChunkDataLayer
+@@ -376,11 +1375,47 @@ public class ChunkDataLayer
  			return;
  		}
  		throw new IndexOutOfRangeException("Chunk blocks index3d must be between 0 and " + 32767 + ", was " + index3d);
  	}
  
-+	// Stratum end.
++	// Stratum end
 +
 +	// Stratum start: added lock (stratumWriteLock) wrapper — SetUnsafe previously had no synchronization at all, making concurrent palette growth a data race. Now serialized through stratumWriteLock alongside all other writers.
 +	/// <summary>Sets a block value without bounds-checking the index. Used for optimized paths.</summary>
@@ -1478,13 +1479,13 @@ index 4d0bf91..8360927 100644
  		index3d /= 32;
  		int num2 = ~num;
  		if (value != 0)
-@@ -449,11 +1482,24 @@ public class ChunkDataLayer
+@@ -449,11 +1484,24 @@ public class ChunkDataLayer
  				dataBits[j][index3d] &= num2;
  			}
  		}
  	}
  
-+	// Stratum end.
++	// Stratum end
 +
 +	// Stratum start: added lock (stratumWriteLock) wrapper — SetZero previously had no synchronization. Concurrent SetZero on a shared chunk could race with concurrent writes through Set/SetUnsafe. Now serialized through stratumWriteLock.
 +	/// <summary>Resets block bits at the index to zero, if the palette is initialized.</summary>
@@ -1503,13 +1504,13 @@ index 4d0bf91..8360927 100644
  		{
  			int num = 1 << index3d;
  			index3d /= 32;
-@@ -464,65 +1510,69 @@ public class ChunkDataLayer
+@@ -464,65 +1512,69 @@ public class ChunkDataLayer
  				dataBits[i][index3d] &= num2;
  			}
  		}
  	}
  
-+	// Stratum end.
++	// Stratum end
 +
 +	// Stratum start: added lock (stratumWriteLock) wrapper — SetBulk previously had no synchronization. Concurrent bulk writes on the same chunk could interleave palette growth and plane updates. Now serialized through stratumWriteLock.
 +	/// <summary>Bulk-sets a value for a lenX * lenZ block region starting at the given index.</summary>
@@ -1522,7 +1523,7 @@ index 4d0bf91..8360927 100644
 +		}
 +	}
 +
-+	// Stratum start: entire method body restructured — replaced per-plane for-loop that built masks incrementally with a single loop over all planes calling Array.Fill (which uses SIMD internally) to write each plane word in bulk. Also consolidated palette lookup logic into a local variable `paletteIndex` and added the same-value cache hit path at the top, reducing redundant lookups when consecutive calls set the same value.
++	// Stratum start: entire method body restructured — replaced per-plane for-loop that built masks incrementally with a single loop over all planes calling Array.Fill (which uses SIMD internally) to write each plane word in bulk. Also consolidated palette lookup logic into a local variable `paletteIndex` and kept the same-value cache hit path at the top, reducing redundant lookups when consecutive calls set the same value.
 +	// Bulk fill left using Array.Fill to leverage CPU SIMD instructions.
 +	/// <summary>SetBulk core. Fills bit-planes with the palette-index mask derived from the target value.</summary>
 +	private void SetBulkCore(int index3d, int lenX, int lenZ, int value)
@@ -1599,7 +1600,7 @@ index 4d0bf91..8360927 100644
 +			Array.Fill(dataBits[i], mask, arrayIndex, lenZ);
  		}
  	}
-+	// Stratum end.
++	// Stratum end
  
 +	/// <summary>Initializes the bit-plane structure and palette for holding the first non-zero value.</summary>
  	protected void NewDataBitsWithFirstValue(int value)
@@ -1607,7 +1608,7 @@ index 4d0bf91..8360927 100644
  		if (dataBits == null)
  		{
  			dataBits = new int[15][];
-@@ -535,10 +1585,11 @@ public class ChunkDataLayer
+@@ -535,10 +1587,11 @@ public class ChunkDataLayer
  		palette[1] = value;
  		Get = GetFromBits1;
  		bitsize = 1;
@@ -1619,7 +1620,7 @@ index 4d0bf91..8360927 100644
  		if (bitsize > 6 && CleanUpPalette())
  		{
  			return paletteCount;
-@@ -555,10 +1606,11 @@ public class ChunkDataLayer
+@@ -555,10 +1608,11 @@ public class ChunkDataLayer
  		Get = selectDelegate(bitsize + 1);
  		bitsize++;
  		return num;
@@ -1631,7 +1632,7 @@ index 4d0bf91..8360927 100644
  		if (pool.server == null)
  		{
  			if (bitsize < 14)
-@@ -653,10 +1705,11 @@ public class ChunkDataLayer
+@@ -653,10 +1707,11 @@ public class ChunkDataLayer
  			}
  		}
  		return true;
@@ -1643,7 +1644,7 @@ index 4d0bf91..8360927 100644
  		if (paletteCount == 0)
  		{
  			return 0;
-@@ -668,10 +1721,11 @@ public class ChunkDataLayer
+@@ -668,10 +1723,11 @@ public class ChunkDataLayer
  			num2++;
  		}
  		return num2;
@@ -1655,7 +1656,7 @@ index 4d0bf91..8360927 100644
  		int num = paletteCount - 1;
  		for (int num2 = num / 32; num2 >= 0; num2--)
  		{
-@@ -698,23 +1752,18 @@ public class ChunkDataLayer
+@@ -698,23 +1754,18 @@ public class ChunkDataLayer
  				}
  			}
  		}
@@ -1682,7 +1683,7 @@ index 4d0bf91..8360927 100644
  		Get = GetFromBits0;
  		int num = bitsize;
  		bitsize = 0;
-@@ -731,10 +1780,11 @@ public class ChunkDataLayer
+@@ -731,10 +1782,11 @@ public class ChunkDataLayer
  		}
  		setBlockIndexCached = 0;
  		setBlockValueCached = 0;
@@ -1694,7 +1695,7 @@ index 4d0bf91..8360927 100644
  		if (dataBits == null)
  		{
  			dataBits = new int[15][];
-@@ -746,19 +1796,21 @@ public class ChunkDataLayer
+@@ -746,19 +1798,21 @@ public class ChunkDataLayer
  		paletteCount = 1;
  		Get = GetFromBits1;
  		bitsize = 1;
@@ -1716,7 +1717,7 @@ index 4d0bf91..8360927 100644
  		int num = 0;
  		readWriteLock.AcquireReadLock();
  		try
-@@ -774,10 +1826,11 @@ public class ChunkDataLayer
+@@ -774,10 +1828,11 @@ public class ChunkDataLayer
  			readWriteLock.ReleaseReadLock();
  		}
  		return Compression.CompressAndCombine(arrayStatic, palette, paletteCount);
@@ -1728,7 +1729,7 @@ index 4d0bf91..8360927 100644
  		int num = 0;
  		lock (palette ?? ((object)readWriteLock))
  		{
-@@ -806,10 +1859,11 @@ public class ChunkDataLayer
+@@ -806,10 +1861,11 @@ public class ChunkDataLayer
  			paletteCompressed = Compression.Compress(palette, paletteCount, chunkdataVersion);
  		}
  		return Compression.Compress(arrayStatic, num, chunkdataVersion);
@@ -1740,7 +1741,7 @@ index 4d0bf91..8360927 100644
  		paletteCount = 0;
  		palette = Compression.DecompressCombined(layerCompressed, ref dataBits, ref paletteCount, pool.NewData);
  		if (palette != null)
-@@ -827,10 +1881,11 @@ public class ChunkDataLayer
+@@ -827,10 +1883,11 @@ public class ChunkDataLayer
  		{
  			bitsize = 0;
  		}
@@ -1752,7 +1753,7 @@ index 4d0bf91..8360927 100644
  		palette = Compression.DecompressToInts(paletteCompressed, ref paletteCount);
  		if (palette != null)
  		{
-@@ -872,10 +1927,11 @@ public class ChunkDataLayer
+@@ -872,10 +1929,11 @@ public class ChunkDataLayer
  			Get = GetFromBits0;
  			bitsize = 0;
  		}
@@ -1764,7 +1765,7 @@ index 4d0bf91..8360927 100644
  		if (dataBits == null)
  		{
  			dataBits = new int[15][];
-@@ -910,39 +1966,190 @@ public class ChunkDataLayer
+@@ -910,39 +1968,192 @@ public class ChunkDataLayer
  		{
  			pool.FreeArrays(this);
  		}
@@ -1808,11 +1809,13 @@ index 4d0bf91..8360927 100644
 +		int num = bitsize > 15 ? 15 : bitsize;
 +
 +		// Stratum: AVX path — reuses the same bit-plane → palette decode as CopyBlocksToUnsafe.
++
 +		if (Avx512F.IsSupported)
 +		{
 +			DecodePlanesAvx512(lightOut, dataBits, palette, num);
 +			return;
 +		}
++
 +		if (Avx2.IsSupported)
 +		{
 +			DecodePlanesAvx2(lightOut, dataBits, palette, num);
@@ -1965,7 +1968,7 @@ index 4d0bf91..8360927 100644
  		readWriteLock.AcquireReadLock();
  		try
  		{
-@@ -950,54 +2157,48 @@ public class ChunkDataLayer
+@@ -950,54 +2161,48 @@ public class ChunkDataLayer
  			for (int i = 0; i < blocksOut.Length; i += 32)
  			{
  				int num2 = i / 32;
@@ -2033,7 +2036,7 @@ index 4d0bf91..8360927 100644
  	{
  		int num = -1;
  		for (int i = 0; i < bitsize; i++)
-@@ -1005,10 +2206,11 @@ public class ChunkDataLayer
+@@ -1005,10 +2210,11 @@ public class ChunkDataLayer
  			num &= (((needle & (1 << i)) != 0) ? dataBits[i][intIndex] : (~dataBits[i][intIndex]));
  		}
  		return num;
@@ -2045,7 +2048,7 @@ index 4d0bf91..8360927 100644
  		for (int i = 0; i < paletteCount; i++)
  		{
  			if (palette[i] != id)
-@@ -1025,18 +2227,20 @@ public class ChunkDataLayer
+@@ -1025,18 +2231,20 @@ public class ChunkDataLayer
  			return false;
  		}
  		return false;
@@ -2066,7 +2069,7 @@ index 4d0bf91..8360927 100644
  		int num = ~mask;
  		readWriteLock.AcquireWriteLock();
  		for (int i = 0; i < bitsize; i++)
-@@ -1051,10 +2255,11 @@ public class ChunkDataLayer
+@@ -1051,10 +2259,11 @@ public class ChunkDataLayer
  			}
  		}
  		readWriteLock.ReleaseWriteLock();
@@ -2078,7 +2081,7 @@ index 4d0bf91..8360927 100644
  		int num = paletteCount - 1;
  		readWriteLock.AcquireWriteLock();
  		int num2 = bitsize;
-@@ -1088,10 +2293,194 @@ public class ChunkDataLayer
+@@ -1088,10 +2297,194 @@ public class ChunkDataLayer
  		palette[deletePosition] = palette[num];
  		paletteCount--;
  		readWriteLock.ReleaseWriteLock();
@@ -2273,7 +2276,7 @@ index 4d0bf91..8360927 100644
  		int[] array = palette;
  		if (array == null)
  		{
-@@ -1104,6 +2493,6 @@ public class ChunkDataLayer
+@@ -1104,6 +2497,6 @@ public class ChunkDataLayer
  			{
  				array[i] = 0;
  			}

--- a/patches/VintagestoryLib/Vintagestory.Common/ChunkDataLayer.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Common/ChunkDataLayer.cs.patch
@@ -1,5 +1,5 @@
 diff --git a/VintagestoryLib/Vintagestory.Common/ChunkDataLayer.cs b/VintagestoryLib/Vintagestory.Common/ChunkDataLayer.cs
-index 4d0bf91..7e52bfd 100644
+index 4d0bf91..8360927 100644
 --- a/VintagestoryLib/Vintagestory.Common/ChunkDataLayer.cs
 +++ b/VintagestoryLib/Vintagestory.Common/ChunkDataLayer.cs
 @@ -1,9 +1,13 @@
@@ -297,8 +297,8 @@ index 4d0bf91..7e52bfd 100644
 +		int b3 = (Unsafe.Add(ref base3, arrayIndex) >> shift) & 1;
 +		int b4 = (Unsafe.Add(ref base4, arrayIndex) >> shift) & 1;
 +		return palette[b0 | (b1 << 1) | (b2 << 2) | (b3 << 3) | (b4 << 4)];
- 	}
- 
++	}
++
 +	/// <summary>Stratum: Fast-path read for bit depth of 6. Extracts the six least significant bits from the first six planes.</summary>
 +	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 +	private int GetFromBits6(int index3d)
@@ -393,8 +393,8 @@ index 4d0bf91..7e52bfd 100644
 +		int b7 = (Unsafe.Add(ref base7, arrayIndex) >> shift) & 1;
 +		int b8 = (Unsafe.Add(ref base8, arrayIndex) >> shift) & 1;
 +		return palette[b0 | (b1 << 1) | (b2 << 2) | (b3 << 3) | (b4 << 4) | (b5 << 5) | (b6 << 6) | (b7 << 7) | (b8 << 8)];
-+	}
-+
+ 	}
+ 
 +	/// <summary>Stratum: Fast-path read for bit depth of 10. Extracts the ten least significant bits from the first ten planes.</summary>
 +	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 +	private int GetFromBits10(int index3d)
@@ -757,7 +757,6 @@ index 4d0bf91..7e52bfd 100644
  		}
  	}
  
--	public int GetUnsafe_PaletteCheck(int index3d)
 +	/// <summary>
 +	/// Stratum: unsafe bulk-read variant of CopyBlocksTo — decodes every block ID in this
 +	/// layer into blocksOut without taking readWriteLock. Null-safe for uninitialized bit-planes.
@@ -765,29 +764,20 @@ index 4d0bf91..7e52bfd 100644
 +	/// scalar fallback for non-AVX2 machines.
 +	/// </summary>
 +	public unsafe void CopyBlocksToUnsafe(int[] blocksOut)
- 	{
--		if (palette == null)
++	{
 +		if (blocksOut == null) return;
 +
 +		if (palette == null || dataBits == null || bitsize == 0)
- 		{
--			return 0;
++		{
 +			Array.Clear(blocksOut, 0, blocksOut.Length);
 +			return;
- 		}
--		return GetUnsafe(index3d);
--	}
- 
--	public int GetUnsafe(int index3d)
--	{
--		try
++		}
++
 +		int num = bitsize > 15 ? 15 : bitsize;
 +
 +		// Stratum: AVX2 path — reuses the same bit-plane → palette decode as CopyBlocksToUnsafe.
 +		if (Avx512F.IsSupported)
- 		{
--			int num = index3d / 32;
--			switch (bitsize)
++		{
 +			DecodePlanesAvx512(blocksOut, dataBits, palette, num);
 +			return;
 +		}
@@ -804,44 +794,21 @@ index 4d0bf91..7e52bfd 100644
 +		for (int word = 0; word < 1024; word++)
 +		{
 +			for (int k = 0; k < num; k++)
- 			{
--			case 0:
--				return 0;
--			case 1:
--				return palette[(dataBit0[num] >> index3d) & 1];
--			case 2:
--				return palette[((dataBit0[num] >> index3d) & 1) + 2 * ((dataBit1[num] >> index3d) & 1)];
--			case 3:
--				return palette[((dataBit0[num] >> index3d) & 1) + 2 * ((dataBit1[num] >> index3d) & 1) + 4 * ((dataBit2[num] >> index3d) & 1)];
--			case 4:
--				return palette[((dataBit0[num] >> index3d) & 1) + 2 * ((dataBit1[num] >> index3d) & 1) + 4 * ((dataBit2[num] >> index3d) & 1) + 8 * ((dataBit3[num] >> index3d) & 1)];
--			case 5:
--				return palette[((dataBit0[num] >> index3d) & 1) + 2 * ((dataBit1[num] >> index3d) & 1) + 4 * ((dataBit2[num] >> index3d) & 1) + 8 * ((dataBit3[num] >> index3d) & 1) + 16 * ((dataBits[4][num] >> index3d) & 1)];
--			default:
++			{
 +				int[] plane = dataBits[k];
 +				words[k] = plane != null ? plane[word] : 0;
 +			}
 +
 +			for (int j = 0; j < 32; j++)
- 			{
--				int num2 = 1;
--				int num3 = (dataBit0[num] >> index3d) & 1;
--				for (int i = 1; i < bitsize; i++)
++			{
 +				int index = 0;
 +				for (int k = 0; k < num; k++)
- 				{
--					num2 *= 2;
--					num3 += ((dataBits[i][num] >> index3d) & 1) * num2;
++				{
 +					index |= ((words[k] >> j) & 1) << k;
- 				}
--				return palette[num3];
--			}
++				}
 +				blocksOut[outIdx++] = (index < palette.Length) ? palette[index] : 0;
- 			}
- 		}
--		catch (NullReferenceException)
--		{
--			if (palette == null)
++			}
++		}
 +	}
 +
 +	// ===== Stratum start: AVX512 decode (64 blocks/iter; vpermd or split-gather lookup) =====
@@ -860,16 +827,13 @@ index 4d0bf91..7e52bfd 100644
 +			// palLen is a power of two; <= 16 means bitsize <= 4, which is the typical terrain case.
 +			Vector512<int> palVec = Vector512<int>.Zero;
 +			if (palLen <= 16)
- 			{
--				throw new Exception("ChunkDataLayer: palette was null, bitsize is " + bitsize);
++			{
 +				for (int i = 0; i < palLen; i++) palVec = palVec.WithElement(i, pPalette[i]);
- 			}
--			if (bitsize > 0 && dataBit0 == null)
++			}
 +			bool perm = palLen <= 16;
 +
 +			for (; word + 1 < 1024; word += 2)
- 			{
--				throw new Exception("ChunkDataLayer: dataBit0 was null, bitsize is " + bitsize + ", dataBits[0] null:" + (dataBits[0] == null));
++			{
 +				long uniIdx;
 +				int mixed = LoadWordsAndClassify2(w0, w1, planes, num, word, out uniIdx);
 +				if (perm)
@@ -877,17 +841,14 @@ index 4d0bf91..7e52bfd 100644
 +				else
 +					DecodeWordAvx512_Gather(w0, w1, num, pPalette, palLen, pOut + outIdx, mixed, uniIdx);
 +				outIdx += 64;
- 			}
--			if (bitsize > 1 && dataBit1 == null)
++			}
 +			if (word < 1024)
- 			{
--				throw new Exception("ChunkDataLayer: dataBit1 was null, bitsize is " + bitsize + ", dataBits[1] null:" + (dataBits[1] == null));
++			{
 +				// Tail: single word (32 blocks) — reuse scalar AVX2 decoder.
 +				int uniIdx;
 +				int mixed = LoadWordsAndClassify(w0, planes, num, word, out uniIdx);
 +				DecodeWordAvx2(w0, num, pPalette, palLen, pOut + outIdx, mixed, uniIdx);
- 			}
--			if (bitsize > 2 && dataBit2 == null)
++			}
 +		}
 +	}
 +
@@ -946,14 +907,12 @@ index 4d0bf91..7e52bfd 100644
 +			Vector256<byte> Q0 = Vector256<byte>.Zero;
 +			Vector256<byte> Q1 = Vector256<byte>.Zero;
 +			for (int k = 8; k < num; k++)
- 			{
--				throw new Exception("ChunkDataLayer: dataBit2 was null, bitsize is " + bitsize + ", dataBits[2] null:" + (dataBits[2] == null));
++			{
 +				int v0 = w0[k];
 +				if (v0 != 0) Q0 = Avx2.Or(Q0, Avx2.Shuffle(Vector256.Create(v0).AsByte(), PackCtl[k - 8]));
 +				int v1 = w1[k];
 +				if (v1 != 0) Q1 = Avx2.Or(Q1, Avx2.Shuffle(Vector256.Create(v1).AsByte(), PackCtl[k - 8]));
- 			}
--			if (bitsize > 3 && dataBit3 == null)
++			}
 +
 +			Vector512<ulong> H512 = Transpose8x8_512(Vector512.Create(Q0, Q1).AsUInt64());
 +			Vector256<ulong> H0 = H512.GetLower();
@@ -1071,8 +1030,7 @@ index 4d0bf91..7e52bfd 100644
 +			int word = 0;
 +
 +			if (num <= 8)
- 			{
--				throw new Exception("ChunkDataLayer: dataBit3 was null, bitsize is " + bitsize + ", dataBits[3] null:" + (dataBits[3] == null));
++			{
 +				// Specialized path for bitsize <= 8.
 +				for (; word + 1 < 1024; word += 2)
 +				{
@@ -1092,11 +1050,9 @@ index 4d0bf91..7e52bfd 100644
 +					int mixed = LoadWordsAndClassify(w, planes, num, word, out uniIdx);
 +					DecodeWordAvx2_LE8(w, num, pPalette, palLen, pOut + outIdx, mixed, uniIdx);
 +				}
- 			}
--			if (bitsize > 4 && dataBits[4] == null)
++			}
 +			else
- 			{
--				throw new Exception("ChunkDataLayer: dataBits[4] was null, bitsize is " + bitsize);
++			{
 +				// General path for bitsize > 8 (original code).
 +				for (; word + 1 < 1024; word += 2)
 +				{
@@ -1116,7 +1072,7 @@ index 4d0bf91..7e52bfd 100644
 +					int mixed = LoadWordsAndClassify(w, planes, num, word, out uniIdx);
 +					DecodeWordAvx2(w, num, pPalette, palLen, pOut + outIdx, mixed, uniIdx);
 +				}
- 			}
++			}
 +		}
 +	}
 +
@@ -1308,24 +1264,49 @@ index 4d0bf91..7e52bfd 100644
 +	// ===== Stratum end =====
 +
 +	/// <summary>Gets the block value at a 3D index with palette null-check. Returns 0 if the palette is not initialized.</summary>
-+	public int GetUnsafe_PaletteCheck(int index3d)
-+	{
-+		if (palette == null)
-+		{
-+			return 0;
-+		}
-+		return GetUnsafe(index3d);
-+	}
-+
+ 	public int GetUnsafe_PaletteCheck(int index3d)
+ 	{
+ 		if (palette == null)
+ 		{
+ 			return 0;
+ 		}
+ 		return GetUnsafe(index3d);
+ 	}
+ 
 +	/// <summary>High-performance block value reader without additional palette check. Uses a switch on bit depth.</summary>
-+	public int GetUnsafe(int index3d)
-+	{
-+		try
-+		{
+ 	public int GetUnsafe(int index3d)
+ 	{
+ 		try
+ 		{
+-			int num = index3d / 32;
+-			switch (bitsize)
+-			{
+-			case 0:
+-				return 0;
+-			case 1:
+-				return palette[(dataBit0[num] >> index3d) & 1];
+-			case 2:
+-				return palette[((dataBit0[num] >> index3d) & 1) + 2 * ((dataBit1[num] >> index3d) & 1)];
+-			case 3:
+-				return palette[((dataBit0[num] >> index3d) & 1) + 2 * ((dataBit1[num] >> index3d) & 1) + 4 * ((dataBit2[num] >> index3d) & 1)];
+-			case 4:
+-				return palette[((dataBit0[num] >> index3d) & 1) + 2 * ((dataBit1[num] >> index3d) & 1) + 4 * ((dataBit2[num] >> index3d) & 1) + 8 * ((dataBit3[num] >> index3d) & 1)];
+-			case 5:
+-				return palette[((dataBit0[num] >> index3d) & 1) + 2 * ((dataBit1[num] >> index3d) & 1) + 4 * ((dataBit2[num] >> index3d) & 1) + 8 * ((dataBit3[num] >> index3d) & 1) + 16 * ((dataBits[4][num] >> index3d) & 1)];
+-			default:
 +			int num = index3d / 32;
 +
 +			switch (bitsize)
-+			{
+ 			{
+-				int num2 = 1;
+-				int num3 = (dataBit0[num] >> index3d) & 1;
+-				for (int i = 1; i < bitsize; i++)
+-				{
+-					num2 *= 2;
+-					num3 += ((dataBits[i][num] >> index3d) & 1) * num2;
+-				}
+-				return palette[num3];
+-			}
 +				case 0: return 0;
 +
 +				case 1: return palette[(dataBit0[num] >> index3d) & 1];
@@ -1367,10 +1348,34 @@ index 4d0bf91..7e52bfd 100644
 +						num3 |= (((dataBits[i][num] >> index3d) & 1)) << (i);
 +					}
 +					return palette[num3];
-+			}
-+		}
-+		catch (NullReferenceException)
-+		{
+ 			}
+ 		}
+ 		catch (NullReferenceException)
+ 		{
+-			if (palette == null)
+-			{
+-				throw new Exception("ChunkDataLayer: palette was null, bitsize is " + bitsize);
+-			}
+-			if (bitsize > 0 && dataBit0 == null)
+-			{
+-				throw new Exception("ChunkDataLayer: dataBit0 was null, bitsize is " + bitsize + ", dataBits[0] null:" + (dataBits[0] == null));
+-			}
+-			if (bitsize > 1 && dataBit1 == null)
+-			{
+-				throw new Exception("ChunkDataLayer: dataBit1 was null, bitsize is " + bitsize + ", dataBits[1] null:" + (dataBits[1] == null));
+-			}
+-			if (bitsize > 2 && dataBit2 == null)
+-			{
+-				throw new Exception("ChunkDataLayer: dataBit2 was null, bitsize is " + bitsize + ", dataBits[2] null:" + (dataBits[2] == null));
+-			}
+-			if (bitsize > 3 && dataBit3 == null)
+-			{
+-				throw new Exception("ChunkDataLayer: dataBit3 was null, bitsize is " + bitsize + ", dataBits[3] null:" + (dataBits[3] == null));
+-			}
+-			if (bitsize > 4 && dataBits[4] == null)
+-			{
+-				throw new Exception("ChunkDataLayer: dataBits[4] was null, bitsize is " + bitsize);
+-			}
 +			if (palette == null) throw new Exception("ChunkDataLayer: palette was null, bitsize is " + bitsize);
 +			if (bitsize > 0 && dataBit0 == null) throw new Exception("ChunkDataLayer: dataBit0 was null, bitsize is " + bitsize + ", dataBits[0] null:" + (dataBits[0] == null));
 +			if (bitsize > 1 && dataBit1 == null) throw new Exception("ChunkDataLayer: dataBit1 was null, bitsize is " + bitsize + ", dataBits[1] null:" + (dataBits[1] == null));
@@ -1759,7 +1764,7 @@ index 4d0bf91..7e52bfd 100644
  		if (dataBits == null)
  		{
  			dataBits = new int[15][];
-@@ -910,39 +1966,111 @@ public class ChunkDataLayer
+@@ -910,39 +1966,190 @@ public class ChunkDataLayer
  		{
  			pool.FreeArrays(this);
  		}
@@ -1781,12 +1786,6 @@ index 4d0bf91..7e52bfd 100644
 -				{
 +				if ((array[j] | array[j + 1] | array[j + 2] | array[j + 3]) != 0)
  					return true;
--				}
--				if (array[j + 1] != 0)
--				{
--					return true;
--				}
--				if (array[j + 2] != 0)
 +			}
 +		}
 +		return false;
@@ -1828,12 +1827,11 @@ index 4d0bf91..7e52bfd 100644
 +			{
 +				int index = 0;
 +				for (int k = 0; k < num; k++)
- 				{
--					return true;
++				{
 +					if (dataBits[k] != null && ((dataBits[k][word] >> j) & 1) != 0)
 +						index |= (1 << k);
  				}
--				if (array[j + 3] != 0)
+-				if (array[j + 1] != 0)
 +				lightOut[i + j] = index < palette.Length ? palette[index] : 0;
 +			}
 +		}
@@ -1842,14 +1840,55 @@ index 4d0bf91..7e52bfd 100644
 +	/// <summary>
 +	/// Stratum: Encodes a flat int array of light values back into bit-planes, rebuilding the palette.
 +	/// Takes the write lock ONCE for the entire chunk. Null-safe.
++	///
++	/// Rewritten to mirror SetBlocksBulkUnsafe: word-wise encode (32 values at once) instead of
++	/// 32768 individual SetUnsafeCore calls. Uniform words (the dominant case for light — large
++	/// flat-lit runs, e.g. open sky or a solid-dark cave interior) take a single palette lookup
++	/// and one mask store per plane; mixed words resolve 32 palette indices then transpose them
++	/// into plane words, one store per plane. Falls back to the original scalar path if the input
++	/// length doesn't match the standard chunk length (32768), to preserve prior tolerance for
++	/// odd-sized arrays without adding partial-word handling complexity to the fast path.
 +	/// </summary>
-+	public void SetLightBulkUnsafe(int[] lightIn)
++	public unsafe void SetLightBulkUnsafe(int[] lightIn)
 +	{
 +		if (lightIn == null) return;
 +
++		if (lightIn.Length != length)
++		{
++			// Non-standard length: keep the old, safe, fully scalar behaviour.
++			lock (stratumWriteLock)
++			{
++				palette = null;
++				paletteCount = 0;
++				bitsize = 0;
++				Get = GetFromBits0;
++				setBlockIndexCached = 0;
++				setBlockValueCached = 0;
++
++				if (dataBits == null) dataBits = new int[15][];
++				for (int i = 0; i < dataBits.Length; i++)
+ 				{
+-					return true;
++					if (dataBits[i] != null) Array.Clear(dataBits[i], 0, 1024);
+ 				}
+-				if (array[j + 2] != 0)
++
++				for (int i = 0; i < length && i < lightIn.Length; i++)
+ 				{
+-					return true;
++					int val = lightIn[i];
++					if (val != 0) SetUnsafeCore(i, val);
+ 				}
+-				if (array[j + 3] != 0)
++			}
++			return;
++		}
++
 +		lock (stratumWriteLock)
 +		{
-+			// Reset state.
++			// Reset state. Planes are NOT cleared here: every word below fully overwrites
++			// planes 0..bitsize-1, and a newly claimed plane is cleared at claim time
++			// (see PaletteIndexForBulk).
 +			palette = null;
 +			paletteCount = 0;
 +			bitsize = 0;
@@ -1858,21 +1897,63 @@ index 4d0bf91..7e52bfd 100644
 +			setBlockValueCached = 0;
 +
 +			if (dataBits == null) dataBits = new int[15][];
-+			for (int i = 0; i < dataBits.Length; i++)
-+			{
-+				if (dataBits[i] != null) Array.Clear(dataBits[i], 0, 1024);
-+			}
 +
-+			// Rebuild using the existing fast-path SetUnsafeCore.
-+			for (int i = 0; i < 32768 && i < lightIn.Length; i++)
++			bool sawNonZero = false;
++			int* idxBuf = stackalloc int[32];
++
++			fixed (int* pIn = lightIn)
 +			{
-+				int val = lightIn[i];
-+				if (val != 0)
++				for (int word = 0; word < 1024; word++)
  				{
 -					return true;
-+					SetUnsafeCore(i, val);
++					int baseIdx = word << 5;
++					int v0 = pIn[baseIdx];
++
++					if (IsUniformWord(pIn + baseIdx, v0))
++					{
++						if (v0 == 0)
++						{
++							// Nothing to encode. If the palette does not exist yet, the planes
++							// don't exist either and are cleared at claim time, so skipping is correct.
++							if (palette != null) WritePlaneWord(word, 0);
++							continue;
++						}
++						sawNonZero = true;
++						WritePlaneWord(word, PaletteIndexForBulk(v0));
++						continue;
++					}
++
++					// Mixed word: resolve palette indices first (the palette may grow during
++					// this), then transpose bits into plane words — one store per plane.
++					for (int j = 0; j < 32; j++)
++					{
++						int v = pIn[baseIdx + j];
++						if (v == 0) { idxBuf[j] = 0; continue; }
++						sawNonZero = true;
++						idxBuf[j] = PaletteIndexForBulk(v);
++					}
++
++					int bs = bitsize;
++					for (int k = 0; k < bs; k++)
++					{
++						int wv = 0;
++						for (int j = 0; j < 32; j++) wv |= ((idxBuf[j] >> k) & 1) << j;
++						dataBits[k][word] = wv;
++					}
  				}
  			}
++
++			if (!sawNonZero)
++			{
++				// All-dark/all-zero light layer: restore the canonical empty state.
++				palette = null;
++				paletteCount = 0;
++				bitsize = 0;
++				Get = GetFromBits0;
++				return;
++			}
++
++			Get = selectDelegate(bitsize);
  		}
 -		return false;
  	}
@@ -1884,7 +1965,7 @@ index 4d0bf91..7e52bfd 100644
  		readWriteLock.AcquireReadLock();
  		try
  		{
-@@ -950,54 +2078,48 @@ public class ChunkDataLayer
+@@ -950,54 +2157,48 @@ public class ChunkDataLayer
  			for (int i = 0; i < blocksOut.Length; i += 32)
  			{
  				int num2 = i / 32;
@@ -1952,7 +2033,7 @@ index 4d0bf91..7e52bfd 100644
  	{
  		int num = -1;
  		for (int i = 0; i < bitsize; i++)
-@@ -1005,10 +2127,11 @@ public class ChunkDataLayer
+@@ -1005,10 +2206,11 @@ public class ChunkDataLayer
  			num &= (((needle & (1 << i)) != 0) ? dataBits[i][intIndex] : (~dataBits[i][intIndex]));
  		}
  		return num;
@@ -1964,7 +2045,7 @@ index 4d0bf91..7e52bfd 100644
  		for (int i = 0; i < paletteCount; i++)
  		{
  			if (palette[i] != id)
-@@ -1025,18 +2148,20 @@ public class ChunkDataLayer
+@@ -1025,18 +2227,20 @@ public class ChunkDataLayer
  			return false;
  		}
  		return false;
@@ -1985,7 +2066,7 @@ index 4d0bf91..7e52bfd 100644
  		int num = ~mask;
  		readWriteLock.AcquireWriteLock();
  		for (int i = 0; i < bitsize; i++)
-@@ -1051,10 +2176,11 @@ public class ChunkDataLayer
+@@ -1051,10 +2255,11 @@ public class ChunkDataLayer
  			}
  		}
  		readWriteLock.ReleaseWriteLock();
@@ -1997,7 +2078,7 @@ index 4d0bf91..7e52bfd 100644
  		int num = paletteCount - 1;
  		readWriteLock.AcquireWriteLock();
  		int num2 = bitsize;
-@@ -1088,10 +2214,194 @@ public class ChunkDataLayer
+@@ -1088,10 +2293,194 @@ public class ChunkDataLayer
  		palette[deletePosition] = palette[num];
  		paletteCount--;
  		readWriteLock.ReleaseWriteLock();
@@ -2192,7 +2273,7 @@ index 4d0bf91..7e52bfd 100644
  		int[] array = palette;
  		if (array == null)
  		{
-@@ -1104,6 +2414,6 @@ public class ChunkDataLayer
+@@ -1104,6 +2493,6 @@ public class ChunkDataLayer
  			{
  				array[i] = 0;
  			}


### PR DESCRIPTION
## Summary

## Problem
`SetLightBulkUnsafe` encoded the input light array back into bitplanes with a naive loop over all 32768 indices, calling `SetUnsafeCore` on each value individually (linear search in the palette + read-modify-write planes for each call). Meanwhile, the adjacent `SetBlocksBulkUnsafe` has long used word-wise fast-path (32 values at a time, with early exit for homogeneous words) – this optimization was never carried over to the light path, even though light is at least no less prone to long homogeneous regions (open sky, evenly lit/dark areas).

## Changes
- `SetLightBulkUnsafe` has been rewritten based on `SetBlocksBulkUnsafe`: data is encoded in words of 32 values.
- A homogeneous word (all 32 values are equal) — one palette lookup + one mask entry per plane (`IsUniformWord` + `WritePlaneWord`).
- A mixed word — 32 palette lookups, then a bitwise transposition in the plane, one write per plane.
- Existing `IsUniformWord`, `WritePlaneWord`, and `PaletteIndexForBulk` functions have been reused in the class — they are not tied to block semantics, only to the palette/bitplanes, so the implementation is not duplicated.
- Added a fallback to the old fully scalar path for the `lightIn.Length != length` case (32768) to avoid extending the fast path to incomplete/non-standard arrays and complicating it with partial word processing.
- The lock (`stratumWriteLock`) is still acquired once per chunk, as before.

---

## Problem
The AVX2 and AVX512 bit-plane decode paths (`DecodePlanesAvx2`/`DecodePlanesAvx512`, shared by both `CopyBlocksToUnsafe` and `CopyLightToUnsafe`) skip the pack/shuffle step for any plane whose word is exactly zero (`if (v == 0) continue;` in `DecodeWordAvx2_LE8`/`DecodeWordAvx2`; equivalent `if (v0 != 0)`/`if (v1 != 0)` guards in `BuildIndices512`). This branch only executes on already-classified "mixed" words (uniform words return earlier via a separate fast path), and on mixed words whether an individual plane happens to be exactly zero is effectively data-dependent — for wide palettes in particular, the chance that all 32 blocks in a word agree on one specific bit is vanishingly small, so the branch is almost never taken but still has to be predicted every time. This turns a hot, per-plane, per-word check into a branch-misprediction risk for no benefit on the common case.

## Changes
- Removed the `if (v == 0) continue;` guards in `DecodeWordAvx2_LE8` and `DecodeWordAvx2` (both the lower 8-plane group and the upper group for `num > 8`), and the equivalent guards in `BuildIndices512` (AVX512 path). The pack/shuffle (`Avx2.Shuffle(Vector256.Create(v).AsByte(), PackCtl[k])` and `Or`) now runs unconditionally.
- This is safe because shuffling an all-zero vector through `PackCtl`/the same permutation table yields an all-zero result regardless of the shuffle mask, and `Or`-ing that into the accumulator is a no-op — so removing the check does not change output for any input, only replaces a data-dependent branch with a fixed-cost operation.
- Correctness was verified with a standalone deterministic microbenchmark (fixed seed, synthetic bit-plane/palette data across `bitsize` ∈ {2, 4, 8, 12}, mix of uniform-zero/uniform-nonzero/mixed words modeled on realistic terrain composition) that decodes the same data through both the old and new code paths and diffs the output block-for-block; all scenarios matched byte-for-byte before any timing was taken.
- The AVX512 (`BuildIndices512`) branchless change was additionally profiled in a live game session and showed a repeatable ~9% reduction in `DecodePlanesAvx512` own time, with an unrelated, unchanged function in the same profile staying flat (~1%) across the same before/after pair, indicating the improvement is not just run-to-run machine noise.

### Alternatives considered
- **x4 ILP unrolling of the AVX512 gather path** (`DecodeWordAvx512_Gather`) was prototyped and profiled, but reverted: it regressed `DecodePlanesAvx512` own time (12 202 ms → 14 201 ms in matched live profiling). `VPGATHERDD` is throughput-bound on a single execution port on the profiled hardware, not latency-bound, so decoding multiple independent words in parallel doesn't hide any latency — it only adds register pressure and buffer-management overhead around a gather that was never going to run any faster. The perm path (`palLen <= 16`, pure `vpermd`/ALU) was also tried with the same x4 unrolling and measured statistically indistinguishable from baseline (~0.7% delta, inside prior documented ±10% run-to-run noise on this hardware), so it was not carried forward either. Both are left out of this PR; the branchless change above is independent of them and was validated on its own.

## Type

- [ ] Bug fix
- [x] Performance
- [ ] New feature
- [ ] Refactor or cleanup
- [ ] Docs or build

## Checklist

- [x] `.\scripts\extract-patches.ps1` ran clean.
- [x] `dotnet build VintageStory.slnx -c Release` is green.
- [x] Every vanilla edit has a `// Stratum` marker.
- [x] No vanilla source committed.
- [x] Tested on a real server start, not just compilation.

## Performance numbers

Tested on the generation of 31417 chunk columns (6 threads) by `/stratum pregen start radius 100 16000 16000`
Seed - seed 1027995113.
World setting - default.
AVX instructions: enabled

Three runs were performed before and after the changes using the Jetbrains dotTrace program.

**Before**
- `ChunkDataLayer.SetLightBulkUnsafe` method execution time: 5967 ms; 6120 ms; 5967 ms.
- **Average:**  6018.0 ms
- **Standard deviation:**  88.34 ms

**After**
- `ChunkDataLayer.SetLightBulkUnsafe` method execution time: 3443 ms; 3486 ms; 3410 ms 
- **Average:**   3446.33 ms
- **Standard deviation:**   38.11 ms

The average execution time of the method decreased by 42.7% (from 6018 ms to 3446 ms), and the variance of results was more than halved, confirming a significant and consistent performance improvement.

**Before**
- `ChunkDataLayer.DecodePlanesAvx512` method execution time: 12327 ms; 11513 ms; 12202 ms.
- **Average:**  12014 ms
- **Standard deviation:** 438.36  ms

**After**
- `ChunkDataLayer.DecodePlanesAvx512` method execution time: 9247 ms; 9838 ms; 11037 ms.
- **Average:** 10040.67  ms
- **Standard deviation:** 912.04  ms

The average execution time of the method decreased by 16.42% (from 12014 ms to 10040.67 ms).

**Before**
- `ChunkDataLayer.DecodePlanesAvx2` method execution time: 13333 ms; 14206 ms; 13575 ms.
- **Average:** 13704.67 ms
- **Standard deviation:** 368.01 ms

**After**
- `ChunkDataLayer.DecodePlanesAvx2` method execution time: 12966 ms; 12120 ms; 13353 ms.
- **Average:** 12813.00 ms
- **Standard deviation:** 514.87 ms

The average execution time of the method decreased by 6.51% (from 13704.67 ms to 12813.00 ms).

