### PR TITLE
Repository hygiene: SDK pin, editorconfig, owners, license detection, docs index

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,47 @@
+# Editor defaults for the tracked tree. Mirrors CONTRIBUTING.md: tabs in Stratum
+# C#, match the surrounding style when editing vanilla, LF everywhere except
+# PowerShell (see .gitattributes).
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# Stratum-owned C#: tabs, file-scoped namespaces (enforced by review, not here).
+[{sources,StratumServer,tests}/**.cs]
+indent_style = tab
+
+# Decompiled VintagestoryLib is emitted with tabs by ilspycmd.
+[VintagestoryLib/**.cs]
+indent_style = tab
+
+# The Anego forks (API, Essentials, Survival) use four spaces. Keep them as they are.
+[{VintagestoryApi,VSEssentials,VSSurvivalMod}/**.cs]
+indent_style = space
+indent_size = 4
+
+# Unified diffs must keep their trailing whitespace and context lines byte for byte.
+[*.patch]
+trim_trailing_whitespace = false
+insert_final_newline = false
+
+[*.{csproj,props,targets,slnx,json,yml,yaml}]
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.sh]
+indent_style = space
+indent_size = 2
+
+[*.ps1]
+end_of_line = crlf
+indent_style = space
+indent_size = 4
+
+[Makefile]
+indent_style = tab

--- a/.editorconfig
+++ b/.editorconfig
@@ -10,24 +10,34 @@ insert_final_newline = true
 trim_trailing_whitespace = true
 
 # Stratum-owned C#: tabs, file-scoped namespaces (enforced by review, not here).
+# A few older files under sources/ are still space-indented; they are the ones
+# out of line, and reformatting them is a separate cleanup.
 [{sources,StratumServer,tests}/**.cs]
 indent_style = tab
 
-# Decompiled VintagestoryLib is emitted with tabs by ilspycmd.
-[VintagestoryLib/**.cs]
+# Generated working trees. extract-patches diffs them against the pristine
+# baseline, so an editor that trims or reformats one of these files on save
+# turns into real hunks in patches/. Leave their whitespace alone.
+#
+# Decompiled by bootstrap into baseline/, tab-indented by ilspycmd.
+[baseline/{VintagestoryLib,VintagestoryServer}/**.cs]
 indent_style = tab
+trim_trailing_whitespace = false
+insert_final_newline = false
 
-# The Anego forks (API, Essentials, Survival) use four spaces. Keep them as they are.
-[{VintagestoryApi,VSEssentials,VSSurvivalMod}/**.cs]
+# Anego forks cloned by bootstrap (forks.json), four spaces.
+[{VintagestoryApi,Cairo,VSCreativeMod,VSEssentials,VSSurvivalMod}/**.cs]
 indent_style = space
 indent_size = 4
+trim_trailing_whitespace = false
+insert_final_newline = false
 
 # Unified diffs must keep their trailing whitespace and context lines byte for byte.
 [*.patch]
 trim_trailing_whitespace = false
 insert_final_newline = false
 
-[*.{csproj,props,targets,slnx,json,yml,yaml}]
+[*.{csproj,props,slnx,json,yml,yaml}]
 indent_style = space
 indent_size = 2
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,7 @@
-* @StratumServer/core
-/docs/ @StratumServer/docs
-.github/ @StratumServer/core
-/scripts/ @StratumServer/core
+# Review suggestions, not a gate: the indev ruleset does not require a code
+# owner review. The org has no GitHub teams yet, so owners are listed by login.
+# Add yourself when you take an area.
+*           @trevorftp @pizza2004 @Pixnop
+/docs/      @trevorftp @pizza2004 @Pixnop @Zaldaryon
+/.github/   @trevorftp @pizza2004 @Pixnop
+/scripts/   @trevorftp @pizza2004 @Pixnop

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
-# Review suggestions, not a gate: the indev ruleset does not require a code
-# owner review. The org has no GitHub teams yet, so owners are listed by login.
-# Add yourself when you take an area.
+# Review suggestions, not a gate: no branch rule requires a code owner review.
+# The org has no GitHub teams yet, so owners are listed by login. Add yourself
+# when you take an area.
 *           @trevorftp @pizza2004 @Pixnop
 /docs/      @trevorftp @pizza2004 @Pixnop @Zaldaryon
 /.github/   @trevorftp @pizza2004 @Pixnop

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,15 +1,1 @@
-# These are supported funding model platforms
-
-github: # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
-patreon: # Replace with a single Patreon username
 open_collective: stratum
-ko_fi: # no longer needed
-tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
-community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
-liberapay: # Replace with a single Liberapay username
-issuehunt: # Replace with a single IssueHunt username
-lfx_crowdfunding: # Replace with a single LFX Crowdfunding project-name e.g., cloud-foundry
-polar: # Replace with a single Polar username
-buy_me_a_coffee: # Replace with a single Buy Me a Coffee username
-thanks_dev: # Replace with a single thanks.dev username
-custom: # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,13 @@
 version: 2
 updates:
+  # Actions only. NuGet is deliberately not listed: the packages the server
+  # references are pinned to what the game ships (Newtonsoft, protobuf and
+  # friends), and a bump there would break the overlay against vanilla.
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,18 @@
+# Code of Conduct
+
+Stratum follows the [Contributor Covenant](https://www.contributor-covenant.org/version/2/1/code_of_conduct/), version 2.1. The short version:
+
+- Be respectful in issues, pull requests, reviews and on Discord. Disagree with the code, not with the person.
+- Reviews are blunt about defects and neutral about people. A rejected change is not a judgement of its author.
+- No harassment, discrimination, personal attacks, or publishing of someone's private information.
+- Assume good faith from contributors who are new to the decompile-and-patch workflow; point them at [CONTRIBUTING.md](CONTRIBUTING.md) instead of at the door.
+
+## Reporting
+
+Report a problem to any maintainer by direct message on [Discord](https://discord.gg/pd24fawhsD). Reports are handled privately. Maintainers who are the subject of a report step out of its handling.
+
+## Enforcement
+
+Maintainers may edit or remove comments, commits, issues and pull requests that break this code, and may temporarily or permanently exclude a contributor from the project for behaviour they judge inappropriate, threatening, offensive, or harmful.
+
+The full text of the Contributor Covenant 2.1, including the enforcement ladder, applies where this page is silent.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -3,7 +3,7 @@
 Stratum follows the [Contributor Covenant](https://www.contributor-covenant.org/version/2/1/code_of_conduct/), version 2.1. The short version:
 
 - Be respectful in issues, pull requests, reviews and on Discord. Disagree with the code, not with the person.
-- Reviews are blunt about defects and neutral about people. A rejected change is not a judgement of its author.
+- Reviews are blunt about defects and neutral about people. A rejected change is not a judgment of its author.
 - No harassment, discrimination, personal attacks, or publishing of someone's private information.
 - Assume good faith from contributors who are new to the decompile-and-patch workflow; point them at [CONTRIBUTING.md](CONTRIBUTING.md) instead of at the door.
 
@@ -13,6 +13,6 @@ Report a problem to any maintainer by direct message on [Discord](https://discor
 
 ## Enforcement
 
-Maintainers may edit or remove comments, commits, issues and pull requests that break this code, and may temporarily or permanently exclude a contributor from the project for behaviour they judge inappropriate, threatening, offensive, or harmful.
+Maintainers may edit or remove comments, commits, issues and pull requests that break this code, and may temporarily or permanently exclude a contributor from the project for behavior they judge inappropriate, threatening, offensive, or harmful.
 
 The full text of the Contributor Covenant 2.1, including the enforcement ladder, applies where this page is silent.

--- a/LICENSE
+++ b/LICENSE
@@ -12,13 +12,6 @@ furnished to do so, subject to the following conditions:
 The above copyright notice and this permission notice shall be included in all
 copies or substantial portions of the Software.
 
-This license applies only to the original work contained in this repository:
-the Stratum source code, patches, scripts, and documentation. It does not grant
-any rights to Vintage Story, which is a separate work owned by Anego Studios.
-Release artifacts may include Stratum-patched managed server files with Anego
-Studios permission. The official server archive is resolved and downloaded from
-Anego's release manifest at install time.
-
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,0 +1,8 @@
+# Notice
+
+The MIT license in [LICENSE](LICENSE) applies only to the original work contained
+in this repository: the Stratum source code, patches, scripts, and documentation.
+It does not grant any rights to Vintage Story, which is a separate work owned by
+Anego Studios. Release artifacts may include Stratum-patched managed server files
+with Anego Studios permission. The official server archive is resolved and
+downloaded from Anego's release manifest at install time.

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Anything else is forwarded to the server, such as `--port` or `--dataPath`.
 
 ## Commands
 
-Stratum adds a set of in-game commands on top of vanilla.
+Stratum adds a set of in-game commands on top of vanilla. The full list of pages is in [docs/README.md](docs/README.md).
 
 - [docs/commands/kits.md](docs/commands/kits.md): `/kit` and `/kitedit`.
 - [docs/role-prefixes.md](docs/role-prefixes.md): stacking role name prefixes.

--- a/README.md
+++ b/README.md
@@ -150,4 +150,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md#versioning-and-releases) for the full sche
 
 ## License
 
-[MIT](LICENSE).
+[MIT](LICENSE) for the Stratum source code, patches, scripts and documentation. It grants no rights to Vintage Story, see [NOTICE.md](NOTICE.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@ Do not file public issues for security bugs.
 
 Preferred: DM a maintainer on [Discord](https://discord.gg/pd24fawhsD). Fastest response.
 
-Backup: open a private report through [GitHub Security Advisories](https://github.com/trevorftp/Stratum/security/advisories/new) if you can't reach anyone on Discord.
+Backup: open a private report through [GitHub Security Advisories](https://github.com/StratumServer/Stratum/security/advisories/new) if you can't reach anyone on Discord.
 
 Include:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,17 @@
+# Stratum documentation
+
+Pages in this folder, by audience.
+
+## Building and contributing
+
+- [BUILDING.md](BUILDING.md): bootstrap, build, embed the patched files, smoke test.
+- [../CONTRIBUTING.md](../CONTRIBUTING.md): repository workflow, patch markers, style, pull request checklist.
+- [../SECURITY.md](../SECURITY.md): how to report a security bug.
+
+## Running a server
+
+- [commands/kits.md](commands/kits.md): `/kit` and `/kitedit`.
+- [commands/friendlyfire.md](commands/friendlyfire.md): `/friendlyfire`, the runtime group friendly-fire toggle.
+- [role-prefixes.md](role-prefixes.md): stacking role name prefixes in chat and nametags.
+
+Config keys live in `stratum.json`, `stratum-commands.json` and `stratum-performance.json` next to the world data; `/stratum get` and `/stratum set` read and write them on a running server.

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@ Pages in this folder, by audience.
 - [BUILDING.md](BUILDING.md): bootstrap, build, embed the patched files, smoke test.
 - [../CONTRIBUTING.md](../CONTRIBUTING.md): repository workflow, patch markers, style, pull request checklist.
 - [../SECURITY.md](../SECURITY.md): how to report a security bug.
+- [../CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md): how contributors treat each other, and how to report a problem.
 
 ## Running a server
 

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "10.0.100",
+    "rollForward": "latestFeature"
+  }
+}

--- a/scripts/pack-release.ps1
+++ b/scripts/pack-release.ps1
@@ -5,7 +5,7 @@ Builds and packages Stratum launcher zips.
 Produces a tiny zip per RID containing only:
   StratumServer.exe (single-file, framework-dependent, with Stratum patched managed files embedded as resources)
   StratumServer.runtimeconfig.json
-  LICENSE, README.md
+  LICENSE, NOTICE.md, README.md
 
 The launcher resolves the matching official server archive through https://api.vintagestory.at/stable-unstable.json on first run
 then writes the embedded Stratum patched files over the extracted server.
@@ -96,6 +96,7 @@ try {
         if (Test-Path $runtimeCfg) { Copy-Item $runtimeCfg $stage }
         Copy-Item (Join-Path $repoRoot 'LICENSE')  $stage
         Copy-Item (Join-Path $repoRoot 'README.md') $stage
+        Copy-Item (Join-Path $repoRoot 'NOTICE.md') $stage
 
 		$zipName = "stratum-$Version-$rid.zip"
         $zipPath = Join-Path $OutDir $zipName


### PR DESCRIPTION
## Summary

Repository hygiene, eight small commits, no code change. Each one is independent and can be dropped on its own.

- **global.json and .editorconfig.** The SDK is pinned to the 10.0 line with `rollForward: latestFeature`, the same major the release workflow installs, so a contributor on a different SDK gets told at restore time instead of at review time. The editorconfig writes down what CONTRIBUTING already asks for: tabs in Stratum-owned C# and in the decompiled VintagestoryLib tree, four spaces in the Anego forks, two spaces in project and YAML files. `*.patch` is excluded from whitespace trimming so an editor cannot corrupt a unified diff.
- **CODEOWNERS by login.** The file pointed at `@StratumServer/core` and `@StratumServer/docs`, and the org has no teams, so it matched nobody and GitHub's validator reported four unknown owners. It now lists the admins, plus Zaldaryon on docs. It is a suggestion list, nothing requires a code owner review; add yourself where you want the pings.
- **SECURITY.md link.** Private reports went to `github.com/trevorftp/Stratum/security/advisories/new`, a personal fork. Now the org repository.
- **NOTICE.md in releases.** `scripts/pack-release.ps1` stages it next to LICENSE and README.md, so the README's link resolves inside every archive.
- **LICENSE detection.** GitHub reports the license as "Other" because the scope paragraph sits inside the MIT text. The paragraph moves verbatim to `NOTICE.md`, the README license section points at it, and LICENSE is the plain MIT text again. Terms unchanged. This is the one commit I would understand someone wanting to keep out; say so and I drop it.
- **Dependabot groups.** One weekly pull request for all action bumps instead of one per action. NuGet stays out on purpose: the server references the package versions the game ships, and a bump there breaks the overlay against vanilla.
- **docs/README.md.** An index of the four pages by audience, linked from the README.
- **FUNDING.yml** trimmed to the platform in use.
- **CODE_OF_CONDUCT.md.** Contributor Covenant 2.1 by reference, with the reporting path SECURITY.md already uses.

## Type

- [ ] Bug fix
- [ ] Performance
- [ ] New feature
- [ ] Refactor or cleanup
- [x] Docs or build

## Checklist

- n/a `scripts/extract-patches.sh`: nothing under `patches/` changes.
- n/a Build: no source changes. `dotnet --version` resolves 10.0.111 through the new global.json.
- n/a `// Stratum` markers: no vanilla file changes.
- [x] No vanilla source committed.
- n/a Server start: nothing in this PR runs.

## Branch protection follow-up

Today `indev` has no ruleset while it is the target of every pull request, and `main` is protected only by the "Restrict Main" ruleset. Once this PR is merged I will add a ruleset on `indev` through the repository settings, no file involved:

- Name `Protect indev`, target `refs/heads/indev`, enforcement active.
- Block branch deletion and force pushes.
- Require a pull request with one approving review, stale reviews dismissed on push, no code owner review required, merge, squash and rebase all allowed.
- No bypass actor. Admins included, so the rule applies to me too.
- No required status check yet. The CI workflow that builds on pull requests is coming in a separate PR, and the check gets added to the ruleset once it has run green on a few PRs.

Repository security settings (secret scanning with push protection, Dependabot alerts and security updates) are off today; I will turn them on at the same time, they change nothing in the tree.

## Related issues

Part of the housekeeping around #147.

