### PR TITLE
Stack a role's name prefixes, ordered by Priority

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,8 @@ Anything else is forwarded to the server, such as `--port` or `--dataPath`.
 ## Commands
 
 Stratum adds a set of in-game commands on top of vanilla. See
-[docs/commands/kits.md](docs/commands/kits.md) for `/kit` and `/kitedit`.
+[docs/commands/kits.md](docs/commands/kits.md) for `/kit` and `/kitedit`, and
+[docs/role-prefixes.md](docs/role-prefixes.md) for stacking role name prefixes.
 
 ## Build
 

--- a/docs/role-prefixes.md
+++ b/docs/role-prefixes.md
@@ -1,0 +1,116 @@
+# Role name prefixes
+
+Stratum can put a coloured tag in front of a player's name in chat and above
+their character, chosen by the player's role. A role can carry more than one
+tag, and they stack in a fixed order. Implementation:
+[`StratumChatFormatter.cs`](../sources/VintagestoryLib/Vintagestory.Server/StratumChatFormatter.cs)
+for chat, [`StratumNametags.cs`](../sources/VintagestoryLib/Vintagestory.Server/StratumNametags.cs)
+for the in-world nametag, both reading
+[`StratumAppearanceConfig.cs`](../sources/VintagestoryLib/Vintagestory.Server/StratumAppearanceConfig.cs).
+
+Server side only. No custom client: the tags ride in on the normal chat and
+nametag protocol, so every stock client renders them.
+
+## Where the config lives
+
+`<dataPath>/stratum.json`, under `Appearance.RolePrefixes`:
+
+```json
+"RolePrefixes": {
+  "Enabled": true,
+  "Format": "[{tag}]",
+  "Roles": {
+    "admin": { "Tag": "Admin", "Color": "#ff5f57", "Bold": true, "Priority": 100 },
+    "villagemod": [
+      { "Tag": "Moderator", "Color": "#4cc9f0", "Bold": true, "Priority": 100 },
+      { "Tag": "XYZ Villager", "Color": "#9bd77e", "Bold": false, "Priority": 10 }
+    ]
+  }
+}
+```
+
+| Key | Meaning |
+| --- | --- |
+| `Enabled` | Master switch for chat prefixes. `false` turns every role's chat tag off. The nametag has its own switch, `Nametags.Enabled` / `Nametags.ApplyRolePrefix`. |
+| `Format` | Wraps each tag. `{tag}` is the placeholder. `"[{tag}]"` gives `[Admin]`, `"{tag} "` gives `Admin `. |
+| `Roles` | Role code to prefix, or role code to a list of prefixes. |
+
+Each prefix entry:
+
+| Field | Default | Meaning |
+| --- | --- | --- |
+| `Tag` | `Staff` | The text inside `Format`. |
+| `Color` | `#ffffff` | `#rrggbb`, or a plain colour word. Chat only (see below). |
+| `Bold` | `true` | Chat only. |
+| `Priority` | `0` | Higher renders closer to the name's left. |
+| `Enabled` | `true` | `false` drops just this one tag. |
+
+## One tag or several
+
+A role's value is written as a bare object for a single tag and as an array for
+several. Both forms are always accepted on read. On save Stratum writes a
+one-tag role back as a bare object, so a config that predates this feature is
+left exactly as it was. Only a role you actually give a second tag turns into an
+array.
+
+To add a second tag to a role, change its `{ ... }` to `[ { ... }, { ... } ]`.
+
+## Order
+
+Tags render highest `Priority` first, left to right, then the name. With the
+example above, a player in `villagemod` shows as `[Moderator][XYZ Villager]
+Name`. Two tags at the same `Priority` keep the order they appear in the config
+file.
+
+## Spacing
+
+The gap between the tags and the name comes from `Format`. `"[{tag}]"` gives
+`[A][B] Name`; `"[{tag}] "` gives `[A] [B] Name`. There is no separate spacing
+key. The nametag has its own `Nametags.PrefixFormat`, which defaults to
+`"[{tag}] "`.
+
+## Colour
+
+Chat colours each tag on its own, from that tag's `Color` and `Bold`.
+
+The nametag is one colour for the whole string. That colour is not per tag: it
+comes from `Nametags.EntitlementColorByRole`, mapped from the player's role to a
+Vintage Story entitlement code, because the stock client has no way to colour
+part of a nametag. `Color` and `Bold` on a prefix entry do nothing for the
+nametag.
+
+## When a role has no prefix
+
+If a role is absent from `Roles`, or every one of its tags is `Enabled: false`,
+that player renders with no prefix at all: a bare name in chat and above their
+head. A player who changes to such a role loses the tag their old role carried.
+
+## Inspecting a running server
+
+`/stratum chat` prints each configured role, the tag stack a player in that role
+sees, and every tag's priority and colour, including disabled ones.
+
+## Scope
+
+This is one role's tags stacking. Giving a single player more than one role is a
+separate, larger change, tracked in
+[#274](https://github.com/StratumServer/Stratum/issues/274).
+
+Keep a stack to two or three tags. A longer one crowds the chat line and widens
+the in-world tag; nothing enforces a limit.
+
+## Keeping this page in sync
+
+| Documented behaviour | Owning symbol |
+| --- | --- |
+| Config shape, one-or-many, save form | `StratumRolePrefixList`, `StratumRolePrefixListConverter` |
+| Which tags apply and their order | `StratumRolePrefixesConfig.ResolveFor` |
+| Chat render | `StratumChatFormatter.TryFormat` |
+| Nametag render | `StratumNametags.ApplyNametagPrefix` |
+| Nametag colour | `StratumNametags.MaybeInjectEntitlement`, `StratumNametagsConfig.EntitlementColorByRole` |
+| `/stratum chat` output | `CmdStratum.HandleChat` |
+
+`scripts/smoke-test.sh` seeds a two-prefix role, boots the server, and asserts
+`/stratum chat` renders the stack in `Priority` order and that the config
+rewrite keeps the one-tag and many-tag shapes. A change here that is not
+mirrored there fails the smoke test.

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -47,6 +47,7 @@ probe_commands=(
   "/kitedit list extra"
   "/kitedit create starter_kit 1 2"
   "/kit"
+  "/stratum chat"
 )
 probe_expect=(
   "No kits exist yet."
@@ -57,6 +58,7 @@ probe_expect=(
   "/kitedit list takes no arguments."
   ""
   "Only a connected player can use /kit."
+  "[Moderator][XYZ Villager]"
 )
 
 # Data path handling.
@@ -68,6 +70,31 @@ else
   data_path="$(mktemp -d)"
 fi
 mkdir -p "$data_path"
+
+# Role-prefix regression seed (StratumServer/Stratum#274). Written before the server starts
+# so the boot config load runs the prefix-list converter for real: "suvisitor" carries two
+# prefixes as an array, deliberately in the wrong file order so the probe below proves
+# Priority reorders them rather than the file order being echoed back, and "admin" stays a
+# bare single object so the pre-#274 shape is covered too. GamePaths.Config resolves to the
+# data path root, not a Config subfolder.
+cat >"$data_path/stratum.json" <<'JSON'
+{
+  "ConfigVersion": 3,
+  "Appearance": {
+    "RolePrefixes": {
+      "Enabled": true,
+      "Format": "[{tag}]",
+      "Roles": {
+        "suvisitor": [
+          { "Enabled": true, "Tag": "XYZ Villager", "Color": "#4cc9f0", "Bold": true, "Priority": 10 },
+          { "Enabled": true, "Tag": "Moderator", "Color": "#ff5f57", "Bold": true, "Priority": 100 }
+        ],
+        "admin": { "Enabled": true, "Tag": "Admin", "Color": "#ff5f57", "Bold": true, "Priority": 100 }
+      }
+    }
+  }
+}
+JSON
 
 cleanup() {
   exec 3>&- 2>/dev/null || true
@@ -200,6 +227,18 @@ if [[ "${SMOKE_TEST_PROBE:-1}" == "1" ]] \
 
   if log_contains "Incomplete command"; then
     probe_failures+="    command registration incomplete: \"Incomplete command\" appeared in the log"$'\n'
+  fi
+
+  # #274: the boot rewrite of stratum.json must not reshape the seeded file. Two prefixes
+  # stay an array, one stays a bare object. This guards against a future change to the
+  # converter that drops the single-object write-back.
+  if [[ -f "$data_path/stratum.json" ]]; then
+    if ! grep -q '"suvisitor": \[' "$data_path/stratum.json"; then
+      probe_failures+="    stratum.json rewrite reshaped the two-prefix role away from an array"$'\n'
+    fi
+    if ! grep -q '"admin": {' "$data_path/stratum.json"; then
+      probe_failures+="    stratum.json rewrite reshaped the single-prefix role into an array"$'\n'
+    fi
   fi
 fi
 

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -231,15 +231,17 @@ if [[ "${SMOKE_TEST_PROBE:-1}" == "1" ]] \
     probe_failures+="    command registration incomplete: \"Incomplete command\" appeared in the log"$'\n'
   fi
 
-  # #274: the boot rewrite of stratum.json must not reshape the seeded file. Two prefixes
-  # stay an array, one stays a bare object. This guards against a future change to the
-  # converter that drops the single-object write-back.
-  if [[ -f "$data_path/stratum.json" ]]; then
-    if ! grep -q '"suvisitor": \[' "$data_path/stratum.json"; then
-      probe_failures+="    stratum.json rewrite reshaped the two-prefix role away from an array"$'\n'
-    fi
-    if ! grep -q '"admin": {' "$data_path/stratum.json"; then
-      probe_failures+="    stratum.json rewrite reshaped the single-prefix role into an array"$'\n'
+  if [[ "$own_data" == "1" ]]; then
+    # #274: the boot rewrite of stratum.json must not reshape the seeded file. Two prefixes
+    # stay an array, one stays a bare object. This guards against a future change to the
+    # converter that drops the single-object write-back.
+    if [[ -f "$data_path/stratum.json" ]]; then
+      if ! grep -q '"suvisitor": \[' "$data_path/stratum.json"; then
+        probe_failures+="    stratum.json rewrite reshaped the two-prefix role away from an array"$'\n'
+      fi
+      if ! grep -q '"admin": {' "$data_path/stratum.json"; then
+        probe_failures+="    stratum.json rewrite reshaped the single-prefix role into an array"$'\n'
+      fi
     fi
   fi
 fi

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -47,7 +47,6 @@ probe_commands=(
   "/kitedit list extra"
   "/kitedit create starter_kit 1 2"
   "/kit"
-  "/stratum chat"
 )
 probe_expect=(
   "No kits exist yet."
@@ -58,7 +57,6 @@ probe_expect=(
   "/kitedit list takes no arguments."
   ""
   "Only a connected player can use /kit."
-  "[Moderator][XYZ Villager]"
 )
 
 # Data path handling.
@@ -76,8 +74,11 @@ mkdir -p "$data_path"
 # prefixes as an array, deliberately in the wrong file order so the probe below proves
 # Priority reorders them rather than the file order being echoed back, and "admin" stays a
 # bare single object so the pre-#274 shape is covered too. GamePaths.Config resolves to the
-# data path root, not a Config subfolder.
-cat >"$data_path/stratum.json" <<'JSON'
+# data path root, not a Config subfolder. Never replace a caller-supplied data path.
+if [[ "$own_data" == "1" ]]; then
+  probe_commands+=("/stratum chat")
+  probe_expect+=("[Moderator][XYZ Villager]")
+  cat >"$data_path/stratum.json" <<'JSON'
 {
   "ConfigVersion": 3,
   "Appearance": {
@@ -95,6 +96,7 @@ cat >"$data_path/stratum.json" <<'JSON'
   }
 }
 JSON
+fi
 
 cleanup() {
   exec 3>&- 2>/dev/null || true

--- a/sources/VintagestoryLib/Vintagestory.Server/CmdStratum.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/CmdStratum.cs
@@ -456,9 +456,40 @@ internal class CmdStratum
 		output.Append(StratumCommandText.Row("URL links", chat.LinkifyUrls ? "true" : "false"));
 		output.Append(StratumCommandText.Row("Prefix format", rolePrefixes.Format));
 
-		foreach (KeyValuePair<string, StratumRolePrefixConfig> entry in rolePrefixes.Roles.OrderBy(entry => entry.Key))
+		foreach (KeyValuePair<string, StratumRolePrefixList> entry in rolePrefixes.Roles.OrderBy(entry => entry.Key, StringComparer.OrdinalIgnoreCase))
 		{
-			output.Append(StratumCommandText.Bullet(entry.Key, rolePrefixes.Format.Replace("{tag}", entry.Value.Tag) + " " + entry.Value.Color + (entry.Value.Enabled ? "" : " disabled")));
+			StringBuilder stack = new StringBuilder();
+			StringBuilder detail = new StringBuilder();
+			if (entry.Value?.Prefixes != null)
+			{
+				foreach (StratumRolePrefixConfig prefix in entry.Value.Prefixes.OrderByDescending(prefix => prefix.Priority))
+				{
+					if (prefix == null)
+					{
+						continue;
+					}
+
+					// The stack shows what a player actually sees, so a disabled tag is listed in
+					// the detail but left out of the render.
+					if (prefix.Enabled)
+					{
+						stack.Append(rolePrefixes.Format.Replace("{tag}", prefix.Tag));
+					}
+
+					if (detail.Length > 0)
+					{
+						detail.Append(", ");
+					}
+
+					detail.Append(prefix.Tag).Append(" p").Append(prefix.Priority).Append(' ').Append(prefix.Color);
+					if (!prefix.Enabled)
+					{
+						detail.Append(" disabled");
+					}
+				}
+			}
+
+			output.Append(StratumCommandText.Bullet(entry.Key, (stack.Length == 0 ? "none" : stack.ToString()) + "  " + detail));
 		}
 
 		return TextCommandResult.Success(output.ToString());

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumAppearanceConfig.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumAppearanceConfig.cs
@@ -1,5 +1,8 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace Vintagestory.Server;
 
@@ -90,7 +93,10 @@ internal class StratumRolePrefixesConfig
 
 	public string Format { get; set; } = "[{tag}]";
 
-	public Dictionary<string, StratumRolePrefixConfig> Roles { get; set; } = CreateDefaults();
+	// One role, one or more prefixes. See StratumRolePrefixList: the value reads and writes as
+	// a bare object for a single prefix and as an array for several, so a config that predates
+	// this feature is not reshaped by the boot rewrite.
+	public Dictionary<string, StratumRolePrefixList> Roles { get; set; } = CreateDefaults();
 
 	public void EnsurePopulated()
 	{
@@ -100,38 +106,142 @@ internal class StratumRolePrefixesConfig
 			Roles = CreateDefaults();
 		}
 
-		foreach (StratumRolePrefixConfig prefix in Roles.Values)
+		foreach (StratumRolePrefixList list in Roles.Values)
 		{
-			prefix?.EnsurePopulated();
+			if (list?.Prefixes == null)
+			{
+				continue;
+			}
+
+			foreach (StratumRolePrefixConfig prefix in list.Prefixes)
+			{
+				prefix?.EnsurePopulated();
+			}
 		}
 	}
 
-	private static Dictionary<string, StratumRolePrefixConfig> CreateDefaults()
+	// The prefixes that apply to a role, highest Priority first. Returns null when the role
+	// has none configured or enabled, so a player with no prefix allocates nothing.
+	public List<StratumRolePrefixConfig> ResolveFor(string roleCode)
 	{
-		return new Dictionary<string, StratumRolePrefixConfig>(StringComparer.OrdinalIgnoreCase)
+		if (Roles == null || string.IsNullOrWhiteSpace(roleCode))
 		{
-			["admin"] = new StratumRolePrefixConfig
+			return null;
+		}
+
+		List<StratumRolePrefixConfig> matches = null;
+		foreach (KeyValuePair<string, StratumRolePrefixList> entry in Roles)
+		{
+			// A linear scan with an explicit case-insensitive compare. Newtonsoft rebuilds the
+			// dictionary on load and drops the OrdinalIgnoreCase comparer, so indexing by key
+			// here would be case sensitive. Do not replace this with Roles.TryGetValue.
+			if (entry.Value?.Prefixes == null || !string.Equals(entry.Key, roleCode, StringComparison.OrdinalIgnoreCase))
 			{
-				Tag = "Admin",
-				Color = "#ff5f57",
-				Bold = true,
-				Priority = 100
-			},
-			["sumod"] = new StratumRolePrefixConfig
-			{
-				Tag = "Mod",
-				Color = "#4cc9f0",
-				Bold = true,
-				Priority = 50
-			},
-			["crmod"] = new StratumRolePrefixConfig
-			{
-				Tag = "Mod",
-				Color = "#4cc9f0",
-				Bold = true,
-				Priority = 50
+				continue;
 			}
+
+			foreach (StratumRolePrefixConfig prefix in entry.Value.Prefixes)
+			{
+				if (prefix == null || !prefix.Enabled)
+				{
+					continue;
+				}
+
+				(matches ??= new List<StratumRolePrefixConfig>()).Add(prefix);
+			}
+		}
+
+		// OrderByDescending is a stable sort, so equal Priority keeps config file order.
+		// Do not swap this for List.Sort, which is unstable and would scramble ties.
+		return matches?.OrderByDescending(prefix => prefix.Priority).ToList();
+	}
+
+	private static Dictionary<string, StratumRolePrefixList> CreateDefaults()
+	{
+		return new Dictionary<string, StratumRolePrefixList>(StringComparer.OrdinalIgnoreCase)
+		{
+			["admin"] = new StratumRolePrefixList(new StratumRolePrefixConfig { Tag = "Admin", Color = "#ff5f57", Bold = true, Priority = 100 }),
+			["sumod"] = new StratumRolePrefixList(new StratumRolePrefixConfig { Tag = "Mod", Color = "#4cc9f0", Bold = true, Priority = 50 }),
+			["crmod"] = new StratumRolePrefixList(new StratumRolePrefixConfig { Tag = "Mod", Color = "#4cc9f0", Bold = true, Priority = 50 })
 		};
+	}
+}
+
+// A role's prefixes. Serialized as a bare object when there is exactly one and as an array
+// otherwise, so an operator who wants two tags writes `[ {...}, {...} ]` and everyone else
+// keeps the pre-#274 `{ ... }` shape untouched through the boot config rewrite.
+[JsonConverter(typeof(StratumRolePrefixListConverter))]
+internal sealed class StratumRolePrefixList
+{
+	public List<StratumRolePrefixConfig> Prefixes { get; } = new List<StratumRolePrefixConfig>();
+
+	public StratumRolePrefixList()
+	{
+	}
+
+	public StratumRolePrefixList(params StratumRolePrefixConfig[] prefixes)
+	{
+		if (prefixes != null)
+		{
+			Prefixes.AddRange(prefixes);
+		}
+	}
+}
+
+internal sealed class StratumRolePrefixListConverter : JsonConverter<StratumRolePrefixList>
+{
+	public override StratumRolePrefixList ReadJson(JsonReader reader, Type objectType, StratumRolePrefixList existingValue, bool hasExistingValue, JsonSerializer serializer)
+	{
+		StratumRolePrefixList result = new StratumRolePrefixList();
+
+		if (reader.TokenType == JsonToken.Null)
+		{
+			return result;
+		}
+
+		if (reader.TokenType == JsonToken.StartArray)
+		{
+			foreach (JToken item in JArray.Load(reader))
+			{
+				StratumRolePrefixConfig prefix = item.ToObject<StratumRolePrefixConfig>(serializer);
+				if (prefix != null)
+				{
+					result.Prefixes.Add(prefix);
+				}
+			}
+
+			return result;
+		}
+
+		StratumRolePrefixConfig single = JObject.Load(reader).ToObject<StratumRolePrefixConfig>(serializer);
+		if (single != null)
+		{
+			result.Prefixes.Add(single);
+		}
+
+		return result;
+	}
+
+	public override void WriteJson(JsonWriter writer, StratumRolePrefixList value, JsonSerializer serializer)
+	{
+		if (value == null)
+		{
+			writer.WriteNull();
+			return;
+		}
+
+		if (value.Prefixes.Count == 1)
+		{
+			serializer.Serialize(writer, value.Prefixes[0]);
+			return;
+		}
+
+		writer.WriteStartArray();
+		foreach (StratumRolePrefixConfig prefix in value.Prefixes)
+		{
+			serializer.Serialize(writer, prefix);
+		}
+		writer.WriteEndArray();
 	}
 }
 

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumChatFormatter.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumChatFormatter.cs
@@ -37,16 +37,27 @@ internal static class StratumChatFormatter
 			return false;
 		}
 
-		KeyValuePair<string, StratumRolePrefixConfig>? prefixEntry = FindPrefix(rolePrefixes.Roles, player.Role.Code);
-		if (prefixEntry == null)
+		List<StratumRolePrefixConfig> prefixes = rolePrefixes.ResolveFor(player.Role.Code);
+		if (prefixes == null)
 		{
 			return false;
 		}
 
-		StratumRolePrefixConfig prefix = prefixEntry.Value.Value;
-		string tag = FormatTag(rolePrefixes.Format, prefix.Tag);
-		string renderedTag = ApplyColorAndWeight(EnsureTrailingSpace(tag), prefix.Color, prefix.Bold);
-		formattedMessage = renderedTag + "<strong>" + EscapeVtml(player.PlayerName) + ":</strong> " + messageBody;
+		StringBuilder renderedTags = new StringBuilder();
+		for (int index = 0; index < prefixes.Count; index++)
+		{
+			StratumRolePrefixConfig prefix = prefixes[index];
+			string tag = FormatTag(rolePrefixes.Format, prefix.Tag);
+			// One space separates the whole stack from the name, so only the last tag carries it.
+			if (index == prefixes.Count - 1)
+			{
+				tag = EnsureTrailingSpace(tag);
+			}
+
+			renderedTags.Append(ApplyColorAndWeight(tag, prefix.Color, prefix.Bold));
+		}
+
+		formattedMessage = renderedTags + "<strong>" + EscapeVtml(player.PlayerName) + ":</strong> " + messageBody;
 		return true;
 	}
 
@@ -151,21 +162,6 @@ internal static class StratumChatFormatter
 	private static string EnsureTrailingSpace(string value)
 	{
 		return string.IsNullOrEmpty(value) || value.EndsWith(" ", StringComparison.Ordinal) ? value : value + " ";
-	}
-
-	private static KeyValuePair<string, StratumRolePrefixConfig>? FindPrefix(Dictionary<string, StratumRolePrefixConfig> prefixes, string roleCode)
-	{
-		if (prefixes == null || string.IsNullOrWhiteSpace(roleCode))
-		{
-			return null;
-		}
-
-		KeyValuePair<string, StratumRolePrefixConfig>[] matches = prefixes
-			.Where(entry => entry.Value != null && entry.Value.Enabled && string.Equals(entry.Key, roleCode, StringComparison.OrdinalIgnoreCase))
-			.OrderByDescending(entry => entry.Value.Priority)
-			.ToArray();
-
-		return matches.Length == 0 ? null : matches[0];
 	}
 
 	private static string FormatTag(string format, string tag)

--- a/sources/VintagestoryLib/Vintagestory.Server/StratumNametags.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/StratumNametags.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using Vintagestory.API.Common;
 using Vintagestory.API.Common.Entities;
 using Vintagestory.API.Server;
@@ -59,11 +60,11 @@ internal sealed class StratumNametags
 		if (player?.Role == null) return false;
 
 		StratumConfig root = StratumRuntime.Config;
-		StratumRolePrefixConfig prefix = FindRolePrefix(root?.Appearance?.RolePrefixes?.Roles, player.Role.Code);
+		List<StratumRolePrefixConfig> prefixes = root?.Appearance?.RolePrefixes?.ResolveFor(player.Role.Code);
 
 		if (cfg.ApplyRolePrefix)
 		{
-			ApplyNametagPrefix(player, prefix, cfg.PrefixFormat);
+			ApplyNametagPrefix(player, prefixes, cfg.PrefixFormat);
 		}
 
 		RemoveInjectedEntitlement(player);
@@ -82,7 +83,7 @@ internal sealed class StratumNametags
 		injectedByUid.Remove(player.PlayerUID);
 	}
 
