### PR TITLE
Warn on an unpatched build; stop the smoke test hiding the Cecil resolver

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,7 +13,7 @@ What changed and why.
 ## Checklist
 
 - [ ] `.\scripts\extract-patches.ps1` ran clean.
-- [ ] `dotnet build VintageStory.slnx -c Release` is green.
+- [ ] `dotnet build VintageStory.slnx -c Release -p:EmbedPatchedFiles=true` is green.
 - [ ] Every vanilla edit has a `// Stratum` marker.
 - [ ] No vanilla source committed.
 - [ ] Tested on a real server start, not just compilation.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,17 +61,22 @@ You need the .NET 10 SDK. Linux and macOS contributors use `scripts/bootstrap.sh
 ```bash
 # Linux / macOS
 scripts/bootstrap.sh
-dotnet build VintageStory.slnx -c Release
+dotnet build VintageStory.slnx -c Release -p:EmbedPatchedFiles=true
 
-# Or use make (runs bootstrap if needed):
+# Or use make (runs bootstrap if needed, and sets the flag for you):
 make build
 ```
 
 ```powershell
 # Windows
 .\scripts\bootstrap.ps1
-dotnet build VintageStory.slnx -c Release
+dotnet build VintageStory.slnx -c Release -p:EmbedPatchedFiles=true
 ```
+
+`-p:EmbedPatchedFiles=true` is what embeds your compiled working tree into
+`StratumServer`. Build without it and the launcher has nothing to overlay, so
+the server boots the downloaded vanilla assemblies unpatched, with no error and
+no warning until this change. `make build` passes it.
 
 `bootstrap.ps1` downloads the matching vanilla server zip, decompiles the assemblies into the working tree, applies every patch, then copies `sources/` on top. After that you have a normal C# solution to edit.
 
@@ -148,7 +153,7 @@ Rules of thumb:
 
 Compilation is not enough. Before opening a PR:
 
-1. `dotnet build VintageStory.slnx -c Release` is green with zero warnings on files you touched.
+1. `dotnet build VintageStory.slnx -c Release -p:EmbedPatchedFiles=true` (or `make build`) is green with zero warnings on files you touched.
 2. Run the smoke test: `make smoke` (or `bash scripts/smoke-test.sh` / `.\scripts\smoke-test.ps1`). It builds, boots the server, waits for RunGame, checks for fatal errors, and (bash only, set `SMOKE_TEST_PROBE=0` to skip) pipes a small set of console commands into the running server to cover command registration and argument handling end to end.
 3. If your change touches a hot path (entity ticking, chunk IO, packet handling), get a before/after measurement. Server timings, frame profiler output, or a sampling profiler are all fine. "Feels faster" is not.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,8 @@ dotnet build VintageStory.slnx -c Release -p:EmbedPatchedFiles=true
 `-p:EmbedPatchedFiles=true` is what embeds your compiled working tree into
 `StratumServer`. Build without it and the launcher has nothing to overlay, so
 the server boots the downloaded vanilla assemblies unpatched, with no error and
-no warning until this change. `make build` passes it.
+no warning until this change. `make build` runs an unembedded pass first to
+produce the sibling outputs, then runs the embedded pass.
 
 `bootstrap.ps1` downloads the matching vanilla server zip, decompiles the assemblies into the working tree, applies every patch, then copies `sources/` on top. After that you have a normal C# solution to edit.
 

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,8 @@ bootstrap: ## Download, decompile, and apply patches
 
 build: ## Build Release (runs bootstrap if working tree is missing)
 	@if [ ! -f VintagestoryApi/VintagestoryAPI.csproj ]; then $(MAKE) bootstrap; fi
+# The first pass intentionally omits EmbedPatchedFiles because the sibling outputs
+# it embeds do not exist until this pass completes.
 	dotnet build VintageStory.slnx -c $(CONFIGURATION)
 # Second pass, only if embedding is on: StratumServer's EmbeddedResource list
 # points at sibling projects' bin output by raw path, not a ProjectReference,

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ make smoke        # build + boot-test the server
 git clone https://github.com/StratumServer/Stratum.git
 cd Stratum
 .\scripts\bootstrap.ps1
-dotnet build VintageStory.slnx -c Release
+dotnet build VintageStory.slnx -c Release -p:EmbedPatchedFiles=true
 .\scripts\smoke-test.ps1    # boot-test the server
 ```
 

--- a/StratumServer/PatchedFileOverlay.cs
+++ b/StratumServer/PatchedFileOverlay.cs
@@ -15,13 +15,20 @@ internal static class PatchedFileOverlay
 	private const string ModsPrefix = "Stratum.PatchedMods.";
 	private const string DataPrefix = "Stratum.PatchedData.";
 