-	private void ApplyNametagPrefix(IServerPlayer player, StratumRolePrefixConfig prefix, string format)
+	private void ApplyNametagPrefix(IServerPlayer player, List<StratumRolePrefixConfig> prefixes, string format)
 	{
 		EntityPlayer entity = player.Entity;
 		if (entity == null) return;
@@ -90,19 +91,20 @@ internal sealed class StratumNametags
 		string baseName = player.PlayerName;
 		if (string.IsNullOrEmpty(baseName)) return;
 
-		string desired;
-		if (prefix != null && prefix.Enabled && !string.IsNullOrWhiteSpace(prefix.Tag))
+		string fmt = string.IsNullOrEmpty(format) ? "[{tag}] " : format;
+		StringBuilder prefixText = new StringBuilder();
+		if (prefixes != null)
 		{
-			string fmt = string.IsNullOrEmpty(format) ? "[{tag}] " : format;
-			string prefixText = fmt.Replace("{tag}", prefix.Tag);
-			desired = prefixText + baseName;
+			foreach (StratumRolePrefixConfig prefix in prefixes)
+			{
+				if (string.IsNullOrWhiteSpace(prefix.Tag)) continue;
+				prefixText.Append(fmt.Replace("{tag}", prefix.Tag));
+			}
 		}
-		else
-		{
-			// New role has no prefix \u2014 strip back to the bare player name so a demoted
-			// admin loses their "[Admin] " badge instead of keeping it stuck.
-			desired = baseName;
-		}
+
+		// Nothing left for the new role, so strip back to the bare player name and a demoted
+		// admin loses their "[Admin] " badge instead of keeping it stuck.
+		string desired = prefixText.Length == 0 ? baseName : prefixText + baseName;
 
 		string current = entity.WatchedAttributes.GetTreeAttribute("nametag")?.GetString("name");
 		if (string.Equals(current, desired, StringComparison.Ordinal)) return;
@@ -151,13 +153,4 @@ internal sealed class StratumNametags
 		StratumRuntime.LogInfo("nametag: injected entitlement '" + entCode + "' for " + player.PlayerName + " (role " + player.Role.Code + ")");
 	}
 
-	private static StratumRolePrefixConfig FindRolePrefix(Dictionary<string, StratumRolePrefixConfig> prefixes, string roleCode)
-	{
-		if (prefixes == null || string.IsNullOrWhiteSpace(roleCode)) return null;
-		return prefixes
-			.Where(kv => kv.Value != null && kv.Value.Enabled && string.Equals(kv.Key, roleCode, StringComparison.OrdinalIgnoreCase))
-			.OrderByDescending(kv => kv.Value.Priority)
-			.Select(kv => kv.Value)
-			.FirstOrDefault();
-	}
 }


### PR DESCRIPTION
## Summary

A role can now carry more than one name prefix. The tags stack in front of the name, ordered by the `Priority` field that was already in the schema, so an operator can put a `[Moderator]` badge in front of a player without losing the tag their gameplay role already gives them.

### Problem

`Appearance.RolePrefixes.Roles` maps a role code to one prefix. `Priority` exists on each prefix but has never changed anything, and an admin who wants a player to show both a staff tag and a gameplay tag has to build a combined role for every pairing, which does not scale.

### Current behaviour

Two prefix entries written under the same role key do not both survive. `Roles` is a JSON object, Newtonsoft's default duplicate-key handling is "keep the last", so the earlier entry is discarded before Stratum's code runs. And because a `Dictionary` holds at most one value per key, the `OrderByDescending(Priority)` in both the chat formatter and the nametag builder has only ever sorted a one-element sequence. `Priority` has been dead.