+	/// <summary>
+	/// Writes the embedded patched files into <paramref name="installDir"/>.
+	/// Returns the number of files written, 0 if the install is already current, or
+	/// -1 if this build carries no embedded patched files at all (built without
+	/// -p:EmbedPatchedFiles=true), in which case the server would run the downloaded
+	/// vanilla assemblies unpatched.
+	/// </summary>
 	internal static int Apply(string installDir, string overlayStamp)
 	{
 		Assembly self = typeof(PatchedFileOverlay).Assembly;
 		string[] names = GetOverlayResourceNames(self);
 		if (names.Length == 0)
 		{
-			return 0;
+			return -1;
 		}
 
 		string markerPath = Path.Combine(installDir, ".stratum-patched-files");

--- a/StratumServer/Program.cs
+++ b/StratumServer/Program.cs
@@ -57,7 +57,12 @@ internal static class Program
 			{
 				string stamp = StratumInfo.Version;
 				int written = PatchedFileOverlay.Apply(AppContext.BaseDirectory, refresh ? stamp + ":refresh:" + Guid.NewGuid().ToString("N") : stamp);
-				if (written > 0)
+				if (written < 0)
+				{
+					Console.Error.WriteLine("Stratum: WARNING this build carries no embedded patched files, so the server is about to run the downloaded vanilla assemblies unpatched.");
+					Console.Error.WriteLine("Stratum: build with 'make build', or 'dotnet build VintageStory.slnx -c Release -p:EmbedPatchedFiles=true'.");
+				}
+				else if (written > 0)
 				{
 					Console.WriteLine($"Stratum: applied patched files ({written} file(s))");
 				}

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -16,7 +16,7 @@ Windows:
 git clone https://github.com/StratumServer/Stratum.git
 cd Stratum
 .\scripts\bootstrap.ps1
-dotnet build VintageStory.slnx -c Release
+dotnet build VintageStory.slnx -c Release -p:EmbedPatchedFiles=true
 ```
 
 Linux and macOS:
@@ -26,6 +26,11 @@ git clone https://github.com/StratumServer/Stratum.git
 cd Stratum
 make build
 ```
+
+`-p:EmbedPatchedFiles=true` embeds this working tree's compiled DLLs into
+`StratumServer` so the launcher overlays them onto the downloaded base game.
+Without it the server boots on the unpatched vanilla assemblies with no error.
+`make build` and `scripts/pack-release.ps1` pass it for you.
 
 Bootstrap does this:
 

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -30,7 +30,9 @@ make build
 `-p:EmbedPatchedFiles=true` embeds this working tree's compiled DLLs into
 `StratumServer` so the launcher overlays them onto the downloaded base game.
 Without it the server boots on the unpatched vanilla assemblies with no error.
-`make build` and `scripts/pack-release.ps1` pass it for you.
+`make build` and `scripts/pack-release.ps1` pass it for you. `make build` uses
+two passes: the first creates the sibling project outputs that `StratumServer`
+embeds, and the second runs with `-p:EmbedPatchedFiles=true`.
 
 Bootstrap does this:
 

--- a/patches/VintagestoryLib/Vintagestory.Common/ModAssemblyLoader.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Common/ModAssemblyLoader.cs.patch
@@ -1,8 +1,8 @@
 diff --git a/VintagestoryLib/Vintagestory.Common/ModAssemblyLoader.cs b/VintagestoryLib/Vintagestory.Common/ModAssemblyLoader.cs
-index 9eabde1..0846399 100644
+index 9eabde1..b4fed75 100644
 --- a/VintagestoryLib/Vintagestory.Common/ModAssemblyLoader.cs
 +++ b/VintagestoryLib/Vintagestory.Common/ModAssemblyLoader.cs
-@@ -11,30 +11,47 @@ public class ModAssemblyLoader : IDisposable
+@@ -11,30 +11,78 @@ public class ModAssemblyLoader : IDisposable
  {
  	private readonly IReadOnlyCollection<string> modSearchPaths;
  
@@ -25,6 +25,10 @@ index 9eabde1..0846399 100644
 +				StratumCecilResolver.AddSearchDirectory(searchPath);
 +			}
 +		}
++		// Cecil freezes the directory list above; a directory that appears later (a zip code
++		// mod unpacked mid-load, an output folder populated late) would never be searched.
++		// This re-probes the current paths when a resolve is about to fail.
++		StratumCecilResolver.ResolveFailure += StratumResolveFailure;
 +		// Stratum end
  		AppDomain.CurrentDomain.AssemblyResolve += AssemblyResolveHandler;
  	}