### Design

Each role's value is now read and written as a bare object for a single prefix and as an array for several:

```json
"Roles": {
  "admin": { "Tag": "Admin", "Priority": 100 },
  "villagemod": [
    { "Tag": "Moderator", "Color": "#4cc9f0", "Priority": 100 },
    { "Tag": "XYZ Villager", "Color": "#9bd77e", "Priority": 10 }
  ]
}
```

Scalar-or-array under one key is the common convention for exactly this shape (npm `bin`, GitHub Actions `on`, ESLint `extends`): the syntax an operator reaches for first is the syntax that works, and a config that only ever wanted one tag never has to learn the array form.

The write side is asymmetric on purpose. `StratumRuntime.LoadOrCreateConfig` rewrites `stratum.json` on every boot, so if a one-prefix role serialised back as a one-element array, every existing server's config would be reshaped on the next start. `StratumRolePrefixListConverter` writes a single prefix back as a bare object, so an untouched role stays byte-for-byte as it was. Only a role you actually give a second tag becomes an array. This also means no `ConfigVersion` bump and no migration: old files load unchanged.

### Change

`sources/VintagestoryLib/Vintagestory.Server/`:

- **`StratumAppearanceConfig.cs`**: `Roles` is now `Dictionary<string, StratumRolePrefixList>`. `StratumRolePrefixList` is a thin holder with a class-level `[JsonConverter]` that reads object-or-array and writes the shape back. `StratumRolePrefixesConfig.ResolveFor(roleCode)` returns the enabled prefixes for a role, highest `Priority` first (a stable sort, so equal priorities keep config-file order). The role-code match is a hand-written case-insensitive scan because `ObjectCreationHandling.Replace` rebuilds the dictionary on load and drops its `OrdinalIgnoreCase` comparer.
- **`StratumChatFormatter.cs`**: `TryFormat` renders each tag through the existing `Format` / colour / weight path and concatenates them, one space before the name. `FindPrefix` is deleted.
- **`StratumNametags.cs`**: `ApplyNametagPrefix` concatenates each tag through `PrefixFormat` into the one nametag string. `FindRolePrefix` is deleted.
- **`CmdStratum.cs`**: `/stratum chat` now prints each role's rendered tag stack plus every tag's priority and colour, disabled ones included.

A role with one prefix renders identically to before on all three surfaces. A role with none, or with every tag disabled, renders a bare name, same as today.

`FindPrefix` and `FindRolePrefix` were the same resolution logic in two files; they are replaced by the single `ResolveFor`.

### Regression proof

`scripts/smoke-test.sh` seeds `stratum.json` before boot with a `suvisitor` role carrying two prefixes as an array, deliberately in the wrong file order (`XYZ Villager` priority 10 before `Moderator` priority 100), and an `admin` role left as a bare object. The seeded file makes the boot config load run the converter through the real `JObject.ToObject<StratumConfig>` path. After `RunGame` the probe asserts, on a real server boot:

- `/stratum chat` renders `[Moderator][XYZ Villager]` for `suvisitor`: the stack is in `Priority` order, not file order.
- the boot rewrite of `stratum.json` keeps `suvisitor` an array and `admin` a bare object.

Verified on `984c3d6`: `bash scripts/smoke-test.sh` reaches RunGame and passes all 9 console probes, and the on-disk `stratum.json` after the run has `"suvisitor": [` and `"admin": {`.

The chat formatter and the nametag string against a live joined player are covered by a scenario in the private Atlas harness (`RolePrefixScenarios`). That scenario is written and compiles, but the harness's synthetic-client bridge is still pinned to Vintage Story 1.22.6 and cannot join a 1.22.7 server, so it does not run yet; the same gap blocks every existing scenario in that harness. The console probe covers the ordering and stacking end to end in the meantime.