@@ -32,8 +36,35 @@ index 9eabde1..0846399 100644
  	public void Dispose()
  	{
  		AppDomain.CurrentDomain.AssemblyResolve -= AssemblyResolveHandler;
++		StratumCecilResolver.ResolveFailure -= StratumResolveFailure; // Stratum: cleanup
 +		StratumCecilResolver.Dispose(); // Stratum: cleanup
++	}
++
++	// Stratum start: last chance to resolve a mod dependency before Cecil throws and the
++	// whole mod is dropped. Re-enumerates the same search paths and reads the assembly by
++	// name; returns null to let Cecil raise its own error if nothing matches.
++	private AssemblyDefinition StratumResolveFailure(object sender, AssemblyNameReference reference)
++	{
++		foreach (string searchPath in GetAssemblySearchPaths())
++		{
++			if (!Directory.Exists(searchPath))
++			{
++				continue;
++			}
++
++			foreach (string extension in new string[] { ".dll", ".exe" })
++			{
++				string candidate = Path.Combine(searchPath, reference.Name + extension);
++				if (File.Exists(candidate))
++				{
++					return AssemblyDefinition.ReadAssembly(candidate, new ReaderParameters { AssemblyResolver = StratumCecilResolver });
++				}
++			}
++		}
++
++		return null;
  	}
++	// Stratum end
  
  	public Assembly LoadFrom(string path)
  	{

--- a/scripts/bootstrap.ps1
+++ b/scripts/bootstrap.ps1
@@ -366,7 +366,7 @@ try {
         Write-Host "Bootstrap FAILED: $($failed.Count) patch(es) did not apply. The working tree is incomplete." -ForegroundColor Red
         exit 1
     }
-    Write-Host "Bootstrap complete. Run: dotnet build VintageStory.slnx -c Release" -ForegroundColor Green
+    Write-Host "Bootstrap complete. Run: dotnet build VintageStory.slnx -c Release -p:EmbedPatchedFiles=true" -ForegroundColor Green
 } finally {
     Pop-Location
 }

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -538,4 +538,4 @@ if [[ "${failed_patch_count:-0}" -gt 0 ]]; then
   echo "Bootstrap FAILED: $failed_patch_count patch(es) did not apply. The working tree is incomplete." >&2
   exit 1
 fi
-echo "Bootstrap complete. Run: dotnet build VintageStory.slnx -c Release"
+echo "Bootstrap complete. Run: dotnet build VintageStory.slnx -c Release -p:EmbedPatchedFiles=true"

--- a/scripts/smoke-test.ps1
+++ b/scripts/smoke-test.ps1
@@ -148,13 +148,16 @@ try {
         }
     }
 
-    # Read final log.
+    # Read final logs. The patched resolver reports failures on stderr on Windows.
+    $errorLog = Join-Path $DataPath 'smoke-test-err.log'
     $finalLog = if (Test-Path $logFile) { Get-Content $logFile -Raw -ErrorAction SilentlyContinue } else { '' }
+    $finalError = if (Test-Path $errorLog) { Get-Content $errorLog -Raw -ErrorAction SilentlyContinue } else { '' }
+    $diagnosticLog = $finalLog + "`n" + $finalError
 
     if (-not $reachedRunGame -and $finalLog -match 'Entering runphase RunGame') {
         $reachedRunGame = $true
     }