### Gates

- `dotnet build VintageStory.slnx -c Release` (two-pass, `EmbedPatchedFiles=true`): green, zero new warnings on the four touched files.
- `bash scripts/smoke-test.sh`: PASS, server reaches RunGame, all 9 console probes verified.
- `scripts/extract-patches.sh`: no `patches/` change. The whole diff is `sources/` and docs.

### Limitations

- In the nametag, all tags share one colour. It comes from `Nametags.EntitlementColorByRole`, mapped from the player's role to a Vintage Story entitlement code, because the stock client has no way to colour part of a nametag. Chat colours each tag on its own. This is a protocol limit, not a shortcut, and it is documented.
- A long stack crowds the chat line and widens the in-world tag. The docs say keep it to two or three; nothing enforces a cap.
- Giving one player more than one role is a separate, larger change and stays out of scope. `Fixes #274` closes the stacking request; the multi-role idea is noted in the issue for its own follow-up.

### Observations, offered as follow-ups rather than bundled here

- `/stratum chat`'s `Prefix format` row prints the literal `{tag}` token, and the server console's result logger runs `string.Format` on every message unconditionally, so that one row logs a `Couldn't write to log file` error. Reproducible on `indev` today by typing `/stratum chat` at the console. The fix belongs in the vanilla console path, not here; the smoke probe reads the row on its own line and is not affected.
- `ObjectCreationHandling.Replace` dropping the dictionary comparer on load also affects `StratumNametagsConfig.EntitlementColorByRole`, which still does a case-sensitive `TryGetValue`. A role code cased differently from its config key gets no entitlement colour. Pre-existing, separate.

## Type

- [ ] Bug fix
- [ ] Performance
- [x] New feature
- [x] Refactor or cleanup
- [ ] Docs or build

## Checklist

- [x] `scripts/extract-patches.sh` ran clean.
- [x] `dotnet build VintageStory.slnx -c Release` is green.
- [x] Every vanilla edit has a `// Stratum` marker. (No vanilla edits: the four changed files are all Stratum-only `sources/`.)
- [x] No vanilla source committed.
- [x] Tested on a real server start, not just compilation.

## Related issues

Fixes #274