-    if ($finalLog -match 'Fatal|Unhandled exception') {
+    if ($diagnosticLog -match 'Fatal|Unhandled exception|Failed to resolve assembly') {
         $hasFatal = $true
     }
 
@@ -171,6 +174,7 @@ try {
         Write-Error "  Fatal errors found in log."
     }
     Write-Error "  Log: $logFile"
+    Write-Error "  Error log: $errorLog"
     exit 1
 
 } finally {

--- a/scripts/smoke-test.ps1
+++ b/scripts/smoke-test.ps1
@@ -33,22 +33,33 @@ param(
 $ErrorActionPreference = 'Stop'
 $repoRoot = Split-Path -Parent $PSScriptRoot
 
+# Prefer StratumServer.exe, Stratum's own launcher, which applies VanillaBootstrap and
+# PatchedFileOverlay. A VintagestoryServer.exe in the same directory is the vanilla
+# archive's own entry point, copied in as a side effect of the first overlay; preferring
+# it would silently boot-test unpatched vanilla code (mirrors scripts/smoke-test.sh).
 $serverDir = Join-Path $repoRoot 'StratumServer\bin\Release\net10.0'
-$serverBin = Join-Path $serverDir 'VintagestoryServer.exe'
-if (-not (Test-Path $serverBin)) {
-    $serverBin = Join-Path $serverDir 'StratumServer.exe'
+function Resolve-ServerBin {
+    $stratum = Join-Path $serverDir 'StratumServer.exe'
+    if (Test-Path $stratum) { return $stratum }
+    $vanilla = Join-Path $serverDir 'VintagestoryServer.exe'
+    if (Test-Path $vanilla) { return $vanilla }
+    return $null
 }
+$serverBin = Resolve-ServerBin
 
 Push-Location $repoRoot
 try {
-    # Build if binary is missing.
-    if (-not (Test-Path $serverBin)) {
+    # Build if binary is missing. -p:EmbedPatchedFiles=true is required so StratumServer
+    # carries this working tree's patched DLLs; without it PatchedFileOverlay has nothing
+    # to overlay and the server silently runs the downloaded vanilla assemblies.
+    if (-not $serverBin) {
         Write-Host "Building Release..."
-        dotnet build VintageStory.slnx -c Release --verbosity quiet
+        dotnet build VintageStory.slnx -c Release -p:EmbedPatchedFiles=true --verbosity quiet
+        $serverBin = Resolve-ServerBin
     }
 
-    if (-not (Test-Path $serverBin)) {
-        Write-Error "Server binary not found: $serverBin"
+    if (-not $serverBin) {
+        Write-Error "Server binary not found in $serverDir"
         exit 1
     }
 

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -115,11 +115,11 @@ mkfifo "$console_fifo"
 exec 3<>"$console_fifo"
 
 log_file="$data_path/smoke-test.log"
-# Run from the server's own directory, not repo_root: Mono.Cecil's default assembly
-# resolver searches the process's current directory, and modinfo scanning at boot
-# fails to resolve VintagestoryAPI (silently dropping every mod, "game" included)
-# when launched from anywhere else.
-(cd "$server_dir" && exec "$server_bin" --dataPath "$data_path" --port "$port" <"$console_fifo" >"$log_file" 2>&1) &
+# Launched from repo_root, not the server's own directory: the Mono.Cecil resolver
+# in ModAssemblyLoader must find VintagestoryAPI.dll for the boot modinfo scan
+# regardless of the working directory (StratumServer/Stratum#276), and running the
+# smoke test from a neutral directory is what keeps that covered.
+"$server_bin" --dataPath "$data_path" --port "$port" <"$console_fifo" >"$log_file" 2>&1 &
 server_pid=$!
 
 last_line_count=0


### PR DESCRIPTION
## Summary

The server in that run was executing **vanilla `VintagestoryLib.dll`**, which has no Cecil resolver at all. The `1fe074b` `ModAssemblyLoader` fix is correct; it just was not loaded.

### Root cause

The repro's second line is `dotnet build VintageStory.slnx -c Release` with no `-p:EmbedPatchedFiles=true`. Without that flag `StratumServer.csproj` embeds no overlay resources, `PatchedFileOverlay.Apply` returns without a word when it finds none, and `VanillaBootstrap`'s downloaded `VintagestoryLib.dll` is what runs. `scripts/smoke-test.sh` only auto-builds when the binary is missing, so its own `-p:EmbedPatchedFiles=true` fallback never fired.

Vanilla `ModAssemblyLoader.LoadAssemblyDefinition` is `AssemblyDefinition.ReadAssembly(path)` with no `ReaderParameters`. Mono.Cecil 0.11.6's `BaseAssemblyResolver` then searches only `{ ".", "bin" }`, relative to the process working directory, which was `repo_root` for `bash scripts/smoke-test.sh` at the time this was filed. `VintagestoryAPI.dll` lives in the server output directory, which is neither.

Reproduced against the real `Lib/Mono.Cecil.dll` and the built `Mods/VSCreativeMod.dll`:

```
--- cwd: <repo root> ---
mod = Mods/VSCreativeMod.dll  (references VintagestoryAPI 1.22.7.0)
[vanilla  ReadAssembly(path)]        -> AssemblyResolutionException: Failed to resolve assembly:
    'VintagestoryAPI, Version=1.22.7.0, Culture=neutral, PublicKeyToken=null'
[Stratum  resolver, BaseDir + Lib]   -> OK modsystems=4
```

The vanilla path succeeds only when run from the server's own output directory. The Stratum resolver succeeds from every directory tested.

Two corrections to the original diagnosis: the resolver is not version-strict (resolving `VintagestoryAPI, Version=9.9.9.9` from a directory holding 1.22.7.0 returns the 1.22.7.0 assembly), and the mod is not dropped silently, `ModContainer.LoadModInfo`'s catch logs it, which is where the stack trace in the issue came from. What was missing was any signal that the build was unpatched.

A correctly built tree (`make build`, or `dotnet build ... -p:EmbedPatchedFiles=true`) reaches RunGame from a neutral working directory with zero resolve errors on current `indev`.

### Change

- **`StratumServer/PatchedFileOverlay.cs`, `StratumServer/Program.cs`**, `Apply` returns `-1` when the build carries no embedded patched files, distinct from `0` for "already current". The launcher then prints a warning that the server is about to run the vanilla assemblies unpatched and how to rebuild. `scripts/pack-release.ps1` always passes the flag, so this never fires in a shipped build.
- **`patches/VintagestoryLib/Vintagestory.Common/ModAssemblyLoader.cs.patch`**, the Stratum Cecil resolver freezes its search-directory list at construction. A `ResolveFailure` handler re-enumerates the same paths at failure time (covering a directory that appears later: a zip code mod unpacked mid-load, an output folder populated late) and reads the assembly by name before Cecil throws. Returns null to let Cecil raise its own error if nothing matches. This turns a previously fixup-only patch into one with a marked behavioural change.
- **`scripts/smoke-test.sh`**, drops the `cd "$server_dir"` wrapper (added to route around this). The server reaches RunGame from `repo_root`, and running the test from a neutral directory keeps the resolver covered on every run: a machine where it genuinely fails now fails the gate instead of passing via the workaround.
- **`scripts/smoke-test.ps1`**, same three latent preconditions this issue needs, none of which were ever fixed here: it preferred `VintagestoryServer.exe`, built without `-p:EmbedPatchedFiles=true`, and (like the new `.sh`) launches from the repo root. First two fixed; the launch directory is already neutral, which is now the intended behaviour. Untested from here, no Windows runner in this environment.
- **`docs/BUILDING.md`, `CONTRIBUTING.md`**, the bare `dotnet build VintageStory.slnx -c Release`, including the pre-PR gate step, produces the unpatched build this issue is an instance of. Every command now carries `-p:EmbedPatchedFiles=true` with a line saying why.

### Gates

- `dotnet build VintageStory.slnx -c Release` then `... -p:EmbedPatchedFiles=true`: green, zero new warnings on the touched files (the 4 solution warnings are the pre-existing vanilla `NU1904`).
- `bash scripts/smoke-test.sh` from `repo_root` with the `cd` wrapper removed: **`PASS: server reached RunGame, no fatal errors, 8 console command(s) verified.`** 3 mods loaded, zero `Failed to resolve assembly` in the boot log.
- `scripts/extract-patches.sh`: the only patch changed is `ModAssemblyLoader.cs.patch`. No `sources/` change.
- Cecil negative control (above): the vanilla path throws the issue's verbatim exception from a neutral cwd; the Stratum path succeeds from three different cwds.

### Limitations

- The original crash is **not reproducible on a correctly built current `indev`**. It is reproducible under the repro's exact command sequence, which is the condition the issue describes and which the doc and warning changes remove.
- `smoke-test.ps1` changes ship untested (mechanical, mirror `smoke-test.sh`).
- A cold-cache `LoadAssets` on `/mnt/c` can exceed the default 60s stall patience. That is a `SMOKE_TEST_PATIENCE` matter, not a resolver regression; a warm run passes well under it. Bumping the default is separate scope.
- The `NullReferenceException` in `WorldConfig.loadWorldConfigValuesFromPlaystyle` downstream of "no mods loaded" is left alone deliberately. It is a symptom of an already-unusable server state, and `WorldConfig.cs.patch` is currently fixup-only. Worth its own issue: "no-mods-loaded should fail with a diagnostic, not an NRE."

## Type

- [x] Bug fix
- [ ] Performance
- [ ] New feature
- [x] Refactor or cleanup
- [x] Docs or build

## Checklist

- [x] `scripts/extract-patches.sh` ran clean (only the one patch this change touches).
- [x] `dotnet build VintageStory.slnx -c Release -p:EmbedPatchedFiles=true` is green.
- [x] Every vanilla edit has a `// Stratum` marker (`ModAssemblyLoader.cs`; `StratumServer/*` is Stratum-only).
- [x] No vanilla source committed.
- [x] Tested on a real server start, not just compilation.

## Related issues

Fixes #276
